### PR TITLE
🐛 Bug fix 828 a few of the docs-ecutable docs are finishing with errors

### DIFF
--- a/config/samples/location_dev.yaml
+++ b/config/samples/location_dev.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: scheduling.kcp.io/v1alpha1
+apiVersion: edge.kcp.io/v1alpha1
 kind: Location
 metadata:
   name: dev
@@ -10,6 +10,6 @@ spec:
     matchLabels:
       env: dev
   resource:
-    group: workload.kcp.io
+    group: edge.kcp.io
     resource: synctargets
     version: v1alpha1

--- a/config/samples/location_prod.yaml
+++ b/config/samples/location_prod.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: scheduling.kcp.io/v1alpha1
+apiVersion: edge.kcp.io/v1alpha1
 kind: Location
 metadata:
   name: prod
@@ -10,6 +10,6 @@ spec:
     matchLabels:
       env: prod
   resource:
-    group: workload.kcp.io
+    group: edge.kcp.io
     resource: synctargets
     version: v1alpha1

--- a/config/samples/synctarget_dev.yaml
+++ b/config/samples/synctarget_dev.yaml
@@ -1,4 +1,4 @@
-apiVersion: workload.kcp.io/v1alpha1
+apiVersion: edge.kcp.io/v1alpha1
 kind: SyncTarget
 metadata:
   name: dev

--- a/config/samples/synctarget_prod.yaml
+++ b/config/samples/synctarget_prod.yaml
@@ -1,4 +1,4 @@
-apiVersion: workload.kcp.io/v1alpha1
+apiVersion: edge.kcp.io/v1alpha1
 kind: SyncTarget
 metadata:
   name: prod

--- a/docs/content/Coding Milestones/PoC2023q1/example1-subs/example1-post-kcp.md
+++ b/docs/content/Coding Milestones/PoC2023q1/example1-subs/example1-post-kcp.md
@@ -60,6 +60,8 @@ with `env=prod`, and also label guilder with `extended=si`.
 ```shell
 kubectl kubestellar ensure location florin  loc-name=florin  env=prod
 kubectl kubestellar ensure location guilder loc-name=guilder env=prod extended=si
+echo "decribe the florin location object"
+kubectl describe location.edge.kcp.io florin
 ```
 
 Those two script invocations are equivalent to creating the following

--- a/docs/content/Coding Milestones/PoC2023q1/example1-subs/example1-post-kcp.md
+++ b/docs/content/Coding Milestones/PoC2023q1/example1-subs/example1-post-kcp.md
@@ -9,16 +9,35 @@ kubectl ws root
 
 ### Get and build or install KubeStellar
 
-Download and build, or install, <a href="{{config.repo_url}}">KubeStellar</a>,
+Contributors interested in running the Continuous Integration scripts
+locally, or from an existing git development branch, should skip the Fetch step
+and resume reading at the Build step.
+
+For new users, download and build, or install, <a href="{{config.repo_url}}">KubeStellar</a>,
 according to your preference.  That is, either (a) `git clone` the
 repo and then `make build` to populate its `bin` directory, or (b)
 fetch the binary archive appropriate for your machine from a release
 and unpack it (creating a `bin` directory).  The commands exhibited
 just below assume that the repo has been fetched but not yet built.
 
-```shell
+Fetch step:
+
+```{.base}
 git clone -b {{ config.ks_branch }} {{ config.repo_url }}
-cd kubestellar
+```
+
+Build step:
+
+```shell
+echo "post kcp build step"
+echo $HOME
+echo $PWD
+if [ "$PWD" = "$HOME/kubestellar" ]
+then echo "pwd is $PWD"
+else 
+  cd kubestellar
+  echo "cd to kubestellar, now in $PWD"
+fi
 make build
 export PATH=$(pwd)/bin:$PATH
 ```

--- a/docs/content/Coding Milestones/PoC2023q1/example1-subs/example1-post-kcp.md
+++ b/docs/content/Coding Milestones/PoC2023q1/example1-subs/example1-post-kcp.md
@@ -32,12 +32,12 @@ Build step:
 echo "post kcp build step"
 echo $HOME
 echo $PWD
-if [ "$PWD" = "$HOME/kubestellar" ]
-then echo "pwd is $PWD"
-else 
-  cd kubestellar
-  echo "cd to kubestellar, now in $PWD"
-fi
+#if [ "$PWD" = "$HOME/kubestellar" ]
+#then echo "pwd is $PWD"
+#else 
+#  cd kubestellar
+#  echo "cd to kubestellar, now in $PWD"
+#fi
 make build
 export PATH=$(pwd)/bin:$PATH
 ```

