### PR TITLE
✨ Remove repo renaming and direct logs to files

### DIFF
--- a/docs/content/Coding Milestones/PoC2023q1/example1-subs/example1-post-kcp.md
+++ b/docs/content/Coding Milestones/PoC2023q1/example1-subs/example1-post-kcp.md
@@ -24,7 +24,7 @@ executables (e.g., `kubectl kubestellar prep-for-syncer` corresponds to
 `bin/kubectl-kubestellar-prep_for_syncer`).
 
 ```shell
-cd ../KubeStellar
+cd ../kubestellar
 make build
 export PATH=$(pwd)/bin:$PATH
 ```

--- a/docs/content/Coding Milestones/PoC2023q1/example1-subs/example1-stage-1a.md
+++ b/docs/content/Coding Milestones/PoC2023q1/example1-subs/example1-stage-1a.md
@@ -1,14 +1,17 @@
 <!--example1-stage-1a-start-->
 ### The mailbox controller
 
-Running the mailbox controller will be conveniently automated.
-Eventually.  In the meantime, you can use the KubeStellar command shown
-here.
+Running the mailbox controller is included in `kubestellar start`.
+Alternatively you could run just that controller now, for example as
+shown below.
 
 ```shell
-go run ./cmd/mailbox-controller -v=2 &
+mailbox-controller -v=2 &> /tmp/ks-mbctlr.log &
 sleep 45
 ```
+
+The log file should get contents like the following.
+
 ``` { .bash .no-copy }
 ...
 I0423 01:09:37.991080   10624 main.go:196] "Found APIExport view" exportName="workload.kcp.io" serverURL="https://192.168.58.123:6443/services/apiexport/root/workload.kcp.io"
@@ -16,7 +19,6 @@ I0423 01:09:37.991080   10624 main.go:196] "Found APIExport view" exportName="wo
 I0423 01:09:38.449395   10624 controller.go:299] "Created APIBinding" worker=1 mbwsName="apmziqj9p9fqlflm-mb-bf452e1f-45a0-4d5d-b35c-ef1ece2879ba" mbwsCluster="yk9a66vjms1pi8hu" bindingName="bind-edge" resourceVersion="914"
 ...
 I0423 01:09:38.842881   10624 controller.go:299] "Created APIBinding" worker=3 mbwsName="apmziqj9p9fqlflm-mb-b8c64c64-070c-435b-b3bd-9c0f0c040a54" mbwsCluster="12299slctppnhjnn" bindingName="bind-edge" resourceVersion="968"
-^C
 ```
 
 You need a `-v` setting of 2 or numerically higher to get log messages
@@ -25,8 +27,7 @@ about individual mailbox workspaces.
 This controller creates a mailbox workspace for each SyncTarget and
 puts an APIBinding to the edge API in each of those mailbox
 workspaces.  For this simple scenario, you do not need to keep this
-controller running after it does those things (hence the `^C` above);
-normally it would run continuously.
+controller running after it does those things.
 
 You can get a listing of those mailbox workspaces as follows.
 

--- a/docs/content/Coding Milestones/PoC2023q1/example1-subs/example1-stage-2.md
+++ b/docs/content/Coding Milestones/PoC2023q1/example1-subs/example1-stage-2.md
@@ -302,9 +302,10 @@ following resolutions of the "where" predicates.
 | edge-placement-c | florin, guilder |
 | edge-placement-s | guilder |
 
-Eventually there will be automation that conveniently runs the
-scheduler.  In the meantime, you can run it by hand: switch to the
-ESPW and invoke the KubeStellar command that runs the scheduler.
+The `kubestellar start` command launches the scheduler along with the
+other controllers.  If you want to exercise the scheduler by itself
+then you could do that as follows.  The scheduler needs to be pointed
+at the ESPW either by command line flags or the current kcp workspace.
 
 ```shell
 kubectl ws root:espw
@@ -313,16 +314,18 @@ kubectl ws root:espw
 Current workspace is "root:espw".
 ```
 ```shell
-go run ./cmd/kubestellar-scheduler &
+kubestellar-scheduler &> /tmp/ks-scheduler.log &
 sleep 45
 ```
