### PR TITLE
:sparkles: Use goreleaser for automating to build and push syncer image to quay.io

### DIFF
--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -40,6 +40,13 @@ jobs:
     - name: Set LDFLAGS
       run: echo LDFLAGS="$(make ldflags)" >> $GITHUB_ENV
 
+    - name: Login to quay.io registry
+      uses: docker/login-action@v2
+      with:
+        registry: quay.io
+        username: ${{ secrets.QUAY_USERNAME }}
+        password: ${{ secrets.QUAY_PASSWORD }}
+
     - name: Run GoReleaser on tag
       uses: goreleaser/goreleaser-action@v4
       with:
@@ -48,7 +55,6 @@ jobs:
         args: release --timeout 60m --clean
       env:
         GITHUB_TOKEN: ${{ secrets.GH_ALL_PROJECT_TOKEN }}
-        KO_TOKEN: ${{ secrets.TOKEN }}
         USER: ${{ github.actor }}
         EMAIL: ${{ github.actor}}@users.noreply.github.com
 
@@ -64,12 +70,12 @@ jobs:
         username: ${{ github.actor }}
         password: ${{ secrets.GH_ALL_PROJECT_TOKEN }}
 
-    - name: Package and push chart
-      run: |
-          make build-kubestellar-syncer-image \ 
-          DOCKER_REPO=${{ env.REGISTRY }}/${{ github.actor }}/kubestellar/syncer \
-          IMAGE_TAG=${{ env.RELEASE_VERSION }} \
-          ARCHS=${{ env.ARCHS }}
+    # - name: Package and push chart
+    #   run: |
+    #       make build-kubestellar-syncer-image \ 
+    #       DOCKER_REPO=${{ env.REGISTRY }}/${{ github.actor }}/kubestellar/syncer \
+    #       IMAGE_TAG=${{ env.RELEASE_VERSION }} \
+    #       ARCHS=${{ env.ARCHS }}
     
     # make chart IMG=${{ env.REGISTRY }}/${{ env.OPERATOR_IMAGE }}:${{github.ref_name}}
     # helm package ${{ env.CHART_PATH }} --destination . --version ${{github.ref_name}}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,0 +1,31 @@
+# .goreleaser.yaml
+builds:
+- skip: true # skip build for now since we have another mechanism to build all kubestellar binaries
+  id: kubestellar-syncer
+  main: ./cmd/syncer
+  binary: kubestellar-syncer
+  goos:
+  - linux
+  - darwin
+  goarch:
+  - amd64
+  - arm64
+  - s390x
+
+kos:
+- build: kubestellar-syncer
+  main: ./cmd/syncer
+  repository: quay.io/kubestellar/syncer
+  tags:
+  - '{{.Version}}'
+  bare: true
+  base_image: cgr.dev/chainguard/static
+  preserve_import_paths: false
+  sbom: none
+  platforms:
+  - linux/amd64
+  - linux/arm64
+  - linux/s390x
+
+release:
+  disable: true # disable to publish artifacts to Github release since we have another mechanism to do it.

--- a/Makefile
+++ b/Makefile
@@ -136,9 +136,10 @@ build-all:
 build-kubestellar-syncer-image: DOCKER_REPO ?= 
 build-kubestellar-syncer-image: IMAGE_TAG ?= latest
 build-kubestellar-syncer-image: ARCHS ?= linux/$(ARCH)
+build-kubestellar-syncer-image: ADDITIONAL_ARGS ?= --sbom=none # quay.io hasn't supported SPDX media type for SBOM yet (https://github.com/ko-build/ko/issues/970#issuecomment-1456951250)
 build-kubestellar-syncer-image: require-ko
-	echo KO_DOCKER_REPO=$(DOCKER_REPO) ko build --platform=$(ARCHS) --bare --tags $(IMAGE_TAG) ./cmd/syncer
-	$(eval SYNCER_IMAGE=$(shell KO_DOCKER_REPO=$(DOCKER_REPO) ko build --platform=$(ARCHS) --bare --tags $(IMAGE_TAG) ./cmd/syncer))
+	echo KO_DOCKER_REPO=$(DOCKER_REPO) ko build --platform=$(ARCHS) --bare --tags $(IMAGE_TAG) $(ADDITIONAL_ARGS) ./cmd/syncer
+	$(eval SYNCER_IMAGE=$(shell KO_DOCKER_REPO=$(DOCKER_REPO) ko build --platform=$(ARCHS) --bare --tags $(IMAGE_TAG) $(ADDITIONAL_ARGS) ./cmd/syncer))
 	@echo "$(SYNCER_IMAGE)"
 
 .PHONY: build-kubestellar-syncer-image-local


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

Currently there is no .goreleaser.yaml that is required for goreleaser github action. I created .goreleaser.yaml whose configuration is to create and push syncer image to `quay.io/kubestellar/syncer:<release tag>` in goreleaser github action. Note that the section `builds` and `release` in  .goreleaser.yaml are disabled since we have another way to build binaries and publish the archive to release artifacts.  

Here is the example in the case of forked github repository with setting my personal quay.io repository to `kos[].repository` in gorelease.yaml.
Github action job: https://github.com/yana1205/kubestellar/actions/runs/5479915632/jobs/9982395090
The pushed image is kubestellar-syncer:0.3.2 (https://quay.io/repository/yanagawa_takumi1205/kubestellar-syncer?tab=tags.)

The following secrets are required in Actions secrets and variables in github.
- QUAY_USERNAME (quay.io username, e.g. yanagawa_takumi1205) 
- QUAY_PASSWORD (quay.io docker login password, https://docs.quay.io/solution/getting-started.html)

## Related issue(s)

Fixes #