--- a/docs/content/Coding Milestones/PoC2023q1/example1-subs/example1-post-kcp.md
+++ b/docs/content/Coding Milestones/PoC2023q1/example1-subs/example1-post-kcp.md
@@ -5,7 +5,6 @@ Use the following commands.
 
 ```shell
 kubectl ws root
-kubectl ws create imw-1 --enter
 ```
 
 ### Get and build or install KubeStellar
@@ -32,68 +31,6 @@ The kubectl plugin lines use fully specific executables (e.g.,
 `kubectl kubestellar prep-for-syncer` corresponds to
 `bin/kubectl-kubestellar-prep_for_syncer`).
 
-### Create SyncTarget and Location objects to represent the florin and guilder clusters
-
-Use the following two commands. They label both florin and guilder
-with `env=prod`, and also label guilder with `extended=si`.
-
-```shell
-kubectl kubestellar ensure location florin  loc-name=florin  env=prod
-kubectl kubestellar ensure location guilder loc-name=guilder env=prod extended=si
-```
-
-Those two script invocations are equivalent to creating the following
-four objects.
-
-```yaml
-apiVersion: workload.kcp.io/v1alpha1
-kind: SyncTarget
-metadata:
-  name: florin
-  labels:
-    id: florin
-    loc-name: florin
-    env: prod
----
-apiVersion: scheduling.kcp.io/v1alpha1
-kind: Location
-metadata:
-  name: florin
-  labels:
-    loc-name: florin
-    env: prod
-spec:
-  resource: {group: workload.kcp.io, version: v1alpha1, resource: synctargets}
-  instanceSelector:
-    matchLabels: {id: florin}
----
-apiVersion: workload.kcp.io/v1alpha1
-kind: SyncTarget
-metadata:
-  name: guilder
-  labels:
-    id: guilder
-    loc-name: guilder
-    env: prod
-    extended: si
----
-apiVersion: scheduling.kcp.io/v1alpha1
-kind: Location
-metadata:
-  name: guilder
-  labels:
-    loc-name: guilder
-    env: prod
-    extended: si
-spec:
-  resource: {group: workload.kcp.io, version: v1alpha1, resource: synctargets}
-  instanceSelector:
-    matchLabels: {id: guilder}
-```
-
-That script also deletes the Location named `default`, which is not
-used in this PoC, if it shows up.
-
 ### Initialize the KubeStellar platform
 
 In this step KubeStellar creates and populates the Edge Service
@@ -109,5 +46,68 @@ are namespaced and are meaningful in KubeStellar.
 ```shell
 kubestellar init
 ```
+ 
+### Create SyncTarget and Location objects to represent the florin and guilder clusters
+
+Use the following two commands. They label both florin and guilder
+with `env=prod`, and also label guilder with `extended=si`.
+
+```shell
+kubectl ws create imw-1 --enter
+kubectl kubestellar ensure location florin  loc-name=florin  env=prod
+kubectl kubestellar ensure location guilder loc-name=guilder env=prod extended=si
+```
+
+Those two script invocations are equivalent to creating the following
+four objects.
+
+```yaml
+apiVersion: edge.kcp.io/v1alpha1
+kind: SyncTarget
+metadata:
+  name: florin
+  labels:
+    id: florin
+    loc-name: florin
+    env: prod
+---
+apiVersion: edge.kcp.io/v1alpha1
+kind: Location
+metadata:
+  name: florin
+  labels:
+    loc-name: florin
+    env: prod
+spec:
+  resource: {group: edge.kcp.io, version: v1alpha1, resource: synctargets}
+  instanceSelector:
+    matchLabels: {id: florin}
+---
+apiVersion: edge.kcp.io/v1alpha1
+kind: SyncTarget
+metadata:
+  name: guilder
+  labels:
+    id: guilder
+    loc-name: guilder
+    env: prod
+    extended: si
+---
+apiVersion: edge.kcp.io/v1alpha1
+kind: Location
+metadata:
+  name: guilder
+  labels:
+    loc-name: guilder
+    env: prod
+    extended: si
+spec:
+  resource: {group: edge.kcp.io, version: v1alpha1, resource: synctargets}
+  instanceSelector:
+    matchLabels: {id: guilder}
+```
+
+That script also deletes the Location named `default`, which is not
+used in this PoC, if it shows up.
 
 <!--example1-post-kcp-end-->

--- a/docs/content/Coding Milestones/PoC2023q1/example1-subs/example1-post-kcp.md
+++ b/docs/content/Coding Milestones/PoC2023q1/example1-subs/example1-post-kcp.md
@@ -1,5 +1,5 @@
 <!--example1-post-kcp-start-->
-### Create an inventory management workspace.
+### Use the root workspace.
 
 Use the following commands.
 
@@ -46,15 +46,18 @@ are namespaced and are meaningful in KubeStellar.
 ```shell
 kubestellar init
 ```
