### PR TITLE
:book: removed quickstart tab on header

### DIFF
--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -19,7 +19,6 @@ nav:
   - Home:
       - Overview: index.md 
       - Readme: readme.md
-  - QuickStart: Getting-Started/quickstart.md
   - Contributing: 
       - Guidelines: Contribution guidelines/CONTRIBUTING.md
       - Code of Conduct: Contribution guidelines/coc.md


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
The Quickstart tab on the header was redundant (pointing to the Getting Started tab), so I removed it. 
