### PR TITLE
✨ No nested fetch

### DIFF
--- a/docs/content/Coding Milestones/PoC2023q1/example1-subs/example1-post-kcp.md
+++ b/docs/content/Coding Milestones/PoC2023q1/example1-subs/example1-post-kcp.md
@@ -8,27 +8,28 @@ kubectl ws root
 kubectl ws create imw-1 --enter
 ```
 
-### Get KubeStellar
+### Get and build or install KubeStellar
 
-Download and build or install
-<a href="{{ config.repo_url }}">KubeStellar</a>, according to your
-preference.  That is, either (a) `git clone` the repo and then `make
-build` to populate its `bin` directory, or (b) fetch the binary
-archive appropriate for your machine from a release and unpack it
-(creating a `bin` directory).  In the following exhibited command
-lines, the commands described as "KubeStellar commands" and the commands
-that start with `kubectl kubestellar` rely on the KubeStellar `bin` directory
-being on the `$PATH`.  Alternatively you could invoke them with
-explicit pathnames.  The kubectl plugin lines use fully specific
-executables (e.g., `kubectl kubestellar prep-for-syncer` corresponds to
-`bin/kubectl-kubestellar-prep_for_syncer`).
+Download and build, or install, <a href="{{config.repo_url}}">KubeStellar</a>,
+according to your preference.  That is, either (a) `git clone` the
+repo and then `make build` to populate its `bin` directory, or (b)
+fetch the binary archive appropriate for your machine from a release
+and unpack it (creating a `bin` directory).  The commands exhibited
+just below assume that the repo has been fetched but not yet buit.
 
 ```shell
-git clone -b {{ config.ks_branch }} {{ config.repo_url }}
-cd ../kubestellar
 make build
 export PATH=$(pwd)/bin:$PATH
 ```
+
+In the following exhibited command lines, the commands described as
+"KubeStellar commands" and the commands that start with `kubectl
+kubestellar` rely on the KubeStellar `bin` directory being on the
+`$PATH`.  Alternatively you could invoke them with explicit pathnames.
+The kubectl plugin lines use fully specific executables (e.g.,
+`kubectl kubestellar prep-for-syncer` corresponds to
+`bin/kubectl-kubestellar-prep_for_syncer`).
+
 ### Create SyncTarget and Location objects to represent the florin and guilder clusters
 
 Use the following two commands. They label both florin and guilder

--- a/docs/content/Coding Milestones/PoC2023q1/example1-subs/example1-stage-4.md
+++ b/docs/content/Coding Milestones/PoC2023q1/example1-subs/example1-stage-4.md
@@ -21,6 +21,10 @@ workspace.  This is driven by the `SyncerConfig` object named
 Using the kubeconfig that `kind` modified, examine the florin cluster.
 Find just the `commonstuff` namespace and the `commond` Deployment.
 
+``` {.bash .hide-me}
+sleep 15
+```
+
 ```shell
 KUBECONFIG=~/.kube/config kubectl --context kind-florin get ns
 ```
@@ -35,6 +39,10 @@ kube-system                          Active   57m
 local-path-storage                   Active   57m
 ```
 
+``` {.bash .hide-me}
+sleep 15
+```
+
 ```shell
 KUBECONFIG=~/.kube/config kubectl --context kind-florin get deploy,rs -A | egrep 'NAME|stuff'
 ```
@@ -46,6 +54,10 @@ commonstuff                          replicaset.apps/commond                    
 
 Examine the guilder cluster.  Find both workload namespaces and both
 Deployments.
+
+``` {.bash .hide-me}
+sleep 15
+```
 
 ```shell
 KUBECONFIG=~/.kube/config kubectl --context kind-guilder get ns | egrep NAME\|stuff
@@ -70,6 +82,10 @@ specialstuff                          replicaset.apps/speciald-76cdbb69b5       
 Examining the common workload in the guilder cluster, for example,
 will show that the replacement-style customization happened.
 
+``` {.bash .hide-me}
+sleep 15
+```
+
 ```shell
 KUBECONFIG=~/.kube/config kubectl --context kind-guilder get rs -n commonstuff commond -o yaml
 ```
@@ -88,7 +104,7 @@ KUBECONFIG=~/.kube/config kubectl --context kind-guilder get rs -n commonstuff c
 Check that the common workload on the florin cluster is working.
 
 ``` {.bash .hide-me}
