### PR TITLE
✨ Add example1 variant with single git clone

### DIFF
--- a/docs/content/Coding Milestones/PoC2023q1/example1-local.md
+++ b/docs/content/Coding Milestones/PoC2023q1/example1-local.md
@@ -1,0 +1,83 @@
+---
+short_name: example1-local
+manifest_name: 'docs/content/Coding Milestones/PoC2023q1/example1-local.md'
+pre_req_name: 'docs/content/common-subs/pre-req.md'
+---
+[![docs-ecutable - example1]({{config.repo_url}}/actions/workflows/docs-ecutable-example1.yml/badge.svg?branch={{config.ks_branch}})]({{config.repo_url}}/actions/workflows/docs-ecutable-example1.yml)
+``` {.bash .hide-me}
+cd ../.. # trim docs/scripts
+```
+
+{%
+   include-markdown "../../common-subs/required-packages.md"
+   start="<!--required-packages-start-->"
+   end="<!--required-packages-end-->"
+%}
+{%
+   include-markdown "../../common-subs/save-some-time-local.md"
+   start="<!--save-some-time-start-->"
+   end="<!--save-some-time-end-->"
+%}
+
+This doc shows a detailed example usage of the KubeStellar components.
+
+This example involves two edge clusters and two workloads.  One
+workload goes on both edge clusters and one workload goes on only one
+edge cluster.  Nothing changes after the initial activity.
+
+This example is presented in stages.  The controllers involved are
+always maintaining relationships.  This document focuses on changes as
+they appear in this example.
+
+## Stage 1
+
+{%
+   include-markdown "example1-subs/example1-pre-kcp.md"
+   start="<!--example1-pre-kcp-start-->"
+   end="<!--example1-pre-kcp-end-->"
+%}
+
+{%
+   include-markdown "example1-subs/example1-start-kcp-local.md"
+   start="<!--example1-start-kcp-start-->"
+   end="<!--example1-start-kcp-end-->"
+%}
+
+{%
+   include-markdown "example1-subs/example1-post-kcp-local.md"
+   start="<!--example1-post-kcp-start-->"
+   end="<!--example1-post-kcp-end-->"
+%}
+
+{%
+   include-markdown "example1-subs/example1-post-espw.md"
+   start="<!--example1-post-espw-start-->"
+   end="<!--example1-post-espw-end-->"
+%}
+
+## Stage 5
+
+![Summarization for special](Edge-PoC-2023q1-Scenario-1-stage-5s.svg "Status summarization for special")
+
+The status summarizer, driven by the EdgePlacement and
+SinglePlacementSlice for the special workload, creates a status
+summary object in the specialstuff namespace in the special workload
+workspace holding a summary of the corresponding Deployment objects.
+In this case there is just one such object, in the mailbox workspace
+for the guilder cluster.
+
+![Summarization for common](Edge-PoC-2023q1-Scenario-1-stage-5c.svg "Status summarization for common")
+
+The status summarizer, driven by the EdgePlacement and
+SinglePlacementSlice for the common workload, creates a status summary
+object in the commonstuff namespace in the common workload workspace
+holding a summary of the corresponding Deployment objects.  Those are
+the `commond` Deployment objects in the two mailbox workspaces.
+
+## Teardown the environment
+
+{%
+   include-markdown "../../common-subs/teardown-the-environment.md"
+   start="<!--teardown-the-environment-start-->"
+   end="<!--teardown-the-environment-end-->"
+%}