- 
+
+### Create an inventory management workspace.
+```shell
+kubectl ws root
+kubectl ws create imw-1 --enter
+```
 ### Create SyncTarget and Location objects to represent the florin and guilder clusters
 
 Use the following two commands. They label both florin and guilder
 with `env=prod`, and also label guilder with `extended=si`.
 
 ```shell
-kubectl ws root
-kubectl ws create imw-1 --enter
 kubectl kubestellar ensure location florin  loc-name=florin  env=prod
 kubectl kubestellar ensure location guilder loc-name=guilder env=prod extended=si
 ```

--- a/docs/content/Coding Milestones/PoC2023q1/example1-subs/example1-post-kcp.md
+++ b/docs/content/Coding Milestones/PoC2023q1/example1-subs/example1-post-kcp.md
@@ -24,20 +24,13 @@ Fetch step:
 
 ```{.base}
 git clone -b {{ config.ks_branch }} {{ config.repo_url }}
+cd kubestellar
 ```
 
 Build step:
 
 ```shell
-echo "post kcp build step"
-echo $HOME
-echo $PWD
-#if [ "$PWD" = "$HOME/kubestellar" ]
-#then echo "pwd is $PWD"
-#else 
-#  cd kubestellar
-#  echo "cd to kubestellar, now in $PWD"
-#fi
+echo "current path is $PWD"
 make build
 export PATH=$(pwd)/bin:$PATH
 ```

--- a/docs/content/Coding Milestones/PoC2023q1/example1-subs/example1-post-kcp.md
+++ b/docs/content/Coding Milestones/PoC2023q1/example1-subs/example1-post-kcp.md
@@ -53,6 +53,7 @@ Use the following two commands. They label both florin and guilder
 with `env=prod`, and also label guilder with `extended=si`.
 
 ```shell
+kubectl ws root
 kubectl ws create imw-1 --enter
 kubectl kubestellar ensure location florin  loc-name=florin  env=prod
 kubectl kubestellar ensure location guilder loc-name=guilder env=prod extended=si

--- a/docs/content/Coding Milestones/PoC2023q1/example1-subs/example1-post-kcp.md
+++ b/docs/content/Coding Milestones/PoC2023q1/example1-subs/example1-post-kcp.md
@@ -58,6 +58,7 @@ Use the following two commands. They label both florin and guilder
 with `env=prod`, and also label guilder with `extended=si`.
 
 ```shell
+kubectl ws root:imw-1
 kubectl kubestellar ensure location florin  loc-name=florin  env=prod
 kubectl kubestellar ensure location guilder loc-name=guilder env=prod extended=si
 echo "decribe the florin location object"

--- a/docs/content/Coding Milestones/PoC2023q1/example1-subs/example1-stage-1a.md
+++ b/docs/content/Coding Milestones/PoC2023q1/example1-subs/example1-stage-1a.md
@@ -11,11 +11,17 @@ sleep 45
 ```
 ``` { .bash .no-copy }
 ...
-I0423 01:09:37.991080   10624 main.go:196] "Found APIExport view" exportName="workload.kcp.io" serverURL="https://192.168.58.123:6443/services/apiexport/root/workload.kcp.io"
+I0721 17:37:10.186848  189094 main.go:206] "Found APIExport view" exportName="e
+dge.kcp.io" serverURL="https://10.0.2.15:6443/services/apiexport/cseslli1ddit3s
+a5/edge.kcp.io"
 ...
-I0423 01:09:38.449395   10624 controller.go:299] "Created APIBinding" worker=1 mbwsName="apmziqj9p9fqlflm-mb-bf452e1f-45a0-4d5d-b35c-ef1ece2879ba" mbwsCluster="yk9a66vjms1pi8hu" bindingName="bind-edge" resourceVersion="914"
+I0721 19:17:21.906984  189094 controller.go:300] "Created APIBinding" worker=1
+mbwsName="1d55jhazpo3d3va6-mb-551bebfd-b75e-47b1-b2e0-ff0a4cb7e006" mbwsCluster
+="32x6b03ixc49cj48" bindingName="bind-edge" resourceVersion="1247"
 ...