-sleep 10
+sleep 15
 ```
 ```shell
 curl http://localhost:8094
@@ -105,7 +121,7 @@ curl http://localhost:8094
 
 Check that the special workload on the guilder cluster is working.
 ``` {.bash .hide-me}
-sleep 10
+sleep 15
 ```
 ```shell
 curl http://localhost:8097
@@ -121,6 +137,10 @@ curl http://localhost:8097
 ```
 
 Check that the common workload on the guilder cluster is working.
+
+``` {.bash .hide-me}
+sleep 15
+```
 
 ```shell
 curl http://localhost:8096

--- a/docs/content/Coding Milestones/PoC2023q1/example1-subs/example1-stage-4.md
+++ b/docs/content/Coding Milestones/PoC2023q1/example1-subs/example1-stage-4.md
@@ -21,12 +21,19 @@ workspace.  This is driven by the `SyncerConfig` object named
 Using the kubeconfig that `kind` modified, examine the florin cluster.
 Find just the `commonstuff` namespace and the `commond` Deployment.
 
-``` {.bash .hide-me}
-sleep 15
-```
-
 ```shell
-KUBECONFIG=~/.kube/config kubectl --context kind-florin get ns
+( KUBECONFIG=~/.kube/config
+  let tries=1
+  while ! kubectl --context kind-florin get ns commonstuff &> /dev/null; do
+    if (( tries >= 30)); then
+      echo "The commonstuff namespace failed to appear in florin!" >&2
+      exit 10
+    fi
+    let tries=tries+1
+    sleep 10
+  done
+  kubectl --context kind-florin get ns
+)
 ```
 ``` { .bash .no-copy }
 NAME                                 STATUS   AGE
@@ -103,10 +110,16 @@ KUBECONFIG=~/.kube/config kubectl --context kind-guilder get rs -n commonstuff c
 
 Check that the common workload on the florin cluster is working.
 
-``` {.bash .hide-me}
-sleep 15
-```
 ```shell
+let tries=1
+while ! curl http://localhost:8094 &> /dev/null; do
+  if (( tries >= 30 )); then
+    echo "The common workload failed to come up on florin!" >&2
+    exit 10
+  fi
+  let tries=tries+1
+  sleep 10
+done
 curl http://localhost:8094
 ```
 ``` { .bash .no-copy }
@@ -120,10 +133,16 @@ curl http://localhost:8094
 ```
 
 Check that the special workload on the guilder cluster is working.
-``` {.bash .hide-me}
-sleep 15
-```
 ```shell
+let tries=1
+while ! curl http://localhost:8097 &> /dev/null; do
+  if (( tries >= 30 )); then
+    echo "The special workload failed to come up on guilder!" >&2
+    exit 10
+  fi
+  let tries=tries+1
+  sleep 10
+done
 curl http://localhost:8097
 ```
 ``` { .bash .no-copy }
@@ -138,11 +157,16 @@ curl http://localhost:8097
 
 Check that the common workload on the guilder cluster is working.
 
-``` {.bash .hide-me}
-sleep 15
-```
-
 ```shell
+let tries=1
+while ! curl http://localhost:8096 &> /dev/null; do
+  if (( tries >= 30 )); then
+    echo "The common workload failed to come up on guilder!" >&2
+    exit 10
+  fi
+  let tries=tries+1
+  sleep 10
+done
 curl http://localhost:8096
 ```
 ``` { .bash .no-copy }

--- a/docs/content/Coding Milestones/PoC2023q1/example1-subs/example1-start-kcp.md
+++ b/docs/content/Coding Milestones/PoC2023q1/example1-subs/example1-start-kcp.md
@@ -22,15 +22,16 @@ git clone -b v0.11.0 https://github.com/kcp-dev/kcp kcp
 ```
 build the kubectl-ws binary and include it in `$PATH`
 ```shell
-cd kcp
+pushd kcp
 make build
+export PATH=$(pwd)/bin:$PATH
 ```
 
 run kcp (kcp will spit out tons of information and stay running in this terminal window)
 ```shell
 export KUBECONFIG=$(pwd)/.kcp/admin.kubeconfig