+
+That will put stuff in the log like the following.
+
 ``` { .bash .no-copy }
 I0423 01:33:37.036752   11305 kubestellar-scheduler.go:212] "Found APIExport view" exportName="edge.kcp.io" serverURL="https://192.168.58.123:6443/services/apiexport/7qkse309upzrv0fy/edge.kcp.io"
 ...
 I0423 01:33:37.320859   11305 reconcile_on_location.go:192] "updated SinglePlacementSlice" controller="kubestellar-scheduler" triggeringKind=Location key="apmziqj9p9fqlflm|florin" locationWorkspace="apmziqj9p9fqlflm" location="florin" workloadWorkspace="10l175x6ejfjag3e" singlePlacementSlice="edge-placement-c"
 ...
 I0423 01:33:37.391772   11305 reconcile_on_location.go:192] "updated SinglePlacementSlice" controller="kubestellar-scheduler" triggeringKind=Location key="apmziqj9p9fqlflm|guilder" locationWorkspace="apmziqj9p9fqlflm" location="guilder" workloadWorkspace="10l175x6ejfjag3e" singlePlacementSlice="edge-placement-c"
-^C
 ```
 
 In this simple scenario you do not need to keep the scheduler running

--- a/docs/content/Coding Milestones/PoC2023q1/example1-subs/example1-stage-3.md
+++ b/docs/content/Coding Milestones/PoC2023q1/example1-subs/example1-stage-3.md
@@ -8,9 +8,11 @@ In Stage 3, in response to the EdgePlacement and SinglePlacementSlice
 objects, the placement translator will copy the workload prescriptions
 into the mailbox workspaces and create `SyncerConfig` objects there.
 
-Eventually there will be convenient automation running the placement
-translator.  In the meantime, you can run it manually: switch to the
-ESPW and use the KubeStellar command that runs the placement translator.
+The `kubestellar start` command launches the placement translator
+along with the other controllers.  If you want to exercise just the
+placement translator then you could launch it as shown below.  The
+placement translator needs to be pointed at the ESPW either by command
+line flags or the current kcp workspace.
 
 ```shell
 kubectl ws root:espw
@@ -19,9 +21,12 @@ kubectl ws root:espw
 Current workspace is "root:espw".
 ```
 ```shell
-go run ./cmd/placement-translator &
+placement-translator &> /tmp/ks-pt.log &
 sleep 120
 ```
+
+That will put a lot of stuff in the log, including the following line.
+
 ``` { .bash .no-copy }
 I0423 01:39:56.362722   11644 shared_informer.go:282] Waiting for caches to sync for placement-translator
 ...

--- a/docs/content/Coding Milestones/PoC2023q1/example1-subs/example1-start-kcp.md
+++ b/docs/content/Coding Milestones/PoC2023q1/example1-subs/example1-start-kcp.md
@@ -17,7 +17,7 @@ It is also assumed that you have the usual kcp kubectl plugins on your
 `$PATH`.
 
 ```shell
-git clone {{ config.repo_url }} KubeStellar
+git clone {{ config.repo_url }} kubestellar
 ```
 
 clone the v0.11.0 branch kcp source:

--- a/docs/content/Coding Milestones/PoC2023q1/kubestellar-scheduler-subs/kubestellar-scheduler-0-pull-kcp-and-kubestellar-source-and-start-kcp.md
+++ b/docs/content/Coding Milestones/PoC2023q1/kubestellar-scheduler-subs/kubestellar-scheduler-0-pull-kcp-and-kubestellar-source-and-start-kcp.md
@@ -1,6 +1,6 @@
 <!--kubestellar-scheduler-0-pull-kcp-and-kubestellar-source-and-start-kcp-start-->
 ```shell
-git clone {{ config.repo_url }} KubeStellar
+git clone {{ config.repo_url }} kubestellar
 ```
 
 Clone the v0.11.0 branch kcp source:

--- a/docs/content/Coding Milestones/PoC2023q1/placement-translator-subs/placement-translator-process-start-without-cd-kubestellar.md
+++ b/docs/content/Coding Milestones/PoC2023q1/placement-translator-subs/placement-translator-process-start-without-cd-kubestellar.md
@@ -1,7 +1,7 @@
 <!--placement-translator-process-start-without-cd-kubestellar-start-->
 ```shell
 kubectl ws root:espw
-go run ./cmd/placement-translator &
+placement-translator &> /tmp/ks-pt.log &
 sleep 120
 ```
 <!--placement-translator-process-start-without-cd-kubestellar-end-->

--- a/docs/content/Coding Milestones/PoC2023q1/placement-translator-subs/placement-translator-process-start.md
+++ b/docs/content/Coding Milestones/PoC2023q1/placement-translator-subs/placement-translator-process-start.md
@@ -1,8 +1,8 @@
 <!--placement-translator-process-start-start-->
 ```shell
 kubectl ws root:espw
-cd ../KubeStellar
-go run ./cmd/placement-translator &
+cd ../kubestellar
+placement-translator &> /tmp/ks-pt.log &
 sleep 120
 ```
 <!--placement-translator-process-start-end-->


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
This PR does two things.
1. It changes example1 to direct controller logs, to address #686 
2. It removes the git repo renaming from the `git clone` commands in example1 (#687) and the placement translator doc.

## Related issue(s)

Fixes #686 
Fixes #687 