-I0423 01:09:38.842881   10624 controller.go:299] "Created APIBinding" worker=3 mbwsName="apmziqj9p9fqlflm-mb-b8c64c64-070c-435b-b3bd-9c0f0c040a54" mbwsCluster="12299slctppnhjnn" bindingName="bind-edge" resourceVersion="968"
+I0721 19:18:56.203057  189094 controller.go:300] "Created APIBinding" worker=0
+mbwsName="1d55jhazpo3d3va6-mb-732cf72a-1ca9-4def-a5e7-78fd0e36e61c" mbwsCluster
+="q31lsrpgur3eg9qk" bindingName="bind-edge" resourceVersion="1329"
 ^C
 ```
 

--- a/docs/content/Coding Milestones/PoC2023q1/example1-subs/example1-stage-1a.md
+++ b/docs/content/Coding Milestones/PoC2023q1/example1-subs/example1-stage-1a.md
@@ -10,7 +10,7 @@ echo "about to start the mailbox controller - example1-stage-1a"
 kubectl ws root:espw
 kubectl api-resources
 go run ./cmd/mailbox-controller -v=2 &
-sleep 360
+sleep 90
 ```
 ``` { .bash .no-copy }
 ...

--- a/docs/content/Coding Milestones/PoC2023q1/example1-subs/example1-stage-1a.md
+++ b/docs/content/Coding Milestones/PoC2023q1/example1-subs/example1-stage-1a.md
@@ -7,7 +7,7 @@ here.
 
 ```shell
 echo "about to start the mailbox controller - example1-stage-1a"
-kubectl ws .
+kubectl ws root:espw
 kubectl api-resources
 go run ./cmd/mailbox-controller -v=2 &
 sleep 360
@@ -44,6 +44,7 @@ echo "stage-1a continuing"
 kubectl ws .
 kubectl api-resources
 kubectl get Workspaces
+kubectl get workspaces
 ```
 ``` { .bash .no-copy }
 NAME                                                       TYPE        REGION   PHASE   URL                                                     AGE

--- a/docs/content/Coding Milestones/PoC2023q1/example1-subs/example1-stage-1a.md
+++ b/docs/content/Coding Milestones/PoC2023q1/example1-subs/example1-stage-1a.md
@@ -8,7 +8,7 @@ here.
 ```shell
 kubectl ws root:espw
 go run ./cmd/mailbox-controller -v=2 &
-sleep 45
+sleep 60
 ```
 ``` { .bash .no-copy }
 ...

--- a/docs/content/Coding Milestones/PoC2023q1/example1-subs/example1-stage-1a.md
+++ b/docs/content/Coding Milestones/PoC2023q1/example1-subs/example1-stage-1a.md
@@ -10,7 +10,7 @@ echo "about to start the mailbox controller - example1-stage-1a"
 kubectl ws .
 kubectl api-resources
 go run ./cmd/mailbox-controller -v=2 &
-sleep 45
+sleep 360
 ```
 ``` { .bash .no-copy }
 ...
@@ -40,6 +40,9 @@ normally it would run continuously.
 You can get a listing of those mailbox workspaces as follows.
 
 ```shell
+echo "stage-1a continuing"
+kubectl ws .
+kubectl api-resources
 kubectl get Workspaces
 ```
 ``` { .bash .no-copy }

--- a/docs/content/Coding Milestones/PoC2023q1/example1-subs/example1-stage-1a.md
+++ b/docs/content/Coding Milestones/PoC2023q1/example1-subs/example1-stage-1a.md
@@ -6,6 +6,9 @@ Eventually.  In the meantime, you can use the KubeStellar command shown
 here.
 
 ```shell
+echo "about to start the mailbox controller - example1-stage-1a"
+kubectl ws .
+kubectl api-resources
 go run ./cmd/mailbox-controller -v=2 &
 sleep 45
 ```

--- a/docs/content/Coding Milestones/PoC2023q1/example1-subs/example1-stage-1a.md
+++ b/docs/content/Coding Milestones/PoC2023q1/example1-subs/example1-stage-1a.md
@@ -6,11 +6,9 @@ Eventually.  In the meantime, you can use the KubeStellar command shown
 here.
 
 ```shell
-echo "about to start the mailbox controller - example1-stage-1a"
 kubectl ws root:espw
-kubectl api-resources
 go run ./cmd/mailbox-controller -v=2 &
-sleep 90
+sleep 45
 ```
 ``` { .bash .no-copy }
 ...
@@ -40,11 +38,7 @@ normally it would run continuously.
 You can get a listing of those mailbox workspaces as follows.
 
 ```shell
-echo "stage-1a continuing"
-kubectl ws .
-kubectl api-resources
 kubectl get Workspaces
-kubectl get workspaces
 ```
 ``` { .bash .no-copy }
 NAME                                                       TYPE        REGION   PHASE   URL                                                     AGE

