### PR TITLE
:sparkles: moved 'serving up documents locally' up higher in the doc

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -11,6 +11,33 @@ additional plugins and tools:
 We have support in place for multiple languages (i18n), although we currently only have documentation in English. If 
 you're interested in contributing translations, please let us know!
 
+### Serving up documents locally
+You can view and modify our documentation in your local development environment.  Simply checkout one of our branches.
+
+```shell
+git clone git@github.com:{{ config.repo_short_name }}.git
+cd {{ config.repo_default_file_path }}/docs
+git checkout {{ config.ks_branch }}
+```
+
+You can view and modify our documentation in the branch you have checked out by using `mkdocs serve` from [mkdocs](https://www.mkdocs.org):
+
+```shell
+pip install -r requirements.txt
+mkdocs serve
+```
+Then open a browser to [`http://localhost:8000/`](http://localhost:8000/)
+
+Another way to view (not modify - this method reflects what has been deployed to the `gh-pages` branch of our repo) all branches/versions of our documentation locally using 'mike' [mike for mkdocs](https://github.com/jimporter/mike):
+
+```shell
+git clone git@github.com:{{ config.repo_short_name }}.git
+cd {{ config.repo_default_file_path }}
+git checkout {{ config.ks_branch }}
+make serve-docs
+```
+Then open a browser to [`http://localhost:8000/`](http://localhost:8000/)
+
 ## File structure
 
 All documentation-related items live in `docs` (with the small exception of various `make` targets and some helper 
@@ -67,33 +94,6 @@ In the document you want to include, add the start and end tags you configured i
 ![Included Markdown](./content/Contribution%20guidelines/operations/included-markdown-example.png)
 
 for more information on the 'include-markdown' plugin for mkdocs look [here](https://github.com/mondeja/mkdocs-include-markdown-plugin)
-
-### Serving up documents locally
-You can view and modify our documentation in your local development environment.  Simply checkout one of our branches.
-
-```shell
-git clone git@github.com:{{ config.repo_short_name }}.git
-cd {{ config.repo_default_file_path }}/docs
-git checkout {{ config.ks_branch }}
-```
-
-You can view and modify our documentation in the branch you have checked out by using `mkdocs serve` from [mkdocs](https://www.mkdocs.org):
-
-```shell
-pip install -r requirements.txt
-mkdocs serve
-```
-Then open a browser to [`http://localhost:8000/`](http://localhost:8000/)
-
-Another way to view (not modify - this method reflects what has been deployed to the `gh-pages` branch of our repo) all branches/versions of our documentation locally using 'mike' [mike for mkdocs](https://github.com/jimporter/mike):
-
-```shell
-git clone git@github.com:{{ config.repo_short_name }}.git
-cd {{ config.repo_default_file_path }}
-git checkout {{ config.ks_branch }}
-make serve-docs
-```
-Then open a browser to [`http://localhost:8000/`](http://localhost:8000/)
 
 ### Supported aliases for our documentation
 We currently support 3 aliases for our documentation:


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

## Related issue(s)

Fixes #717 
