### PR TITLE
✨ Switch go prefix in release 0.2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -204,7 +204,7 @@ docs-ecutable:
 .PHONY: write-time-to-file
 write-time-to-file: 
 	FILENAME=$(FILENAME) docs/scripts/get-elapsed-time.sh
-	
+
 tools: $(GOLANGCI_LINT) $(CONTROLLER_GEN) $(API_GEN) $(YAML_PATCH) $(GOTESTSUM) $(OPENSHIFT_GOIMPORTS) $(CODE_GENERATOR)
 .PHONY: tools
 
@@ -235,8 +235,8 @@ codegen: crds $(CODE_GENERATOR)
 .PHONY: verify-codegen
 verify-codegen:
 	if [[ -n "${GITHUB_WORKSPACE}" ]]; then \
-		mkdir -p $$(go env GOPATH)/src/github.com/kcp-dev; \
-		ln -s ${GITHUB_WORKSPACE} $$(go env GOPATH)/src/github.com/kcp-dev/edge-mc; \
+		mkdir -p $$(go env GOPATH)/src/github.com/kubestellar; \
+		ln -s ${GITHUB_WORKSPACE} $$(go env GOPATH)/src/github.com/kubestellar/kubestellar; \
 	fi
 
 	$(MAKE) codegen
@@ -250,8 +250,8 @@ verify-codegen:
 .PHONY: verify-syncer-codegen
 verify-syncer-codegen:
 	if [[ -n "${GITHUB_WORKSPACE}" ]]; then \
-		mkdir -p $$(go env GOPATH)/src/github.com/kcp-dev; \
-		ln -s ${GITHUB_WORKSPACE} $$(go env GOPATH)/src/github.com/kcp-dev/edge-mc; \
+		mkdir -p $$(go env GOPATH)/src/github.com/kubestellar; \
+		ln -s ${GITHUB_WORKSPACE} $$(go env GOPATH)/src/github.com/kubestellar/kubestellar; \
 	fi
 
 #	$(MAKE) syncer-codegen
@@ -267,7 +267,7 @@ $(OPENSHIFT_GOIMPORTS):
 
 .PHONY: imports
 imports: $(OPENSHIFT_GOIMPORTS) verify-go-versions
-	$(OPENSHIFT_GOIMPORTS) -i github.com/kcp-dev -m github.com/kcp-dev/edge-mc
+	$(OPENSHIFT_GOIMPORTS) -i github.com/kcp-dev -m github.com/kubestellar/kubestellar
 
 $(TOOLS_DIR)/verify_boilerplate.py:
 	mkdir -p $(TOOLS_DIR)