--- a/docs/content/Coding Milestones/PoC2023q1/example1-subs/example1-stage-1b.md
+++ b/docs/content/Coding Milestones/PoC2023q1/example1-subs/example1-stage-1b.md
@@ -7,6 +7,7 @@ write a file containing YAML for deploying the syncer in the guilder
 cluster.
 
 ```shell
+kubectl kcp bind apiexport root:espw:edge.kcp.io
 kubectl kubestellar prep-for-syncer --imw root:imw-1 guilder
 ```
 ``` { .bash .no-copy }

--- a/docs/content/Coding Milestones/PoC2023q1/example1-subs/example1-stage-2.md
+++ b/docs/content/Coding Milestones/PoC2023q1/example1-subs/example1-stage-2.md
@@ -82,7 +82,7 @@ data:
     <html>
       <body>
         This is a common web site.
-        Running in %(env).
+        Running in %(loc-name).
       </body>
     </html>
 ---

--- a/docs/content/Coding Milestones/PoC2023q1/example1-subs/example1-stage-2.md
+++ b/docs/content/Coding Milestones/PoC2023q1/example1-subs/example1-stage-2.md
@@ -82,7 +82,7 @@ data:
     <html>
       <body>
         This is a common web site.
-        Running in %(loc-name).
+        Running in %(env).
       </body>
     </html>
 ---

--- a/docs/content/Coding Milestones/PoC2023q1/kubestellar-syncer-subs/kubestellar-syncer-0-deploy-florin.md
+++ b/docs/content/Coding Milestones/PoC2023q1/kubestellar-syncer-subs/kubestellar-syncer-0-deploy-florin.md
@@ -2,6 +2,7 @@
 Go to inventory management workspace and find the mailbox workspace name.
 ```shell
 kubectl ws root:imw-1
+kubectl ws .
 mbws=`kubectl get SyncTarget florin -o jsonpath="{.metadata.annotations['kcp\.io/cluster']}-mb-{.metadata.uid}"`
 echo "mailbox workspace name = $mbws"
 ```

--- a/docs/content/Coding Milestones/PoC2023q1/kubestellar-syncer-subs/kubestellar-syncer-0-deploy-florin.md
+++ b/docs/content/Coding Milestones/PoC2023q1/kubestellar-syncer-subs/kubestellar-syncer-0-deploy-florin.md
@@ -2,8 +2,7 @@
 Go to inventory management workspace and find the mailbox workspace name.
 ```shell
 kubectl ws root:imw-1
-kubectl ws .
-mbws=`kubectl get SyncTarget florin -o jsonpath="{.metadata.annotations['kcp\.io/cluster']}-mb-{.metadata.uid}"`
+mbws=`kubectl get synctargets.edge.kcp.io florin -o jsonpath="{.metadata.annotations['kcp\.io/cluster']}-mb-{.metadata.uid}"`
 echo "mailbox workspace name = $mbws"
 ```
 ``` { .bash .no-copy }

--- a/docs/content/Coding Milestones/PoC2023q1/kubestellar-syncer-subs/kubestellar-syncer-0-deploy-guilder.md
+++ b/docs/content/Coding Milestones/PoC2023q1/kubestellar-syncer-subs/kubestellar-syncer-0-deploy-guilder.md
@@ -4,6 +4,7 @@ Go to inventory management workspace and find the mailbox workspace name.
 kubectl ws root:imw-1
 kubectl get SyncTargets
 kubectl get synctargets.edge.kcp.io
+kubectl describe synctargets.edge.kcp.io guilder
 kubectl describe Synctarget guilder
 mbws=`kubectl get SyncTarget guilder -o jsonpath="{.metadata.annotations['kcp\.io/cluster']}-mb-{.metadata.uid}"`
 echo "mailbox workspace name = $mbws"

--- a/docs/content/Coding Milestones/PoC2023q1/kubestellar-syncer-subs/kubestellar-syncer-0-deploy-guilder.md
+++ b/docs/content/Coding Milestones/PoC2023q1/kubestellar-syncer-subs/kubestellar-syncer-0-deploy-guilder.md
@@ -4,6 +4,7 @@ Go to inventory management workspace and find the mailbox workspace name.
 kubectl ws root:imw-1
 kubectl get SyncTargets
 kubectl get synctargets.edge.kcp.io
