### PR TITLE
🐛 Fix comment on workload projector

### DIFF
--- a/pkg/placement/workload-projector.go
+++ b/pkg/placement/workload-projector.go
@@ -64,9 +64,10 @@ const FieldManager = "placement-translator"
 // (a) maintains SyncerConfig objects in mailbox workspaces, and
 // (b) propagates changes from source workspaces to mailbox workspaces.
 //
-// This workload projector currently does not react to changes in workload objects
-// in mailbox workspaces. There is currently no designed need for that, except
-// perhaps the general principal that a controller should overwriting competing writes.
+// For a given mailbox workspace, for every resource that the WP is
+// projecting to that MBWS, the WP has an informer on that resource
+// and reacts to the presence of objects previously projected that
+// should not now be projected by deleting that object.
 //
 // This workload projector maintains a dynamic informer for each relevant combination
 // of source cluster, API group, and resource.  Further filtering is done here,


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
This PR updates the comment in the workload projector file's outline comment, to track the addition (done months ago) of monitoring of projected objects.

## Related issue(s)

Fixes #
