### PR TITLE
✨ Remove 'all cluster' kcp clientset from the kubestellar-scheduler

### DIFF
--- a/cmd/kubestellar-where-resolver/cmd/where-resolver-cmd.go
+++ b/cmd/kubestellar-where-resolver/cmd/where-resolver-cmd.go
@@ -143,11 +143,6 @@ func Run(ctx context.Context, options *resolveroptions.Options) error {
 		logger.Error(err, "failed to create config from flags")
 		return err
 	}
-	kcpClusterClientset, err := kcpclientset.NewForConfig(sysAdmRestConfig)
-	if err != nil {
-		logger.Error(err, "failed to create kcp clientset for controller")
-		return err
-	}
 	edgeClusterClientset, err := edgeclientset.NewForConfig(sysAdmRestConfig)
 	if err != nil {
 		logger.Error(err, "failed to create edge clientset for controller")
@@ -155,7 +150,6 @@ func Run(ctx context.Context, options *resolveroptions.Options) error {
 	}
 	es, err := wheresolver.NewController(
 		ctx,
-		kcpClusterClientset,
 		edgeClusterClientset,
 		edgeSharedInformerFactory.Edge().V1alpha1().EdgePlacements(),
 		edgeSharedInformerFactory.Edge().V1alpha1().SinglePlacementSlices(),

--- a/pkg/where-resolver/controller.go
+++ b/pkg/where-resolver/controller.go
@@ -31,7 +31,6 @@ import (
 	kcpcache "github.com/kcp-dev/apimachinery/v2/pkg/cache"
 	schedulingv1alpha1 "github.com/kcp-dev/kcp/pkg/apis/scheduling/v1alpha1"
 	workloadv1alpha1 "github.com/kcp-dev/kcp/pkg/apis/workload/v1alpha1"
-	kcpclientset "github.com/kcp-dev/kcp/pkg/client/clientset/versioned/cluster"
 	schedulingv1alpha1informers "github.com/kcp-dev/kcp/pkg/client/informers/externalversions/scheduling/v1alpha1"
 	workloadv1alpha1informers "github.com/kcp-dev/kcp/pkg/client/informers/externalversions/workload/v1alpha1"
 	schedulingv1alpha1listers "github.com/kcp-dev/kcp/pkg/client/listers/scheduling/v1alpha1"
@@ -63,7 +62,6 @@ type controller struct {
 	context context.Context
 	queue   workqueue.RateLimitingInterface
 
-	kcpClusterClient  kcpclientset.ClusterInterface
 	edgeClusterClient edgeclientset.ClusterInterface
 
 	singlePlacementSliceLister  edgev1alpha1listers.SinglePlacementSliceClusterLister
@@ -81,7 +79,6 @@ type controller struct {
 
 func NewController(
 	context context.Context,
-	kcpClusterClient kcpclientset.ClusterInterface,
 	edgeClusterClient edgeclientset.ClusterInterface,
 	edgePlacementAccess edgev1alpha1informers.EdgePlacementClusterInformer,
 	singlePlacementSliceAccess edgev1alpha1informers.SinglePlacementSliceClusterInformer,
@@ -95,7 +92,6 @@ func NewController(
 		context: context,
 		queue:   queue,
 
-		kcpClusterClient:  kcpClusterClient,
 		edgeClusterClient: edgeClusterClient,
 
 		edgePlacementLister:  edgePlacementAccess.Lister(),


### PR DESCRIPTION
## Summary
This PR removes the 'all cluster' kcp clientset from the scheduler because it is proved that the scheduler doesn't need it.
Thanks to @MikeSpreitzer 's [previous review](https://github.com/kubestellar/kubestellar/pull/206#discussion_r1134941611).

## Related issue(s)
#711 

/cc @MikeSpreitzer 