+kubectl describe Synctarget guilder
 mbws=`kubectl get SyncTarget guilder -o jsonpath="{.metadata.annotations['kcp\.io/cluster']}-mb-{.metadata.uid}"`
 echo "mailbox workspace name = $mbws"
 ```

--- a/docs/content/Coding Milestones/PoC2023q1/kubestellar-syncer-subs/kubestellar-syncer-0-deploy-guilder.md
+++ b/docs/content/Coding Milestones/PoC2023q1/kubestellar-syncer-subs/kubestellar-syncer-0-deploy-guilder.md
@@ -5,8 +5,8 @@ kubectl ws root:imw-1
 kubectl get SyncTargets
 kubectl get synctargets.edge.kcp.io
 kubectl describe synctargets.edge.kcp.io guilder
-kubectl describe Synctarget guilder
-mbws=`kubectl get SyncTarget guilder -o jsonpath="{.metadata.annotations['kcp\.io/cluster']}-mb-{.metadata.uid}"`
+#kubectl describe Synctarget guilder
+mbws=`kubectl get synctargets.edge.kcp.io guilder -o jsonpath="{.metadata.annotations['kcp\.io/cluster']}-mb-{.metadata.uid}"`
 echo "mailbox workspace name = $mbws"
 ```
 ``` { .bash .no-copy }

--- a/docs/content/Coding Milestones/PoC2023q1/kubestellar-syncer-subs/kubestellar-syncer-0-deploy-guilder.md
+++ b/docs/content/Coding Milestones/PoC2023q1/kubestellar-syncer-subs/kubestellar-syncer-0-deploy-guilder.md
@@ -2,6 +2,8 @@
 Go to inventory management workspace and find the mailbox workspace name.
 ```shell
 kubectl ws root:imw-1
+kubectl get SyncTargets
+kubectl get synctargets.edge.kcp.io
 mbws=`kubectl get SyncTarget guilder -o jsonpath="{.metadata.annotations['kcp\.io/cluster']}-mb-{.metadata.uid}"`
 echo "mailbox workspace name = $mbws"
 ```

--- a/docs/content/Coding Milestones/PoC2023q1/mailbox-controller-subs/mailbox-controller-process-start-without-cd-kubestellar.md
+++ b/docs/content/Coding Milestones/PoC2023q1/mailbox-controller-subs/mailbox-controller-process-start-without-cd-kubestellar.md
@@ -1,9 +1,9 @@
 <!--mailbox-controller-process-start-without-cd-kubestellar-start-->
 ```shell
 kubectl ws root:espw
-echo "mailbox-controll-start-without"
+echo "mailbox-controller-start-without"
 kubectl api-resources
 go run ./cmd/mailbox-controller -v=2 &
-sleep 240
+sleep 360
 ```
 <!--mailbox-controller-process-start-without-cd-kubestellar-end-->

--- a/docs/content/Coding Milestones/PoC2023q1/mailbox-controller-subs/mailbox-controller-process-start-without-cd-kubestellar.md
+++ b/docs/content/Coding Milestones/PoC2023q1/mailbox-controller-subs/mailbox-controller-process-start-without-cd-kubestellar.md
@@ -1,9 +1,7 @@
 <!--mailbox-controller-process-start-without-cd-kubestellar-start-->
 ```shell
 kubectl ws root:espw
-echo "mailbox-controller-start-without"
-kubectl api-resources
 go run ./cmd/mailbox-controller -v=2 &
-sleep 90
+sleep 45
 ```
 <!--mailbox-controller-process-start-without-cd-kubestellar-end-->

--- a/docs/content/Coding Milestones/PoC2023q1/mailbox-controller-subs/mailbox-controller-process-start-without-cd-kubestellar.md
+++ b/docs/content/Coding Milestones/PoC2023q1/mailbox-controller-subs/mailbox-controller-process-start-without-cd-kubestellar.md
@@ -4,6 +4,6 @@ kubectl ws root:espw
 echo "mailbox-controller-start-without"
 kubectl api-resources
 go run ./cmd/mailbox-controller -v=2 &
-sleep 360
+sleep 90
 ```
 <!--mailbox-controller-process-start-without-cd-kubestellar-end-->

--- a/docs/content/Coding Milestones/PoC2023q1/mailbox-controller-subs/mailbox-controller-process-start-without-cd-kubestellar.md
+++ b/docs/content/Coding Milestones/PoC2023q1/mailbox-controller-subs/mailbox-controller-process-start-without-cd-kubestellar.md
@@ -4,6 +4,6 @@ kubectl ws root:espw
 echo "mailbox-controll-start-without"
 kubectl api-resources
 go run ./cmd/mailbox-controller -v=2 &
-sleep 45
+sleep 240
 ```
 <!--mailbox-controller-process-start-without-cd-kubestellar-end-->

--- a/docs/content/Coding Milestones/PoC2023q1/mailbox-controller-subs/mailbox-controller-process-start-without-cd-kubestellar.md
+++ b/docs/content/Coding Milestones/PoC2023q1/mailbox-controller-subs/mailbox-controller-process-start-without-cd-kubestellar.md
@@ -1,6 +1,8 @@
 <!--mailbox-controller-process-start-without-cd-kubestellar-start-->
 ```shell
 kubectl ws root:espw
+echo "mailbox-controll-start-without"
+kubectl api-resources
 go run ./cmd/mailbox-controller -v=2 &
 sleep 45
 ```

--- a/docs/content/Coding Milestones/PoC2023q1/mailbox-controller.md
+++ b/docs/content/Coding Milestones/PoC2023q1/mailbox-controller.md
@@ -135,6 +135,7 @@ In a separate terminal window(3), create an inventory management workspace as fo
 ```shell
 kubectl ws \~
 kubectl ws create imw --enter