--- a/docs/content/Coding Milestones/PoC2023q1/example1-subs/example1-post-kcp-local.md
+++ b/docs/content/Coding Milestones/PoC2023q1/example1-subs/example1-post-kcp-local.md
@@ -1,0 +1,108 @@
+<!--example1-post-kcp-start-->
+### Create an inventory management workspace.
+
+Use the following commands.
+
+```shell
+kubectl ws root
+kubectl ws create imw-1 --enter
+```
+
+### Build or Install KubeStellar
+
+Download and build or install
+<a href="{{ config.repo_url }}">KubeStellar</a>, according to your
+preference.  That is, either (a) `git clone` the repo and then `make
+build` to populate its `bin` directory, or (b) fetch the binary
+archive appropriate for your machine from a release and unpack it
+(creating a `bin` directory).  In the following exhibited command
+lines, the commands described as "KubeStellar commands" and the commands
+that start with `kubectl kubestellar` rely on the KubeStellar `bin` directory
+being on the `$PATH`.  Alternatively you could invoke them with
+explicit pathnames.  The kubectl plugin lines use fully specific
+executables (e.g., `kubectl kubestellar prep-for-syncer` corresponds to
+`bin/kubectl-kubestellar-prep_for_syncer`).
+
+```shell
+make build
+export PATH=$(pwd)/bin:$PATH
+```
+### Create SyncTarget and Location objects to represent the florin and guilder clusters
+
+Use the following two commands. They label both florin and guilder
+with `env=prod`, and also label guilder with `extended=si`.
+
+```shell
+kubectl kubestellar ensure location florin  loc-name=florin  env=prod
+kubectl kubestellar ensure location guilder loc-name=guilder env=prod extended=si
+```
+
+Those two script invocations are equivalent to creating the following
+four objects.
+
+```yaml
+apiVersion: workload.kcp.io/v1alpha1
+kind: SyncTarget
+metadata:
+  name: florin
+  labels:
+    id: florin
+    loc-name: florin
+    env: prod
+---
+apiVersion: scheduling.kcp.io/v1alpha1
+kind: Location
+metadata:
+  name: florin
+  labels:
+    loc-name: florin
+    env: prod
+spec:
+  resource: {group: workload.kcp.io, version: v1alpha1, resource: synctargets}
+  instanceSelector:
+    matchLabels: {id: florin}
+---
+apiVersion: workload.kcp.io/v1alpha1
+kind: SyncTarget
+metadata:
+  name: guilder
+  labels:
+    id: guilder
+    loc-name: guilder
+    env: prod
+    extended: si
+---
+apiVersion: scheduling.kcp.io/v1alpha1
+kind: Location
+metadata:
+  name: guilder
+  labels:
+    loc-name: guilder
+    env: prod
+    extended: si
+spec:
+  resource: {group: workload.kcp.io, version: v1alpha1, resource: synctargets}
+  instanceSelector:
+    matchLabels: {id: guilder}
+```
+
+That script also deletes the Location named `default`, which is not
+used in this PoC, if it shows up.
+
+### Initialize the KubeStellar platform
+
+In this step KubeStellar creates and populates the Edge Service
+Provider Workspace (ESPW), which exports the KubeStellar API, and also
+augments the `root:compute` workspace from kcp TMC as needed here.
+Those augmentation consists of adding authorization to update the
+relevant `/status` and `/scale` subresources (missing in kcp TMC) and
+extending the supported subset of the Kubernetes API for managing
+containerized workloads from the four resources built into kcp TMC
+(`Deployment`, `Pod`, `Service`, and `Ingress`) to the other ones that
+are namespaced and are meaningful in KubeStellar.
+
+```shell
+kubestellar init
+```
+
+<!--example1-post-kcp-end-->

--- a/docs/content/Coding Milestones/PoC2023q1/example1-subs/example1-start-kcp-local.md
+++ b/docs/content/Coding Milestones/PoC2023q1/example1-subs/example1-start-kcp-local.md
@@ -1,0 +1,38 @@
+<!--example1-start-kcp-start-->
+### Start kcp
+
+Download and build or install [kcp](https://github.com/kcp-dev/kcp/releases/tag/v0.11.0),
+according to your preference.
+
+In some shell that will be used only for this purpose, issue the `kcp
+start` command.  If you have junk from previous runs laying around,
+you should probably `rm -rf .kcp` first.
+
+In the shell commands in all the following steps it is assumed that
+`kcp` is running and `$KUBECONFIG` is set to the
+`.kcp/admin.kubeconfig` that `kcp` produces, except where explicitly
+noted that the florin or guilder cluster is being accessed.
+
+It is also assumed that you have the usual kcp kubectl plugins on your
+`$PATH`.
+
+clone the v0.11.0 branch kcp source:
+```shell
+git clone -b v0.11.0 https://github.com/kcp-dev/kcp kcp
+```
+build the kubectl-ws binary and include it in `$PATH`
+```shell
+pushd kcp
+make build
+export PATH=$(pwd)/bin:$PATH
+```
+
+run kcp (kcp will spit out tons of information and stay running in this terminal window)
+```shell
+export KUBECONFIG=$(pwd)/.kcp/admin.kubeconfig
+kcp start &> /dev/null &
+popd
+sleep 30 
+```
+<!--example1-start-kcp-end-->
+<!-- > /dev/null & -->

--- a/docs/content/common-subs/save-some-time-local.md
+++ b/docs/content/common-subs/save-some-time-local.md
@@ -1,0 +1,15 @@
+<!--save-some-time-start-->
+!!! tip "This document is 'docs-ecutable' - you can 'run' this document, just like we do in our testing, on your local environment"
+    ```
+    git clone -b {{config.ks_branch}} {{config.repo_url}}
+    cd {{config.repo_default_file_path}}
+    make MANIFEST="'{{page.meta.pre_req_name}}','{{page.meta.manifest_name}}'" docs-ecutable
+    ```
+
+    ```
+    # done? remove everything
+    make MANIFEST="docs/content/common-subs/remove-all.md" docs-ecutable
+    cd ..
+    rm -rf {{config.repo_default_file_path}}
+    ```
+<!--save-some-time-end-->

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -43,6 +43,7 @@ nav:
           - Inivitation to Contribute: Coding Milestones/PoC2023q1/coding-milestone-invite-q1.md
           - KubeStellar-Syncer: Coding Milestones/PoC2023q1/kubestellar-syncer.md
           - Extended Example: Coding Milestones/PoC2023q1/example1.md
+          - Extended Example (single git clone): Coding Milestones/PoC2023q1/example1-local.md
           - KubeStellar Processes:
               - KubeStellar Scheduler: Coding Milestones/PoC2023q1/kubestellar-scheduler.md
               - KubeStellar Mailbox Controller: Coding Milestones/PoC2023q1/mailbox-controller.md


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
This PR introduces `example1-local.md` that, when executed, uses the local content rather than fetching from github.  Thus, this executable doc can be used for CI and can be used by a developer to test before pushing and even before committing.

## Related issue(s)

Making all the executable docs work like this would resolve #720 
