### PR TITLE
:book: moved kubestellar clone to get kubestellar section

### DIFF
--- a/docs/content/Coding Milestones/PoC2023q1/example1-subs/example1-post-kcp.md
+++ b/docs/content/Coding Milestones/PoC2023q1/example1-subs/example1-post-kcp.md
@@ -24,6 +24,7 @@ executables (e.g., `kubectl kubestellar prep-for-syncer` corresponds to
 `bin/kubectl-kubestellar-prep_for_syncer`).
 
 ```shell
+git clone -b {{ config.ks_branch }} {{ config.repo_url }}
 cd ../kubestellar
 make build
 export PATH=$(pwd)/bin:$PATH

--- a/docs/content/Coding Milestones/PoC2023q1/example1-subs/example1-start-kcp.md
+++ b/docs/content/Coding Milestones/PoC2023q1/example1-subs/example1-start-kcp.md
@@ -16,10 +16,6 @@ noted that the florin or guilder cluster is being accessed.
 It is also assumed that you have the usual kcp kubectl plugins on your
 `$PATH`.
 
-```shell
-git clone -b {{ config.ks_branch }} {{ config.repo_url }}
-```
-
 clone the v0.11.0 branch kcp source:
 ```shell
 git clone -b v0.11.0 https://github.com/kcp-dev/kcp kcp


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
I moved the command to clone the KubeStellar Repo to the 'Get KubeStellar' section. 

## Related issue(s)
#692 