-export PATH=$(pwd)/bin:$PATH
 kcp start &> /dev/null &
+popd
 sleep 30 
 ```
 <!--example1-start-kcp-end-->

--- a/docs/content/Coding Milestones/PoC2023q1/kubestellar-scheduler-subs/kubestellar-scheduler-0-pull-kcp-and-kubestellar-source-and-start-kcp.md
+++ b/docs/content/Coding Milestones/PoC2023q1/kubestellar-scheduler-subs/kubestellar-scheduler-0-pull-kcp-and-kubestellar-source-and-start-kcp.md
@@ -1,22 +1,21 @@
 <!--kubestellar-scheduler-0-pull-kcp-and-kubestellar-source-and-start-kcp-start-->
-```shell
-git clone -b {{ config.ks_branch }} {{ config.repo_url }}
-```
-
 Clone the v0.11.0 branch kcp source:
 ```shell
 git clone -b v0.11.0 https://github.com/kcp-dev/kcp kcp
 ```
 Build the kubectl-ws binary and include it in `$PATH`
 ```shell
-cd kcp
+pushd kcp
 make build
 export PATH=$(pwd)/bin:$PATH
 ```
 
-Run kcp (kcp will spit out tons of information and stay running in this terminal window)
+Run kcp (kcp will spit out tons of information and stay running in this terminal window).
+Set your `KUBECONFIG` environment variable to name the kubernetes client config file that `kcp` generates.
 ```shell
 kcp start &> /dev/null &
+export KUBECONFIG=$(pwd)/.kcp/admin.kubeconfig
+popd
 sleep 30
 ```
 <!--kubestellar-scheduler-0-pull-kcp-and-kubestellar-source-and-start-kcp-end-->

--- a/docs/content/Coding Milestones/PoC2023q1/kubestellar-scheduler-subs/kubestellar-scheduler-1-build-kubestellar.md
+++ b/docs/content/Coding Milestones/PoC2023q1/kubestellar-scheduler-subs/kubestellar-scheduler-1-build-kubestellar.md
@@ -1,0 +1,6 @@
+<!--kubestellar-scheduler-1-build-kubestellar-start-->
+```shell
+make build
+export PATH=$(pwd)/bin:$PATH
+```
+<!--kubestellar-scheduler-1-build-kubestellar-end-->

--- a/docs/content/Coding Milestones/PoC2023q1/kubestellar-scheduler-subs/kubestellar-scheduler-1-export-kubeconfig-and-path-for-kcp.md
+++ b/docs/content/Coding Milestones/PoC2023q1/kubestellar-scheduler-subs/kubestellar-scheduler-1-export-kubeconfig-and-path-for-kcp.md
@@ -1,6 +1,0 @@
-<!--kubestellar-scheduler-1-export-kubeconfig-and-path-for-kcp-start-->
-```shell
-export KUBECONFIG=$(pwd)/.kcp/admin.kubeconfig
-export PATH=$(pwd)/bin:$PATH
-```
-<!--kubestellar-scheduler-1-export-kubeconfig-and-path-for-kcp-end-->

--- a/docs/content/Coding Milestones/PoC2023q1/kubestellar-scheduler-subs/kubestellar-scheduler-2-ws-root-and-ws-create-edge.md
+++ b/docs/content/Coding Milestones/PoC2023q1/kubestellar-scheduler-subs/kubestellar-scheduler-2-ws-root-and-ws-create-edge.md
@@ -1,9 +1,7 @@
 <!--kubestellar-scheduler-2-ws-root-and-ws-create-edge-start-->
-Next, create the edge service provider workspace:
+Next, use the command that makes sure the Edge Service Provider Workspace (ESPW), which is `root:espw`, and the TMC provider workspace (`root:compute`) are properly set up.
 
-Use workspace `root:espw` as the Edge Service Provider Workspace (ESPW).
 ```shell
-kubectl ws root
-kubectl ws create espw
+kubestellar init
 ```
 <!--kubestellar-scheduler-2-ws-root-and-ws-create-edge-end-->

--- a/docs/content/Coding Milestones/PoC2023q1/kubestellar-scheduler-subs/kubestellar-scheduler-imports.md
+++ b/docs/content/Coding Milestones/PoC2023q1/kubestellar-scheduler-subs/kubestellar-scheduler-imports.md
@@ -6,6 +6,6 @@ kubectl ws \~
 
 Bind APIs.
 ```shell
