### PR TITLE
✨ Make the where-resolver less privileged

### DIFF
--- a/cmd/kubestellar-where-resolver/cmd/where-resolver-cmd.go
+++ b/cmd/kubestellar-where-resolver/cmd/where-resolver-cmd.go
@@ -138,12 +138,12 @@ func Run(ctx context.Context, options *resolveroptions.Options) error {
 	workloadSharedInformerFactory := kcpinformers.NewSharedInformerFactoryWithOptions(workloadViewClusterClientset, resyncPeriod)
 
 	// create where-resolver
-	sysAdmRestConfig, err := options.SysAdmClientOpts.ToRESTConfig()
+	baseRestConfig, err := options.BaseClientOpts.ToRESTConfig()
 	if err != nil {
 		logger.Error(err, "failed to create config from flags")
 		return err
 	}
-	edgeClusterClientset, err := edgeclientset.NewForConfig(sysAdmRestConfig)
+	edgeClusterClientset, err := edgeclientset.NewForConfig(baseRestConfig)
 	if err != nil {
 		logger.Error(err, "failed to create edge clientset for controller")
 		return err

--- a/cmd/kubestellar-where-resolver/options/options.go
+++ b/cmd/kubestellar-where-resolver/options/options.go
@@ -26,10 +26,10 @@ import (
 )
 
 type Options struct {
-	EspwClientOpts   clientoptions.ClientOpts
-	RootClientOpts   clientoptions.ClientOpts
-	SysAdmClientOpts clientoptions.ClientOpts
-	Logs             *logs.Options
+	EspwClientOpts clientoptions.ClientOpts
+	RootClientOpts clientoptions.ClientOpts
+	BaseClientOpts clientoptions.ClientOpts
+	Logs           *logs.Options
 }
 
 func NewOptions() *Options {
@@ -38,10 +38,10 @@ func NewOptions() *Options {
 	logs.Config.Verbosity = config.VerbosityLevel(2)
 
 	return &Options{
-		EspwClientOpts:   *clientoptions.NewClientOpts("espw", "access to the edge service provider workspace"),
-		RootClientOpts:   *clientoptions.NewClientOpts("root", "access to all clusters"),
-		SysAdmClientOpts: *clientoptions.NewClientOpts("sysadm", "access to all clusters as system:admin"),
-		Logs:             logs,
+		EspwClientOpts: *clientoptions.NewClientOpts("espw", "access to the edge service provider workspace"),
+		RootClientOpts: *clientoptions.NewClientOpts("root", "access to the root workspace"),
+		BaseClientOpts: *clientoptions.NewClientOpts("base", "access to all logical clusters as kcp-admin"),
+		Logs:           logs,
 	}
 }
 
@@ -49,8 +49,8 @@ func (options *Options) AddFlags(fs *pflag.FlagSet) {
 	options.EspwClientOpts.AddFlags(fs)
 	options.RootClientOpts.SetDefaultUserAndCluster("kcp-admin", "root")
 	options.RootClientOpts.AddFlags(fs)
-	options.SysAdmClientOpts.SetDefaultCurrentContext("system:admin")
-	options.SysAdmClientOpts.AddFlags(fs)
+	options.BaseClientOpts.SetDefaultUserAndCluster("kcp-admin", "base")
+	options.BaseClientOpts.AddFlags(fs)
 	options.Logs.AddFlags(fs)
 }
 


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
This PR removes unnecessary privileges from the where-resolver, by switching from the `shard-admin` user to the `kcp-admin` user.

Below are the two relevant contexts in kcp's admin-kubeconfig:
```yaml
- context:
    cluster: base
    user: kcp-admin
  name: base
- context:
    cluster: base
    user: shard-admin
  name: system:admin
```

/cc @MikeSpreitzer 

## Related issue(s)
#711 
