### PR TITLE
✨ Make where-resolver work for both kcp and plain Kubernetes

### DIFF
--- a/cmd/kubestellar-where-resolver/cmd/where-resolver-cmd.go
+++ b/cmd/kubestellar-where-resolver/cmd/where-resolver-cmd.go
@@ -36,7 +36,7 @@ import (
 
 	resolveroptions "github.com/kubestellar/kubestellar/cmd/kubestellar-where-resolver/options"
 	ksclientset "github.com/kubestellar/kubestellar/pkg/client/clientset/versioned"
-	edgeclientset "github.com/kubestellar/kubestellar/pkg/client/clientset/versioned/cluster"
+	edgeclusterclientset "github.com/kubestellar/kubestellar/pkg/client/clientset/versioned/cluster"
 	edgeinformers "github.com/kubestellar/kubestellar/pkg/client/informers/externalversions"
 	edgev1alpha1informers "github.com/kubestellar/kubestellar/pkg/client/informers/externalversions/edge/v1alpha1"
 	wheresolver "github.com/kubestellar/kubestellar/pkg/where-resolver"
@@ -116,7 +116,7 @@ func Run(ctx context.Context, options *resolveroptions.Options) error {
 			logger.Error(err, "failed to create config from flags")
 			return err
 		}
-		edgeClusterClientset, err := edgeclientset.NewForConfig(baseRestConfig)
+		edgeClusterClientset, err := edgeclusterclientset.NewForConfig(baseRestConfig)
 		if err != nil {
 			logger.Error(err, "failed to create edge all-cluster clientset for controller")
 			return err
@@ -162,7 +162,7 @@ func Run(ctx context.Context, options *resolveroptions.Options) error {
 
 		return nil
 	} else { // kcp
-		edgeViewClusterClientset, err := edgeclientset.NewForConfig(edgeViewConfig)
+		edgeViewClusterClientset, err := edgeclusterclientset.NewForConfig(edgeViewConfig)
 		if err != nil {
 			logger.Error(err, "failed to create clientset for view of edge exports")
 			return err
@@ -174,7 +174,7 @@ func Run(ctx context.Context, options *resolveroptions.Options) error {
 			logger.Error(err, "failed to create config from flags")
 			return err
 		}
-		edgeClusterClientset, err := edgeclientset.NewForConfig(baseRestConfig)
+		edgeClusterClientset, err := edgeclusterclientset.NewForConfig(baseRestConfig)
 		if err != nil {
 			logger.Error(err, "failed to create edge all-cluster clientset for controller")
 			return err

--- a/cmd/kubestellar-where-resolver/cmd/where-resolver-cmd.go
+++ b/cmd/kubestellar-where-resolver/cmd/where-resolver-cmd.go
@@ -98,7 +98,7 @@ func Run(ctx context.Context, options *resolveroptions.Options) error {
 	}
 
 	var edgeViewConfig *rest.Config
-	if options.Provider == resolveroptions.ClusterProviderKCP {
+	if options.Provider == wheresolver.ClusterProviderKCP {
 		edgeViewConfig, err = configForViewOfExport(ctx, espwRestConfig, "edge.kubestellar.io")
 		if err != nil {
 			logger.Error(err, "failed to create config for view of edge exports")
@@ -108,7 +108,7 @@ func Run(ctx context.Context, options *resolveroptions.Options) error {
 		edgeViewConfig = espwRestConfig
 	}
 
-	if options.Provider == resolveroptions.ClusterProviderKube {
+	if options.Provider == wheresolver.ClusterProviderKube {
 		edgeViewClusterClientset, err := ksclientset.NewForConfig(edgeViewConfig)
 		if err != nil {
 			logger.Error(err, "failed to create clientset for view of edge exports")
@@ -135,12 +135,15 @@ func Run(ctx context.Context, options *resolveroptions.Options) error {
 		var singlePlacementSliceAccess = edgeSharedInformerFactory.Edge().V1alpha1().SinglePlacementSlices()
 		var locationAccess = edgeSharedInformerFactory.Edge().V1alpha1().Locations()
 		var synctargetAccess = edgeSharedInformerFactory.Edge().V1alpha1().SyncTargets()
-		// experiment
+		// TODO(waltforme): sanity check
 		wheresolver.IdentifyEpAccessScope(&edgePlacementAccess)
 		es, err := wheresolver.NewController[
 			*edgev1alpha1informers.EdgePlacementInformer,
 			*edgev1alpha1informers.SinglePlacementSliceInformer,
+			*edgev1alpha1informers.LocationInformer,
+			*edgev1alpha1informers.SyncTargetInformer,
 		](
+			options.Provider,
 			ctx,
 			edgeClusterClientset,
 			edgeClientset,
@@ -178,7 +181,7 @@ func Run(ctx context.Context, options *resolveroptions.Options) error {
 			return err
 		}
 		var schedulingViewConfig *rest.Config = rootRestConfig
-		if options.Provider == resolveroptions.ClusterProviderKCP {
+		if options.Provider == wheresolver.ClusterProviderKCP {
 			schedulingViewConfig, err = configForViewOfExport(ctx, rootRestConfig, "scheduling.kcp.io")
 			if err != nil {
 				logger.Error(err, "failed to create config for view of scheduling exports")
@@ -194,7 +197,7 @@ func Run(ctx context.Context, options *resolveroptions.Options) error {
 
 		// create workloadSharedInformerFactory
 		var workloadViewConfig *rest.Config = rootRestConfig
-		if options.Provider == resolveroptions.ClusterProviderKCP {
+		if options.Provider == wheresolver.ClusterProviderKCP {
 			workloadViewConfig, err = configForViewOfExport(ctx, rootRestConfig, "workload.kcp.io")
 			if err != nil {
 				logger.Error(err, "failed to create config for view of workload exports")
@@ -227,9 +230,15 @@ func Run(ctx context.Context, options *resolveroptions.Options) error {
 		var singlePlacementSliceAccess = edgeSharedInformerFactory.Edge().V1alpha1().SinglePlacementSlices()
 		var locationAccess = edgeSharedInformerFactory.Edge().V1alpha1().Locations()
 		var synctargetAccess = edgeSharedInformerFactory.Edge().V1alpha1().SyncTargets()
-		// experiment
+		// TODO(waltforme): sanity check
 		wheresolver.IdentifyEpAccessScope(&edgePlacementAccess)
-		es, err := wheresolver.NewController[*edgev1alpha1informers.EdgePlacementClusterInformer](
+		es, err := wheresolver.NewController[
+			*edgev1alpha1informers.EdgePlacementClusterInformer,
+			*edgev1alpha1informers.SinglePlacementSliceClusterInformer,
+			*edgev1alpha1informers.LocationClusterInformer,
+			*edgev1alpha1informers.SyncTargetClusterInformer,
+		](
+			options.Provider,
 			ctx,
 			edgeClusterClientset,
 			edgeClientset,

--- a/cmd/kubestellar-where-resolver/cmd/where-resolver-cmd.go
+++ b/cmd/kubestellar-where-resolver/cmd/where-resolver-cmd.go
@@ -94,10 +94,13 @@ func Run(ctx context.Context, options *resolveroptions.Options) error {
 		logger.Error(err, "failed to create config from flags")
 		return err
 	}
-	edgeViewConfig, err := configForViewOfExport(ctx, espwRestConfig, "edge.kubestellar.io")
-	if err != nil {
-		logger.Error(err, "failed to create config for view of edge exports")
-		return err
+	var edgeViewConfig *rest.Config = espwRestConfig
+	if options.Provider == resolveroptions.ClusterProviderKCP {
+		edgeViewConfig, err = configForViewOfExport(ctx, espwRestConfig, "edge.kubestellar.io")
+		if err != nil {
+			logger.Error(err, "failed to create config for view of edge exports")
+			return err
+		}
 	}
 	edgeViewClusterClientset, err := edgeclientset.NewForConfig(edgeViewConfig)
 	if err != nil {
@@ -112,10 +115,13 @@ func Run(ctx context.Context, options *resolveroptions.Options) error {
 		logger.Error(err, "failed to create config from flags")
 		return err
 	}
-	schedulingViewConfig, err := configForViewOfExport(ctx, rootRestConfig, "scheduling.kcp.io")
-	if err != nil {
-		logger.Error(err, "failed to create config for view of scheduling exports")
-		return err
+	var schedulingViewConfig *rest.Config = rootRestConfig
+	if options.Provider == resolveroptions.ClusterProviderKCP {
+		schedulingViewConfig, err = configForViewOfExport(ctx, rootRestConfig, "scheduling.kcp.io")
+		if err != nil {
+			logger.Error(err, "failed to create config for view of scheduling exports")
+			return err
+		}
 	}
 	schedulingViewClusterClientset, err := kcpclientset.NewForConfig(schedulingViewConfig)
 	if err != nil {
@@ -125,10 +131,13 @@ func Run(ctx context.Context, options *resolveroptions.Options) error {
 	schedulingSharedInformerFactory := kcpinformers.NewSharedInformerFactoryWithOptions(schedulingViewClusterClientset, resyncPeriod)
 
 	// create workloadSharedInformerFactory
-	workloadViewConfig, err := configForViewOfExport(ctx, rootRestConfig, "workload.kcp.io")
-	if err != nil {
-		logger.Error(err, "failed to create config for view of workload exports")
-		return err
+	var workloadViewConfig *rest.Config = rootRestConfig
+	if options.Provider == resolveroptions.ClusterProviderKCP {
+		workloadViewConfig, err = configForViewOfExport(ctx, rootRestConfig, "workload.kcp.io")
+		if err != nil {
+			logger.Error(err, "failed to create config for view of workload exports")
+			return err
+		}
 	}
 	workloadViewClusterClientset, err := kcpclientset.NewForConfig(workloadViewConfig)
 	if err != nil {

--- a/cmd/kubestellar-where-resolver/options/options.go
+++ b/cmd/kubestellar-where-resolver/options/options.go
@@ -41,7 +41,6 @@ func NewOptions() *Options {
 
 	// Default to use kcp
 	var provider wheresolver.ClusterProvider = wheresolver.ClusterProviderKCP
-	// var provider wheresolver.ClusterProvider = wheresolver.ClusterProviderKube
 
 	return &Options{
 		EspwClientOpts: *clientoptions.NewClientOpts("espw", "access to the edge service provider workspace"),

--- a/cmd/kubestellar-where-resolver/options/options.go
+++ b/cmd/kubestellar-where-resolver/options/options.go
@@ -23,13 +23,7 @@ import (
 	"k8s.io/component-base/logs"
 
 	clientoptions "github.com/kubestellar/kubestellar/pkg/client-options"
-)
-
-type ClusterProvider string
-
-const (
-	ClusterProviderKCP  = "kcp"
-	ClusterProviderKube = "kubernetes"
+	wheresolver "github.com/kubestellar/kubestellar/pkg/where-resolver"
 )
 
 type Options struct {
@@ -37,7 +31,7 @@ type Options struct {
 	RootClientOpts clientoptions.ClientOpts
 	BaseClientOpts clientoptions.ClientOpts
 	Logs           *logs.Options
-	Provider       ClusterProvider
+	Provider       wheresolver.ClusterProvider
 }
 
 func NewOptions() *Options {
@@ -46,8 +40,8 @@ func NewOptions() *Options {
 	logs.Config.Verbosity = config.VerbosityLevel(2)
 
 	// Default to use kcp
-	// var provider ClusterProvider = ClusterProviderKCP
-	var provider ClusterProvider = ClusterProviderKube
+	var provider wheresolver.ClusterProvider = wheresolver.ClusterProviderKCP
+	// var provider wheresolver.ClusterProvider = wheresolver.ClusterProviderKube
 
 	return &Options{
 		EspwClientOpts: *clientoptions.NewClientOpts("espw", "access to the edge service provider workspace"),
@@ -63,7 +57,7 @@ func (options *Options) AddFlags(fs *pflag.FlagSet) {
 	options.RootClientOpts.AddFlags(fs)
 	options.BaseClientOpts.AddFlags(fs)
 
-	if options.Provider == ClusterProviderKCP {
+	if options.Provider == wheresolver.ClusterProviderKCP {
 		options.RootClientOpts.SetDefaultUserAndCluster("kcp-admin", "root")
 		options.BaseClientOpts.SetDefaultUserAndCluster("kcp-admin", "base")
 	}

--- a/cmd/kubestellar-where-resolver/options/options.go
+++ b/cmd/kubestellar-where-resolver/options/options.go
@@ -46,7 +46,8 @@ func NewOptions() *Options {
 	logs.Config.Verbosity = config.VerbosityLevel(2)
 
 	// Default to use kcp
-	var provider ClusterProvider = ClusterProviderKCP
+	// var provider ClusterProvider = ClusterProviderKCP
+	var provider ClusterProvider = ClusterProviderKube
 
 	return &Options{
 		EspwClientOpts: *clientoptions.NewClientOpts("espw", "access to the edge service provider workspace"),

--- a/pkg/where-resolver/clienttypes.go
+++ b/pkg/where-resolver/clienttypes.go
@@ -1,0 +1,64 @@
+/*
+Copyright 2023 The KubeStellar Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package where_resolver
+
+import (
+	"fmt"
+
+	ksclientset "github.com/kubestellar/kubestellar/pkg/client/clientset/versioned"
+	edgeclientset "github.com/kubestellar/kubestellar/pkg/client/clientset/versioned/cluster"
+	edgev1alpha1informers "github.com/kubestellar/kubestellar/pkg/client/informers/externalversions/edge/v1alpha1"
+	// edgev1alpha1listers "github.com/kubestellar/kubestellar/pkg/client/listers/edge/v1alpha1"
+)
+
+type (
+	OneClusterClient ksclientset.Interface
+	AllClusterClient edgeclientset.ClusterInterface
+
+	EpAccess interface {
+		*edgev1alpha1informers.EdgePlacementInformer | *edgev1alpha1informers.EdgePlacementClusterInformer
+	}
+
+	SpsAccess interface {
+		*edgev1alpha1informers.SinglePlacementSliceInformer | *edgev1alpha1informers.SinglePlacementSliceClusterInformer
+	}
+
+	LocAccess interface {
+		*edgev1alpha1informers.LocationInformer | *edgev1alpha1informers.LocationClusterInformer
+	}
+
+	StAccess interface {
+		*edgev1alpha1informers.SyncTargetInformer | *edgev1alpha1informers.SyncTargetClusterInformer
+	}
+)
+
+func IdentifyEpAccessScope[A EpAccess](access A) string {
+	switch any(access).(type) {
+	case string:
+		return "a string"
+	default:
+		if a, ok := any(access).(*edgev1alpha1informers.EdgePlacementInformer); ok {
+			fmt.Printf("pointer of edgev1alpha1informers.EdgePlacementInformer at %v\n", a)
+			return "one cluster EdgePlacement Access"
+		} else if a, ok := any(access).(*edgev1alpha1informers.EdgePlacementClusterInformer); ok {
+			fmt.Printf("pointer of edgev1alpha1informers.EdgePlacementClusterInformer at %v\n", a)
+			return "all Cluster EdgePlacement Access"
+		}
+	}
+	fmt.Println("something mystery")
+	return "something mystery"
+}

--- a/pkg/where-resolver/clienttypes.go
+++ b/pkg/where-resolver/clienttypes.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 
 	ksclientset "github.com/kubestellar/kubestellar/pkg/client/clientset/versioned"
-	edgeclientset "github.com/kubestellar/kubestellar/pkg/client/clientset/versioned/cluster"
+	edgeclusterclientset "github.com/kubestellar/kubestellar/pkg/client/clientset/versioned/cluster"
 	edgev1alpha1informers "github.com/kubestellar/kubestellar/pkg/client/informers/externalversions/edge/v1alpha1"
 )
 
@@ -33,7 +33,7 @@ const (
 
 type (
 	OneClusterClient ksclientset.Interface
-	AllClusterClient edgeclientset.ClusterInterface
+	AllClusterClient edgeclusterclientset.ClusterInterface
 
 	EpAccess interface {
 		*edgev1alpha1informers.EdgePlacementInformer | *edgev1alpha1informers.EdgePlacementClusterInformer

--- a/pkg/where-resolver/clienttypes.go
+++ b/pkg/where-resolver/clienttypes.go
@@ -22,7 +22,13 @@ import (
 	ksclientset "github.com/kubestellar/kubestellar/pkg/client/clientset/versioned"
 	edgeclientset "github.com/kubestellar/kubestellar/pkg/client/clientset/versioned/cluster"
 	edgev1alpha1informers "github.com/kubestellar/kubestellar/pkg/client/informers/externalversions/edge/v1alpha1"
-	// edgev1alpha1listers "github.com/kubestellar/kubestellar/pkg/client/listers/edge/v1alpha1"
+)
+
+type ClusterProvider string
+
+const (
+	ClusterProviderKCP  ClusterProvider = "kcp"
+	ClusterProviderKube ClusterProvider = "kubernetes"
 )
 
 type (
@@ -32,15 +38,12 @@ type (
 	EpAccess interface {
 		*edgev1alpha1informers.EdgePlacementInformer | *edgev1alpha1informers.EdgePlacementClusterInformer
 	}
-
 	SpsAccess interface {
 		*edgev1alpha1informers.SinglePlacementSliceInformer | *edgev1alpha1informers.SinglePlacementSliceClusterInformer
 	}
-
 	LocAccess interface {
 		*edgev1alpha1informers.LocationInformer | *edgev1alpha1informers.LocationClusterInformer
 	}
-
 	StAccess interface {
 		*edgev1alpha1informers.SyncTargetInformer | *edgev1alpha1informers.SyncTargetClusterInformer
 	}
@@ -56,7 +59,7 @@ func IdentifyEpAccessScope[A EpAccess](access A) string {
 			return "one cluster EdgePlacement Access"
 		} else if a, ok := any(access).(*edgev1alpha1informers.EdgePlacementClusterInformer); ok {
 			fmt.Printf("pointer of edgev1alpha1informers.EdgePlacementClusterInformer at %v\n", a)
-			return "all Cluster EdgePlacement Access"
+			return "all cluster EdgePlacement Access"
 		}
 	}
 	fmt.Println("something mystery")

--- a/pkg/where-resolver/controller.go
+++ b/pkg/where-resolver/controller.go
@@ -31,6 +31,7 @@ import (
 	kcpcache "github.com/kcp-dev/apimachinery/v2/pkg/cache"
 
 	edgev1alpha1 "github.com/kubestellar/kubestellar/pkg/apis/edge/v1alpha1"
+	ksclientset "github.com/kubestellar/kubestellar/pkg/client/clientset/versioned"
 	edgeclientset "github.com/kubestellar/kubestellar/pkg/client/clientset/versioned/cluster"
 	edgev1alpha1informers "github.com/kubestellar/kubestellar/pkg/client/informers/externalversions/edge/v1alpha1"
 	edgev1alpha1listers "github.com/kubestellar/kubestellar/pkg/client/listers/edge/v1alpha1"
@@ -58,27 +59,37 @@ type controller struct {
 	queue   workqueue.RateLimitingInterface
 
 	edgeClusterClient edgeclientset.ClusterInterface
+	edgeClient        ksclientset.Interface
 
-	singlePlacementSliceLister  edgev1alpha1listers.SinglePlacementSliceClusterLister
+	// singlePlacementSliceLister  edgev1alpha1listers.SinglePlacementSliceClusterLister
+	singlePlacementSliceLister  edgev1alpha1listers.SinglePlacementSliceLister
 	singlePlacementSliceIndexer cache.Indexer
 
-	edgePlacementLister  edgev1alpha1listers.EdgePlacementClusterLister
+	// edgePlacementLister  edgev1alpha1listers.EdgePlacementClusterLister
+	edgePlacementLister  edgev1alpha1listers.EdgePlacementLister
 	edgePlacementIndexer cache.Indexer
 
-	locationLister  edgev1alpha1listers.LocationClusterLister
+	// locationLister  edgev1alpha1listers.LocationClusterLister
+	locationLister  edgev1alpha1listers.LocationLister
 	locationIndexer cache.Indexer
 
-	synctargetLister  edgev1alpha1listers.SyncTargetClusterLister
+	// synctargetLister  edgev1alpha1listers.SyncTargetClusterLister
+	synctargetLister  edgev1alpha1listers.SyncTargetLister
 	synctargetIndexer cache.Indexer
 }
 
 func NewController(
 	context context.Context,
 	edgeClusterClient edgeclientset.ClusterInterface,
-	edgePlacementAccess edgev1alpha1informers.EdgePlacementClusterInformer,
-	singlePlacementSliceAccess edgev1alpha1informers.SinglePlacementSliceClusterInformer,
-	locationAccess edgev1alpha1informers.LocationClusterInformer,
-	syncTargetAccess edgev1alpha1informers.SyncTargetClusterInformer,
+	edgeClient ksclientset.Interface,
+	// edgePlacementAccess edgev1alpha1informers.EdgePlacementClusterInformer,
+	// singlePlacementSliceAccess edgev1alpha1informers.SinglePlacementSliceClusterInformer,
+	// locationAccess edgev1alpha1informers.LocationClusterInformer,
+	// syncTargetAccess edgev1alpha1informers.SyncTargetClusterInformer,
+	edgePlacementAccess edgev1alpha1informers.EdgePlacementInformer,
+	singlePlacementSliceAccess edgev1alpha1informers.SinglePlacementSliceInformer,
+	locationAccess edgev1alpha1informers.LocationInformer,
+	syncTargetAccess edgev1alpha1informers.SyncTargetInformer,
 ) (*controller, error) {
 	context = klog.NewContext(context, klog.FromContext(context).WithValues("controller", ControllerName))
 	queue := workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), ControllerName)
@@ -88,6 +99,7 @@ func NewController(
 		queue:   queue,
 
 		edgeClusterClient: edgeClusterClient,
+		edgeClient:        edgeClient,
 
 		edgePlacementLister:  edgePlacementAccess.Lister(),
 		edgePlacementIndexer: edgePlacementAccess.Informer().GetIndexer(),

--- a/pkg/where-resolver/controller.go
+++ b/pkg/where-resolver/controller.go
@@ -33,7 +33,7 @@ import (
 
 	edgev1alpha1 "github.com/kubestellar/kubestellar/pkg/apis/edge/v1alpha1"
 	ksclientset "github.com/kubestellar/kubestellar/pkg/client/clientset/versioned"
-	edgeclientset "github.com/kubestellar/kubestellar/pkg/client/clientset/versioned/cluster"
+	edgeclusterclientset "github.com/kubestellar/kubestellar/pkg/client/clientset/versioned/cluster"
 	edgev1alpha1informers "github.com/kubestellar/kubestellar/pkg/client/informers/externalversions/edge/v1alpha1"
 	edgev1alpha1listers "github.com/kubestellar/kubestellar/pkg/client/listers/edge/v1alpha1"
 )
@@ -60,7 +60,7 @@ type controller struct {
 	context  context.Context
 	queue    workqueue.RateLimitingInterface
 
-	edgeClusterClient edgeclientset.ClusterInterface
+	edgeClusterClient edgeclusterclientset.ClusterInterface
 	edgeClient        ksclientset.Interface
 
 	edgePlacementClusterLister edgev1alpha1listers.EdgePlacementClusterLister
@@ -88,7 +88,7 @@ func NewController[
 ](
 	provider ClusterProvider,
 	context context.Context,
-	edgeClusterClient edgeclientset.ClusterInterface,
+	edgeClusterClient edgeclusterclientset.ClusterInterface,
 	edgeClient ksclientset.Interface,
 	edgePlacementAccess EpA,
 	singlePlacementSliceAccess SpsA,

--- a/pkg/where-resolver/controller.go
+++ b/pkg/where-resolver/controller.go
@@ -32,7 +32,7 @@ import (
 	kcpcache "github.com/kcp-dev/apimachinery/v2/pkg/cache"
 
 	edgev1alpha1 "github.com/kubestellar/kubestellar/pkg/apis/edge/v1alpha1"
-	ksclientset "github.com/kubestellar/kubestellar/pkg/client/clientset/versioned"
+	edgeclientset "github.com/kubestellar/kubestellar/pkg/client/clientset/versioned"
 	edgeclusterclientset "github.com/kubestellar/kubestellar/pkg/client/clientset/versioned/cluster"
 	edgev1alpha1informers "github.com/kubestellar/kubestellar/pkg/client/informers/externalversions/edge/v1alpha1"
 	edgev1alpha1listers "github.com/kubestellar/kubestellar/pkg/client/listers/edge/v1alpha1"
@@ -61,7 +61,7 @@ type controller struct {
 	queue    workqueue.RateLimitingInterface
 
 	edgeClusterClient edgeclusterclientset.ClusterInterface
-	edgeClient        ksclientset.Interface
+	edgeClient        edgeclientset.Interface
 
 	edgePlacementClusterLister edgev1alpha1listers.EdgePlacementClusterLister
 	edgePlacementLister        edgev1alpha1listers.EdgePlacementLister
@@ -89,7 +89,7 @@ func NewController[
 	provider ClusterProvider,
 	context context.Context,
 	edgeClusterClient edgeclusterclientset.ClusterInterface,
-	edgeClient ksclientset.Interface,
+	edgeClient edgeclientset.Interface,
 	edgePlacementAccess EpA,
 	singlePlacementSliceAccess SpsA,
 	locationAccess LocA,

--- a/pkg/where-resolver/controller.go
+++ b/pkg/where-resolver/controller.go
@@ -56,8 +56,9 @@ type queueItem struct {
 }
 
 type controller struct {
-	context context.Context
-	queue   workqueue.RateLimitingInterface
+	provider ClusterProvider
+	context  context.Context
+	queue    workqueue.RateLimitingInterface
 
 	edgeClusterClient edgeclientset.ClusterInterface
 	edgeClient        ksclientset.Interface
@@ -85,6 +86,7 @@ func NewController[
 	LocA LocAccess,
 	StA StAccess,
 ](
+	provider ClusterProvider,
 	context context.Context,
 	edgeClusterClient edgeclientset.ClusterInterface,
 	edgeClient ksclientset.Interface,
@@ -106,8 +108,9 @@ func NewController[
 	loca := reflect.ValueOf(locationAccess).Interface().(*edgev1alpha1informers.LocationInformer)
 	sta := reflect.ValueOf(syncTargetAccess).Interface().(*edgev1alpha1informers.SyncTargetInformer)
 	c := &controller{
-		context: context,
-		queue:   queue,
+		provider: provider,
+		context:  context,
+		queue:    queue,
 
 		edgeClusterClient: edgeClusterClient,
 		edgeClient:        edgeClient,

--- a/pkg/where-resolver/reconcile_on_edgeplacement.go
+++ b/pkg/where-resolver/reconcile_on_edgeplacement.go
@@ -57,7 +57,8 @@ func (c *controller) reconcileOnEdgePlacement(ctx context.Context, epKey string)
 	store.l.Lock()
 	defer store.l.Unlock() // TODO(waltforme): Is it safe to shorten the critical section?
 
-	ep, err := c.edgePlacementLister.Cluster(epws).Get(epName)
+	// ep, err := c.edgePlacementLister.Cluster(epws).Get(epName)
+	ep, err := c.edgePlacementLister.Get(epName)
 	if err != nil {
 		if errors.IsNotFound(err) {
 			logger.V(1).Info("EdgePlacement not found")
@@ -86,7 +87,8 @@ func (c *controller) reconcileOnEdgePlacement(ctx context.Context, epKey string)
 	for _, loc := range locsFilteredByEp {
 		// 2)
 		lws := logicalcluster.From(loc)
-		stsInLws, err := c.synctargetLister.Cluster(lws).List(labels.Everything())
+		// stsInLws, err := c.synctargetLister.Cluster(lws).List(labels.Everything())
+		stsInLws, err := c.synctargetLister.List(labels.Everything())
 		if err != nil {
 			logger.Error(err, "failed to list SyncTargets in Location workspace", "locationWorkspace", lws.String())
 			return err
@@ -114,7 +116,8 @@ func (c *controller) reconcileOnEdgePlacement(ctx context.Context, epKey string)
 	}
 
 	// 4)
-	currentSPS, err := c.singlePlacementSliceLister.Cluster(epws).Get(epName)
+	// currentSPS, err := c.singlePlacementSliceLister.Cluster(epws).Get(epName)
+	currentSPS, err := c.singlePlacementSliceLister.Get(epName)
 	if err != nil {
 		if errors.IsNotFound(err) { // create
 			logger.V(1).Info("creating SinglePlacementSlice")
@@ -132,7 +135,8 @@ func (c *controller) reconcileOnEdgePlacement(ctx context.Context, epKey string)
 				},
 				Destinations: singles,
 			}
-			_, err = c.edgeClusterClient.Cluster(epws.Path()).EdgeV1alpha1().SinglePlacementSlices().Create(ctx, sps, metav1.CreateOptions{})
+			// _, err = c.edgeClusterClient.Cluster(epws.Path()).EdgeV1alpha1().SinglePlacementSlices().Create(ctx, sps, metav1.CreateOptions{})
+			_, err = c.edgeClient.EdgeV1alpha1().SinglePlacementSlices().Create(ctx, sps, metav1.CreateOptions{})
 			if err != nil {
 				if !errors.IsAlreadyExists(err) {
 					logger.Error(err, "failed creating SinglePlacementSlice")
@@ -147,7 +151,8 @@ func (c *controller) reconcileOnEdgePlacement(ctx context.Context, epKey string)
 		}
 	} else { // update
 		currentSPS.Destinations = singles
-		_, err = c.edgeClusterClient.Cluster(epws.Path()).EdgeV1alpha1().SinglePlacementSlices().Update(ctx, currentSPS, metav1.UpdateOptions{})
+		// _, err = c.edgeClusterClient.Cluster(epws.Path()).EdgeV1alpha1().SinglePlacementSlices().Update(ctx, currentSPS, metav1.UpdateOptions{})
+		_, err = c.edgeClient.EdgeV1alpha1().SinglePlacementSlices().Update(ctx, currentSPS, metav1.UpdateOptions{})
 		if err != nil {
 			logger.Error(err, "failed updating SinglePlacementSlice")
 			return err

--- a/pkg/where-resolver/reconcile_on_location.go
+++ b/pkg/where-resolver/reconcile_on_location.go
@@ -66,7 +66,8 @@ func (c *controller) reconcileOnLocation(ctx context.Context, locKey string) err
 	defer store.l.Unlock() // TODO(waltforme): Is it safe to shorten the critical section?
 
 	locDeleted := false
-	loc, err := c.locationLister.Cluster(lws).Get(lName)
+	// loc, err := c.locationLister.Cluster(lws).Get(lName)
+	loc, err := c.locationLister.Get(lName)
 	if err != nil {
 		if errors.IsNotFound(err) {
 			logger.V(1).Info("Location not found")
@@ -83,7 +84,8 @@ func (c *controller) reconcileOnLocation(ctx context.Context, locKey string) err
 	// 2a)
 	stsFilteredByLoc := []*edgev1alpha1.SyncTarget{}
 	if !locDeleted {
-		stsInLws, err := c.synctargetLister.Cluster(lws).List(labels.Everything())
+		// stsInLws, err := c.synctargetLister.Cluster(lws).List(labels.Everything())
+		stsInLws, err := c.synctargetLister.List(labels.Everything())
 		if err != nil {
 			logger.Error(err, "failed to list SyncTargets")
 			return err
@@ -148,13 +150,15 @@ func (c *controller) reconcileOnLocation(ctx context.Context, locKey string) err
 				logger.Error(err, "invalid EdgePlacement key")
 				return err
 			}
-			currentSPS, err := c.singlePlacementSliceLister.Cluster(ws).Get(name)
+			// currentSPS, err := c.singlePlacementSliceLister.Cluster(ws).Get(name)
+			currentSPS, err := c.singlePlacementSliceLister.Get(name)
 			if err != nil {
 				logger.Error(err, "failed to get SinglePlacementSlice", "workloadWorkspace", ws, "singlePlacementSlice", name)
 				return err
 			}
 			nextSPS := cleanSPSByLoc(currentSPS, lws.String(), lName)
-			_, err = c.edgeClusterClient.EdgeV1alpha1().SinglePlacementSlices().Cluster(ws.Path()).Update(ctx, nextSPS, metav1.UpdateOptions{})
+			// _, err = c.edgeClusterClient.EdgeV1alpha1().SinglePlacementSlices().Cluster(ws.Path()).Update(ctx, nextSPS, metav1.UpdateOptions{})
+			_, err = c.edgeClient.EdgeV1alpha1().SinglePlacementSlices().Update(ctx, nextSPS, metav1.UpdateOptions{})
 			if err != nil {
 				logger.Error(err, "failed to update SinglePlacementSlice", "workloadWorkspace", ws, "singlePlacementSlice", nextSPS.Name)
 				return err
@@ -173,7 +177,8 @@ func (c *controller) reconcileOnLocation(ctx context.Context, locKey string) err
 				logger.Error(err, "invalid EdgePlacement key")
 				return err
 			}
-			currentSPS, err := c.singlePlacementSliceLister.Cluster(ws).Get(name)
+			// currentSPS, err := c.singlePlacementSliceLister.Cluster(ws).Get(name)
+			currentSPS, err := c.singlePlacementSliceLister.Get(name)
 			if err != nil {
 				logger.Error(err, "failed to get SinglePlacementSlice", "workloadWorkspace", ws, "singlePlacementSlice", name)
 				return err
@@ -182,7 +187,8 @@ func (c *controller) reconcileOnLocation(ctx context.Context, locKey string) err
 			nextSPS := cleanSPSByLoc(currentSPS, lws.String(), lName)
 			nextSPS = extendSPS(nextSPS, singles)
 
-			_, err = c.edgeClusterClient.EdgeV1alpha1().SinglePlacementSlices().Cluster(ws.Path()).Update(ctx, nextSPS, metav1.UpdateOptions{})
+			// _, err = c.edgeClusterClient.EdgeV1alpha1().SinglePlacementSlices().Cluster(ws.Path()).Update(ctx, nextSPS, metav1.UpdateOptions{})
+			_, err = c.edgeClient.EdgeV1alpha1().SinglePlacementSlices().Update(ctx, nextSPS, metav1.UpdateOptions{})
 			if err != nil {
 				logger.Error(err, "failed to update SinglePlacementSlice", "workloadWorkspace", ws, "singlePlacementSlice", nextSPS.Name)
 				return err
@@ -203,7 +209,8 @@ func (c *controller) reconcileOnLocation(ctx context.Context, locKey string) err
 				logger.Error(err, "invalid EdgePlacement key")
 				return err
 			}
-			currentSPS, err := c.singlePlacementSliceLister.Cluster(ws).Get(name)
+			// currentSPS, err := c.singlePlacementSliceLister.Cluster(ws).Get(name)
+			currentSPS, err := c.singlePlacementSliceLister.Get(name)
 			if err != nil {
 				logger.Error(err, "failed to get SinglePlacementSlice", "workloadWorkspace", ws, "singlePlacementSlice", name)
 				return err
@@ -212,7 +219,8 @@ func (c *controller) reconcileOnLocation(ctx context.Context, locKey string) err
 			nextSPS := cleanSPSByLoc(currentSPS, lws.String(), lName)
 			nextSPS = extendSPS(nextSPS, singles)
 
-			_, err = c.edgeClusterClient.EdgeV1alpha1().SinglePlacementSlices().Cluster(ws.Path()).Update(ctx, nextSPS, metav1.UpdateOptions{})
+			// _, err = c.edgeClusterClient.EdgeV1alpha1().SinglePlacementSlices().Cluster(ws.Path()).Update(ctx, nextSPS, metav1.UpdateOptions{})
+			_, err = c.edgeClient.EdgeV1alpha1().SinglePlacementSlices().Update(ctx, nextSPS, metav1.UpdateOptions{})
 			if err != nil {
 				logger.Error(err, "failed to update SinglePlacementSlice", "workloadWorkspace", ws, "singlePlacementSlice", nextSPS.Name)
 				return err

--- a/pkg/where-resolver/reconcile_on_synctarget.go
+++ b/pkg/where-resolver/reconcile_on_synctarget.go
@@ -64,7 +64,8 @@ func (c *controller) reconcileOnSyncTarget(ctx context.Context, stKey string) er
 	defer store.l.Unlock() // TODO(waltforme): Is it safe to shorten the critical section?
 
 	stDeleted := false
-	st, err := c.synctargetLister.Cluster(stws).Get(stName)
+	// st, err := c.synctargetLister.Cluster(stws).Get(stName)
+	st, err := c.synctargetLister.Get(stName)
 	if err != nil {
 		if errors.IsNotFound(err) {
 			logger.V(1).Info("SyncTarget not found")
@@ -81,7 +82,8 @@ func (c *controller) reconcileOnSyncTarget(ctx context.Context, stKey string) er
 	// 2a)
 	locsFilteredBySt := []*edgev1alpha1.Location{}
 	if !stDeleted {
-		locsInStws, err := c.locationLister.Cluster(stws).List(labels.Everything())
+		// locsInStws, err := c.locationLister.Cluster(stws).List(labels.Everything())
+		locsInStws, err := c.locationLister.List(labels.Everything())
 		if err != nil {
 			logger.Error(err, "failed to list Locations")
 			return err
@@ -126,13 +128,15 @@ func (c *controller) reconcileOnSyncTarget(ctx context.Context, stKey string) er
 				logger.Error(err, "invalid EdgePlacement key")
 				return err
 			}
-			currentSPS, err := c.singlePlacementSliceLister.Cluster(ws).Get(name)
+			// currentSPS, err := c.singlePlacementSliceLister.Cluster(ws).Get(name)
+			currentSPS, err := c.singlePlacementSliceLister.Get(name)
 			if err != nil {
 				logger.Error(err, "failed to get SinglePlacementSlice", "workloadWorkspace", ws, "singlePlacementSlice", name)
 				return err
 			}
 			nextSPS := cleanSPSBySt(currentSPS, stws.String(), stName)
-			_, err = c.edgeClusterClient.EdgeV1alpha1().SinglePlacementSlices().Cluster(ws.Path()).Update(ctx, nextSPS, metav1.UpdateOptions{})
+			// _, err = c.edgeClusterClient.EdgeV1alpha1().SinglePlacementSlices().Cluster(ws.Path()).Update(ctx, nextSPS, metav1.UpdateOptions{})
+			_, err = c.edgeClient.EdgeV1alpha1().SinglePlacementSlices().Update(ctx, nextSPS, metav1.UpdateOptions{})
 			if err != nil {
 				logger.Error(err, "failed to update SinglePlacementSlice", "workloadWorkspace", ws, "singlePlacementSlice", nextSPS.Name)
 				return err
@@ -152,14 +156,16 @@ func (c *controller) reconcileOnSyncTarget(ctx context.Context, stKey string) er
 				logger.Error(err, "invalid EdgePlacement key")
 				return err
 			}
-			currentSPS, err := c.singlePlacementSliceLister.Cluster(ws).Get(name)
+			// currentSPS, err := c.singlePlacementSliceLister.Cluster(ws).Get(name)
+			currentSPS, err := c.singlePlacementSliceLister.Get(name)
 			if err != nil {
 				logger.Error(err, "failed to get SinglePlacementSlice", "workloadWorkspace", ws, "singlePlacementSlice", name)
 				return err
 			}
 			nextSPS := cleanSPSBySt(currentSPS, stws.String(), stName)
 
-			epObj, err := c.edgePlacementLister.Cluster(ws).Get(name)
+			// epObj, err := c.edgePlacementLister.Cluster(ws).Get(name)
+			epObj, err := c.edgePlacementLister.Get(name)
 			if err != nil {
 				logger.Error(err, "failed to get EdgePlacement", "workloadWorkspace", ws, "edgePlacement", name)
 				return err
@@ -172,7 +178,8 @@ func (c *controller) reconcileOnSyncTarget(ctx context.Context, stKey string) er
 			additionalSingles := makeSinglePlacementsForSt(locsFilteredByStAndEp, st)
 			nextSPS = extendSPS(nextSPS, additionalSingles)
 
-			_, err = c.edgeClusterClient.EdgeV1alpha1().SinglePlacementSlices().Cluster(ws.Path()).Update(ctx, nextSPS, metav1.UpdateOptions{})
+			// _, err = c.edgeClusterClient.EdgeV1alpha1().SinglePlacementSlices().Cluster(ws.Path()).Update(ctx, nextSPS, metav1.UpdateOptions{})
+			_, err = c.edgeClient.EdgeV1alpha1().SinglePlacementSlices().Update(ctx, nextSPS, metav1.UpdateOptions{})
 			if err != nil {
 				logger.Error(err, "failed to update SinglePlacementSlice", "workloadWorkspace", ws, "singlePlacementSlice", nextSPS.Name)
 				return err
@@ -193,14 +200,16 @@ func (c *controller) reconcileOnSyncTarget(ctx context.Context, stKey string) er
 				logger.Error(err, "invalid EdgePlacement key")
 				return err
 			}
-			currentSPS, err := c.singlePlacementSliceLister.Cluster(ws).Get(name)
+			// currentSPS, err := c.singlePlacementSliceLister.Cluster(ws).Get(name)
+			currentSPS, err := c.singlePlacementSliceLister.Get(name)
 			if err != nil {
 				logger.Error(err, "failed to get SinglePlacementSlice", "workloadWorkspace", ws, "singlePlacementSlice", name)
 				return err
 			}
 			nextSPS := cleanSPSBySt(currentSPS, stws.String(), stName)
 
-			epObj, err := c.edgePlacementLister.Cluster(ws).Get(name)
+			// epObj, err := c.edgePlacementLister.Cluster(ws).Get(name)
+			epObj, err := c.edgePlacementLister.Get(name)
 			if err != nil {
 				logger.Error(err, "failed to get EdgePlacement", "workloadWorkspace", ws, "edgePlacement", name)
 				return err
@@ -213,7 +222,8 @@ func (c *controller) reconcileOnSyncTarget(ctx context.Context, stKey string) er
 			additionalSingles := makeSinglePlacementsForSt(locsFilteredByStAndEp, st)
 			nextSPS = extendSPS(nextSPS, additionalSingles)
 
-			_, err = c.edgeClusterClient.EdgeV1alpha1().SinglePlacementSlices().Cluster(ws.Path()).Update(ctx, nextSPS, metav1.UpdateOptions{})
+			// _, err = c.edgeClusterClient.EdgeV1alpha1().SinglePlacementSlices().Cluster(ws.Path()).Update(ctx, nextSPS, metav1.UpdateOptions{})
+			_, err = c.edgeClient.EdgeV1alpha1().SinglePlacementSlices().Update(ctx, nextSPS, metav1.UpdateOptions{})
 			if err != nil {
 				logger.Error(err, "failed to update SinglePlacementSlice", "workloadWorkspace", ws, "singlePlacementSlice", nextSPS.Name)
 				return err

--- a/pkg/where-resolver/reconcile_on_synctarget.go
+++ b/pkg/where-resolver/reconcile_on_synctarget.go
@@ -64,8 +64,12 @@ func (c *controller) reconcileOnSyncTarget(ctx context.Context, stKey string) er
 	defer store.l.Unlock() // TODO(waltforme): Is it safe to shorten the critical section?
 
 	stDeleted := false
-	// st, err := c.synctargetLister.Cluster(stws).Get(stName)
-	st, err := c.synctargetLister.Get(stName)
+	var st *edgev1alpha1.SyncTarget
+	if c.provider == ClusterProviderKCP {
+		st, err = c.synctargetClusterLister.Cluster(stws).Get(stName)
+	} else {
+		st, err = c.synctargetLister.Get(stName)
+	}
 	if err != nil {
 		if errors.IsNotFound(err) {
 			logger.V(1).Info("SyncTarget not found")
@@ -82,8 +86,12 @@ func (c *controller) reconcileOnSyncTarget(ctx context.Context, stKey string) er
 	// 2a)
 	locsFilteredBySt := []*edgev1alpha1.Location{}
 	if !stDeleted {
-		// locsInStws, err := c.locationLister.Cluster(stws).List(labels.Everything())
-		locsInStws, err := c.locationLister.List(labels.Everything())
+		var locsInStws []*edgev1alpha1.Location
+		if c.provider == ClusterProviderKCP {
+			locsInStws, err = c.locationClusterLister.Cluster(stws).List(labels.Everything())
+		} else {
+			locsInStws, err = c.locationLister.List(labels.Everything())
+		}
 		if err != nil {
 			logger.Error(err, "failed to list Locations")
 			return err
@@ -128,15 +136,22 @@ func (c *controller) reconcileOnSyncTarget(ctx context.Context, stKey string) er
 				logger.Error(err, "invalid EdgePlacement key")
 				return err
 			}
-			// currentSPS, err := c.singlePlacementSliceLister.Cluster(ws).Get(name)
-			currentSPS, err := c.singlePlacementSliceLister.Get(name)
+			var currentSPS *edgev1alpha1.SinglePlacementSlice
+			if c.provider == ClusterProviderKCP {
+				currentSPS, err = c.singlePlacementSliceClusterLister.Cluster(ws).Get(name)
+			} else {
+				currentSPS, err = c.singlePlacementSliceLister.Get(name)
+			}
 			if err != nil {
 				logger.Error(err, "failed to get SinglePlacementSlice", "workloadWorkspace", ws, "singlePlacementSlice", name)
 				return err
 			}
 			nextSPS := cleanSPSBySt(currentSPS, stws.String(), stName)
-			// _, err = c.edgeClusterClient.EdgeV1alpha1().SinglePlacementSlices().Cluster(ws.Path()).Update(ctx, nextSPS, metav1.UpdateOptions{})
-			_, err = c.edgeClient.EdgeV1alpha1().SinglePlacementSlices().Update(ctx, nextSPS, metav1.UpdateOptions{})
+			if c.provider == ClusterProviderKCP {
+				_, err = c.edgeClusterClient.EdgeV1alpha1().SinglePlacementSlices().Cluster(ws.Path()).Update(ctx, nextSPS, metav1.UpdateOptions{})
+			} else {
+				_, err = c.edgeClient.EdgeV1alpha1().SinglePlacementSlices().Update(ctx, nextSPS, metav1.UpdateOptions{})
+			}
 			if err != nil {
 				logger.Error(err, "failed to update SinglePlacementSlice", "workloadWorkspace", ws, "singlePlacementSlice", nextSPS.Name)
 				return err
@@ -156,16 +171,24 @@ func (c *controller) reconcileOnSyncTarget(ctx context.Context, stKey string) er
 				logger.Error(err, "invalid EdgePlacement key")
 				return err
 			}
-			// currentSPS, err := c.singlePlacementSliceLister.Cluster(ws).Get(name)
-			currentSPS, err := c.singlePlacementSliceLister.Get(name)
+			var currentSPS *edgev1alpha1.SinglePlacementSlice
+			if c.provider == ClusterProviderKCP {
+				currentSPS, err = c.singlePlacementSliceClusterLister.Cluster(ws).Get(name)
+			} else {
+				currentSPS, err = c.singlePlacementSliceLister.Get(name)
+			}
 			if err != nil {
 				logger.Error(err, "failed to get SinglePlacementSlice", "workloadWorkspace", ws, "singlePlacementSlice", name)
 				return err
 			}
 			nextSPS := cleanSPSBySt(currentSPS, stws.String(), stName)
 
-			// epObj, err := c.edgePlacementLister.Cluster(ws).Get(name)
-			epObj, err := c.edgePlacementLister.Get(name)
+			var epObj *edgev1alpha1.EdgePlacement
+			if c.provider == ClusterProviderKCP {
+				epObj, err = c.edgePlacementClusterLister.Cluster(ws).Get(name)
+			} else {
+				epObj, err = c.edgePlacementLister.Get(name)
+			}
 			if err != nil {
 				logger.Error(err, "failed to get EdgePlacement", "workloadWorkspace", ws, "edgePlacement", name)
 				return err
@@ -178,8 +201,11 @@ func (c *controller) reconcileOnSyncTarget(ctx context.Context, stKey string) er
 			additionalSingles := makeSinglePlacementsForSt(locsFilteredByStAndEp, st)
 			nextSPS = extendSPS(nextSPS, additionalSingles)
 
-			// _, err = c.edgeClusterClient.EdgeV1alpha1().SinglePlacementSlices().Cluster(ws.Path()).Update(ctx, nextSPS, metav1.UpdateOptions{})
-			_, err = c.edgeClient.EdgeV1alpha1().SinglePlacementSlices().Update(ctx, nextSPS, metav1.UpdateOptions{})
+			if c.provider == ClusterProviderKCP {
+				_, err = c.edgeClusterClient.EdgeV1alpha1().SinglePlacementSlices().Cluster(ws.Path()).Update(ctx, nextSPS, metav1.UpdateOptions{})
+			} else {
+				_, err = c.edgeClient.EdgeV1alpha1().SinglePlacementSlices().Update(ctx, nextSPS, metav1.UpdateOptions{})
+			}
 			if err != nil {
 				logger.Error(err, "failed to update SinglePlacementSlice", "workloadWorkspace", ws, "singlePlacementSlice", nextSPS.Name)
 				return err
@@ -200,16 +226,24 @@ func (c *controller) reconcileOnSyncTarget(ctx context.Context, stKey string) er
 				logger.Error(err, "invalid EdgePlacement key")
 				return err
 			}
-			// currentSPS, err := c.singlePlacementSliceLister.Cluster(ws).Get(name)
-			currentSPS, err := c.singlePlacementSliceLister.Get(name)
+			var currentSPS *edgev1alpha1.SinglePlacementSlice
+			if c.provider == ClusterProviderKCP {
+				currentSPS, err = c.singlePlacementSliceClusterLister.Cluster(ws).Get(name)
+			} else {
+				currentSPS, err = c.singlePlacementSliceLister.Get(name)
+			}
 			if err != nil {
 				logger.Error(err, "failed to get SinglePlacementSlice", "workloadWorkspace", ws, "singlePlacementSlice", name)
 				return err
 			}
 			nextSPS := cleanSPSBySt(currentSPS, stws.String(), stName)
 
-			// epObj, err := c.edgePlacementLister.Cluster(ws).Get(name)
-			epObj, err := c.edgePlacementLister.Get(name)
+			var epObj *edgev1alpha1.EdgePlacement
+			if c.provider == ClusterProviderKCP {
+				epObj, err = c.edgePlacementClusterLister.Cluster(ws).Get(name)
+			} else {
+				epObj, err = c.edgePlacementLister.Get(name)
+			}
 			if err != nil {
 				logger.Error(err, "failed to get EdgePlacement", "workloadWorkspace", ws, "edgePlacement", name)
 				return err
@@ -222,8 +256,11 @@ func (c *controller) reconcileOnSyncTarget(ctx context.Context, stKey string) er
 			additionalSingles := makeSinglePlacementsForSt(locsFilteredByStAndEp, st)
 			nextSPS = extendSPS(nextSPS, additionalSingles)
 
-			// _, err = c.edgeClusterClient.EdgeV1alpha1().SinglePlacementSlices().Cluster(ws.Path()).Update(ctx, nextSPS, metav1.UpdateOptions{})
-			_, err = c.edgeClient.EdgeV1alpha1().SinglePlacementSlices().Update(ctx, nextSPS, metav1.UpdateOptions{})
+			if c.provider == ClusterProviderKCP {
+				_, err = c.edgeClusterClient.EdgeV1alpha1().SinglePlacementSlices().Cluster(ws.Path()).Update(ctx, nextSPS, metav1.UpdateOptions{})
+			} else {
+				_, err = c.edgeClient.EdgeV1alpha1().SinglePlacementSlices().Update(ctx, nextSPS, metav1.UpdateOptions{})
+			}
 			if err != nil {
 				logger.Error(err, "failed to update SinglePlacementSlice", "workloadWorkspace", ws, "singlePlacementSlice", nextSPS.Name)
 				return err


### PR DESCRIPTION
This PR enables the where-resolver to run on top of both kcp (by default) and plain Kubernetes, controlled by a switch.

It is verified in this PR, that the kcp fork of client-go is a superset of the original client-go, in the sense that a subset of the fork can interact with a regular Kubernetes apiserver, to watch and CRUD KubeStellar's API objects.

This PR also removes the obsolete code which watches the Locations and SyncTargets views that are exposed by APIExports "scheduling.kcp.io" and "workload.kcp.io". We are currently using APIExport "edge.kubestellar.io" for Locations and SyncTargets.

## Summary

## Related issue(s)

#524