-kubectl apply -f ../kubestellar/config/imports/
+kubectl apply -f config/imports/
 ```
 <!--kubestellar-scheduler-imports-end-->

--- a/docs/content/Coding Milestones/PoC2023q1/kubestellar-scheduler-subs/kubestellar-scheduler-process-start.md
+++ b/docs/content/Coding Milestones/PoC2023q1/kubestellar-scheduler-subs/kubestellar-scheduler-process-start.md
@@ -1,8 +1,7 @@
 <!--kubestellar-scheduler-process-start-start-->
 ```shell
 kubectl ws root:espw
-cd ../kubestellar
-go run cmd/kubestellar-scheduler/main.go -v 2 &
+kubestellar-scheduler -v 2 &
 sleep 45
 ```
 <!--kubestellar-scheduler-process-start-end-->

--- a/docs/content/Coding Milestones/PoC2023q1/kubestellar-scheduler.md
+++ b/docs/content/Coding Milestones/PoC2023q1/kubestellar-scheduler.md
@@ -16,33 +16,28 @@ pre_req_name: 'docs/content/common-subs/pre-req.md'
 %}
 ## Steps to try the scheduler
 
-### Pull the kcp and KubeStellar source code, build the kubectl-ws binary, and start kcp
-Open a terminal window(1) and clone the latest KubeStellar source:
+### Pull the kcp source code, build kcp, and start kcp
+
+At this point you should have cloned the KubeStellar repo and `cd`ed into it as directed above.
 {%
    include-markdown "kubestellar-scheduler-subs/kubestellar-scheduler-0-pull-kcp-and-kubestellar-source-and-start-kcp.md"
    start="<!--kubestellar-scheduler-0-pull-kcp-and-kubestellar-source-and-start-kcp-start-->"
    end="<!--kubestellar-scheduler-0-pull-kcp-and-kubestellar-source-and-start-kcp-end-->"
 %}
 
-### Create the Edge Service Provider Workspace (ESPW) and populate it with CRDs and APIs
-Open another terminal window(2) and point `$KUBECONFIG` to the admin kubeconfig for the kcp server and include the location of kubectl-ws in `$PATH`.
+### Build and initialize KubeStellar
+
+First build KubeStellar and add the result to your `$PATH`.
 {%
-   include-markdown "kubestellar-scheduler-subs/kubestellar-scheduler-1-export-kubeconfig-and-path-for-kcp.md"
-   start="<!--kubestellar-scheduler-1-export-kubeconfig-and-path-for-kcp-start-->"
-   end="<!--kubestellar-scheduler-1-export-kubeconfig-and-path-for-kcp-end-->"
+   include-markdown "kubestellar-scheduler-subs/kubestellar-scheduler-1-build-kubestellar.md"
+   start="<!--kubestellar-scheduler-1-build-kubestellar-start-->"
+   end="<!--kubestellar-scheduler-1-build-kubestellar-end-->"
 %}
 
 {%
    include-markdown "kubestellar-scheduler-subs/kubestellar-scheduler-2-ws-root-and-ws-create-edge.md"
    start="<!--kubestellar-scheduler-2-ws-root-and-ws-create-edge-start-->"
    end="<!--kubestellar-scheduler-2-ws-root-and-ws-create-edge-end-->"
-%}
-
-Install CRDs and APIExport.
-{%
-   include-markdown "kubestellar-scheduler-subs/kubestellar-scheduler-exports.md"
-   start="<!--kubestellar-scheduler-exports-start-->"
-   end="<!--kubestellar-scheduler-exports-end-->"
 %}
 
 ### Create the Workload Management Workspace (WMW) and bind it to the ESPW APIs
@@ -68,12 +63,6 @@ I0605 10:53:00.261128   29786 controller.go:201] "starting controller" controlle
 ```
 
 ### Create the Inventory Management Workspace (IMW) and populate it with locations and synctargets