+kubectl kcp bind apiexport root:espw:edge.kcp.io
 ```
 
 Then in that workspace, run the following command to create a `SyncTarget` object.

--- a/docs/content/Coding Milestones/PoC2023q1/mailbox-controller.md
+++ b/docs/content/Coding Milestones/PoC2023q1/mailbox-controller.md
@@ -34,9 +34,9 @@ provider workspace).
 
 The mailbox controller needs three Kubernetes client configurations.
 One --- concerned with reading inventory --- is to access the
-APIExport view of the `workload.kcp.io` API group, to read the
+APIExport view of the `edge.kcp.io` API group, to read the
 `SyncTarget` objects.  This must be a client config that is pointed at
-the workspace (which is always `root`, as far as I know) that has this
+the workspace (which is always `root:espw`, as far as I know) that has this
 APIExport and is authorized to read its view.  Another client config
 is needed to give read/write access to all the mailbox workspaces, so
 that the controller can create `APIBinding` objects to the edge
@@ -141,7 +141,7 @@ Then in that workspace, run the following command to create a `SyncTarget` objec
 
 ```shell
 cat <<EOF | kubectl apply -f -
-apiVersion: workload.kcp.io/v1alpha1
+apiVersion: edge.kcp.io/v1alpha1
 kind: SyncTarget
 metadata:
   name: stest1

--- a/docs/content/Coding Milestones/PoC2023q1/mailbox-controller.md
+++ b/docs/content/Coding Milestones/PoC2023q1/mailbox-controller.md
@@ -201,6 +201,7 @@ kubectl ws \~
 kubectl ws .
 kubectl ws imw
 kubectl ws .
+kubectl get synctargets.edge.kcp.io
 kubectl delete SyncTarget stest1
 ```
 and watch the mailbox controller react as follows.

--- a/docs/content/Coding Milestones/PoC2023q1/mailbox-controller.md
+++ b/docs/content/Coding Milestones/PoC2023q1/mailbox-controller.md
@@ -161,6 +161,11 @@ I0305 18:07:20.490417   85556 main.go:369] "Created missing workspace" worker=0 
 And you can verify that as follows:
 
 ```shell
+kubectl ws .
+kubectl get synctargets.edge.kcp.io
+```
+
+```shell
 kubectl ws root:espw
 ```
 ``` {.bash .no-copy }
@@ -168,6 +173,7 @@ Current workspace is "root:espw".
 ```
 
 ```shell
+kubectl ws tree 
 kubectl get workspaces
 ```
 ``` { .bash .no-copy }

--- a/docs/content/Coding Milestones/PoC2023q1/mailbox-controller.md
+++ b/docs/content/Coding Milestones/PoC2023q1/mailbox-controller.md
@@ -198,7 +198,9 @@ Finally, go back to your inventory workspace to delete the `SyncTarget`:
 
 ```shell
 kubectl ws \~
-#kubectl ws imw
+kubectl ws .
+kubectl ws imw
+kubectl ws .
 kubectl delete SyncTarget stest1
 ```
 and watch the mailbox controller react as follows.

--- a/docs/content/Coding Milestones/PoC2023q1/mailbox-controller.md
+++ b/docs/content/Coding Milestones/PoC2023q1/mailbox-controller.md
@@ -202,7 +202,7 @@ kubectl ws .
 kubectl ws imw
 kubectl ws .
 kubectl get synctargets.edge.kcp.io
-kubectl delete SyncTarget stest1
+kubectl delete synctargets.edge.kcp.io stest1
 ```
 and watch the mailbox controller react as follows.
 

--- a/docs/content/Coding Milestones/PoC2023q1/mailbox-controller.md
+++ b/docs/content/Coding Milestones/PoC2023q1/mailbox-controller.md
@@ -192,7 +192,7 @@ Finally, go back to your inventory workspace to delete the `SyncTarget`:
 
 ```shell
 kubectl ws \~
