### PR TITLE
✨ Bump latest version in VERSION to 0.4.0

### DIFF
--- a/VERSION
+++ b/VERSION
@@ -1,2 +1,2 @@
 stable=v0.3.1
-latest=v0.3.1
+latest=v0.4.0


### PR DESCRIPTION
## Summary

Bump `latest` version in VERSION to v0.4.0
Stay `stable` version at v0.3.1

## Related issue(s)

Fixes #