-open another terminal window(3) and point `$KUBECONFIG` to the admin kubeconfig for the kcp server and include the location of kubectl-ws in $PATH.
-```shell
-cd ../kcp
-export KUBECONFIG=$(pwd)/.kcp/admin.kubeconfig
-export PATH=$(pwd)/bin:$PATH
-```
 
 Use workspace `root:compute` as the Inventory Management Workspace (IMW).
 ```shell
@@ -82,10 +71,10 @@ kubectl ws root:compute
 
 Create two Locations and two SyncTargets.
 ```shell
-kubectl create -f ../kubestellar/config/samples/location_prod.yaml
-kubectl create -f ../kubestellar/config/samples/location_dev.yaml
-kubectl create -f ../kubestellar/config/samples/synctarget_prod.yaml
-kubectl create -f ../kubestellar/config/samples/synctarget_dev.yaml
+kubectl create -f config/samples/location_prod.yaml
+kubectl create -f config/samples/location_dev.yaml
+kubectl create -f config/samples/synctarget_prod.yaml
+kubectl create -f config/samples/synctarget_dev.yaml
 sleep 5
 ```
 
@@ -108,7 +97,7 @@ synctarget.workload.kcp.io/prod   2m12s
 Go to Workload Management Workspace (WMW) and create an EdgePlacement `all2all`.
 ```shell
 kubectl ws \~
-kubectl create -f ../kubestellar/config/samples/edgeplacement_all2all.yaml
+kubectl create -f config/samples/edgeplacement_all2all.yaml
 sleep 3
 ```
 
@@ -154,7 +143,7 @@ EdgePlacement `all2all` selects all the 3 Locations in `root:compute`.
 
 Create a more specific EdgePlacement which selects Locations labeled by `env: dev`.
 ```shell
-kubectl create -f ../kubestellar/config/samples/edgeplacement_dev.yaml
+kubectl create -f config/samples/edgeplacement_dev.yaml
 sleep 3
 ```
 

--- a/docs/content/Coding Milestones/PoC2023q1/mailbox-controller-subs/mailbox-controller-process-start.md
+++ b/docs/content/Coding Milestones/PoC2023q1/mailbox-controller-subs/mailbox-controller-process-start.md
@@ -1,8 +1,7 @@
 <!--mailbox-controller-process-start-start-->
 ```shell
 kubectl ws root:espw
-cd ../kubestellar
-go run ./cmd/mailbox-controller -v=2 &
+mailbox-controller -v=2 &
 sleep 45
 ```
 <!--mailbox-controller-process-start-end-->

--- a/docs/content/Coding Milestones/PoC2023q1/mailbox-controller.md
+++ b/docs/content/Coding Milestones/PoC2023q1/mailbox-controller.md
@@ -86,9 +86,9 @@ Open a terminal window(1) and clone the latest KubeStellar source:
 Open another terminal window(2) and point `$KUBECONFIG` to the admin kubeconfig for the kcp server and include the location of kubectl-ws in `$PATH`.
 
 {%
-   include-markdown "kubestellar-scheduler-subs/kubestellar-scheduler-1-export-kubeconfig-and-path-for-kcp.md"
-   start="<!--kubestellar-scheduler-1-export-kubeconfig-and-path-for-kcp-start-->"
-   end="<!--kubestellar-scheduler-1-export-kubeconfig-and-path-for-kcp-end-->"
+   include-markdown "kubestellar-scheduler-subs/kubestellar-scheduler-1-build-kubestellar.md"
+   start="<!--kubestellar-scheduler-1-build-kubestellar-start-->"
+   end="<!--kubestellar-scheduler-1-build-kubestellar-end-->"
 %}
 
 {%

--- a/docs/content/Coding Milestones/PoC2023q1/placement-translator-subs/placement-translator-process-start-without-cd-kubestellar.md
+++ b/docs/content/Coding Milestones/PoC2023q1/placement-translator-subs/placement-translator-process-start-without-cd-kubestellar.md
@@ -1,7 +1,7 @@
 <!--placement-translator-process-start-without-cd-kubestellar-start-->
 ```shell
 kubectl ws root:espw
