### PR TITLE
🐛 DO NOT MERGE YET - Touch workload-projector.go to provoke SonarCloud

### DIFF
--- a/pkg/placement/workload-projector.go
+++ b/pkg/placement/workload-projector.go
@@ -857,7 +857,7 @@ func (wp *workloadProjector) syncSourceObject(ctx context.Context, soRef sourceO
 		var tryAgain bool
 		remWork := []func() bool{}
 		destinations.Visit(func(destination SinglePlacement) error {
-			retryThis, rem := wp.syncSourceToDestLocked(ctx, logger, soRef, srcMRObject, namespaced, deleted, modesForSync, destination)
+			retryThis, rem := wp.syncSourceToDestWhileLocked(ctx, logger, soRef, srcMRObject, namespaced, deleted, modesForSync, destination)
 			tryAgain = tryAgain || retryThis
 			if rem != nil {
 				remWork = append(remWork, rem)
@@ -883,7 +883,7 @@ var returnTrue = func() bool { return true }
 
 // Sync a source object to one MBWS.
 // Returns `(retry bool, unlocked func() (retry bool))`
-func (wp *workloadProjector) syncSourceToDestLocked(ctx context.Context, logger klog.Logger,
+func (wp *workloadProjector) syncSourceToDestWhileLocked(ctx context.Context, logger klog.Logger,
 	soRef sourceObjectRef, srcMRObject mrObject, namespaced, deleted bool,
 	modesForSync FactoredMap[ProjectionModeKey, SinglePlacement, metav1.GroupResource, ProjectionModeVal],
 	destination SinglePlacement) (bool, func() bool) {

--- a/pkg/placement/workload-projector.go
+++ b/pkg/placement/workload-projector.go
@@ -1339,6 +1339,8 @@ func (wpd *wpPerDestination) enqueueDestinationObject(gr metav1.GroupResource, n
 	wpd.wp.queue.Add(ref)
 }
 
+// ObjectIsSystem says whether an object of a kind that _can_ be workload
+// is in fact part of the infrastructure of the space where that object appears.
 func ObjectIsSystem(objm metav1.Object) bool {
 	obju := objm.(*unstructured.Unstructured)
 	objt := objm.(metav1.Type)


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
Hopefully this PR will eventually fix the code smells that SonarCloud detects in the workload projector source code.  The first task here is to get SonarCloud to reveal what it has a problem with.

## Related issue(s)

Fixes #791 