--- a/cmd/cluster-watchall/main.go
+++ b/cmd/cluster-watchall/main.go
@@ -53,8 +53,8 @@ import (
 	extkcpinformers "github.com/kcp-dev/kcp/pkg/client/informers/externalversions"
 	"github.com/kcp-dev/logicalcluster/v3"
 
-	urmetav1a1 "github.com/kcp-dev/edge-mc/pkg/apis/meta/v1alpha1"
-	"github.com/kcp-dev/edge-mc/pkg/apiwatch"
+	urmetav1a1 "github.com/kubestellar/kubestellar/pkg/apis/meta/v1alpha1"
+	"github.com/kubestellar/kubestellar/pkg/apiwatch"
 )
 
 /* This program is a kcp client that monitors all LogicalClusters and,

--- a/cmd/emc-customize/main.go
+++ b/cmd/emc-customize/main.go
@@ -33,8 +33,8 @@ import (
 
 	schedulingv1alpha1 "github.com/kcp-dev/kcp/pkg/apis/scheduling/v1alpha1"
 
-	edgeapi "github.com/kcp-dev/edge-mc/pkg/apis/edge/v1alpha1"
-	"github.com/kcp-dev/edge-mc/pkg/customize"
+	edgeapi "github.com/kubestellar/kubestellar/pkg/apis/edge/v1alpha1"
+	"github.com/kubestellar/kubestellar/pkg/customize"
 )
 
 func main() {

--- a/cmd/inform-syncer-configs/main.go
+++ b/cmd/inform-syncer-configs/main.go
@@ -36,11 +36,11 @@ import (
 	kcpscopedclient "github.com/kcp-dev/kcp/pkg/client/clientset/versioned"
 	kcpinformers "github.com/kcp-dev/kcp/pkg/client/informers/externalversions"
 
-	edgeapi "github.com/kcp-dev/edge-mc/pkg/apis/edge/v1alpha1"
-	clientopts "github.com/kcp-dev/edge-mc/pkg/client-options"
-	emcclusterclientset "github.com/kcp-dev/edge-mc/pkg/client/clientset/versioned/cluster"
-	edgescopedclient "github.com/kcp-dev/edge-mc/pkg/client/clientset/versioned/typed/edge/v1alpha1"
-	"github.com/kcp-dev/edge-mc/pkg/mailboxwatch"
+	edgeapi "github.com/kubestellar/kubestellar/pkg/apis/edge/v1alpha1"
+	clientopts "github.com/kubestellar/kubestellar/pkg/client-options"
+	emcclusterclientset "github.com/kubestellar/kubestellar/pkg/client/clientset/versioned/cluster"
+	edgescopedclient "github.com/kubestellar/kubestellar/pkg/client/clientset/versioned/typed/edge/v1alpha1"
+	"github.com/kubestellar/kubestellar/pkg/mailboxwatch"
 )
 
 func main() {

--- a/cmd/kube-watchall/go.mod
+++ b/cmd/kube-watchall/go.mod
@@ -1,4 +1,4 @@
-module github.com/kcp-dev/edge-mc/cmd/watchall
+module github.com/kubestellar/kubestellar/cmd/watchall
 
 go 1.19
 

--- a/cmd/kubectl-kubestellar-syncer_gen/main.go
+++ b/cmd/kubectl-kubestellar-syncer_gen/main.go
@@ -27,7 +27,7 @@ import (
 	"k8s.io/component-base/version"
 	"k8s.io/klog/v2"
 
-	plugin "github.com/kcp-dev/edge-mc/pkg/cliplugins/kubestellar/syncer-gen"
+	plugin "github.com/kubestellar/kubestellar/pkg/cliplugins/kubestellar/syncer-gen"
 )
 
 var (

--- a/cmd/kubestellar-scheduler/cmd/scheduler.go
+++ b/cmd/kubestellar-scheduler/cmd/scheduler.go
@@ -36,10 +36,10 @@ import (
 	kcpinformers "github.com/kcp-dev/kcp/pkg/client/informers/externalversions"
 	kcpfeatures "github.com/kcp-dev/kcp/pkg/features"
 
-	scheduleroptions "github.com/kcp-dev/edge-mc/cmd/kubestellar-scheduler/options"
-	edgeclientset "github.com/kcp-dev/edge-mc/pkg/client/clientset/versioned/cluster"
-	edgeinformers "github.com/kcp-dev/edge-mc/pkg/client/informers/externalversions"
-	"github.com/kcp-dev/edge-mc/pkg/scheduler"
+	scheduleroptions "github.com/kubestellar/kubestellar/cmd/kubestellar-scheduler/options"
+	edgeclientset "github.com/kubestellar/kubestellar/pkg/client/clientset/versioned/cluster"
+	edgeinformers "github.com/kubestellar/kubestellar/pkg/client/informers/externalversions"
+	"github.com/kubestellar/kubestellar/pkg/scheduler"
 )
 
 func NewSchedulerCommand() *cobra.Command {

--- a/cmd/kubestellar-scheduler/main.go
+++ b/cmd/kubestellar-scheduler/main.go
@@ -22,7 +22,7 @@ import (
 	"k8s.io/component-base/cli"
 	_ "k8s.io/component-base/logs/json/register"
 
-	"github.com/kcp-dev/edge-mc/cmd/kubestellar-scheduler/cmd"
+	"github.com/kubestellar/kubestellar/cmd/kubestellar-scheduler/cmd"
 )
 
 func main() {

--- a/cmd/kubestellar-scheduler/options/options.go
+++ b/cmd/kubestellar-scheduler/options/options.go
@@ -22,7 +22,7 @@ import (
 	"k8s.io/component-base/config"
 	"k8s.io/component-base/logs"
 
-	clientoptions "github.com/kcp-dev/edge-mc/pkg/client-options"
+	clientoptions "github.com/kubestellar/kubestellar/pkg/client-options"
 )
 
 type Options struct {

--- a/cmd/ls-syncer-config/main.go
+++ b/cmd/ls-syncer-config/main.go
@@ -34,9 +34,9 @@ import (
 
 	"github.com/kcp-dev/logicalcluster/v3"
 
-	edgeapi "github.com/kcp-dev/edge-mc/pkg/apis/edge/v1alpha1"
-	clientopts "github.com/kcp-dev/edge-mc/pkg/client-options"
-	clusterclientset "github.com/kcp-dev/edge-mc/pkg/client/clientset/versioned/cluster"
+	edgeapi "github.com/kubestellar/kubestellar/pkg/apis/edge/v1alpha1"
+	clientopts "github.com/kubestellar/kubestellar/pkg/client-options"
+	clusterclientset "github.com/kubestellar/kubestellar/pkg/client/clientset/versioned/cluster"
 )
 
 func main() {

--- a/cmd/mailbox-controller/main.go
+++ b/cmd/mailbox-controller/main.go
@@ -51,7 +51,7 @@ import (
 	kcpinformers "github.com/kcp-dev/kcp/pkg/client/informers/externalversions"
 	"github.com/kcp-dev/logicalcluster/v3"
 
-	clientopts "github.com/kcp-dev/edge-mc/pkg/client-options"
+	clientopts "github.com/kubestellar/kubestellar/pkg/client-options"
 )
 
 func main() {

--- a/cmd/placement-translator/main.go
+++ b/cmd/placement-translator/main.go
@@ -58,10 +58,10 @@ import (
 	kcpinformers "github.com/kcp-dev/kcp/pkg/client/informers/externalversions"
 	tenancyv1a1informers "github.com/kcp-dev/kcp/pkg/client/informers/externalversions/tenancy/v1alpha1"
 
-	emcclusterclientset "github.com/kcp-dev/edge-mc/pkg/client/clientset/versioned/cluster"
-	emcinformers "github.com/kcp-dev/edge-mc/pkg/client/informers/externalversions"
-	edgev1a1informers "github.com/kcp-dev/edge-mc/pkg/client/informers/externalversions/edge/v1alpha1"
-	"github.com/kcp-dev/edge-mc/pkg/placement"
+	emcclusterclientset "github.com/kubestellar/kubestellar/pkg/client/clientset/versioned/cluster"
+	emcinformers "github.com/kubestellar/kubestellar/pkg/client/informers/externalversions"
+	edgev1a1informers "github.com/kubestellar/kubestellar/pkg/client/informers/externalversions/edge/v1alpha1"
+	"github.com/kubestellar/kubestellar/pkg/placement"
 )
 
 type ClientOpts struct {

--- a/cmd/syncer/helm/converter.go
+++ b/cmd/syncer/helm/converter.go
@@ -34,7 +34,7 @@ import (
 	"k8s.io/klog/v2"
 	sigyaml "sigs.k8s.io/yaml"
 
-	edgev1alpha1 "github.com/kcp-dev/edge-mc/pkg/apis/edge/v1alpha1"
+	edgev1alpha1 "github.com/kubestellar/kubestellar/pkg/apis/edge/v1alpha1"
 )
 
 func main() {

--- a/cmd/syncer/main.go
+++ b/cmd/syncer/main.go
@@ -30,8 +30,8 @@ import (
 
 	"github.com/kcp-dev/logicalcluster/v3"
 
-	synceroptions "github.com/kcp-dev/edge-mc/cmd/syncer/options"
-	"github.com/kcp-dev/edge-mc/pkg/syncer"
+	synceroptions "github.com/kubestellar/kubestellar/cmd/syncer/options"
+	"github.com/kubestellar/kubestellar/pkg/syncer"
 )
 
 func main() {

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/kcp-dev/edge-mc
+module github.com/kubestellar/kubestellar
 
 go 1.19
 

--- a/hack/update-codegen-clients.sh
+++ b/hack/update-codegen-clients.sh
@@ -29,40 +29,40 @@ CODEGEN_PKG=${CODEGEN_PKG:-$(cd "${SCRIPT_ROOT}"; go list -f '{{.Dir}}' -m k8s.i
 
 # "core:v1alpha1 workload:v1alpha1 apiresource:v1alpha1 tenancy:v1alpha1 tenancy:v1beta1 apis:v1alpha1 scheduling:v1alpha1 topology:v1alpha1" \
 bash "${CODEGEN_PKG}"/generate-groups.sh "deepcopy,client" \
-  github.com/kcp-dev/edge-mc/pkg/client github.com/kcp-dev/edge-mc/pkg/apis \
+  github.com/kubestellar/kubestellar/pkg/client github.com/kubestellar/kubestellar/pkg/apis \
   "edge:v1alpha1 meta:v1alpha1" \
   --go-header-file "${SCRIPT_ROOT}"/hack/boilerplate/boilerplate.generatego.txt \
   --output-base "${SCRIPT_ROOT}" \
-  --trim-path-prefix github.com/kcp-dev/edge-mc
+  --trim-path-prefix github.com/kubestellar/kubestellar
 
 pushd ./pkg/apis
 ${CODE_GENERATOR} \
-  "client:outputPackagePath=github.com/kcp-dev/edge-mc/pkg/client,apiPackagePath=github.com/kcp-dev/edge-mc/pkg/apis,singleClusterClientPackagePath=github.com/kcp-dev/edge-mc/pkg/client/clientset/versioned,headerFile=${BOILERPLATE_HEADER}" \
-  "lister:apiPackagePath=github.com/kcp-dev/edge-mc/pkg/apis,headerFile=${BOILERPLATE_HEADER}" \
-  "informer:outputPackagePath=github.com/kcp-dev/edge-mc/pkg/client,apiPackagePath=github.com/kcp-dev/edge-mc/pkg/apis,singleClusterClientPackagePath=github.com/kcp-dev/edge-mc/pkg/client/clientset/versioned,headerFile=${BOILERPLATE_HEADER}" \
+  "client:outputPackagePath=github.com/kubestellar/kubestellar/pkg/client,apiPackagePath=github.com/kubestellar/kubestellar/pkg/apis,singleClusterClientPackagePath=github.com/kubestellar/kubestellar/pkg/client/clientset/versioned,headerFile=${BOILERPLATE_HEADER}" \
+  "lister:apiPackagePath=github.com/kubestellar/kubestellar/pkg/apis,headerFile=${BOILERPLATE_HEADER}" \
+  "informer:outputPackagePath=github.com/kubestellar/kubestellar/pkg/client,apiPackagePath=github.com/kubestellar/kubestellar/pkg/apis,singleClusterClientPackagePath=github.com/kubestellar/kubestellar/pkg/client/clientset/versioned,headerFile=${BOILERPLATE_HEADER}" \
   "paths=./..." \
   "output:dir=./../client"
 popd
 
 # bash "${CODEGEN_PKG}"/generate-groups.sh "deepcopy" \
-#   github.com/kcp-dev/edge-mc/third_party/conditions/client github.com/kcp-dev/edge-mc/third_party/conditions/apis \
+#   github.com/kubestellar/kubestellar/third_party/conditions/client github.com/kubestellar/kubestellar/third_party/conditions/apis \
 #   "conditions:v1alpha1" \
 #   --go-header-file "${SCRIPT_ROOT}"/hack/boilerplate/boilerplate.generatego.txt \
 #   --output-base "${SCRIPT_ROOT}" \
-#   --trim-path-prefix github.com/kcp-dev/edge-mc
+#   --trim-path-prefix github.com/kubestellar/kubestellar
 
 # bash "${CODEGEN_PKG}"/generate-groups.sh "deepcopy,client" \
-#   github.com/kcp-dev/edge-mc/test/e2e/fixtures/wildwest/client github.com/kcp-dev/edge-mc/test/e2e/fixtures/wildwest/apis \
+#   github.com/kubestellar/kubestellar/test/e2e/fixtures/wildwest/client github.com/kubestellar/kubestellar/test/e2e/fixtures/wildwest/apis \
 #   "wildwest:v1alpha1" \
 #   --go-header-file "${SCRIPT_ROOT}"/hack/boilerplate/boilerplate.generatego.txt \
 #   --output-base "${SCRIPT_ROOT}" \
-#   --trim-path-prefix github.com/kcp-dev/edge-mc
+#   --trim-path-prefix github.com/kubestellar/kubestellar
 
 # pushd ./test/e2e/fixtures/wildwest/apis
 # ${CODE_GENERATOR} \
-#   "client:outputPackagePath=github.com/kcp-dev/edge-mc/test/e2e/fixtures/wildwest/client,apiPackagePath=github.com/kcp-dev/edge-mc/test/e2e/fixtures/wildwest/apis,singleClusterClientPackagePath=github.com/kcp-dev/kcp/test/e2e/fixtures/wildwest/client/clientset/versioned,headerFile=${BOILERPLATE_HEADER}" \
-#   "lister:apiPackagePath=github.com/kcp-dev/edge-mc/test/e2e/fixtures/wildwest/apis,headerFile=${BOILERPLATE_HEADER}" \
-#   "informer:outputPackagePath=github.com/kcp-dev/edge-mc/test/e2e/fixtures/wildwest/client,singleClusterClientPackagePath=github.com/kcp-dev/kcp/test/e2e/fixtures/wildwest/client/clientset/versioned,apiPackagePath=github.com/kcp-dev/edge-mc/test/e2e/fixtures/wildwest/apis,headerFile=${BOILERPLATE_HEADER}" \
+#   "client:outputPackagePath=github.com/kubestellar/kubestellar/test/e2e/fixtures/wildwest/client,apiPackagePath=github.com/kubestellar/kubestellar/test/e2e/fixtures/wildwest/apis,singleClusterClientPackagePath=github.com/kcp-dev/kcp/test/e2e/fixtures/wildwest/client/clientset/versioned,headerFile=${BOILERPLATE_HEADER}" \
+#   "lister:apiPackagePath=github.com/kubestellar/kubestellar/test/e2e/fixtures/wildwest/apis,headerFile=${BOILERPLATE_HEADER}" \
+#   "informer:outputPackagePath=github.com/kubestellar/kubestellar/test/e2e/fixtures/wildwest/client,singleClusterClientPackagePath=github.com/kcp-dev/kcp/test/e2e/fixtures/wildwest/client/clientset/versioned,apiPackagePath=github.com/kubestellar/kubestellar/test/e2e/fixtures/wildwest/apis,headerFile=${BOILERPLATE_HEADER}" \
 #   "paths=./..." \
 #   "output:dir=./../client"
 # popd
@@ -70,17 +70,17 @@ popd
 go install "${CODEGEN_PKG}"/cmd/openapi-gen
 
 # "$GOPATH"/bin/openapi-gen  \
-# # --input-dirs github.com/kcp-dev/edge-mc/pkg/apis/workload/v1alpha1 \
-# # --input-dirs github.com/kcp-dev/edge-mc/pkg/apis/core/v1alpha1 \
-# # --input-dirs github.com/kcp-dev/edge-mc/pkg/apis/apiresource/v1alpha1 \
-# # --input-dirs github.com/kcp-dev/edge-mc/pkg/apis/tenancy/v1alpha1 \
-# # --input-dirs github.com/kcp-dev/edge-mc/pkg/apis/tenancy/v1beta1 \
-# # --input-dirs github.com/kcp-dev/edge-mc/pkg/apis/apis/v1alpha1 \
-# # --input-dirs github.com/kcp-dev/edge-mc/pkg/apis/scheduling/v1alpha1 \
-# # --input-dirs github.com/kcp-dev/edge-mc/pkg/apis/topology/v1alpha1 \
-# # --input-dirs github.com/kcp-dev/edge-mc/pkg/apis/third_party/conditions/apis/conditions/v1alpha1 \
+# # --input-dirs github.com/kubestellar/kubestellar/pkg/apis/workload/v1alpha1 \
+# # --input-dirs github.com/kubestellar/kubestellar/pkg/apis/core/v1alpha1 \
+# # --input-dirs github.com/kubestellar/kubestellar/pkg/apis/apiresource/v1alpha1 \
+# # --input-dirs github.com/kubestellar/kubestellar/pkg/apis/tenancy/v1alpha1 \
+# # --input-dirs github.com/kubestellar/kubestellar/pkg/apis/tenancy/v1beta1 \
+# # --input-dirs github.com/kubestellar/kubestellar/pkg/apis/apis/v1alpha1 \
+# # --input-dirs github.com/kubestellar/kubestellar/pkg/apis/scheduling/v1alpha1 \
+# # --input-dirs github.com/kubestellar/kubestellar/pkg/apis/topology/v1alpha1 \
+# # --input-dirs github.com/kubestellar/kubestellar/pkg/apis/third_party/conditions/apis/conditions/v1alpha1 \
 # --input-dirs k8s.io/apimachinery/pkg/apis/meta/v1,k8s.io/apimachinery/pkg/runtime,k8s.io/apimachinery/pkg/version \
-# --output-package github.com/kcp-dev/edge-mc/pkg/openapi -O zz_generated.openapi \
+# --output-package github.com/kubestellar/kubestellar/pkg/openapi -O zz_generated.openapi \
 # --go-header-file ./hack/../hack/boilerplate/boilerplate.generatego.txt \
 # --output-base "${SCRIPT_ROOT}" \
-# --trim-path-prefix github.com/kcp-dev/edge-mc
+# --trim-path-prefix github.com/kubestellar/kubestellar

--- a/pkg/apis/edge/v1alpha1/register.go
+++ b/pkg/apis/edge/v1alpha1/register.go
@@ -21,7 +21,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 
-	edgeapi "github.com/kcp-dev/edge-mc/pkg/apis/edge"
+	edgeapi "github.com/kubestellar/kubestellar/pkg/apis/edge"
 )
 
 // SchemeGroupVersion is group version used to register these objects

--- a/pkg/apis/meta/v1alpha1/register.go
+++ b/pkg/apis/meta/v1alpha1/register.go
@@ -21,7 +21,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 
-	metaapi "github.com/kcp-dev/edge-mc/pkg/apis/meta"
+	metaapi "github.com/kubestellar/kubestellar/pkg/apis/meta"
 )
 
 // SchemeGroupVersion is group version used to register these objects

--- a/pkg/apiwatch/resources.go
+++ b/pkg/apiwatch/resources.go
@@ -35,7 +35,7 @@ import (
 	_ "k8s.io/component-base/metrics/prometheus/clientgo"
 	"k8s.io/klog/v2"
 
-	urmetav1a1 "github.com/kcp-dev/edge-mc/pkg/apis/meta/v1alpha1"
+	urmetav1a1 "github.com/kubestellar/kubestellar/pkg/apis/meta/v1alpha1"
 )
 
 // Invalidatable is a cache that has to be explicitly invalidated

--- a/pkg/client/clientset/versioned/clientset.go
+++ b/pkg/client/clientset/versioned/clientset.go
@@ -26,8 +26,8 @@ import (
 	rest "k8s.io/client-go/rest"
 	flowcontrol "k8s.io/client-go/util/flowcontrol"
 
-	edgev1alpha1 "github.com/kcp-dev/edge-mc/pkg/client/clientset/versioned/typed/edge/v1alpha1"
-	metav1alpha1 "github.com/kcp-dev/edge-mc/pkg/client/clientset/versioned/typed/meta/v1alpha1"
+	edgev1alpha1 "github.com/kubestellar/kubestellar/pkg/client/clientset/versioned/typed/edge/v1alpha1"
+	metav1alpha1 "github.com/kubestellar/kubestellar/pkg/client/clientset/versioned/typed/meta/v1alpha1"
 )
 
 type Interface interface {

--- a/pkg/client/clientset/versioned/cluster/clientset.go
+++ b/pkg/client/clientset/versioned/cluster/clientset.go
@@ -32,9 +32,9 @@ import (
 	kcpclient "github.com/kcp-dev/apimachinery/v2/pkg/client"
 	"github.com/kcp-dev/logicalcluster/v3"
 
-	client "github.com/kcp-dev/edge-mc/pkg/client/clientset/versioned"
-	edgev1alpha1 "github.com/kcp-dev/edge-mc/pkg/client/clientset/versioned/cluster/typed/edge/v1alpha1"
-	metav1alpha1 "github.com/kcp-dev/edge-mc/pkg/client/clientset/versioned/cluster/typed/meta/v1alpha1"
+	client "github.com/kubestellar/kubestellar/pkg/client/clientset/versioned"
+	edgev1alpha1 "github.com/kubestellar/kubestellar/pkg/client/clientset/versioned/cluster/typed/edge/v1alpha1"
+	metav1alpha1 "github.com/kubestellar/kubestellar/pkg/client/clientset/versioned/cluster/typed/meta/v1alpha1"
 )
 
 type ClusterInterface interface {

--- a/pkg/client/clientset/versioned/cluster/fake/clientset.go
+++ b/pkg/client/clientset/versioned/cluster/fake/clientset.go
@@ -29,15 +29,15 @@ import (
 	kcptesting "github.com/kcp-dev/client-go/third_party/k8s.io/client-go/testing"
 	"github.com/kcp-dev/logicalcluster/v3"
 
-	client "github.com/kcp-dev/edge-mc/pkg/client/clientset/versioned"
-	kcpclient "github.com/kcp-dev/edge-mc/pkg/client/clientset/versioned/cluster"
-	kcpedgev1alpha1 "github.com/kcp-dev/edge-mc/pkg/client/clientset/versioned/cluster/typed/edge/v1alpha1"
-	fakeedgev1alpha1 "github.com/kcp-dev/edge-mc/pkg/client/clientset/versioned/cluster/typed/edge/v1alpha1/fake"
-	kcpmetav1alpha1 "github.com/kcp-dev/edge-mc/pkg/client/clientset/versioned/cluster/typed/meta/v1alpha1"
-	fakemetav1alpha1 "github.com/kcp-dev/edge-mc/pkg/client/clientset/versioned/cluster/typed/meta/v1alpha1/fake"
-	clientscheme "github.com/kcp-dev/edge-mc/pkg/client/clientset/versioned/scheme"
-	edgev1alpha1 "github.com/kcp-dev/edge-mc/pkg/client/clientset/versioned/typed/edge/v1alpha1"
-	metav1alpha1 "github.com/kcp-dev/edge-mc/pkg/client/clientset/versioned/typed/meta/v1alpha1"
+	client "github.com/kubestellar/kubestellar/pkg/client/clientset/versioned"
+	kcpclient "github.com/kubestellar/kubestellar/pkg/client/clientset/versioned/cluster"
+	kcpedgev1alpha1 "github.com/kubestellar/kubestellar/pkg/client/clientset/versioned/cluster/typed/edge/v1alpha1"
+	fakeedgev1alpha1 "github.com/kubestellar/kubestellar/pkg/client/clientset/versioned/cluster/typed/edge/v1alpha1/fake"
+	kcpmetav1alpha1 "github.com/kubestellar/kubestellar/pkg/client/clientset/versioned/cluster/typed/meta/v1alpha1"
+	fakemetav1alpha1 "github.com/kubestellar/kubestellar/pkg/client/clientset/versioned/cluster/typed/meta/v1alpha1/fake"
+	clientscheme "github.com/kubestellar/kubestellar/pkg/client/clientset/versioned/scheme"
+	edgev1alpha1 "github.com/kubestellar/kubestellar/pkg/client/clientset/versioned/typed/edge/v1alpha1"
+	metav1alpha1 "github.com/kubestellar/kubestellar/pkg/client/clientset/versioned/typed/meta/v1alpha1"
 )
 
 // NewSimpleClientset returns a clientset that will respond with the provided objects.

--- a/pkg/client/clientset/versioned/cluster/scheme/register.go
+++ b/pkg/client/clientset/versioned/cluster/scheme/register.go
@@ -28,8 +28,8 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/serializer"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 
-	edgev1alpha1 "github.com/kcp-dev/edge-mc/pkg/apis/edge/v1alpha1"
-	metav1alpha1 "github.com/kcp-dev/edge-mc/pkg/apis/meta/v1alpha1"
+	edgev1alpha1 "github.com/kubestellar/kubestellar/pkg/apis/edge/v1alpha1"
+	metav1alpha1 "github.com/kubestellar/kubestellar/pkg/apis/meta/v1alpha1"
 )
 
 var Scheme = runtime.NewScheme()

--- a/pkg/client/clientset/versioned/cluster/typed/edge/v1alpha1/customizer.go
+++ b/pkg/client/clientset/versioned/cluster/typed/edge/v1alpha1/customizer.go
@@ -30,8 +30,8 @@ import (
 	kcpclient "github.com/kcp-dev/apimachinery/v2/pkg/client"
 	"github.com/kcp-dev/logicalcluster/v3"
 
-	edgev1alpha1 "github.com/kcp-dev/edge-mc/pkg/apis/edge/v1alpha1"
-	edgev1alpha1client "github.com/kcp-dev/edge-mc/pkg/client/clientset/versioned/typed/edge/v1alpha1"
+	edgev1alpha1 "github.com/kubestellar/kubestellar/pkg/apis/edge/v1alpha1"
+	edgev1alpha1client "github.com/kubestellar/kubestellar/pkg/client/clientset/versioned/typed/edge/v1alpha1"
 )
 
 // CustomizersClusterGetter has a method to return a CustomizerClusterInterface.

--- a/pkg/client/clientset/versioned/cluster/typed/edge/v1alpha1/edge_client.go
+++ b/pkg/client/clientset/versioned/cluster/typed/edge/v1alpha1/edge_client.go
@@ -29,7 +29,7 @@ import (
 	kcpclient "github.com/kcp-dev/apimachinery/v2/pkg/client"
 	"github.com/kcp-dev/logicalcluster/v3"
 
-	edgev1alpha1 "github.com/kcp-dev/edge-mc/pkg/client/clientset/versioned/typed/edge/v1alpha1"
+	edgev1alpha1 "github.com/kubestellar/kubestellar/pkg/client/clientset/versioned/typed/edge/v1alpha1"
 )
 
 type EdgeV1alpha1ClusterInterface interface {

--- a/pkg/client/clientset/versioned/cluster/typed/edge/v1alpha1/edgeplacement.go
+++ b/pkg/client/clientset/versioned/cluster/typed/edge/v1alpha1/edgeplacement.go
@@ -30,8 +30,8 @@ import (
 	kcpclient "github.com/kcp-dev/apimachinery/v2/pkg/client"
 	"github.com/kcp-dev/logicalcluster/v3"
 
-	edgev1alpha1 "github.com/kcp-dev/edge-mc/pkg/apis/edge/v1alpha1"
-	edgev1alpha1client "github.com/kcp-dev/edge-mc/pkg/client/clientset/versioned/typed/edge/v1alpha1"
+	edgev1alpha1 "github.com/kubestellar/kubestellar/pkg/apis/edge/v1alpha1"
+	edgev1alpha1client "github.com/kubestellar/kubestellar/pkg/client/clientset/versioned/typed/edge/v1alpha1"
 )
 
 // EdgePlacementsClusterGetter has a method to return a EdgePlacementClusterInterface.

--- a/pkg/client/clientset/versioned/cluster/typed/edge/v1alpha1/edgesyncconfig.go
+++ b/pkg/client/clientset/versioned/cluster/typed/edge/v1alpha1/edgesyncconfig.go
@@ -30,8 +30,8 @@ import (
 	kcpclient "github.com/kcp-dev/apimachinery/v2/pkg/client"
 	"github.com/kcp-dev/logicalcluster/v3"
 
-	edgev1alpha1 "github.com/kcp-dev/edge-mc/pkg/apis/edge/v1alpha1"
-	edgev1alpha1client "github.com/kcp-dev/edge-mc/pkg/client/clientset/versioned/typed/edge/v1alpha1"
+	edgev1alpha1 "github.com/kubestellar/kubestellar/pkg/apis/edge/v1alpha1"
+	edgev1alpha1client "github.com/kubestellar/kubestellar/pkg/client/clientset/versioned/typed/edge/v1alpha1"
 )
 
 // EdgeSyncConfigsClusterGetter has a method to return a EdgeSyncConfigClusterInterface.

--- a/pkg/client/clientset/versioned/cluster/typed/edge/v1alpha1/fake/customizer.go
+++ b/pkg/client/clientset/versioned/cluster/typed/edge/v1alpha1/fake/customizer.go
@@ -34,9 +34,9 @@ import (
 	kcptesting "github.com/kcp-dev/client-go/third_party/k8s.io/client-go/testing"
 	"github.com/kcp-dev/logicalcluster/v3"
 
-	edgev1alpha1 "github.com/kcp-dev/edge-mc/pkg/apis/edge/v1alpha1"
-	kcpedgev1alpha1 "github.com/kcp-dev/edge-mc/pkg/client/clientset/versioned/cluster/typed/edge/v1alpha1"
-	edgev1alpha1client "github.com/kcp-dev/edge-mc/pkg/client/clientset/versioned/typed/edge/v1alpha1"
+	edgev1alpha1 "github.com/kubestellar/kubestellar/pkg/apis/edge/v1alpha1"
+	kcpedgev1alpha1 "github.com/kubestellar/kubestellar/pkg/client/clientset/versioned/cluster/typed/edge/v1alpha1"
+	edgev1alpha1client "github.com/kubestellar/kubestellar/pkg/client/clientset/versioned/typed/edge/v1alpha1"
 )
 
 var customizersResource = schema.GroupVersionResource{Group: "edge.kcp.io", Version: "v1alpha1", Resource: "customizers"}

--- a/pkg/client/clientset/versioned/cluster/typed/edge/v1alpha1/fake/edge_client.go
+++ b/pkg/client/clientset/versioned/cluster/typed/edge/v1alpha1/fake/edge_client.go
@@ -27,8 +27,8 @@ import (
 	kcptesting "github.com/kcp-dev/client-go/third_party/k8s.io/client-go/testing"
 	"github.com/kcp-dev/logicalcluster/v3"
 
-	kcpedgev1alpha1 "github.com/kcp-dev/edge-mc/pkg/client/clientset/versioned/cluster/typed/edge/v1alpha1"
-	edgev1alpha1 "github.com/kcp-dev/edge-mc/pkg/client/clientset/versioned/typed/edge/v1alpha1"
+	kcpedgev1alpha1 "github.com/kubestellar/kubestellar/pkg/client/clientset/versioned/cluster/typed/edge/v1alpha1"
+	edgev1alpha1 "github.com/kubestellar/kubestellar/pkg/client/clientset/versioned/typed/edge/v1alpha1"
 )
 
 var _ kcpedgev1alpha1.EdgeV1alpha1ClusterInterface = (*EdgeV1alpha1ClusterClient)(nil)

--- a/pkg/client/clientset/versioned/cluster/typed/edge/v1alpha1/fake/edgeplacement.go
+++ b/pkg/client/clientset/versioned/cluster/typed/edge/v1alpha1/fake/edgeplacement.go
@@ -34,8 +34,8 @@ import (
 	kcptesting "github.com/kcp-dev/client-go/third_party/k8s.io/client-go/testing"
 	"github.com/kcp-dev/logicalcluster/v3"
 
-	edgev1alpha1 "github.com/kcp-dev/edge-mc/pkg/apis/edge/v1alpha1"
-	edgev1alpha1client "github.com/kcp-dev/edge-mc/pkg/client/clientset/versioned/typed/edge/v1alpha1"
+	edgev1alpha1 "github.com/kubestellar/kubestellar/pkg/apis/edge/v1alpha1"
+	edgev1alpha1client "github.com/kubestellar/kubestellar/pkg/client/clientset/versioned/typed/edge/v1alpha1"
 )
 
 var edgePlacementsResource = schema.GroupVersionResource{Group: "edge.kcp.io", Version: "v1alpha1", Resource: "edgeplacements"}

--- a/pkg/client/clientset/versioned/cluster/typed/edge/v1alpha1/fake/edgesyncconfig.go
+++ b/pkg/client/clientset/versioned/cluster/typed/edge/v1alpha1/fake/edgesyncconfig.go
@@ -34,8 +34,8 @@ import (
 	kcptesting "github.com/kcp-dev/client-go/third_party/k8s.io/client-go/testing"
 	"github.com/kcp-dev/logicalcluster/v3"
 
-	edgev1alpha1 "github.com/kcp-dev/edge-mc/pkg/apis/edge/v1alpha1"
-	edgev1alpha1client "github.com/kcp-dev/edge-mc/pkg/client/clientset/versioned/typed/edge/v1alpha1"
+	edgev1alpha1 "github.com/kubestellar/kubestellar/pkg/apis/edge/v1alpha1"
+	edgev1alpha1client "github.com/kubestellar/kubestellar/pkg/client/clientset/versioned/typed/edge/v1alpha1"
 )
 
 var edgeSyncConfigsResource = schema.GroupVersionResource{Group: "edge.kcp.io", Version: "v1alpha1", Resource: "edgesyncconfigs"}

--- a/pkg/client/clientset/versioned/cluster/typed/edge/v1alpha1/fake/singleplacementslice.go
+++ b/pkg/client/clientset/versioned/cluster/typed/edge/v1alpha1/fake/singleplacementslice.go
@@ -34,8 +34,8 @@ import (
 	kcptesting "github.com/kcp-dev/client-go/third_party/k8s.io/client-go/testing"
 	"github.com/kcp-dev/logicalcluster/v3"
 
-	edgev1alpha1 "github.com/kcp-dev/edge-mc/pkg/apis/edge/v1alpha1"
-	edgev1alpha1client "github.com/kcp-dev/edge-mc/pkg/client/clientset/versioned/typed/edge/v1alpha1"
+	edgev1alpha1 "github.com/kubestellar/kubestellar/pkg/apis/edge/v1alpha1"
+	edgev1alpha1client "github.com/kubestellar/kubestellar/pkg/client/clientset/versioned/typed/edge/v1alpha1"
 )
 
 var singlePlacementSlicesResource = schema.GroupVersionResource{Group: "edge.kcp.io", Version: "v1alpha1", Resource: "singleplacementslices"}

--- a/pkg/client/clientset/versioned/cluster/typed/edge/v1alpha1/fake/syncerconfig.go
+++ b/pkg/client/clientset/versioned/cluster/typed/edge/v1alpha1/fake/syncerconfig.go
@@ -34,8 +34,8 @@ import (
 	kcptesting "github.com/kcp-dev/client-go/third_party/k8s.io/client-go/testing"
 	"github.com/kcp-dev/logicalcluster/v3"
 
-	edgev1alpha1 "github.com/kcp-dev/edge-mc/pkg/apis/edge/v1alpha1"
-	edgev1alpha1client "github.com/kcp-dev/edge-mc/pkg/client/clientset/versioned/typed/edge/v1alpha1"
+	edgev1alpha1 "github.com/kubestellar/kubestellar/pkg/apis/edge/v1alpha1"
+	edgev1alpha1client "github.com/kubestellar/kubestellar/pkg/client/clientset/versioned/typed/edge/v1alpha1"
 )
 
 var syncerConfigsResource = schema.GroupVersionResource{Group: "edge.kcp.io", Version: "v1alpha1", Resource: "syncerconfigs"}

--- a/pkg/client/clientset/versioned/cluster/typed/edge/v1alpha1/singleplacementslice.go
+++ b/pkg/client/clientset/versioned/cluster/typed/edge/v1alpha1/singleplacementslice.go
@@ -30,8 +30,8 @@ import (
 	kcpclient "github.com/kcp-dev/apimachinery/v2/pkg/client"
 	"github.com/kcp-dev/logicalcluster/v3"
 
-	edgev1alpha1 "github.com/kcp-dev/edge-mc/pkg/apis/edge/v1alpha1"
-	edgev1alpha1client "github.com/kcp-dev/edge-mc/pkg/client/clientset/versioned/typed/edge/v1alpha1"
+	edgev1alpha1 "github.com/kubestellar/kubestellar/pkg/apis/edge/v1alpha1"
+	edgev1alpha1client "github.com/kubestellar/kubestellar/pkg/client/clientset/versioned/typed/edge/v1alpha1"
 )
 
 // SinglePlacementSlicesClusterGetter has a method to return a SinglePlacementSliceClusterInterface.

--- a/pkg/client/clientset/versioned/cluster/typed/edge/v1alpha1/syncerconfig.go
+++ b/pkg/client/clientset/versioned/cluster/typed/edge/v1alpha1/syncerconfig.go
@@ -30,8 +30,8 @@ import (
 	kcpclient "github.com/kcp-dev/apimachinery/v2/pkg/client"
 	"github.com/kcp-dev/logicalcluster/v3"
 
-	edgev1alpha1 "github.com/kcp-dev/edge-mc/pkg/apis/edge/v1alpha1"
-	edgev1alpha1client "github.com/kcp-dev/edge-mc/pkg/client/clientset/versioned/typed/edge/v1alpha1"
+	edgev1alpha1 "github.com/kubestellar/kubestellar/pkg/apis/edge/v1alpha1"
+	edgev1alpha1client "github.com/kubestellar/kubestellar/pkg/client/clientset/versioned/typed/edge/v1alpha1"
 )
 
 // SyncerConfigsClusterGetter has a method to return a SyncerConfigClusterInterface.

--- a/pkg/client/clientset/versioned/cluster/typed/meta/v1alpha1/apiresource.go
+++ b/pkg/client/clientset/versioned/cluster/typed/meta/v1alpha1/apiresource.go
@@ -30,8 +30,8 @@ import (
 	kcpclient "github.com/kcp-dev/apimachinery/v2/pkg/client"
 	"github.com/kcp-dev/logicalcluster/v3"
 
-	metav1alpha1 "github.com/kcp-dev/edge-mc/pkg/apis/meta/v1alpha1"
-	metav1alpha1client "github.com/kcp-dev/edge-mc/pkg/client/clientset/versioned/typed/meta/v1alpha1"
+	metav1alpha1 "github.com/kubestellar/kubestellar/pkg/apis/meta/v1alpha1"
+	metav1alpha1client "github.com/kubestellar/kubestellar/pkg/client/clientset/versioned/typed/meta/v1alpha1"
 )
 
 // APIResourcesClusterGetter has a method to return a APIResourceClusterInterface.

--- a/pkg/client/clientset/versioned/cluster/typed/meta/v1alpha1/fake/apiresource.go
+++ b/pkg/client/clientset/versioned/cluster/typed/meta/v1alpha1/fake/apiresource.go
@@ -34,8 +34,8 @@ import (
 	kcptesting "github.com/kcp-dev/client-go/third_party/k8s.io/client-go/testing"
 	"github.com/kcp-dev/logicalcluster/v3"
 
-	metav1alpha1 "github.com/kcp-dev/edge-mc/pkg/apis/meta/v1alpha1"
-	metav1alpha1client "github.com/kcp-dev/edge-mc/pkg/client/clientset/versioned/typed/meta/v1alpha1"
+	metav1alpha1 "github.com/kubestellar/kubestellar/pkg/apis/meta/v1alpha1"
+	metav1alpha1client "github.com/kubestellar/kubestellar/pkg/client/clientset/versioned/typed/meta/v1alpha1"
 )
 
 var aPIResourcesResource = schema.GroupVersionResource{Group: "meta.kcp.io", Version: "v1alpha1", Resource: "apiresources"}

--- a/pkg/client/clientset/versioned/cluster/typed/meta/v1alpha1/fake/meta_client.go
+++ b/pkg/client/clientset/versioned/cluster/typed/meta/v1alpha1/fake/meta_client.go
@@ -27,8 +27,8 @@ import (
 	kcptesting "github.com/kcp-dev/client-go/third_party/k8s.io/client-go/testing"
 	"github.com/kcp-dev/logicalcluster/v3"
 
-	kcpmetav1alpha1 "github.com/kcp-dev/edge-mc/pkg/client/clientset/versioned/cluster/typed/meta/v1alpha1"
-	metav1alpha1 "github.com/kcp-dev/edge-mc/pkg/client/clientset/versioned/typed/meta/v1alpha1"
+	kcpmetav1alpha1 "github.com/kubestellar/kubestellar/pkg/client/clientset/versioned/cluster/typed/meta/v1alpha1"
+	metav1alpha1 "github.com/kubestellar/kubestellar/pkg/client/clientset/versioned/typed/meta/v1alpha1"
 )
 
 var _ kcpmetav1alpha1.MetaV1alpha1ClusterInterface = (*MetaV1alpha1ClusterClient)(nil)

--- a/pkg/client/clientset/versioned/cluster/typed/meta/v1alpha1/meta_client.go
+++ b/pkg/client/clientset/versioned/cluster/typed/meta/v1alpha1/meta_client.go
@@ -29,7 +29,7 @@ import (
 	kcpclient "github.com/kcp-dev/apimachinery/v2/pkg/client"
 	"github.com/kcp-dev/logicalcluster/v3"
 
-	metav1alpha1 "github.com/kcp-dev/edge-mc/pkg/client/clientset/versioned/typed/meta/v1alpha1"
+	metav1alpha1 "github.com/kubestellar/kubestellar/pkg/client/clientset/versioned/typed/meta/v1alpha1"
 )
 
 type MetaV1alpha1ClusterInterface interface {

--- a/pkg/client/clientset/versioned/fake/clientset_generated.go
+++ b/pkg/client/clientset/versioned/fake/clientset_generated.go
@@ -25,11 +25,11 @@ import (
 	fakediscovery "k8s.io/client-go/discovery/fake"
 	"k8s.io/client-go/testing"
 
-	clientset "github.com/kcp-dev/edge-mc/pkg/client/clientset/versioned"
-	edgev1alpha1 "github.com/kcp-dev/edge-mc/pkg/client/clientset/versioned/typed/edge/v1alpha1"
-	fakeedgev1alpha1 "github.com/kcp-dev/edge-mc/pkg/client/clientset/versioned/typed/edge/v1alpha1/fake"
-	metav1alpha1 "github.com/kcp-dev/edge-mc/pkg/client/clientset/versioned/typed/meta/v1alpha1"
-	fakemetav1alpha1 "github.com/kcp-dev/edge-mc/pkg/client/clientset/versioned/typed/meta/v1alpha1/fake"
+	clientset "github.com/kubestellar/kubestellar/pkg/client/clientset/versioned"
+	edgev1alpha1 "github.com/kubestellar/kubestellar/pkg/client/clientset/versioned/typed/edge/v1alpha1"
+	fakeedgev1alpha1 "github.com/kubestellar/kubestellar/pkg/client/clientset/versioned/typed/edge/v1alpha1/fake"
+	metav1alpha1 "github.com/kubestellar/kubestellar/pkg/client/clientset/versioned/typed/meta/v1alpha1"
+	fakemetav1alpha1 "github.com/kubestellar/kubestellar/pkg/client/clientset/versioned/typed/meta/v1alpha1/fake"
 )
 
 // NewSimpleClientset returns a clientset that will respond with the provided objects.

--- a/pkg/client/clientset/versioned/fake/register.go
+++ b/pkg/client/clientset/versioned/fake/register.go
@@ -25,8 +25,8 @@ import (
 	serializer "k8s.io/apimachinery/pkg/runtime/serializer"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 
-	edgev1alpha1 "github.com/kcp-dev/edge-mc/pkg/apis/edge/v1alpha1"
-	metav1alpha1 "github.com/kcp-dev/edge-mc/pkg/apis/meta/v1alpha1"
+	edgev1alpha1 "github.com/kubestellar/kubestellar/pkg/apis/edge/v1alpha1"
+	metav1alpha1 "github.com/kubestellar/kubestellar/pkg/apis/meta/v1alpha1"
 )
 
 var scheme = runtime.NewScheme()

--- a/pkg/client/clientset/versioned/scheme/register.go
+++ b/pkg/client/clientset/versioned/scheme/register.go
@@ -25,8 +25,8 @@ import (
 	serializer "k8s.io/apimachinery/pkg/runtime/serializer"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 
-	edgev1alpha1 "github.com/kcp-dev/edge-mc/pkg/apis/edge/v1alpha1"
-	metav1alpha1 "github.com/kcp-dev/edge-mc/pkg/apis/meta/v1alpha1"
+	edgev1alpha1 "github.com/kubestellar/kubestellar/pkg/apis/edge/v1alpha1"
+	metav1alpha1 "github.com/kubestellar/kubestellar/pkg/apis/meta/v1alpha1"
 )
 
 var Scheme = runtime.NewScheme()

--- a/pkg/client/clientset/versioned/typed/edge/v1alpha1/customizer.go
+++ b/pkg/client/clientset/versioned/typed/edge/v1alpha1/customizer.go
@@ -27,8 +27,8 @@ import (
 	watch "k8s.io/apimachinery/pkg/watch"
 	rest "k8s.io/client-go/rest"
 
-	v1alpha1 "github.com/kcp-dev/edge-mc/pkg/apis/edge/v1alpha1"
-	scheme "github.com/kcp-dev/edge-mc/pkg/client/clientset/versioned/scheme"
+	v1alpha1 "github.com/kubestellar/kubestellar/pkg/apis/edge/v1alpha1"
+	scheme "github.com/kubestellar/kubestellar/pkg/client/clientset/versioned/scheme"
 )
 
 // CustomizersGetter has a method to return a CustomizerInterface.

--- a/pkg/client/clientset/versioned/typed/edge/v1alpha1/edge_client.go
+++ b/pkg/client/clientset/versioned/typed/edge/v1alpha1/edge_client.go
@@ -23,8 +23,8 @@ import (
 
 	rest "k8s.io/client-go/rest"
 
-	v1alpha1 "github.com/kcp-dev/edge-mc/pkg/apis/edge/v1alpha1"
-	"github.com/kcp-dev/edge-mc/pkg/client/clientset/versioned/scheme"
+	v1alpha1 "github.com/kubestellar/kubestellar/pkg/apis/edge/v1alpha1"
+	"github.com/kubestellar/kubestellar/pkg/client/clientset/versioned/scheme"
 )
 
 type EdgeV1alpha1Interface interface {

--- a/pkg/client/clientset/versioned/typed/edge/v1alpha1/edgeplacement.go
+++ b/pkg/client/clientset/versioned/typed/edge/v1alpha1/edgeplacement.go
@@ -27,8 +27,8 @@ import (
 	watch "k8s.io/apimachinery/pkg/watch"
 	rest "k8s.io/client-go/rest"
 
-	v1alpha1 "github.com/kcp-dev/edge-mc/pkg/apis/edge/v1alpha1"
-	scheme "github.com/kcp-dev/edge-mc/pkg/client/clientset/versioned/scheme"
+	v1alpha1 "github.com/kubestellar/kubestellar/pkg/apis/edge/v1alpha1"
+	scheme "github.com/kubestellar/kubestellar/pkg/client/clientset/versioned/scheme"
 )
 
 // EdgePlacementsGetter has a method to return a EdgePlacementInterface.

--- a/pkg/client/clientset/versioned/typed/edge/v1alpha1/edgesyncconfig.go
+++ b/pkg/client/clientset/versioned/typed/edge/v1alpha1/edgesyncconfig.go
@@ -27,8 +27,8 @@ import (
 	watch "k8s.io/apimachinery/pkg/watch"
 	rest "k8s.io/client-go/rest"
 
-	v1alpha1 "github.com/kcp-dev/edge-mc/pkg/apis/edge/v1alpha1"
-	scheme "github.com/kcp-dev/edge-mc/pkg/client/clientset/versioned/scheme"
+	v1alpha1 "github.com/kubestellar/kubestellar/pkg/apis/edge/v1alpha1"
+	scheme "github.com/kubestellar/kubestellar/pkg/client/clientset/versioned/scheme"
 )
 
 // EdgeSyncConfigsGetter has a method to return a EdgeSyncConfigInterface.

--- a/pkg/client/clientset/versioned/typed/edge/v1alpha1/fake/fake_customizer.go
+++ b/pkg/client/clientset/versioned/typed/edge/v1alpha1/fake/fake_customizer.go
@@ -28,7 +28,7 @@ import (
 	watch "k8s.io/apimachinery/pkg/watch"
 	testing "k8s.io/client-go/testing"
 
-	v1alpha1 "github.com/kcp-dev/edge-mc/pkg/apis/edge/v1alpha1"
+	v1alpha1 "github.com/kubestellar/kubestellar/pkg/apis/edge/v1alpha1"
 )
 
 // FakeCustomizers implements CustomizerInterface

--- a/pkg/client/clientset/versioned/typed/edge/v1alpha1/fake/fake_edge_client.go
+++ b/pkg/client/clientset/versioned/typed/edge/v1alpha1/fake/fake_edge_client.go
@@ -22,7 +22,7 @@ import (
 	rest "k8s.io/client-go/rest"
 	testing "k8s.io/client-go/testing"
 
-	v1alpha1 "github.com/kcp-dev/edge-mc/pkg/client/clientset/versioned/typed/edge/v1alpha1"
+	v1alpha1 "github.com/kubestellar/kubestellar/pkg/client/clientset/versioned/typed/edge/v1alpha1"
 )
 
 type FakeEdgeV1alpha1 struct {

--- a/pkg/client/clientset/versioned/typed/edge/v1alpha1/fake/fake_edgeplacement.go
+++ b/pkg/client/clientset/versioned/typed/edge/v1alpha1/fake/fake_edgeplacement.go
@@ -28,7 +28,7 @@ import (
 	watch "k8s.io/apimachinery/pkg/watch"
 	testing "k8s.io/client-go/testing"
 
-	v1alpha1 "github.com/kcp-dev/edge-mc/pkg/apis/edge/v1alpha1"
+	v1alpha1 "github.com/kubestellar/kubestellar/pkg/apis/edge/v1alpha1"
 )
 
 // FakeEdgePlacements implements EdgePlacementInterface

--- a/pkg/client/clientset/versioned/typed/edge/v1alpha1/fake/fake_edgesyncconfig.go
+++ b/pkg/client/clientset/versioned/typed/edge/v1alpha1/fake/fake_edgesyncconfig.go
@@ -28,7 +28,7 @@ import (
 	watch "k8s.io/apimachinery/pkg/watch"
 	testing "k8s.io/client-go/testing"
 
-	v1alpha1 "github.com/kcp-dev/edge-mc/pkg/apis/edge/v1alpha1"
+	v1alpha1 "github.com/kubestellar/kubestellar/pkg/apis/edge/v1alpha1"
 )
 
 // FakeEdgeSyncConfigs implements EdgeSyncConfigInterface

--- a/pkg/client/clientset/versioned/typed/edge/v1alpha1/fake/fake_singleplacementslice.go
+++ b/pkg/client/clientset/versioned/typed/edge/v1alpha1/fake/fake_singleplacementslice.go
@@ -28,7 +28,7 @@ import (
 	watch "k8s.io/apimachinery/pkg/watch"
 	testing "k8s.io/client-go/testing"
 
-	v1alpha1 "github.com/kcp-dev/edge-mc/pkg/apis/edge/v1alpha1"
+	v1alpha1 "github.com/kubestellar/kubestellar/pkg/apis/edge/v1alpha1"
 )
 
 // FakeSinglePlacementSlices implements SinglePlacementSliceInterface

--- a/pkg/client/clientset/versioned/typed/edge/v1alpha1/fake/fake_syncerconfig.go
+++ b/pkg/client/clientset/versioned/typed/edge/v1alpha1/fake/fake_syncerconfig.go
@@ -28,7 +28,7 @@ import (
 	watch "k8s.io/apimachinery/pkg/watch"
 	testing "k8s.io/client-go/testing"
 
-	v1alpha1 "github.com/kcp-dev/edge-mc/pkg/apis/edge/v1alpha1"
+	v1alpha1 "github.com/kubestellar/kubestellar/pkg/apis/edge/v1alpha1"
 )
 
 // FakeSyncerConfigs implements SyncerConfigInterface

--- a/pkg/client/clientset/versioned/typed/edge/v1alpha1/singleplacementslice.go
+++ b/pkg/client/clientset/versioned/typed/edge/v1alpha1/singleplacementslice.go
@@ -27,8 +27,8 @@ import (
 	watch "k8s.io/apimachinery/pkg/watch"
 	rest "k8s.io/client-go/rest"
 
-	v1alpha1 "github.com/kcp-dev/edge-mc/pkg/apis/edge/v1alpha1"
-	scheme "github.com/kcp-dev/edge-mc/pkg/client/clientset/versioned/scheme"
+	v1alpha1 "github.com/kubestellar/kubestellar/pkg/apis/edge/v1alpha1"
+	scheme "github.com/kubestellar/kubestellar/pkg/client/clientset/versioned/scheme"
 )
 
 // SinglePlacementSlicesGetter has a method to return a SinglePlacementSliceInterface.

--- a/pkg/client/clientset/versioned/typed/edge/v1alpha1/syncerconfig.go
+++ b/pkg/client/clientset/versioned/typed/edge/v1alpha1/syncerconfig.go
@@ -27,8 +27,8 @@ import (
 	watch "k8s.io/apimachinery/pkg/watch"
 	rest "k8s.io/client-go/rest"
 
-	v1alpha1 "github.com/kcp-dev/edge-mc/pkg/apis/edge/v1alpha1"
-	scheme "github.com/kcp-dev/edge-mc/pkg/client/clientset/versioned/scheme"
+	v1alpha1 "github.com/kubestellar/kubestellar/pkg/apis/edge/v1alpha1"
+	scheme "github.com/kubestellar/kubestellar/pkg/client/clientset/versioned/scheme"
 )
 
 // SyncerConfigsGetter has a method to return a SyncerConfigInterface.

--- a/pkg/client/clientset/versioned/typed/meta/v1alpha1/apiresource.go
+++ b/pkg/client/clientset/versioned/typed/meta/v1alpha1/apiresource.go
@@ -27,8 +27,8 @@ import (
 	watch "k8s.io/apimachinery/pkg/watch"
 	rest "k8s.io/client-go/rest"
 
-	v1alpha1 "github.com/kcp-dev/edge-mc/pkg/apis/meta/v1alpha1"
-	scheme "github.com/kcp-dev/edge-mc/pkg/client/clientset/versioned/scheme"
+	v1alpha1 "github.com/kubestellar/kubestellar/pkg/apis/meta/v1alpha1"
+	scheme "github.com/kubestellar/kubestellar/pkg/client/clientset/versioned/scheme"
 )
 
 // APIResourcesGetter has a method to return a APIResourceInterface.

--- a/pkg/client/clientset/versioned/typed/meta/v1alpha1/fake/fake_apiresource.go
+++ b/pkg/client/clientset/versioned/typed/meta/v1alpha1/fake/fake_apiresource.go
@@ -28,7 +28,7 @@ import (
 	watch "k8s.io/apimachinery/pkg/watch"
 	testing "k8s.io/client-go/testing"
 
-	v1alpha1 "github.com/kcp-dev/edge-mc/pkg/apis/meta/v1alpha1"
+	v1alpha1 "github.com/kubestellar/kubestellar/pkg/apis/meta/v1alpha1"
 )
 
 // FakeAPIResources implements APIResourceInterface

--- a/pkg/client/clientset/versioned/typed/meta/v1alpha1/fake/fake_meta_client.go
+++ b/pkg/client/clientset/versioned/typed/meta/v1alpha1/fake/fake_meta_client.go
@@ -22,7 +22,7 @@ import (
 	rest "k8s.io/client-go/rest"
 	testing "k8s.io/client-go/testing"
 
-	v1alpha1 "github.com/kcp-dev/edge-mc/pkg/client/clientset/versioned/typed/meta/v1alpha1"
+	v1alpha1 "github.com/kubestellar/kubestellar/pkg/client/clientset/versioned/typed/meta/v1alpha1"
 )
 
 type FakeMetaV1alpha1 struct {

--- a/pkg/client/clientset/versioned/typed/meta/v1alpha1/meta_client.go
+++ b/pkg/client/clientset/versioned/typed/meta/v1alpha1/meta_client.go
@@ -23,8 +23,8 @@ import (
 
 	rest "k8s.io/client-go/rest"
 
-	v1alpha1 "github.com/kcp-dev/edge-mc/pkg/apis/meta/v1alpha1"
-	"github.com/kcp-dev/edge-mc/pkg/client/clientset/versioned/scheme"
+	v1alpha1 "github.com/kubestellar/kubestellar/pkg/apis/meta/v1alpha1"
+	"github.com/kubestellar/kubestellar/pkg/client/clientset/versioned/scheme"
 )
 
 type MetaV1alpha1Interface interface {

--- a/pkg/client/informers/externalversions/edge/interface.go
+++ b/pkg/client/informers/externalversions/edge/interface.go
@@ -22,8 +22,8 @@ limitations under the License.
 package edge
 
 import (
-	"github.com/kcp-dev/edge-mc/pkg/client/informers/externalversions/edge/v1alpha1"
-	"github.com/kcp-dev/edge-mc/pkg/client/informers/externalversions/internalinterfaces"
+	"github.com/kubestellar/kubestellar/pkg/client/informers/externalversions/edge/v1alpha1"
+	"github.com/kubestellar/kubestellar/pkg/client/informers/externalversions/internalinterfaces"
 )
 
 type ClusterInterface interface {

--- a/pkg/client/informers/externalversions/edge/v1alpha1/customizer.go
+++ b/pkg/client/informers/externalversions/edge/v1alpha1/customizer.go
@@ -34,11 +34,11 @@ import (
 	kcpinformers "github.com/kcp-dev/apimachinery/v2/third_party/informers"
 	"github.com/kcp-dev/logicalcluster/v3"
 
-	edgev1alpha1 "github.com/kcp-dev/edge-mc/pkg/apis/edge/v1alpha1"
-	scopedclientset "github.com/kcp-dev/edge-mc/pkg/client/clientset/versioned"
-	clientset "github.com/kcp-dev/edge-mc/pkg/client/clientset/versioned/cluster"
-	"github.com/kcp-dev/edge-mc/pkg/client/informers/externalversions/internalinterfaces"
-	edgev1alpha1listers "github.com/kcp-dev/edge-mc/pkg/client/listers/edge/v1alpha1"
+	edgev1alpha1 "github.com/kubestellar/kubestellar/pkg/apis/edge/v1alpha1"
+	scopedclientset "github.com/kubestellar/kubestellar/pkg/client/clientset/versioned"
+	clientset "github.com/kubestellar/kubestellar/pkg/client/clientset/versioned/cluster"
+	"github.com/kubestellar/kubestellar/pkg/client/informers/externalversions/internalinterfaces"
+	edgev1alpha1listers "github.com/kubestellar/kubestellar/pkg/client/listers/edge/v1alpha1"
 )
 
 // CustomizerClusterInformer provides access to a shared informer and lister for

--- a/pkg/client/informers/externalversions/edge/v1alpha1/edgeplacement.go
+++ b/pkg/client/informers/externalversions/edge/v1alpha1/edgeplacement.go
@@ -34,11 +34,11 @@ import (
 	kcpinformers "github.com/kcp-dev/apimachinery/v2/third_party/informers"
 	"github.com/kcp-dev/logicalcluster/v3"
 
-	edgev1alpha1 "github.com/kcp-dev/edge-mc/pkg/apis/edge/v1alpha1"
-	scopedclientset "github.com/kcp-dev/edge-mc/pkg/client/clientset/versioned"
-	clientset "github.com/kcp-dev/edge-mc/pkg/client/clientset/versioned/cluster"
-	"github.com/kcp-dev/edge-mc/pkg/client/informers/externalversions/internalinterfaces"
-	edgev1alpha1listers "github.com/kcp-dev/edge-mc/pkg/client/listers/edge/v1alpha1"
+	edgev1alpha1 "github.com/kubestellar/kubestellar/pkg/apis/edge/v1alpha1"
+	scopedclientset "github.com/kubestellar/kubestellar/pkg/client/clientset/versioned"
+	clientset "github.com/kubestellar/kubestellar/pkg/client/clientset/versioned/cluster"
+	"github.com/kubestellar/kubestellar/pkg/client/informers/externalversions/internalinterfaces"
+	edgev1alpha1listers "github.com/kubestellar/kubestellar/pkg/client/listers/edge/v1alpha1"
 )
 
 // EdgePlacementClusterInformer provides access to a shared informer and lister for

--- a/pkg/client/informers/externalversions/edge/v1alpha1/edgesyncconfig.go
+++ b/pkg/client/informers/externalversions/edge/v1alpha1/edgesyncconfig.go
@@ -34,11 +34,11 @@ import (
 	kcpinformers "github.com/kcp-dev/apimachinery/v2/third_party/informers"
 	"github.com/kcp-dev/logicalcluster/v3"
 
-	edgev1alpha1 "github.com/kcp-dev/edge-mc/pkg/apis/edge/v1alpha1"
-	scopedclientset "github.com/kcp-dev/edge-mc/pkg/client/clientset/versioned"
-	clientset "github.com/kcp-dev/edge-mc/pkg/client/clientset/versioned/cluster"
-	"github.com/kcp-dev/edge-mc/pkg/client/informers/externalversions/internalinterfaces"
-	edgev1alpha1listers "github.com/kcp-dev/edge-mc/pkg/client/listers/edge/v1alpha1"
+	edgev1alpha1 "github.com/kubestellar/kubestellar/pkg/apis/edge/v1alpha1"
+	scopedclientset "github.com/kubestellar/kubestellar/pkg/client/clientset/versioned"
+	clientset "github.com/kubestellar/kubestellar/pkg/client/clientset/versioned/cluster"
+	"github.com/kubestellar/kubestellar/pkg/client/informers/externalversions/internalinterfaces"
+	edgev1alpha1listers "github.com/kubestellar/kubestellar/pkg/client/listers/edge/v1alpha1"
 )
 
 // EdgeSyncConfigClusterInformer provides access to a shared informer and lister for

--- a/pkg/client/informers/externalversions/edge/v1alpha1/interface.go
+++ b/pkg/client/informers/externalversions/edge/v1alpha1/interface.go
@@ -22,7 +22,7 @@ limitations under the License.
 package v1alpha1
 
 import (
-	"github.com/kcp-dev/edge-mc/pkg/client/informers/externalversions/internalinterfaces"
+	"github.com/kubestellar/kubestellar/pkg/client/informers/externalversions/internalinterfaces"
 )
 
 type ClusterInterface interface {

--- a/pkg/client/informers/externalversions/edge/v1alpha1/singleplacementslice.go
+++ b/pkg/client/informers/externalversions/edge/v1alpha1/singleplacementslice.go
@@ -34,11 +34,11 @@ import (
 	kcpinformers "github.com/kcp-dev/apimachinery/v2/third_party/informers"
 	"github.com/kcp-dev/logicalcluster/v3"
 
-	edgev1alpha1 "github.com/kcp-dev/edge-mc/pkg/apis/edge/v1alpha1"
-	scopedclientset "github.com/kcp-dev/edge-mc/pkg/client/clientset/versioned"
-	clientset "github.com/kcp-dev/edge-mc/pkg/client/clientset/versioned/cluster"
-	"github.com/kcp-dev/edge-mc/pkg/client/informers/externalversions/internalinterfaces"
-	edgev1alpha1listers "github.com/kcp-dev/edge-mc/pkg/client/listers/edge/v1alpha1"
+	edgev1alpha1 "github.com/kubestellar/kubestellar/pkg/apis/edge/v1alpha1"
+	scopedclientset "github.com/kubestellar/kubestellar/pkg/client/clientset/versioned"
+	clientset "github.com/kubestellar/kubestellar/pkg/client/clientset/versioned/cluster"
+	"github.com/kubestellar/kubestellar/pkg/client/informers/externalversions/internalinterfaces"
+	edgev1alpha1listers "github.com/kubestellar/kubestellar/pkg/client/listers/edge/v1alpha1"
 )
 
 // SinglePlacementSliceClusterInformer provides access to a shared informer and lister for

--- a/pkg/client/informers/externalversions/edge/v1alpha1/syncerconfig.go
+++ b/pkg/client/informers/externalversions/edge/v1alpha1/syncerconfig.go
@@ -34,11 +34,11 @@ import (
 	kcpinformers "github.com/kcp-dev/apimachinery/v2/third_party/informers"
 	"github.com/kcp-dev/logicalcluster/v3"
 
-	edgev1alpha1 "github.com/kcp-dev/edge-mc/pkg/apis/edge/v1alpha1"
-	scopedclientset "github.com/kcp-dev/edge-mc/pkg/client/clientset/versioned"
-	clientset "github.com/kcp-dev/edge-mc/pkg/client/clientset/versioned/cluster"
-	"github.com/kcp-dev/edge-mc/pkg/client/informers/externalversions/internalinterfaces"
-	edgev1alpha1listers "github.com/kcp-dev/edge-mc/pkg/client/listers/edge/v1alpha1"
+	edgev1alpha1 "github.com/kubestellar/kubestellar/pkg/apis/edge/v1alpha1"
+	scopedclientset "github.com/kubestellar/kubestellar/pkg/client/clientset/versioned"
+	clientset "github.com/kubestellar/kubestellar/pkg/client/clientset/versioned/cluster"
+	"github.com/kubestellar/kubestellar/pkg/client/informers/externalversions/internalinterfaces"
+	edgev1alpha1listers "github.com/kubestellar/kubestellar/pkg/client/listers/edge/v1alpha1"
 )
 
 // SyncerConfigClusterInformer provides access to a shared informer and lister for

--- a/pkg/client/informers/externalversions/factory.go
+++ b/pkg/client/informers/externalversions/factory.go
@@ -34,11 +34,11 @@ import (
 	kcpcache "github.com/kcp-dev/apimachinery/v2/pkg/cache"
 	"github.com/kcp-dev/logicalcluster/v3"
 
-	scopedclientset "github.com/kcp-dev/edge-mc/pkg/client/clientset/versioned"
-	clientset "github.com/kcp-dev/edge-mc/pkg/client/clientset/versioned/cluster"
-	edgeinformers "github.com/kcp-dev/edge-mc/pkg/client/informers/externalversions/edge"
-	"github.com/kcp-dev/edge-mc/pkg/client/informers/externalversions/internalinterfaces"
-	metainformers "github.com/kcp-dev/edge-mc/pkg/client/informers/externalversions/meta"
+	scopedclientset "github.com/kubestellar/kubestellar/pkg/client/clientset/versioned"
+	clientset "github.com/kubestellar/kubestellar/pkg/client/clientset/versioned/cluster"
+	edgeinformers "github.com/kubestellar/kubestellar/pkg/client/informers/externalversions/edge"
+	"github.com/kubestellar/kubestellar/pkg/client/informers/externalversions/internalinterfaces"
+	metainformers "github.com/kubestellar/kubestellar/pkg/client/informers/externalversions/meta"
 )
 
 // SharedInformerOption defines the functional option type for SharedInformerFactory.

--- a/pkg/client/informers/externalversions/generic.go
+++ b/pkg/client/informers/externalversions/generic.go
@@ -30,8 +30,8 @@ import (
 	kcpcache "github.com/kcp-dev/apimachinery/v2/pkg/cache"
 	"github.com/kcp-dev/logicalcluster/v3"
 
-	edgev1alpha1 "github.com/kcp-dev/edge-mc/pkg/apis/edge/v1alpha1"
-	metav1alpha1 "github.com/kcp-dev/edge-mc/pkg/apis/meta/v1alpha1"
+	edgev1alpha1 "github.com/kubestellar/kubestellar/pkg/apis/edge/v1alpha1"
+	metav1alpha1 "github.com/kubestellar/kubestellar/pkg/apis/meta/v1alpha1"
 )
 
 type GenericClusterInformer interface {

--- a/pkg/client/informers/externalversions/internalinterfaces/factory_interfaces.go
+++ b/pkg/client/informers/externalversions/internalinterfaces/factory_interfaces.go
@@ -30,8 +30,8 @@ import (
 
 	kcpcache "github.com/kcp-dev/apimachinery/v2/pkg/cache"
 
-	scopedclientset "github.com/kcp-dev/edge-mc/pkg/client/clientset/versioned"
-	clientset "github.com/kcp-dev/edge-mc/pkg/client/clientset/versioned/cluster"
+	scopedclientset "github.com/kubestellar/kubestellar/pkg/client/clientset/versioned"
+	clientset "github.com/kubestellar/kubestellar/pkg/client/clientset/versioned/cluster"
 )
 
 // NewInformerFunc takes clientset.ClusterInterface and time.Duration to return a ScopeableSharedIndexInformer.

--- a/pkg/client/informers/externalversions/meta/interface.go
+++ b/pkg/client/informers/externalversions/meta/interface.go
@@ -22,8 +22,8 @@ limitations under the License.
 package meta
 
 import (
-	"github.com/kcp-dev/edge-mc/pkg/client/informers/externalversions/internalinterfaces"
-	"github.com/kcp-dev/edge-mc/pkg/client/informers/externalversions/meta/v1alpha1"
+	"github.com/kubestellar/kubestellar/pkg/client/informers/externalversions/internalinterfaces"
+	"github.com/kubestellar/kubestellar/pkg/client/informers/externalversions/meta/v1alpha1"
 )
 
 type ClusterInterface interface {

--- a/pkg/client/informers/externalversions/meta/v1alpha1/apiresource.go
+++ b/pkg/client/informers/externalversions/meta/v1alpha1/apiresource.go
@@ -34,11 +34,11 @@ import (
 	kcpinformers "github.com/kcp-dev/apimachinery/v2/third_party/informers"
 	"github.com/kcp-dev/logicalcluster/v3"
 
-	metav1alpha1 "github.com/kcp-dev/edge-mc/pkg/apis/meta/v1alpha1"
-	scopedclientset "github.com/kcp-dev/edge-mc/pkg/client/clientset/versioned"
-	clientset "github.com/kcp-dev/edge-mc/pkg/client/clientset/versioned/cluster"
-	"github.com/kcp-dev/edge-mc/pkg/client/informers/externalversions/internalinterfaces"
-	metav1alpha1listers "github.com/kcp-dev/edge-mc/pkg/client/listers/meta/v1alpha1"
+	metav1alpha1 "github.com/kubestellar/kubestellar/pkg/apis/meta/v1alpha1"
+	scopedclientset "github.com/kubestellar/kubestellar/pkg/client/clientset/versioned"
+	clientset "github.com/kubestellar/kubestellar/pkg/client/clientset/versioned/cluster"
+	"github.com/kubestellar/kubestellar/pkg/client/informers/externalversions/internalinterfaces"
+	metav1alpha1listers "github.com/kubestellar/kubestellar/pkg/client/listers/meta/v1alpha1"
 )
 
 // APIResourceClusterInformer provides access to a shared informer and lister for

--- a/pkg/client/informers/externalversions/meta/v1alpha1/interface.go
+++ b/pkg/client/informers/externalversions/meta/v1alpha1/interface.go
@@ -22,7 +22,7 @@ limitations under the License.
 package v1alpha1
 
 import (
-	"github.com/kcp-dev/edge-mc/pkg/client/informers/externalversions/internalinterfaces"
+	"github.com/kubestellar/kubestellar/pkg/client/informers/externalversions/internalinterfaces"
 )
 
 type ClusterInterface interface {

--- a/pkg/client/listers/edge/v1alpha1/customizer.go
+++ b/pkg/client/listers/edge/v1alpha1/customizer.go
@@ -29,7 +29,7 @@ import (
 	kcpcache "github.com/kcp-dev/apimachinery/v2/pkg/cache"
 	"github.com/kcp-dev/logicalcluster/v3"
 
-	edgev1alpha1 "github.com/kcp-dev/edge-mc/pkg/apis/edge/v1alpha1"
+	edgev1alpha1 "github.com/kubestellar/kubestellar/pkg/apis/edge/v1alpha1"
 )
 
 // CustomizerClusterLister can list Customizers across all workspaces, or scope down to a CustomizerLister for one workspace.

--- a/pkg/client/listers/edge/v1alpha1/edgeplacement.go
+++ b/pkg/client/listers/edge/v1alpha1/edgeplacement.go
@@ -29,7 +29,7 @@ import (
 	kcpcache "github.com/kcp-dev/apimachinery/v2/pkg/cache"
 	"github.com/kcp-dev/logicalcluster/v3"
 
-	edgev1alpha1 "github.com/kcp-dev/edge-mc/pkg/apis/edge/v1alpha1"
+	edgev1alpha1 "github.com/kubestellar/kubestellar/pkg/apis/edge/v1alpha1"
 )
 
 // EdgePlacementClusterLister can list EdgePlacements across all workspaces, or scope down to a EdgePlacementLister for one workspace.

--- a/pkg/client/listers/edge/v1alpha1/edgesyncconfig.go
+++ b/pkg/client/listers/edge/v1alpha1/edgesyncconfig.go
@@ -29,7 +29,7 @@ import (
 	kcpcache "github.com/kcp-dev/apimachinery/v2/pkg/cache"
 	"github.com/kcp-dev/logicalcluster/v3"
 
-	edgev1alpha1 "github.com/kcp-dev/edge-mc/pkg/apis/edge/v1alpha1"
+	edgev1alpha1 "github.com/kubestellar/kubestellar/pkg/apis/edge/v1alpha1"
 )
 
 // EdgeSyncConfigClusterLister can list EdgeSyncConfigs across all workspaces, or scope down to a EdgeSyncConfigLister for one workspace.

--- a/pkg/client/listers/edge/v1alpha1/singleplacementslice.go
+++ b/pkg/client/listers/edge/v1alpha1/singleplacementslice.go
@@ -29,7 +29,7 @@ import (
 	kcpcache "github.com/kcp-dev/apimachinery/v2/pkg/cache"
 	"github.com/kcp-dev/logicalcluster/v3"
 
-	edgev1alpha1 "github.com/kcp-dev/edge-mc/pkg/apis/edge/v1alpha1"
+	edgev1alpha1 "github.com/kubestellar/kubestellar/pkg/apis/edge/v1alpha1"
 )
 
 // SinglePlacementSliceClusterLister can list SinglePlacementSlices across all workspaces, or scope down to a SinglePlacementSliceLister for one workspace.

--- a/pkg/client/listers/edge/v1alpha1/syncerconfig.go
+++ b/pkg/client/listers/edge/v1alpha1/syncerconfig.go
@@ -29,7 +29,7 @@ import (
 	kcpcache "github.com/kcp-dev/apimachinery/v2/pkg/cache"
 	"github.com/kcp-dev/logicalcluster/v3"
 
-	edgev1alpha1 "github.com/kcp-dev/edge-mc/pkg/apis/edge/v1alpha1"
+	edgev1alpha1 "github.com/kubestellar/kubestellar/pkg/apis/edge/v1alpha1"
 )
 
 // SyncerConfigClusterLister can list SyncerConfigs across all workspaces, or scope down to a SyncerConfigLister for one workspace.

--- a/pkg/client/listers/meta/v1alpha1/apiresource.go
+++ b/pkg/client/listers/meta/v1alpha1/apiresource.go
@@ -29,7 +29,7 @@ import (
 	kcpcache "github.com/kcp-dev/apimachinery/v2/pkg/cache"
 	"github.com/kcp-dev/logicalcluster/v3"
 
-	metav1alpha1 "github.com/kcp-dev/edge-mc/pkg/apis/meta/v1alpha1"
+	metav1alpha1 "github.com/kubestellar/kubestellar/pkg/apis/meta/v1alpha1"
 )
 
 // APIResourceClusterLister can list APIResources across all workspaces, or scope down to a APIResourceLister for one workspace.

--- a/pkg/customize/customize.go
+++ b/pkg/customize/customize.go
@@ -26,8 +26,8 @@ import (
 
 	schedulingv1alpha1 "github.com/kcp-dev/kcp/pkg/apis/scheduling/v1alpha1"
 
-	edgeapi "github.com/kcp-dev/edge-mc/pkg/apis/edge/v1alpha1"
-	"github.com/kcp-dev/edge-mc/pkg/jsonpath"
+	edgeapi "github.com/kubestellar/kubestellar/pkg/apis/edge/v1alpha1"
+	"github.com/kubestellar/kubestellar/pkg/jsonpath"
 )
 
 func Customize(logger klog.Logger, input *unstructured.Unstructured, customizer *edgeapi.Customizer, loc *schedulingv1alpha1.Location) *unstructured.Unstructured {

--- a/pkg/mailboxwatch/impl.go
+++ b/pkg/mailboxwatch/impl.go
@@ -37,7 +37,7 @@ import (
 	tenancyv1a1informers "github.com/kcp-dev/kcp/pkg/client/informers/externalversions/tenancy/v1alpha1"
 	"github.com/kcp-dev/logicalcluster/v3"
 
-	"github.com/kcp-dev/edge-mc/pkg/placement"
+	"github.com/kubestellar/kubestellar/pkg/placement"
 )
 
 func newCrossClusterListerWatcher[Scoped ScopedListerWatcher[ListType], ListType runtime.Object](

--- a/pkg/mailboxwatch/impl_test.go
+++ b/pkg/mailboxwatch/impl_test.go
@@ -39,11 +39,11 @@ import (
 	kcpinformers "github.com/kcp-dev/kcp/pkg/client/informers/externalversions"
 	"github.com/kcp-dev/logicalcluster/v3"
 
-	edgeapi "github.com/kcp-dev/edge-mc/pkg/apis/edge/v1alpha1"
-	edgefakeclient "github.com/kcp-dev/edge-mc/pkg/client/clientset/versioned/cluster/fake"
-	edgeclusterclient "github.com/kcp-dev/edge-mc/pkg/client/clientset/versioned/cluster/typed/edge/v1alpha1"
-	edgescopedclient "github.com/kcp-dev/edge-mc/pkg/client/clientset/versioned/typed/edge/v1alpha1"
-	"github.com/kcp-dev/edge-mc/pkg/placement"
+	edgeapi "github.com/kubestellar/kubestellar/pkg/apis/edge/v1alpha1"
+	edgefakeclient "github.com/kubestellar/kubestellar/pkg/client/clientset/versioned/cluster/fake"
+	edgeclusterclient "github.com/kubestellar/kubestellar/pkg/client/clientset/versioned/cluster/typed/edge/v1alpha1"
+	edgescopedclient "github.com/kubestellar/kubestellar/pkg/client/clientset/versioned/typed/edge/v1alpha1"
+	"github.com/kubestellar/kubestellar/pkg/placement"
 )
 
 var _ edgeapi.SyncerConfig

--- a/pkg/placement/apiwatch-map-provider.go
+++ b/pkg/placement/apiwatch-map-provider.go
@@ -32,8 +32,8 @@ import (
 	kcpinformers "github.com/kcp-dev/client-go/informers"
 	"github.com/kcp-dev/logicalcluster/v3"
 
-	urmetav1a1 "github.com/kcp-dev/edge-mc/pkg/apis/meta/v1alpha1"
-	apiwatch "github.com/kcp-dev/edge-mc/pkg/apiwatch"
+	urmetav1a1 "github.com/kubestellar/kubestellar/pkg/apis/meta/v1alpha1"
+	apiwatch "github.com/kubestellar/kubestellar/pkg/apiwatch"
 )
 
 // NewAPIWatchMapProvider constructs an APIMapProvider that gets its information

--- a/pkg/placement/binding-organizer.go
+++ b/pkg/placement/binding-organizer.go
@@ -24,7 +24,7 @@ import (
 
 	"github.com/kcp-dev/logicalcluster/v3"
 
-	edgeapi "github.com/kcp-dev/edge-mc/pkg/apis/edge/v1alpha1"
+	edgeapi "github.com/kubestellar/kubestellar/pkg/apis/edge/v1alpha1"
 )
 
 // SimpleBindingOrganizer constructs a BindingOrganizer.

--- a/pkg/placement/declarations.go
+++ b/pkg/placement/declarations.go
@@ -27,7 +27,7 @@ import (
 
 	"github.com/kcp-dev/logicalcluster/v3"
 
-	edgeapi "github.com/kcp-dev/edge-mc/pkg/apis/edge/v1alpha1"
+	edgeapi "github.com/kubestellar/kubestellar/pkg/apis/edge/v1alpha1"
 )
 
 // This file contains declarations of the interfaces between the main parts

--- a/pkg/placement/hash-domain.go
+++ b/pkg/placement/hash-domain.go
@@ -21,7 +21,7 @@ import (
 
 	"github.com/kcp-dev/logicalcluster/v3"
 
-	edgeapi "github.com/kcp-dev/edge-mc/pkg/apis/edge/v1alpha1"
+	edgeapi "github.com/kubestellar/kubestellar/pkg/apis/edge/v1alpha1"
 )
 
 type HashDomain[Elt any] interface {

--- a/pkg/placement/main.go
+++ b/pkg/placement/main.go
@@ -33,10 +33,10 @@ import (
 	tenancyv1a1informers "github.com/kcp-dev/kcp/pkg/client/informers/externalversions/tenancy/v1alpha1"
 	tenancyv1a1listers "github.com/kcp-dev/kcp/pkg/client/listers/tenancy/v1alpha1"
 
-	edgeapi "github.com/kcp-dev/edge-mc/pkg/apis/edge/v1alpha1"
-	edgeclusterclientset "github.com/kcp-dev/edge-mc/pkg/client/clientset/versioned/cluster"
-	edgev1a1informers "github.com/kcp-dev/edge-mc/pkg/client/informers/externalversions/edge/v1alpha1"
-	edgev1a1listers "github.com/kcp-dev/edge-mc/pkg/client/listers/edge/v1alpha1"
+	edgeapi "github.com/kubestellar/kubestellar/pkg/apis/edge/v1alpha1"
+	edgeclusterclientset "github.com/kubestellar/kubestellar/pkg/client/clientset/versioned/cluster"
+	edgev1a1informers "github.com/kubestellar/kubestellar/pkg/client/informers/externalversions/edge/v1alpha1"
+	edgev1a1listers "github.com/kubestellar/kubestellar/pkg/client/listers/edge/v1alpha1"
 )
 
 type placementTranslator struct {

--- a/pkg/placement/rotations_test.go
+++ b/pkg/placement/rotations_test.go
@@ -27,7 +27,7 @@ import (
 
 	"github.com/kcp-dev/logicalcluster/v3"
 
-	edgeapi "github.com/kcp-dev/edge-mc/pkg/apis/edge/v1alpha1"
+	edgeapi "github.com/kubestellar/kubestellar/pkg/apis/edge/v1alpha1"
 )
 
 func exerciseFactorer[Whole, PartA, PartB comparable](factor Factorer[Whole, PartA, PartB], exampleWhole Whole, examplePartA PartA, examplePartB PartB) func(*testing.T) {

--- a/pkg/placement/set-binder-assembly.go
+++ b/pkg/placement/set-binder-assembly.go
@@ -23,7 +23,7 @@ import (
 
 	"github.com/kcp-dev/logicalcluster/v3"
 
-	edgeapi "github.com/kcp-dev/edge-mc/pkg/apis/edge/v1alpha1"
+	edgeapi "github.com/kubestellar/kubestellar/pkg/apis/edge/v1alpha1"
 )
 
 // A setBinder works as follows.

--- a/pkg/placement/set-binder-test.go
+++ b/pkg/placement/set-binder-test.go
@@ -25,7 +25,7 @@ import (
 
 	"github.com/kcp-dev/logicalcluster/v3"
 
-	edgeapi "github.com/kcp-dev/edge-mc/pkg/apis/edge/v1alpha1"
+	edgeapi "github.com/kubestellar/kubestellar/pkg/apis/edge/v1alpha1"
 )
 
 // exerciseSetBinder tests a given SetBinder.

--- a/pkg/placement/what-resolver.go
+++ b/pkg/placement/what-resolver.go
@@ -41,11 +41,11 @@ import (
 	kcpinformers "github.com/kcp-dev/client-go/informers"
 	"github.com/kcp-dev/logicalcluster/v3"
 
-	edgeapi "github.com/kcp-dev/edge-mc/pkg/apis/edge/v1alpha1"
-	urmetav1a1 "github.com/kcp-dev/edge-mc/pkg/apis/meta/v1alpha1"
-	"github.com/kcp-dev/edge-mc/pkg/apiwatch"
-	edgev1alpha1informers "github.com/kcp-dev/edge-mc/pkg/client/informers/externalversions/edge/v1alpha1"
-	edgev1alpha1listers "github.com/kcp-dev/edge-mc/pkg/client/listers/edge/v1alpha1"
+	edgeapi "github.com/kubestellar/kubestellar/pkg/apis/edge/v1alpha1"
+	urmetav1a1 "github.com/kubestellar/kubestellar/pkg/apis/meta/v1alpha1"
+	"github.com/kubestellar/kubestellar/pkg/apiwatch"
+	edgev1alpha1informers "github.com/kubestellar/kubestellar/pkg/client/informers/externalversions/edge/v1alpha1"
+	edgev1alpha1listers "github.com/kubestellar/kubestellar/pkg/client/listers/edge/v1alpha1"
 )
 
 type whatResolver struct {

--- a/pkg/placement/where-resolver.go
+++ b/pkg/placement/where-resolver.go
@@ -30,9 +30,9 @@ import (
 
 	kcpcache "github.com/kcp-dev/apimachinery/v2/pkg/cache"
 
-	edgeapi "github.com/kcp-dev/edge-mc/pkg/apis/edge/v1alpha1"
-	edgev1alpha1informers "github.com/kcp-dev/edge-mc/pkg/client/informers/externalversions/edge/v1alpha1"
-	edgev1alpha1listers "github.com/kcp-dev/edge-mc/pkg/client/listers/edge/v1alpha1"
+	edgeapi "github.com/kubestellar/kubestellar/pkg/apis/edge/v1alpha1"
+	edgev1alpha1informers "github.com/kubestellar/kubestellar/pkg/client/informers/externalversions/edge/v1alpha1"
+	edgev1alpha1listers "github.com/kubestellar/kubestellar/pkg/client/listers/edge/v1alpha1"
 )
 
 type whereResolver struct {

--- a/pkg/placement/workload-projector.go
+++ b/pkg/placement/workload-projector.go
@@ -49,9 +49,9 @@ import (
 	tenancyv1a1listers "github.com/kcp-dev/kcp/pkg/client/listers/tenancy/v1alpha1"
 	"github.com/kcp-dev/logicalcluster/v3"
 
-	edgeapi "github.com/kcp-dev/edge-mc/pkg/apis/edge/v1alpha1"
-	edgeclusterclientset "github.com/kcp-dev/edge-mc/pkg/client/clientset/versioned/cluster"
-	edgev1a1listers "github.com/kcp-dev/edge-mc/pkg/client/listers/edge/v1alpha1"
+	edgeapi "github.com/kubestellar/kubestellar/pkg/apis/edge/v1alpha1"
+	edgeclusterclientset "github.com/kubestellar/kubestellar/pkg/client/clientset/versioned/cluster"
+	edgev1a1listers "github.com/kubestellar/kubestellar/pkg/client/listers/edge/v1alpha1"
 )
 
 const SyncerConfigName = "the-one"

--- a/pkg/scheduler/controller.go
+++ b/pkg/scheduler/controller.go
@@ -37,9 +37,9 @@ import (
 	schedulingv1alpha1listers "github.com/kcp-dev/kcp/pkg/client/listers/scheduling/v1alpha1"
 	workloadv1alpha1listers "github.com/kcp-dev/kcp/pkg/client/listers/workload/v1alpha1"
 
-	edgeclientset "github.com/kcp-dev/edge-mc/pkg/client/clientset/versioned/cluster"
-	edgev1alpha1informers "github.com/kcp-dev/edge-mc/pkg/client/informers/externalversions/edge/v1alpha1"
-	edgev1alpha1listers "github.com/kcp-dev/edge-mc/pkg/client/listers/edge/v1alpha1"
+	edgeclientset "github.com/kubestellar/kubestellar/pkg/client/clientset/versioned/cluster"
+	edgev1alpha1informers "github.com/kubestellar/kubestellar/pkg/client/informers/externalversions/edge/v1alpha1"
+	edgev1alpha1listers "github.com/kubestellar/kubestellar/pkg/client/listers/edge/v1alpha1"
 )
 
 const (

--- a/pkg/scheduler/reconcile_on_edgeplacement.go
+++ b/pkg/scheduler/reconcile_on_edgeplacement.go
@@ -27,7 +27,7 @@ import (
 	kcpcache "github.com/kcp-dev/apimachinery/v2/pkg/cache"
 	"github.com/kcp-dev/logicalcluster/v3"
 
-	edgev1alpha1 "github.com/kcp-dev/edge-mc/pkg/apis/edge/v1alpha1"
+	edgev1alpha1 "github.com/kubestellar/kubestellar/pkg/apis/edge/v1alpha1"
 )
 
 func (c *controller) reconcileOnEdgePlacement(ctx context.Context, epKey string) error {

--- a/pkg/scheduler/reconcile_on_location.go
+++ b/pkg/scheduler/reconcile_on_location.go
@@ -29,7 +29,7 @@ import (
 	workloadv1alpha1 "github.com/kcp-dev/kcp/pkg/apis/workload/v1alpha1"
 	"github.com/kcp-dev/logicalcluster/v3"
 
-	edgev1alpha1 "github.com/kcp-dev/edge-mc/pkg/apis/edge/v1alpha1"
+	edgev1alpha1 "github.com/kubestellar/kubestellar/pkg/apis/edge/v1alpha1"
 )
 
 func (c *controller) reconcileOnLocation(ctx context.Context, locKey string) error {

--- a/pkg/scheduler/reconcile_on_synctarget.go
+++ b/pkg/scheduler/reconcile_on_synctarget.go
@@ -29,7 +29,7 @@ import (
 	workloadv1alpha1 "github.com/kcp-dev/kcp/pkg/apis/workload/v1alpha1"
 	"github.com/kcp-dev/logicalcluster/v3"
 
-	edgev1alpha1 "github.com/kcp-dev/edge-mc/pkg/apis/edge/v1alpha1"
+	edgev1alpha1 "github.com/kubestellar/kubestellar/pkg/apis/edge/v1alpha1"
 )
 
 func (c *controller) reconcileOnSyncTarget(ctx context.Context, stKey string) error {

--- a/pkg/syncer/clientfactory/client.go
+++ b/pkg/syncer/clientfactory/client.go
@@ -24,7 +24,7 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/client-go/dynamic"
 
-	edgev1alpha1 "github.com/kcp-dev/edge-mc/pkg/apis/edge/v1alpha1"
+	edgev1alpha1 "github.com/kubestellar/kubestellar/pkg/apis/edge/v1alpha1"
 )
 
 type Client struct {

--- a/pkg/syncer/controller/controller_test.go
+++ b/pkg/syncer/controller/controller_test.go
@@ -34,9 +34,9 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/klog/v2"
 
-	edgev1alpha1 "github.com/kcp-dev/edge-mc/pkg/apis/edge/v1alpha1"
-	edgefakeclient "github.com/kcp-dev/edge-mc/pkg/client/clientset/versioned/fake"
-	edgeinformers "github.com/kcp-dev/edge-mc/pkg/client/informers/externalversions"
+	edgev1alpha1 "github.com/kubestellar/kubestellar/pkg/apis/edge/v1alpha1"
+	edgefakeclient "github.com/kubestellar/kubestellar/pkg/client/clientset/versioned/fake"
+	edgeinformers "github.com/kubestellar/kubestellar/pkg/client/informers/externalversions"
 )
 
 var scheme *runtime.Scheme

--- a/pkg/syncer/controller/controllerbase.go
+++ b/pkg/syncer/controller/controllerbase.go
@@ -27,7 +27,7 @@ import (
 	"k8s.io/client-go/util/workqueue"
 	"k8s.io/klog/v2"
 
-	"github.com/kcp-dev/edge-mc/pkg/syncer/shared"
+	"github.com/kubestellar/kubestellar/pkg/syncer/shared"
 )
 
 type controllerBase struct {

--- a/pkg/syncer/controller/edgesynccontroller.go
+++ b/pkg/syncer/controller/edgesynccontroller.go
@@ -26,10 +26,10 @@ import (
 	"k8s.io/client-go/util/workqueue"
 	"k8s.io/klog/v2"
 
-	edgev1alpha1typed "github.com/kcp-dev/edge-mc/pkg/client/clientset/versioned/typed/edge/v1alpha1"
-	edgev1alpha1informers "github.com/kcp-dev/edge-mc/pkg/client/informers/externalversions/edge/v1alpha1"
-	edgev1alpha1listers "github.com/kcp-dev/edge-mc/pkg/client/listers/edge/v1alpha1"
-	"github.com/kcp-dev/edge-mc/pkg/syncer/syncers"
+	edgev1alpha1typed "github.com/kubestellar/kubestellar/pkg/client/clientset/versioned/typed/edge/v1alpha1"
+	edgev1alpha1informers "github.com/kubestellar/kubestellar/pkg/client/informers/externalversions/edge/v1alpha1"
+	edgev1alpha1listers "github.com/kubestellar/kubestellar/pkg/client/listers/edge/v1alpha1"
+	"github.com/kubestellar/kubestellar/pkg/syncer/syncers"
 )
 
 // NewEdgeSyncConfigController returns a edgeSyncConfigController watching a [edge.kcp.io.EdgeSyncConfig] and update down/up syncer,

--- a/pkg/syncer/controller/syncconfigmanager.go
+++ b/pkg/syncer/controller/syncconfigmanager.go
@@ -22,7 +22,7 @@ import (
 
 	"k8s.io/klog/v2"
 
-	edgev1alpha1 "github.com/kcp-dev/edge-mc/pkg/apis/edge/v1alpha1"
+	edgev1alpha1 "github.com/kubestellar/kubestellar/pkg/apis/edge/v1alpha1"
 )
 
 type SyncConfigManager struct {

--- a/pkg/syncer/controller/syncerconfigcontroller.go
+++ b/pkg/syncer/controller/syncerconfigcontroller.go
@@ -25,9 +25,9 @@ import (
 	"k8s.io/client-go/util/workqueue"
 	"k8s.io/klog/v2"
 
-	edgev1alpha1typed "github.com/kcp-dev/edge-mc/pkg/client/clientset/versioned/typed/edge/v1alpha1"
-	edgev1alpha1informers "github.com/kcp-dev/edge-mc/pkg/client/informers/externalversions/edge/v1alpha1"
-	edgev1alpha1listers "github.com/kcp-dev/edge-mc/pkg/client/listers/edge/v1alpha1"
+	edgev1alpha1typed "github.com/kubestellar/kubestellar/pkg/client/clientset/versioned/typed/edge/v1alpha1"
+	edgev1alpha1informers "github.com/kubestellar/kubestellar/pkg/client/informers/externalversions/edge/v1alpha1"
+	edgev1alpha1listers "github.com/kubestellar/kubestellar/pkg/client/listers/edge/v1alpha1"
 )
 
 func NewSyncerConfigController(

--- a/pkg/syncer/controller/syncerconfigcontroller_test.go
+++ b/pkg/syncer/controller/syncerconfigcontroller_test.go
@@ -36,10 +36,10 @@ import (
 	clientset "k8s.io/client-go/kubernetes/fake"
 	"k8s.io/klog/v2"
 
-	edgev1alpha1 "github.com/kcp-dev/edge-mc/pkg/apis/edge/v1alpha1"
-	edgefakeclient "github.com/kcp-dev/edge-mc/pkg/client/clientset/versioned/fake"
-	edgeinformers "github.com/kcp-dev/edge-mc/pkg/client/informers/externalversions"
-	"github.com/kcp-dev/edge-mc/pkg/syncer/clientfactory"
+	edgev1alpha1 "github.com/kubestellar/kubestellar/pkg/apis/edge/v1alpha1"
+	edgefakeclient "github.com/kubestellar/kubestellar/pkg/client/clientset/versioned/fake"
+	edgeinformers "github.com/kubestellar/kubestellar/pkg/client/informers/externalversions"
+	"github.com/kubestellar/kubestellar/pkg/syncer/clientfactory"
 )
 
 var testAPIResourceList = []*metav1.APIResourceList{

--- a/pkg/syncer/controller/syncerconfigmanager.go
+++ b/pkg/syncer/controller/syncerconfigmanager.go
@@ -25,8 +25,8 @@ import (
 	"k8s.io/client-go/restmapper"
 	"k8s.io/klog/v2"
 
-	edgev1alpha1 "github.com/kcp-dev/edge-mc/pkg/apis/edge/v1alpha1"
-	"github.com/kcp-dev/edge-mc/pkg/syncer/clientfactory"
+	edgev1alpha1 "github.com/kubestellar/kubestellar/pkg/apis/edge/v1alpha1"
+	"github.com/kubestellar/kubestellar/pkg/syncer/clientfactory"
 )
 
 const (

--- a/pkg/syncer/syncer.go
+++ b/pkg/syncer/syncer.go
@@ -30,12 +30,12 @@ import (
 
 	"github.com/kcp-dev/logicalcluster/v3"
 
-	edgev1alpha1 "github.com/kcp-dev/edge-mc/pkg/apis/edge/v1alpha1"
-	edgeclientset "github.com/kcp-dev/edge-mc/pkg/client/clientset/versioned"
-	edgeinformers "github.com/kcp-dev/edge-mc/pkg/client/informers/externalversions"
-	"github.com/kcp-dev/edge-mc/pkg/syncer/clientfactory"
-	"github.com/kcp-dev/edge-mc/pkg/syncer/controller"
-	"github.com/kcp-dev/edge-mc/pkg/syncer/syncers"
+	edgev1alpha1 "github.com/kubestellar/kubestellar/pkg/apis/edge/v1alpha1"
+	edgeclientset "github.com/kubestellar/kubestellar/pkg/client/clientset/versioned"
+	edgeinformers "github.com/kubestellar/kubestellar/pkg/client/informers/externalversions"
+	"github.com/kubestellar/kubestellar/pkg/syncer/clientfactory"
+	"github.com/kubestellar/kubestellar/pkg/syncer/controller"
+	"github.com/kubestellar/kubestellar/pkg/syncer/syncers"
 )
 
 type SyncerConfig struct {

--- a/pkg/syncer/syncers/common.go
+++ b/pkg/syncer/syncers/common.go
@@ -26,8 +26,8 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/klog/v2"
 
-	edgev1alpha1 "github.com/kcp-dev/edge-mc/pkg/apis/edge/v1alpha1"
-	. "github.com/kcp-dev/edge-mc/pkg/syncer/clientfactory"
+	edgev1alpha1 "github.com/kubestellar/kubestellar/pkg/apis/edge/v1alpha1"
+	. "github.com/kubestellar/kubestellar/pkg/syncer/clientfactory"
 )
 
 func resourceToString(resource edgev1alpha1.EdgeSyncConfigResource) string {

--- a/pkg/syncer/syncers/downsyncer.go
+++ b/pkg/syncer/syncers/downsyncer.go
@@ -26,8 +26,8 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/klog/v2"
 
-	edgev1alpha1 "github.com/kcp-dev/edge-mc/pkg/apis/edge/v1alpha1"
-	. "github.com/kcp-dev/edge-mc/pkg/syncer/clientfactory"
+	edgev1alpha1 "github.com/kubestellar/kubestellar/pkg/apis/edge/v1alpha1"
+	. "github.com/kubestellar/kubestellar/pkg/syncer/clientfactory"
 )
 
 type DownSyncer struct {

--- a/pkg/syncer/syncers/interface.go
+++ b/pkg/syncer/syncers/interface.go
@@ -16,7 +16,7 @@ limitations under the License.
 
 package syncers
 
-import edgev1alpha1 "github.com/kcp-dev/edge-mc/pkg/apis/edge/v1alpha1"
+import edgev1alpha1 "github.com/kubestellar/kubestellar/pkg/apis/edge/v1alpha1"
 
 type SyncerInterface interface {
 	ReInitializeClients(resources []edgev1alpha1.EdgeSyncConfigResource, conversions []edgev1alpha1.EdgeSynConversion) error

--- a/pkg/syncer/syncers/upsyncer.go
+++ b/pkg/syncer/syncers/upsyncer.go
@@ -26,8 +26,8 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/klog/v2"
 
-	edgev1alpha1 "github.com/kcp-dev/edge-mc/pkg/apis/edge/v1alpha1"
-	. "github.com/kcp-dev/edge-mc/pkg/syncer/clientfactory"
+	edgev1alpha1 "github.com/kubestellar/kubestellar/pkg/apis/edge/v1alpha1"
+	. "github.com/kubestellar/kubestellar/pkg/syncer/clientfactory"
 )
 
 type UpSyncer struct {

--- a/test/e2e/framework/kubestellar_syncer.go
+++ b/test/e2e/framework/kubestellar_syncer.go
@@ -53,7 +53,7 @@ import (
 	"github.com/kcp-dev/kcp/test/e2e/framework"
 	"github.com/kcp-dev/logicalcluster/v3"
 
-	"github.com/kcp-dev/edge-mc/pkg/syncer"
+	"github.com/kubestellar/kubestellar/pkg/syncer"
 )
 
 //go:embed testdata/*

--- a/test/e2e/kubestellar-syncer/common_test.go
+++ b/test/e2e/kubestellar-syncer/common_test.go
@@ -31,7 +31,7 @@ import (
 	"github.com/kcp-dev/kcp/test/e2e/framework"
 	"github.com/kcp-dev/logicalcluster/v3"
 
-	edgeframework "github.com/kcp-dev/edge-mc/test/e2e/framework"
+	edgeframework "github.com/kubestellar/kubestellar/test/e2e/framework"
 )
 
 //go:embed testdata/*

--- a/test/e2e/kubestellar-syncer/syncer_kyverno_test.go
+++ b/test/e2e/kubestellar-syncer/syncer_kyverno_test.go
@@ -30,7 +30,7 @@ import (
 
 	"github.com/kcp-dev/kcp/test/e2e/framework"
 
-	edgeframework "github.com/kcp-dev/edge-mc/test/e2e/framework"
+	edgeframework "github.com/kubestellar/kubestellar/test/e2e/framework"
 )
 
 func TestKubeStellarSyncerForKyvernoWithSyncerConfig(t *testing.T) {

--- a/test/e2e/kubestellar-syncer/syncer_syncerconfig_test.go
+++ b/test/e2e/kubestellar-syncer/syncer_syncerconfig_test.go
@@ -31,7 +31,7 @@ import (
 
 	"github.com/kcp-dev/kcp/test/e2e/framework"
 
-	edgeframework "github.com/kcp-dev/edge-mc/test/e2e/framework"
+	edgeframework "github.com/kubestellar/kubestellar/test/e2e/framework"
 )
 
 func TestKubeStellarSyncerWithSyncerConfig(t *testing.T) {

--- a/test/e2e/kubestellar-syncer/syncer_test.go
+++ b/test/e2e/kubestellar-syncer/syncer_test.go
@@ -31,7 +31,7 @@ import (
 
 	"github.com/kcp-dev/kcp/test/e2e/framework"
 
-	edgeframework "github.com/kcp-dev/edge-mc/test/e2e/framework"
+	edgeframework "github.com/kubestellar/kubestellar/test/e2e/framework"
 )
 
 func TestKubeStellarSyncerWithEdgeSyncConfig(t *testing.T) {

--- a/test/e2e/kubestellar-syncer/syncer_turbo_for_deletion_scenario_test.go
+++ b/test/e2e/kubestellar-syncer/syncer_turbo_for_deletion_scenario_test.go
@@ -31,7 +31,7 @@ import (
 
 	"github.com/kcp-dev/kcp/test/e2e/framework"
 
-	edgeframework "github.com/kcp-dev/edge-mc/test/e2e/framework"
+	edgeframework "github.com/kubestellar/kubestellar/test/e2e/framework"
 )
 
 func TestKubeStellarSyncerForTurboForDeletionScenario(t *testing.T) {

--- a/test/e2e/kubestellar-syncer/syncer_update_status_test.go
+++ b/test/e2e/kubestellar-syncer/syncer_update_status_test.go
@@ -32,7 +32,7 @@ import (
 
 	"github.com/kcp-dev/kcp/test/e2e/framework"
 
-	edgeframework "github.com/kcp-dev/edge-mc/test/e2e/framework"
+	edgeframework "github.com/kubestellar/kubestellar/test/e2e/framework"
 )
 
 func TestKubeStellarSyncerForUpdateStatus(t *testing.T) {


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
This PR updates the `release-0.2` branch go sources, replacing the package prefix `github.com/kcp-dev/edge-mc` with `github.com/kubestellar/kubestellar`.

Done with the following command.

```bash
find * \( -name "*.go" -or -name go.mod \) | while read fn; do sed -i .bak 's:github.com/kcp-dev/edge-mc:github.com/kubestellar/kubestellar:' "$fn"; done
```

## Related issue(s)

This addresses part, only part, of #539 .

/cc @clubanderson 
/cc @francostellari 
/cc @pdettori 