-go run ./cmd/placement-translator &
+placement-translator &
 sleep 120
 ```
 <!--placement-translator-process-start-without-cd-kubestellar-end-->

--- a/docs/content/common-subs/pre-req.md
+++ b/docs/content/common-subs/pre-req.md
@@ -101,9 +101,9 @@ else
     fi
 fi
 
-ps -ef | grep mailbox-controller | grep -v grep | awk '{print $2}' | xargs kill >/dev/null 2>&1 || true
-ps -ef | grep kubestellar-scheduler | grep -v grep | awk '{print $2}' | xargs kill >/dev/null 2>&1 || true
-ps -ef | grep placement-translator | grep -v grep | awk '{print $2}' | xargs kill >/dev/null 2>&1 || true
+ps -ef | grep mailbox-controller | grep -v grep | grep -v make | awk '{print $2}' | xargs kill >/dev/null 2>&1 || true
+ps -ef | grep kubestellar-scheduler | grep -v grep | grep -v make | awk '{print $2}' | xargs kill >/dev/null 2>&1 || true
+ps -ef | grep placement-translator | grep -v grep | grep -v make | awk '{print $2}' | xargs kill >/dev/null 2>&1 || true
 ps -ef | grep kcp | grep -v grep | awk '{print $2}' | xargs kill >/dev/null 2>&1 || true
 ps -ef | grep 'exe/main -v 2' | grep -v grep | awk '{print $2}' | xargs kill >/dev/null 2>&1 || true
 kind delete cluster --name florin 2>&1

--- a/docs/content/common-subs/save-some-time.md
+++ b/docs/content/common-subs/save-some-time.md
@@ -1,17 +1,15 @@
 <!--save-some-time-start-->
 !!! tip "This document is 'docs-ecutable' - you can 'run' this document, just like we do in our testing, on your local environment"
     ```
-    git clone -n -b {{config.ks_branch}} {{config.repo_url}} --depth 1 {{config.site_name}}-{{page.meta.short_name}}
-    cd {{config.site_name}}-{{page.meta.short_name}}
-    git restore --staged Makefile Makefile.venv go.mod docs/mkdocs.yml docs/content docs/scripts/docs-ecutable.sh
-    git checkout Makefile Makefile.venv go.mod docs/mkdocs.yml docs/content docs/scripts/docs-ecutable.sh
+    git clone -b {{config.ks_branch}} {{config.repo_url}}
+    cd {{config.repo_default_file_path}}
     make MANIFEST="'{{page.meta.pre_req_name}}','{{page.meta.manifest_name}}'" docs-ecutable
     ```
 
     ```
     # done? remove everything
     make MANIFEST="docs/content/common-subs/remove-all.md" docs-ecutable
-    cd ../
-    rm -rf {{config.site_name}}-{{page.meta.short_name}}
+    cd ..
+    rm -rf {{config.repo_default_file_path}}
     ```
 <!--save-some-time-end-->

--- a/docs/content/common-subs/teardown-the-environment.md
+++ b/docs/content/common-subs/teardown-the-environment.md
@@ -13,7 +13,7 @@ kind delete cluster --name florin
 kind delete cluster --name guilder
 ```
 
-Stop and uninstall KubeStellar use the following command:
+The following command will stop whatever KubeStellar controllers are running.
 
 ``` {.bash}
 kubestellar stop

--- a/docs/scripts/docs-ecutable.sh
+++ b/docs/scripts/docs-ecutable.sh
@@ -36,7 +36,8 @@ include_pattern="\s*include-markdown\s*"
 
 # array to store the shell code blocks
 code_blocks=()
-code_blocks+=("cd $REPO_ROOT/docs/scripts/")
+# code_blocks+=("cd $REPO_ROOT/docs/scripts/")
+code_blocks+=("cd $REPO_ROOT")
 
 if [ -f "/etc/os-release" ]; then
   if [[ $(grep -i "ubuntu" /etc/os-release) ]]; then
@@ -122,7 +123,13 @@ for code_block in "${code_blocks[@]}"; do
   echo "$code_block"  >> "$generated_script_file"
 done
 
+echo
+echo "Generated script file follows"
 cat "$generated_script_file"
+
+echo
+echo "Execution follows"
+set -o xtrace
 
 # make the generated script executable
 chmod +x "$generated_script_file"


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
This PR changes the executable docs to not fetch the KubeStellar repo but rather use the copy of the repo that they find themselves executing in.

This makes the executable documents useful as tests, to developers and to CI.

## Related issue(s)

Fixes #720 
