### PR TITLE
✨ Draft scripts to support external processes

### DIFF
--- a/docs/content/Coding Milestones/PoC2023q1/commands.md
+++ b/docs/content/Coding Milestones/PoC2023q1/commands.md
@@ -34,6 +34,22 @@ name.
 
 ### kubestellar-ensure-kcp-server-creds
 
+#### kubestellar-ensure-kcp-server-creds pre-reqs
+
+The `kubestellar-ensure-kcp-server-creds` command requires that
+Easy-RSA is installed.  As outlined in
+https://easy-rsa.readthedocs.io/en/latest/#obtaining-and-using-easy-rsa,
+this involves selecting a release archive from [the list on
+GitHub](https://github.com/OpenVPN/easy-rsa/releases), unpacking it,
+and adding the EasyRSA directory to your `$PATH`; `easyrsa` is a bash
+script, so you do not need to worry about building or fetching a
+binary specific to your OS or ISA.
+
+Easy-RSA uses [OpenSSL](https://www.openssl.org/), so you will need
+that installed too.
+
+#### kubestellar-ensure-kcp-server-creds usage
+
 This command is given exactly one thing on the command line, a DNS
 domain name.  This command creates --- or re-uses if it finds already
 existing --- a private key and public X.509 certificate for the kcp

--- a/docs/content/Coding Milestones/PoC2023q1/commands.md
+++ b/docs/content/Coding Milestones/PoC2023q1/commands.md
@@ -1,3 +1,6 @@
+---
+short_name: commands
+---
 This PoC includes two sorts of commands for users to use.  Most are
 executables delivered in the `bin` directory.  The other sort of
 command for users is a `bash` script that is designed to be fetched
@@ -15,7 +18,164 @@ your chosen kubeconfig file; for this reason, they are not suitable
 for executing concurrently with anything that depends on that setting
 in that file.
 
-## Platform control
+## kcp control
+
+KubeStellar has some commands to support situations in which some
+clients of the kcp server need to connect to it by opening a
+connection to a DNS domain name rather than an IP address that the
+server can bind its socket to.  The key idea is using the
+`--tls-sni-cert-key` command line flag of `kcp start` to configure the
+server to respond with a bespoke server certificate in TLS handshakes
+in which the client addresses the server by a given domain name.
+
+These commands are designed so that they can be used multiple times if
+there are multiple sets of clients that need to use a distinct domain
+name.
+
+### kubestellar-ensure-kcp-server-creds
+
+This command is given exactly one thing on the command line, a DNS
+domain name.  This command creates --- or re-uses if it finds already
+existing --- a private key and public X.509 certificate for the kcp
+server to use.  The certificate has exactly one
+SubjectAlternativeName, which is of the DNS form and specifies the
+given domain name.  For example: `kubestellar-ensure-kcp-server-creds
+foo.bar` creates a certificate with one SAN, commonly rendered as
+`DNS:foo.bar`.
+
+This command uses a Public Key Infrastructure (PKI) and Certificate
+Authority (CA) implemented by
+[easy-rsa](https://github.com/OpenVPN/easy-rsa), rooted at the
+subdirectory `pki` of the current working directory.  This command
+will create the PKI if it does not already exist, and will initialize
+the CA if that has not already been done.  The CA's public certificate
+appears at the usual place for easy-rsa: `pki/ca.crt`.
+
+This command prints some stuff --- mostly progress remarks from
+easy-rsa --- to stderr and prints one line of results to stdout.  The
+`bash` shell will parse that one line as three words.  Each is an
+absolute pathname of one certificate or key.  The three are as
+follows.
+
+1. The CA certificate for the client to use in verifying the server.
+2. The X.509 certificate for the server to put in its ServerHello in a
+   TLS handshake in which the ClientHello has a Server Name Indicator
+   (SNI) that matches the given domain name.
+3. The private key corresponding to that server certificate.
+
+Following is an example of invoking this command and examining its
+results.
+
+```console
+bash-5.2$ eval pieces=($(scripts/kubestellar-ensure-kcp-server-creds yep.yep))
+Re-using PKI at /Users/mspreitz/go/src/github.com/kubestellar/kubestellar/pki
+Re-using CA at /Users/mspreitz/go/src/github.com/kubestellar/kubestellar/pki/private/ca.key
+Accepting existing credentials
+
+bash-5.2$ echo ${pieces[0]}
+/Users/mspreitz/go/src/github.com/kubestellar/kubestellar/pki/ca.crt
+
+bash-5.2$ echo ${pieces[1]}
+/Users/mspreitz/go/src/github.com/kubestellar/kubestellar/pki/issued/kcp-server.crt
+
+bash-5.2$ echo ${pieces[2]}
+/Users/mspreitz/go/src/github.com/kubestellar/kubestellar/pki/private/kcp-server.key
+```
+
+Following is an example of using those results in launching the kcp
+server.  The `--tls-sni-cert-key` flag can appear multiple times on
+the command line, configuring the server to respond in a different way
+to each of multiple different SNIs.
+
+```console
+bash-5.2$ kcp start --tls-sni-cert-key ${pieces[1]},${pieces[2]} &> /tmp/kcp.log &
+[1] 66974
+```
+
+### wait-and-switch-domain
+
+This command is for using after the kcp server has been launched.
+Since the `kcp start` command really means `kcp run`, all usage of
+that server has to be done by concurrent processes.  The
+`wait-and-switch-domain` command bundles two things: waiting for the
+kcp server to start handling kubectl requests, and making an alternate
+kubeconfig file for a set of clients to use.  This command is pointed
+at an existing kubeconfig file and reads it but does not write it; the
+alternate config file is written, with the same base name, into a
+parallel directory (which this command `mkdir -p`s).  This command
+takes exactly six command line positional arguments, as follows.
+
+1. Pathname (absoute or relative) of the directory holding the input kubeconfig.
+2. Filename of the input kubeconfig (just the base, no directory part).
+3. Name of the kubeconfig "context" that identifies what to replace.
+4. Domain name to put in the replacement server URLs.
+5. Port number to put in the replacement server URLs.
+6. Pathname (absolute or relative) of a file holding the CA
+   certificate to put in the alternate kubeconfig file.
+
+Creation of the alternate kubeconfig file starts by looking in the
+input kubeconfig file for the "context" with the given name, to find
+the name of a "cluster".  The server URL of that cluster is examined,
+and its `protocol://host:port` prefix is extracted.  The alternate
+kubeconfig will differ from the input kubeconfig in the contents of
+the cluster objects whose server URLs start with that same prefix.
+There will be the following two differences.
+
+1. In the server URL's `protocol://host:port` prefix, the host will be
+   replaced by the given domain name and the port will be replaced by
+   the given port.
+2. The cluster will be given a `certificate-authority-data` that holds
+   the contents (base64 encoded, as usual) of the given CA certificate
+   file.
+
+This command does a `mkdir -p` on a directory name that is the input
+kubeconfig directory name followed by a dash ("-") and the given
+domain name.  This command writes the alternate kubeconfig file into
+that directory.
+
+Following is an example of using this command and examining the
+results.  The context and port number chosen work for the kubeconfig
+file that `kcp start` (kcp release v0.11.0) creates by default.
+
+```console
+bash-5.2$ scripts/wait-and-switch-domain .kcp admin.kubeconfig root yep.yep 6443 ${pieces[0]}
+
+bash-5.2$ diff -w .kcp/admin.kubeconfig .kcp-yep.yep/admin.kubeconfig 
+4,5c4,5
+<     certificate-authority-data: LS0...LQo=
+<     server: https://192.168.something.something:6443
+---
+>       certificate-authority-data: LS0...LQo=
+>       server: https://yep.yep:6443
+8,9c8,9
+<     certificate-authority-data: LS0...LQo=
+<     server: https://192.168.something.something:6443/clusters/root
+---
+>       certificate-authority-data: LS0...LQo=
+>       server: https://yep.yep:6443/clusters/root
+```
+
+Following is an example of using the alternate kubeconfig file, in a
+context where the domain name "yep.yep" resolves to an IP address of
+the network namespace in which the kcp server is running.
+
+```console
+bash-5.2$ KUBECONFIG=.kcp-yep.yep/admin.kubeconfig kubectl ws .
+Current workspace is "root".
+```
+
+Because this command reads the given kubeconfig file, it is important
+to invoke this command while nothing is concurrently writing it and
+while the caller reliably knows the name of a kubeconfig context that
+identifies what to replace.
+
+### switch-domain
+
+This command is the second part of `wait-and-switch-domain`: the part
+of creating the alternate kubeconfig file.  It has the same inputs and
+outputs.
+
+## KubeStellar Platform control
 
 The `kubestellar` command has three subcommands, one to finish setup
 and two for process control.

--- a/scripts/kubestellar-ensure-ca
+++ b/scripts/kubestellar-ensure-ca
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+
+# Usage: $0
+
+# This script ensures that an [easy-rsa](https://github.com/OpenVPN/easy-rsa)
+# PKI and CA have been created at $PWD/pki.
+
+set -e
+
+export EASYRSA_PKI=${PWD}/pki
+
+if [ -d $EASYRSA_PKI ] &&
+   [ -d $EASYRSA_PKI/reqs ] &&
+   [ -d $EASYRSA_PKI/private ] &&
+   [ -f $EASYRSA_PKI/openssl-easyrsa.cnf ]; then
+    echo "Re-using PKI at $EASYRSA_PKI" >&2
+else
+    # init
+    easyrsa --batch init-pki
+fi
+
+if [ -f $EASYRSA_PKI/ca.crt ] &&
+   [ -d $EASYRSA_PKI/certs_by_serial ] &&
+   [ -f $EASYRSA_PKI/index.txt ] &&
+   [ -f $EASYRSA_PKI/index.txt.attr ] &&
+   [ -d $EASYRSA_PKI/issued ] &&
+   [ -f $EASYRSA_PKI/private/ca.key ] &&
+   [ -d $EASYRSA_PKI/revoked ] &&
+   [ -d $EASYRSA_PKI/revoked/certs_by_serial ] &&
+   [ -d $EASYRSA_PKI/revoked/private_by_serial ] &&
+   [ -d $EASYRSA_PKI/revoked/reqs_by_serial ] &&
+   [ -f $EASYRSA_PKI/serial ]; then
+    echo "Re-using CA at $EASYRSA_PKI/private/ca.key" >&2
+else
+    # Generate a new certificate authority (CA)
+    easyrsa --batch "--req-cn=easy@`date +%s`" build-ca nopass
+fi

--- a/scripts/kubestellar-ensure-kcp-server-creds
+++ b/scripts/kubestellar-ensure-kcp-server-creds
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+
+# Usage: $0 dns-name
+
+# This makes a TLS server certificate and private key.
+# The uses, creating if necessary, a PKI and CA at $PWD/pki.
+# The cert has one SubjectAlternativeName: a DNS form one
+# using the given domain name.
+# This script prints one line that parses as three bash words:
+# the first holds the absolute pathname of the CA's public cert,
+# the second holds the absolute pathname of the server cert,
+# the third holds the absolute pathname of the server's private key.
+# Join the last two with a comma and give that value to the `--tls-sni-cert-key`
+# command line flag of a kcp or plain kube apiserver.
+# Also edit the dns-name and CA cert into kube client config,
+# to make that client connect to that domain name and verify
+# the server's cert against that CA.
+
+if [ $# != 1 ]; then
+    echo "Usage: $0 dns-name" >&2
+    exit 1
+fi
+
+set -e
+
+this="$0"
+domain="$1"
+
+if [ $(wc -w <<<$domain) != 1 ]; then
+    echo "$0: the given domain name must be one word" >&2
+    exit 2
+fi
+
+${this%kcp-server-creds}ca >&2
+
+export EASYRSA_PKI=${PWD}/pki
+
+need=true
+
+cacert="${PWD}/pki/ca.crt"
+svrcert="${PWD}/pki/issued/kcp-server.crt"
+svrkey="${PWD}/pki/private/kcp-server.key"
+
+if [ -r "$svrcert" ] && [ -r "$svrkey" ]; then
+    if oldsan=$(easyrsa show-cert kcp-server |
+		    grep -A1 'X509v3 Subject Alternative Name' |
+		    tail -1 | awk '{ print $1 }'); then
+	if [ "$oldsan" == "DNS:$domain" ]
+	then echo Accepting existing credentials >&2
+	     need=false
+	else echo Rejecting existing credentials with SAN ${oldsan@Q} >&2
+	fi
+    fi
+fi
+
+if [ "$need" == "true" ];
+then ${this%ensure-kcp-server-creds}make-kcp-server-cert --subject-alt-names="DNS:$domain" >&2
+fi
+
+echo ${cacert@Q} ${svrcert@Q} ${svrkey@Q}

--- a/scripts/kubestellar-make-kcp-server-cert
+++ b/scripts/kubestellar-make-kcp-server-cert
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+
+# Usage: $0 --subject-alt-names=$names
+
+# Assumes easy-rsa PKI with CA is at $PWD/pki.
+# Creates server public cert and private key at
+# pki/kcp-server.crt and pki/kcp-server.key.
+# Creates an ed25519 key.
+# Makes a cert good for 10000 days.
+
+if [ $# != 1 ] || [[ "$1" != --subject-alt-names=?* ]]; then
+    echo "Usage: $0 --subject-alt-names=\$names" >&2
+    exit 1
+fi
+
+SAN="${1#--subject-alt-names=}"
+
+SERVERNAME=kcp-server
+
+export EASYRSA_PKI=${PWD}/pki
+
+rm -f ${EASYRSA_PKI}/reqs/${SERVERNAME}.req ${EASYRSA_PKI}/issued/${SERVERNAME}.crt ${EASYRSA_PKI}/private/${SERVERNAME}.key
+easyrsa --batch --use-algo=ed --curve=ed25519 \
+    --subject-alt-name="$SAN" \
+    --days=10000 \
+    build-server-full $SERVERNAME nopass

--- a/scripts/switch-domain
+++ b/scripts/switch-domain
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+
+# Usage: $0 inpath outpath context domain port
+
+# Reads a kubeconfig file from $inpath and writes a modified
+# kubeconfig file on $outpath.
+# The modification consists of setting the host:port in the
+# server URL in the clusters whose protocol://host:port originally
+# matched that of the cluster of the given context.
+
+if [ $# != 6 ]; then
+   echo "Usage: $0 configdir configfile context domain port cacert_file" >&2
+   exit 1
+fi
+
+set -o errexit
+set -o pipefail
+
+configdir="$(cd $1; pwd)"
+shift
+configfile="$1"
+shift
+context=$1
+shift
+domain=$1
+shift
+port=$1
+shift
+cacert_file="$1"
+
+inpath="${configdir}/${configfile}"
+outdir="${configdir}-${domain}"
+outpath="${outdir}/${configfile}"
+
+if ! cacert=$(base64 -w 0 < "$cacert_file" 2>/dev/null) ; then
+    cacert=$(base64 < "$cacert_file")
+fi
+
+export context
+protocluster=$(yq '.contexts[] | select(.name == strenv(context)) | .context.cluster' "$inpath")
+
+if [ -z "$protocluster" ]; then
+   echo "$0: there is no context named ${context@Q}" >&2
+   exit 10
+fi
+export protocluster
+protourl=$(yq '.clusters[] | select(.name == strenv(protocluster)) | .cluster.server' "$inpath")
+
+mkdir -p "${outdir}"
+
+protocol=$(cut -d: -f1 <<<$protourl)
+authpath=$(cut -d: -f2- <<<$protourl)
+authority=${protocol}:$(cut -d/ -f1-3 <<<$authpath)
+authpat="^"$(sed 's/\./\\./g' <<<$authority)
+replacement="${protocol}://${domain}:${port}"
+
+export authpat replacement cacert
+
+midpath=/tmp/$$
+
+yq '(.clusters[] | .cluster | select(.server | test(strenv(authpat))) | .certificate-authority-data) = strenv(cacert)' $inpath > $midpath
+yq '(.clusters[] | .cluster | select(.server | test(strenv(authpat))) | .server) |= ( . | sub(strenv(authpat), strenv(replacement)) )' $midpath > $outpath
+
+rm $midpath

--- a/scripts/wait-and-switch-domain
+++ b/scripts/wait-and-switch-domain
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+
+# Waits for kube server to be running then produces an alternate kubeconfig.
+# The alternate kubeconfig goes in a directory whose name equals
+# the name of the original's directory extended with a dash and
+# the given domain name.
+# The alternate kubeconfig equals the given kubeconfig except for
+# the replacement of the protocol://host:port prefix of some
+# `server` fields in some `cluster` values.
+# In particular, the ones that are replaced are the ones that
+# originally equaled the prefix of the cluster of the given context.
+
+if [ $# != 6 ]; then
+   echo "Usage: $0 configdir configfile context domain port cacert" >&2
+   exit 1
+fi
+
+this="$0"
+
+set -e
+
+configdir="$(cd $1; pwd)"
+shift
+configfile="$1"
+shift
+context="$1"
+shift
+domain="$1"
+shift
+port="$1"
+shift
+cacert_file="$1"
+
+inpath="${configdir}/${configfile}"
+
+while ! kubectl --kubeconfig "$inpath" get ns &> /dev/null; do
+      sleep 10
+done
+
+${this%wait-and-switch-domain}switch-domain "$configdir" "$configfile" "$context" "$domain" "$port" "$cacert_file"


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
This PR adds a first draft of scripts designed to support more complex deployment scenarios, as outlined in #788.  These scripts are concerned with the following two things.

1. Support generation of server credentials to pass to kcp or plain kube server via `--tls-sni-cert-key`.
2. Create alternate kubeconfig files by replacing the protocol://host:port prefix of cluster server URLs and the CA certificate data.

These scripts are factored so that the user can launch the kcp server in their own way and support multiple sets of clients needing to connect to the kcp server using different domain names.

## Related issue(s)

Fixes #