-kubectl ws imw
+#kubectl ws imw
 kubectl delete SyncTarget stest1
 ```
 and watch the mailbox controller react as follows.

--- a/docs/content/Coding Milestones/PoC2023q1/outline.md
+++ b/docs/content/Coding Milestones/PoC2023q1/outline.md
@@ -153,8 +153,8 @@ in an eventually consistent way, it is not just one-and-done.
 
 In this design the primary interface between infrastructure management
 and workload management is API objects in _inventory management_
-workspaces.  We abuse the `Location` and `SyncTarget` object types
-from [kcp TMC](https://github.com/kcp-dev/kcp/tree/v0.11.0/pkg/apis) for
+workspaces.  We use the `Location` and `SyncTarget` object types
+from Kubestellar's edge.kcp.io api group (created by `kubestellar init`) for
 this purpose.  The people doing infrastructure management are
 responsible for creating the inventory management workspaces and
 populating them with `Location` and `SyncTarget` objects, one
@@ -318,7 +318,7 @@ their workload desired and reported state.
 | core.kcp.io/v1alpha1 | LogicalCluster | false |
 | core.kcp.io/v1alpha1 | Shard | false |
 | events.k8s.io/v1 | Event | true |
-| scheduling.kcp.io/v1alpha1 | Location | false |
+|~~ scheduling.kcp.io/v1alpha1 | Location | false ~~|
 | scheduling.kcp.io/v1alpha1 | Placement | false |
 | tenancy.kcp.io/v1alpha1 | ClusterWorkspace | false |
 | tenancy.kcp.io/v1alpha1 | Workspace | false |
@@ -329,7 +329,7 @@ their workload desired and reported state.
 | v1 | ComponentStatus | false |
 | v1 | Event | true |
 | v1 | Node | false |
-| workload.kcp.io/v1alpha1 | SyncTarget | false |
+| ~~workload.kcp.io/v1alpha1 | SyncTarget | false~~ |
 
 #### Already denatured in center, want natured in edge
 

--- a/docs/content/Coding Milestones/PoC2023q1/where-resolver-subs/where-resolver-1-build-kubestellar.md
+++ b/docs/content/Coding Milestones/PoC2023q1/where-resolver-subs/where-resolver-1-build-kubestellar.md
@@ -1,5 +1,9 @@
 <!--where-resolver-1-build-kubestellar-start-->
 ```shell
+make imports
+make codegen
+make crds
+make update-contextual-logging
 make build
 export PATH=$(pwd)/bin:$PATH
 ```

--- a/docs/content/Coding Milestones/PoC2023q1/where-resolver.md
+++ b/docs/content/Coding Milestones/PoC2023q1/where-resolver.md
@@ -107,6 +107,7 @@ I0605 10:53:00.261128   29786 controller.go:201] "starting controller" controlle
 Use workspace `root:compute` as the Inventory Management Workspace (IMW).
 ```shell
 kubectl ws root:compute
+kubectl kcp bind apiexport root:espw:edge.kcp.io
 ```
 
 Create two Locations and two SyncTargets.

--- a/docs/content/Coding Milestones/PoC2023q1/where-resolver.md
+++ b/docs/content/Coding Milestones/PoC2023q1/where-resolver.md
@@ -124,13 +124,13 @@ kubectl get locations,synctargets
 ```
 ``` { .bash .no-copy }
 NAME                                 RESOURCE      AVAILABLE   INSTANCES   LABELS   AGE
-location.scheduling.kcp.io/default   synctargets   0           2                    2m12s
-location.scheduling.kcp.io/dev       synctargets   0           1                    2m39s
-location.scheduling.kcp.io/prod      synctargets   0           1                    3m13s
+location.edge.kcp.io/default   synctargets   0           2                    2m12s
+location.edge.kcp.io/dev       synctargets   0           1                    2m39s
+location.edge.kcp.io/prod      synctargets   0           1                    3m13s
 
 NAME                              AGE
-synctarget.workload.kcp.io/dev    110s
-synctarget.workload.kcp.io/prod   2m12s
+synctarget.edge.kcp.io/dev    110s
+synctarget.edge.kcp.io/prod   2m12s
 ```
 
 ### Create some EdgePlacements in the WMW

--- a/scripts/kubectl-kubestellar-prep_for_syncer
+++ b/scripts/kubectl-kubestellar-prep_for_syncer
@@ -175,7 +175,7 @@ if ! kubectl get APIBinding bind-edge &> /dev/null; then
 fi
 
 # Now the needed APIBinding exists, has it taken effect?
-sleep 5 # hope so
+sleep 10 # hope so
 
 
 "$bindir/kubectl-kubestellar-syncer_gen" "$stname" --syncer-image "$syncer_image" -o "$output"


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
1) Fix the docs-ecutable so it runs from the current github branch environment rather than cloning a previously packaged release.
Otherwise the newly pushed code is never exercised in the case of contributions.
2) Fix the docs-ecutable related to issue 814, pivoting from kcp's synctargets.workload.kcp.io and locations.scheduling.kcp.io to kubestellar's synctargets.edge.kcp.io and locations.edge.kcp.io in order to help wean kubestellar from kcp.

Comment: Unfortunately this PR has many, many commits. These commits were used to test in the Github Actions environment, since I thought there might be a timing issue involved.

## Related issue(s)
814
828
Fixes #
828
