### PR TITLE
📖 Update roadmap remarks on website to support PoC2023q4

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,9 @@ tools
 build
 .vscode
 
+# Python virtual environment for working on docs
+docs/.venv
+
 # JetBrains IDE files
 .idea/
 *.iml

--- a/.gitignore
+++ b/.gitignore
@@ -5,9 +5,6 @@ tools
 build
 .vscode
 
-# Python virtual environment for working on docs
-docs/.venv
-
 # JetBrains IDE files
 .idea/
 *.iml

--- a/README.md
+++ b/README.md
@@ -45,6 +45,14 @@ KubeStellar is an opensource project focused on concerns arising from multi-clus
 - Status from many destinations​: Center clients may need a way to access status from individual edge copies
 - Status summarization​: Client needs a way to specify how statuses from edge copies are processed/reduced along the way from edge to center​.
 
+## Roadmap for the Project
+
+We have defined and largely completed the
+[PoC2023q1](https://docs.kubestellar.io/main/Coding%20Milestones/PoC2023q1/outline/).
+The current activity is refining the definition of, and producing, the
+[PoC2023q3](https://docs.kubestellar.io/main/Coding%20Milestones/PoC2023q3/outline/).
+Goals not addressed in that PoC are to be explored later.
+
 ## QuickStart
 
 Checkout our [QuickStart Guide](https://docs.kubestellar.io/stable/Getting-Started/quickstart/)

--- a/docs/README.md
+++ b/docs/README.md
@@ -20,18 +20,17 @@ cd {{ config.repo_default_file_path }}/docs
 git checkout {{ config.ks_branch }}
 ```
 
-You can view and modify our documentation in the branch you have checked out by using `mkdocs serve` from [mkdocs](https://www.mkdocs.org).  We have a Python requirements file in `requirements.txt`.  You can either install those requirements into your global Python environment or make and use a virtual environment for this purpose.  To install those requirements into your global Python environment, do the following usual thing.
+You can view and modify our documentation in the branch you have checked out by using `mkdocs serve` from [mkdocs](https://www.mkdocs.org).  We have a Python requirements file in `requirements.txt`, and a Makefile target that builds a Python virtual environment and installs the requirements there.  You can either install those requirements into your global Python environment or use the Makefile target.  To install those requirements into your global Python environment, do the following usual thing.
 
 ```shell
 pip install -r requirements.txt
 ```
 
-Alternatively, you could make and install the requirements into a virtual environment in the usual way.  The following commands illustrate that.
+Alternatively, use the following commands to use the Makefile target to construct an adequate virtual environment and enter it.
 
 ```shell
-python3 -m venv .venv
-. .venv/bin/activate
-pip install -r requirements.txt
+( cd ..; make venv )
+. venv/bin/activate
 ```
 
 Then, using your chosen environment with the requirements installed, build and serve the documents with the following command.

--- a/docs/README.md
+++ b/docs/README.md
@@ -20,10 +20,23 @@ cd {{ config.repo_default_file_path }}/docs
 git checkout {{ config.ks_branch }}
 ```
 
-You can view and modify our documentation in the branch you have checked out by using `mkdocs serve` from [mkdocs](https://www.mkdocs.org):
+You can view and modify our documentation in the branch you have checked out by using `mkdocs serve` from [mkdocs](https://www.mkdocs.org).  We have a Python requirements file in `requirements.txt`.  You can either install those requirements into your global Python environment or make and use a virtual environment for this purpose.  To install those requirements into your global Python environment, do the following usual thing.
 
 ```shell
 pip install -r requirements.txt
+```
+
+Alternatively, you could make and install the requirements into a virtual environment in the usual way.  The following commands illustrate that.
+
+```shell
+python3 -m venv .venv
+. .venv/bin/activate
+pip install -r requirements.txt
+```
+
+Then, using your chosen environment with the requirements installed, build and serve the documents with the following command.
+
+```shell
 mkdocs serve
 ```
 Then open a browser to [`http://localhost:8000/`](http://localhost:8000/)

--- a/docs/content/Coding Milestones/PoC2023q1/outline.md
+++ b/docs/content/Coding Milestones/PoC2023q1/outline.md
@@ -2,15 +2,13 @@
 title: "Details"
 ---
 
-Want to get involved? Check out our [good-first-issue list]({{ config.repo_url }}/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22).
-
-
 ![poc2023q1 architecture](Edge-PoC-2023q1.svg)
 
 ## Status of this memo
 
-This summarizes the current state of design work that is still in
-progress.
+This summarizes the design for a Proof-of-Concept intended to be
+completed in early 2023.  It has been completed except for the
+summarization feature.
 
 ## Introduction
 
@@ -57,7 +55,7 @@ Some important things that are not attempted in this PoC include the following.
 - Very strong isolation between tenants in the edge computing
   platform.
 
-## Development Roadmap
+## Development Roadmap for this PoC
 
 Some features will get implemented later than others, so that we can
 start being able to run interesting end-to-end scenarios relatively

--- a/docs/content/Coding Milestones/PoC2023q1/roadmap-uses.md
+++ b/docs/content/Coding Milestones/PoC2023q1/roadmap-uses.md
@@ -1,7 +1,7 @@
 ## Background
 
 The outline [mentions features that need not be implement at
-first](../outline/#development-roadmap).  In the following sections we
+first](../outline/#development-roadmap-for-this-poc).  In the following sections we
 consider some particular use cases.
 
 ## MVI

--- a/docs/content/Coding Milestones/PoC2023q3/outline.md
+++ b/docs/content/Coding Milestones/PoC2023q3/outline.md
@@ -2,4 +2,78 @@
 title: "Details"
 ---
 
-# Coming Soon
+Want to get involved? Check out our [good-first-issue list]({{ config.repo_url }}/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22).
+
+TODO: draw new picture
+
+## Status of this memo
+
+This document outlines near-term plans for building on what was
+produced in the work on [the PoC for 2023q1](../../PoC2023q1/outline/).
+
+## Introduction
+
+PoC2023q1 was defined with the over-arching goal of supporting edge
+computing scenarios.  Since then we have realized that the technical
+problems that we took on are not that specific, they appear in other
+multi-cluster scenarios as well.
+
+The goals of this PoC are as follows.  Ones that are substantially
+different from what has been accomplished for PoC2023q1 are
+highlighted.
+
+- Separation of infrastructure and workload management.
+- The focus here is on workload management, and that strictly reads
+  an inventory of infrastructure.
+- What passes from inventory to workload management is kcp TMC
+  Location and SyncTarget objects.
+- **Compared to PoC2023q1, decoupling from kcp TMC by making our own
+  copy of the definitions of SyncTarget and Location.**
+- **Potentialy: switch from using SyncTarget and Location to some
+  other representatin of inventory.**
+- **Compared to PoC2023q1, decoupling from kcp core by (1) introducing
+  an abstraction layer that delivers the essential functionality of
+  kcp's logical clusters based on a variety of implementations and (2)
+  using [kube-bind](https://github.com/kube-bind/kube-bind) instead of
+  kcp's APIExport/APIBinding.  Where PoC2023q1 used the concept of a
+  kcp workspace, PoC2023q3 uses the abstract concept that we call a
+  "space".**
+- Use of a space as the container for the central spec of a workload.
+- Propagation of desired state from center outward, as directed by
+  EdgePlacement objects and the referenced inventory objects.
+- Interfaces designed for a large number of workload execution clusters.
+- Interfaces designed with the intention that workload execution
+  clusters operate independently of each other and the center (e.g.,
+  can tolerate only occasional connectivity) and thus any "service
+  providers" (in the technical sense from kcp) in the center or
+  elsewhere.
+- Rule-based customization of desired state.
+- Propagation of reported state from workload execution clusters to center.
+- Summarization of reported state in the center.
+- **Exact, not summarized, reported state returned to workload
+  description space in the case of placement on exactly 1 workload
+  execution cluster.**
+- Return and/or summarization of state from associated objects (e.g.,
+  ReplicaSet or Pod objects associated with a given Deployment
+  object).
+- The TCP connections are opened in the inward direction, not outward.
+- A platform "product" that can be deployed (as opposed to a service
+  that is used).
+- **Codified support for scenarios where the syncers in the workload
+  execution clusters have to go through load balancers and/or other
+  proxies to reach the central server(s).**
+- **A hierarchy with more than two levels.**
+
+Some important things that are not attempted in this PoC include the following.
+
+- An implementation that supports a very large volume of reported
+  state (which could come from either a large number of workload
+  executino clusters and/or a large amount of reported state in each
+  one of those).
+- User control over ordering of propagation from center outward,
+  either among destinations or kinds of objects.
+- More than baseline security (baseline being, e.g., HTTPS, Secret
+  objects, non-rotating bearer token based service authentication).
+- A good design for bootstrapping the workload management in the
+  workload execution clusters.
+- Very strong isolation between tenants of this platform.

--- a/docs/content/Coding Milestones/PoC2023q3/outline.md
+++ b/docs/content/Coding Milestones/PoC2023q3/outline.md
@@ -30,7 +30,7 @@ highlighted.
 - **Compared to PoC2023q1, decoupling from kcp TMC by making our own
   copy of the definitions of SyncTarget and Location.**
 - **Potentialy: switch from using SyncTarget and Location to some
-  other representatin of inventory.**
+  other representation of inventory.**
 - **Compared to PoC2023q1, decoupling from kcp core by (1) introducing
   an abstraction layer that delivers the essential functionality of
   kcp's logical clusters based on a variety of implementations and (2)
@@ -59,9 +59,12 @@ highlighted.
 - The TCP connections are opened in the inward direction, not outward.
 - A platform "product" that can be deployed (as opposed to a service
   that is used).
-- **Codified support for scenarios where the syncers in the workload
-  execution clusters have to go through load balancers and/or other
-  proxies to reach the central server(s).**
+- **Codified support for scenarios where some KubeStellar clients and
+  the syncers in some of the workload execution clusters have to go
+  through load balancers and/or other proxies to reach the central
+  server(s).**
+- **Compared to PoC2023q1, codification of closer to production grade
+  deployment technique(s).**
 - **A hierarchy with more than two levels.**
 
 Some important things that are not attempted in this PoC include the following.

--- a/docs/content/readme.md
+++ b/docs/content/readme.md
@@ -45,6 +45,14 @@ KubeStellar is an opensource project focused on concerns arising from multi-clus
 - Status from many destinations​: Center clients may need a way to access status from individual edge copies
 - Status summarization​: Client needs a way to specify how statuses from edge copies are processed/reduced along the way from edge to center​.
 
+## Roadmap for the Project
+
+We have defined and largely completed the
+[PoC2023q1](../Coding%20Milestones/PoC2023q1/outline/).
+The current activity is refining the definition of, and producing, the
+[PoC2023q3](../Coding%20Milestones/PoC2023q3/outline/).
+Goals not addressed in that PoC are to be explored later.
+
 ## QuickStart
 
 Checkout our [QuickStart Guide]({{ config.docs_url }}/{{ config.ks_branch }}/Getting-Started/quickstart/)

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -47,7 +47,7 @@ nav:
               - KubeStellar Where Resolver: Coding Milestones/PoC2023q1/where-resolver.md
               - KubeStellar Mailbox Controller: Coding Milestones/PoC2023q1/mailbox-controller.md
               - KubeStellar Placement Translator: Coding Milestones/PoC2023q1/placement-translator.md
-          - Roadmap: Coding Milestones/PoC2023q1/roadmap-uses.md
+          - Use Cases Affecting the Roadmap for PoC2023q1: Coding Milestones/PoC2023q1/roadmap-uses.md
           - Environments:
               - Overview: Coding Milestones/PoC2023q1/environments/_index.md
               - Cloud Environment: Coding Milestones/PoC2023q1/environments/cloud-env.md


### PR DESCRIPTION
Also describe how to use a Python virtual environment to preview the docs.

<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
This PR updates the roadmap remarks on the website.  That consists of the following three things.
1. Clarify that the `roadmap-uses.md` doc was about use cases that guided thoughts about roadmapping the 2023q1 PoC.
2. Start writing a definition of the 2023q3 PoC.
3. Add to the project README a bigger roadmapping throught in terms of a march of PoCs.

This PR also updates the instructions in `docs/README.md` to add guidance for those who prefer to use Python virtual environments to disentangle their various Python-based projects.

## Related issue(s)

Fixes #697
