### PR TITLE
:sparkles:Add stop for cluster discovery.

### DIFF
--- a/cluster-provider-client/kind/kind.go
+++ b/cluster-provider-client/kind/kind.go
@@ -85,17 +85,12 @@ func (k KindClusterProvider) List() ([]string, error) {
 	return logicalNameList, err
 }
 
-func (k KindClusterProvider) StartWatch() (clusterprovider.Watcher, error) {
+func (k KindClusterProvider) Watch() (clusterprovider.Watcher, error) {
 	w := &KindWatcher{
 		ch:       make(chan clusterprovider.WatchEvent),
 		provider: &k}
 	k.watch = w
 	return w, nil
-}
-
-func (k KindClusterProvider) StopWatch() error {
-	k.watch.Stop()
-	return nil
 }
 
 type KindWatcher struct {

--- a/cluster-provider-client/provider.go
+++ b/cluster-provider-client/provider.go
@@ -50,9 +50,6 @@ func NewProvider(ctx context.Context,
 // Provider defines methods to retrieve, list, and watch fleet of clusters.
 // The provider is responsible for discovering and managing the lifecycle of each
 // cluster.
-//
-// Example:
-// ES: add example, remove list() add Get()
 type ProviderClient interface {
 	Create(ctx context.Context, name string, opts clusterprovider.Options) (clusterprovider.LogicalClusterInfo, error)
 	Delete(ctx context.Context, name string, opts clusterprovider.Options) error
@@ -62,11 +59,7 @@ type ProviderClient interface {
 	// and to refresh the list of logical clusters periodically.
 	List() ([]string, error)
 
-	// StartWatch returns a Watcher that watches for changes to a list of logical clusters
+	// Watch returns a Watcher that watches for changes to a list of logical clusters
 	// and react to potential changes.
-	StartWatch() (clusterprovider.Watcher, error)
-
-	// StopWatch stops a Watcher that watches for changes to a list of logical clusters
-	// and react to potential changes.
-	StopWatch() error
+	Watch() (clusterprovider.Watcher, error)
 }

--- a/hack/logcheck.out
+++ b/hack/logcheck.out
@@ -2,8 +2,6 @@
 /cmd/kcp-watchall/main.go:103:3: Key positional arguments are expected to be inlined constant strings. Please replace &{flg Name} provided with string value.
 /cmd/mailbox-controller/main.go:88:3: Key positional arguments are expected to be inlined constant strings. Please replace &{flg Name} provided with string value.
 /cmd/placement-translator/main.go:121:3: Key positional arguments are expected to be inlined constant strings. Please replace &{flg Name} provided with string value.
-/pkg/clustermanager/provider-cluster/provider_cluster.go:122:5: Additional arguments to Info should always be Key Value pairs. Please check if there is any key or value missing.
-/pkg/clustermanager/provider-cluster/provider_cluster.go:136:4: Additional arguments to Info should always be Key Value pairs. Please check if there is any key or value missing.
 /pkg/placement/workload-projector.go:687:4: the result of logger.V should be stored in a variable and then be used multiple times: if logger := logger.V(); logger.Enabled() { ... logger.Info ... }
 /pkg/placement/workload-projector.go:709:2: the result of logger.V should be stored in a variable and then be used multiple times: if logger := logger.V(); logger.Enabled() { ... logger.Info ... }
 /pkg/placement/workload-projector.go:882:1: A function should accept either a context or a logger, but not both. Having both makes calling the function harder because it must be defined whether the context must contain the logger and callers have to follow that.

--- a/pkg/clustermanager/discovery.go
+++ b/pkg/clustermanager/discovery.go
@@ -94,11 +94,11 @@ func (c *controller) StopDiscovery(providerName string) error {
 
 	providerInfo, ok := c.providers[providerName]
 	if !ok {
-		return errors.New("failed to stop provider discovery. provider info not exists")
+		return errors.New("failed to stop provider discovery. provider info does not exist")
 	}
 
 	if providerInfo.providerWatcher == nil {
-		return errors.New("failed to stop provider discovery. provider watcher not exists")
+		return errors.New("failed to stop provider discovery. provider watcher does not exist")
 	}
 	providerInfo.providerWatcher.Stop()
 	return nil

--- a/pkg/clustermanager/discovery.go
+++ b/pkg/clustermanager/discovery.go
@@ -30,12 +30,12 @@ import (
 	edgeclient "github.com/kubestellar/kubestellar/pkg/client/clientset/versioned"
 )
 
-func (c *controller) GetProvider(
-	providerName string, providerType lcv1alpha1apis.ClusterProviderType) (clusterproviderclient.ProviderClient, error) {
+// GetProvider returns provider client interface for provider
+func (c *controller) GetProvider(providerName string) (clusterproviderclient.ProviderClient, error) {
 	c.lock.Lock()
 	defer c.lock.Unlock()
 
-	provider, exists := c.providers.providerList[providerName]
+	provider, exists := c.providers[providerName]
 	if !exists {
 		// If the provider does not exists in the list, then likely the provider object was
 		// recentely added, and the provider is in the process of being added.  Return an
@@ -44,15 +44,16 @@ func (c *controller) GetProvider(
 		err := errors.New("provider does not exist in the provider list")
 		return nil, err
 	}
-	return provider, nil
+	return provider.providerClient, nil
 }
 
+// CreateProvider returns new provider client
 func (c *controller) CreateProvider(
 	providerName string, providerType lcv1alpha1apis.ClusterProviderType) (clusterproviderclient.ProviderClient, error) {
 	c.lock.Lock()
 	defer c.lock.Unlock()
 
-	_, exists := c.providers.providerList[providerName]
+	_, exists := c.providers[providerName]
 	if exists {
 		err := errors.New("provider already in the list")
 		return nil, err
@@ -61,22 +62,49 @@ func (c *controller) CreateProvider(
 	if err != nil {
 		return nil, err
 	}
-	c.providers.providerList[providerName] = newProvider
+	c.providers[providerName] = providerInfo{providerClient: newProvider}
 	return newProvider, nil
 }
 
-func (c *controller) StartDiscovery(
-	provider clusterproviderclient.ProviderClient,
-	providerName string) error {
-	w, err := provider.StartWatch()
+// StartDiscovery will start watching provider clusters for changes
+func (c *controller) StartDiscovery(providerName string) error {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+
+	providerInfo, ok := c.providers[providerName]
+	if !ok {
+		return errors.New("failed to start provider discovery. provider info not exists")
+	}
+
+	watcher, err := providerInfo.providerClient.Watch()
 	if err != nil {
 		return err
 	}
-	go ProcessProviderWatchEvents(c.context, w, c.clientset, providerName)
+	go processProviderWatchEvents(c.context, watcher, c.clientset, providerName)
+
+	providerInfo.providerWatcher = watcher
+	c.providers[providerName] = providerInfo
 	return nil
 }
 
-func ProcessProviderWatchEvents(ctx context.Context, w clusterprovider.Watcher, clientset edgeclient.Interface, providerName string) {
+// StopDiscovery will stop watching provider clusters for changes
+func (c *controller) StopDiscovery(providerName string) error {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+
+	providerInfo, ok := c.providers[providerName]
+	if !ok {
+		return errors.New("failed to stop provider discovery. provider info not exists")
+	}
+
+	if providerInfo.providerWatcher == nil {
+		return errors.New("failed to stop provider discovery. provider watcher not exists")
+	}
+	providerInfo.providerWatcher.Stop()
+	return nil
+}
+
+func processProviderWatchEvents(ctx context.Context, w clusterprovider.Watcher, clientset edgeclient.Interface, providerName string) {
 	logger := klog.FromContext(ctx)
 	for {
 		event, ok := <-w.ResultChan()

--- a/pkg/clustermanager/discovery.go
+++ b/pkg/clustermanager/discovery.go
@@ -110,7 +110,7 @@ func processProviderWatchEvents(ctx context.Context, w clusterprovider.Watcher, 
 		event, ok := <-w.ResultChan()
 		if !ok {
 			w.Stop()
-			logger.Info("stopping")
+			logger.Info("stopping cluster provider watch", "provider", providerName)
 			// TODO: return an error
 			return
 		}
@@ -131,7 +131,7 @@ func processProviderWatchEvents(ctx context.Context, w clusterprovider.Watcher, 
 				}
 			}
 			if !found {
-				logger.Info("Creating new LogicalCluster object", event.Name)
+				logger.Info("Creating new LogicalCluster object", "cluster", event.Name)
 				var eventLogicalCluster lcv1alpha1apis.LogicalCluster
 				eventLogicalCluster.Name = event.Name
 				eventLogicalCluster.Spec.ClusterProviderDescName = providerName
@@ -145,7 +145,7 @@ func processProviderWatchEvents(ctx context.Context, w clusterprovider.Watcher, 
 				}
 			}
 		case watch.Deleted:
-			logger.Info("Deleting LogicalCluster object", event.Name)
+			logger.Info("Deleting LogicalCluster object", "cluster", event.Name)
 			err := clientset.LogicalclusterV1alpha1().LogicalClusters(clusterproviderclient.GetNamespace(providerName)).Delete(ctx, event.Name, v1.DeleteOptions{})
 			if err != nil {
 				// TODO: If the logical cluster object does not exist, ignore the error.
@@ -155,9 +155,7 @@ func processProviderWatchEvents(ctx context.Context, w clusterprovider.Watcher, 
 			}
 
 		default:
-			// Unknown!
-			logger.Info("unknown event")
-			// TODO return an error or panic?
+			logger.Info("unknown event type", "type", event.Type)
 		}
 	}
 }

--- a/pkg/clustermanager/reconcile_clusterprovider.go
+++ b/pkg/clustermanager/reconcile_clusterprovider.go
@@ -19,17 +19,8 @@ package clustermanager
 import (
 	"errors"
 
-	clusterproviderclient "github.com/kubestellar/kubestellar/cluster-provider-client"
 	lcv1alpha1 "github.com/kubestellar/kubestellar/pkg/apis/logicalcluster/v1alpha1"
 )
-
-type providers struct {
-	providerList map[string]clusterproviderclient.ProviderClient
-}
-
-func (c *controller) InitProviders() {
-	c.providers.providerList = make(map[string]clusterproviderclient.ProviderClient)
-}
 
 func (c *controller) reconcileClusterProviderDesc(key string) error {
 	providerObj, exists, err := c.clusterProviderInformer.GetIndexer().GetByKey(key)
@@ -56,13 +47,13 @@ func (c *controller) reconcileClusterProviderDesc(key string) error {
 // TODO: perform discovery
 // TODO: requeue the add if the provider is already hashed in the provider list?
 func (c *controller) processAdd(providerName string, providerType lcv1alpha1.ClusterProviderType) error {
-	newProvider, err := c.CreateProvider(providerName, providerType)
+	_, err := c.CreateProvider(providerName, providerType)
 	if err != nil {
 		// TODO: Check if the err is because the provider already exists
 		c.logger.V(2).Info("processAdd", "resource", providerName)
 		return err
 	}
-	err = c.StartDiscovery(newProvider, providerName)
+	err = c.StartDiscovery(providerName)
 	if err != nil {
 		c.logger.V(2).Info("processAdd", "resource", providerName)
 		return err

--- a/pkg/clustermanager/reconcile_logicalcluster.go
+++ b/pkg/clustermanager/reconcile_logicalcluster.go
@@ -69,7 +69,7 @@ func (c *controller) processAddLC(newCluster *lcv1alpha1.LogicalCluster) error {
 		return err
 	}
 
-	provider, err := c.GetProvider(providerInfo.Name, providerInfo.Spec.ProviderType)
+	provider, err := c.GetProvider(providerInfo.Name)
 	if err != nil {
 		logger.Error(err, "failed to get provider client")
 		return err
@@ -142,7 +142,7 @@ func (c *controller) processDeleteLC(delCluster *lcv1alpha1.LogicalCluster) erro
 		return err
 	}
 
-	provider, err := c.GetProvider(providerInfo.Name, providerInfo.Spec.ProviderType)
+	provider, err := c.GetProvider(providerInfo.Name)
 	if err != nil {
 		logger.Error(err, "failed to get provider client")
 		return err


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
This will add the ability to stop cluster provider discovery loop when provider object is deleted. 

## Related issue(s)

Fixes #
