### PR TITLE
🐛 Fix 836 Ensure workload-projector uses Kubestellar locations.edge.kcp.io instead of KCP's locations

### DIFF
--- a/cmd/emc-customize/main.go
+++ b/cmd/emc-customize/main.go
@@ -31,10 +31,9 @@ import (
 	machjson "k8s.io/apimachinery/pkg/runtime/serializer/json"
 	"k8s.io/klog/v2"
 
-	schedulingv1alpha1 "github.com/kcp-dev/kcp/pkg/apis/scheduling/v1alpha1"
-
 	edgeapi "github.com/kubestellar/kubestellar/pkg/apis/edge/v1alpha1"
 	"github.com/kubestellar/kubestellar/pkg/customize"
+	//schedulingv1alpha1 "github.com/kcp-dev/kcp/pkg/apis/scheduling/v1alpha1"
 )
 
 func main() {
@@ -60,7 +59,7 @@ func main() {
 
 	scheme := machruntime.NewScheme()
 	edgeapi.AddToScheme(scheme)
-	schedulingv1alpha1.AddToScheme(scheme)
+	//schedulingv1alpha1.AddToScheme(scheme)
 
 	codecFactory := machserializer.NewCodecFactory(scheme)
 	decoder := codecFactory.UniversalDeserializer()
@@ -101,14 +100,17 @@ func main() {
 		os.Exit(1)
 	}
 
-	var location *schedulingv1alpha1.Location
+	//var location *schedulingv1alpha1.Location
+	var location *edgeapi.Location
 	if fs.NArg() > 1 {
-		obj, err := readObject(decoder, fs.Arg(1), &schedulingv1alpha1.Location{})
+		//obj, err := readObject(decoder, fs.Arg(1), &schedulingv1alpha1.Location{})
+		obj, err := readObject(decoder, fs.Arg(1), &edgeapi.Location{})
 		if err != nil {
 			logger.Error(err, "Failed to read Location", "locationFilename", fs.Arg(1))
 			os.Exit(30)
 		}
-		location = obj.(*schedulingv1alpha1.Location)
+		//location = obj.(*schedulingv1alpha1.Location)
+		location = obj.(*edgeapi.Location)
 	}
 	logger.V(2).Info("Location", "loc", location)
 

--- a/cmd/placement-translator/main.go
+++ b/cmd/placement-translator/main.go
@@ -59,8 +59,6 @@ import (
 	tenancyv1a1informers "github.com/kcp-dev/kcp/pkg/client/informers/externalversions/tenancy/v1alpha1"
 
 	emcclusterclientset "github.com/kubestellar/kubestellar/pkg/client/clientset/versioned/cluster"
-
-	//schedulingv1a1informers "github.com/kcp-dev/kcp/pkg/client/informers/externalversions/scheduling/v1alpha1"
 	emcinformers "github.com/kubestellar/kubestellar/pkg/client/informers/externalversions"
 	edgev1a1informers "github.com/kubestellar/kubestellar/pkg/client/informers/externalversions/edge/v1alpha1"
 	"github.com/kubestellar/kubestellar/pkg/placement"
@@ -209,9 +207,7 @@ func main() {
 	}
 
 	sspwInformerFactory := kcpinformers.NewSharedInformerFactoryWithOptions(schedViewClusterClientset, resyncPeriod)
-	//locationClusterPreInformer := sspwInformerFactory.Scheduling().V1alpha1().Locations()
 	locationClusterPreInformer := edgeInformerFactory.Edge().V1alpha1().Locations()
-	//var _ schedulingv1a1informers.LocationClusterInformer = locationClusterPreInformer
 	var _ edgev1a1informers.LocationClusterInformer = locationClusterPreInformer
 
 	kcpClusterClientset, err := kcpclusterclientset.NewForConfig(baseRestConfig)

--- a/cmd/placement-translator/main.go
+++ b/cmd/placement-translator/main.go
@@ -56,10 +56,11 @@ import (
 	kcpscopedclientset "github.com/kcp-dev/kcp/pkg/client/clientset/versioned"
 	kcpclusterclientset "github.com/kcp-dev/kcp/pkg/client/clientset/versioned/cluster"
 	kcpinformers "github.com/kcp-dev/kcp/pkg/client/informers/externalversions"
-	schedulingv1a1informers "github.com/kcp-dev/kcp/pkg/client/informers/externalversions/scheduling/v1alpha1"
 	tenancyv1a1informers "github.com/kcp-dev/kcp/pkg/client/informers/externalversions/tenancy/v1alpha1"
 
 	emcclusterclientset "github.com/kubestellar/kubestellar/pkg/client/clientset/versioned/cluster"
+
+	//schedulingv1a1informers "github.com/kcp-dev/kcp/pkg/client/informers/externalversions/scheduling/v1alpha1"
 	emcinformers "github.com/kubestellar/kubestellar/pkg/client/informers/externalversions"
 	edgev1a1informers "github.com/kubestellar/kubestellar/pkg/client/informers/externalversions/edge/v1alpha1"
 	"github.com/kubestellar/kubestellar/pkg/placement"
@@ -208,8 +209,10 @@ func main() {
 	}
 
 	sspwInformerFactory := kcpinformers.NewSharedInformerFactoryWithOptions(schedViewClusterClientset, resyncPeriod)
-	locationClusterPreInformer := sspwInformerFactory.Scheduling().V1alpha1().Locations()
-	var _ schedulingv1a1informers.LocationClusterInformer = locationClusterPreInformer
+	//locationClusterPreInformer := sspwInformerFactory.Scheduling().V1alpha1().Locations()
+	locationClusterPreInformer := edgeInformerFactory.Edge().V1alpha1().Locations()
+	//var _ schedulingv1a1informers.LocationClusterInformer = locationClusterPreInformer
+	var _ edgev1a1informers.LocationClusterInformer = locationClusterPreInformer
 
 	kcpClusterClientset, err := kcpclusterclientset.NewForConfig(baseRestConfig)
 	if err != nil {

--- a/hack/logcheck.out
+++ b/hack/logcheck.out
@@ -2,8 +2,8 @@
 /cmd/kcp-watchall/main.go:103:3: Key positional arguments are expected to be inlined constant strings. Please replace &{flg Name} provided with string value.
 /cmd/mailbox-controller/main.go:198:4: Additional arguments to Info should always be Key Value pairs. Please check if there is any key or value missing.
 /cmd/mailbox-controller/main.go:91:3: Key positional arguments are expected to be inlined constant strings. Please replace &{flg Name} provided with string value.
-/cmd/placement-translator/main.go:121:3: Key positional arguments are expected to be inlined constant strings. Please replace &{flg Name} provided with string value.
-/pkg/placement/workload-projector.go:688:4: the result of logger.V should be stored in a variable and then be used multiple times: if logger := logger.V(); logger.Enabled() { ... logger.Info ... }
-/pkg/placement/workload-projector.go:710:2: the result of logger.V should be stored in a variable and then be used multiple times: if logger := logger.V(); logger.Enabled() { ... logger.Info ... }
-/pkg/placement/workload-projector.go:886:1: A function should accept either a context or a logger, but not both. Having both makes calling the function harder because it must be defined whether the context must contain the logger and callers have to follow that.
-/pkg/placement/workload-projector.go:968:4: the result of logger.V should be stored in a variable and then be used multiple times: if logger := logger.V(); logger.Enabled() { ... logger.Info ... }
+/cmd/placement-translator/main.go:122:3: Key positional arguments are expected to be inlined constant strings. Please replace &{flg Name} provided with string value.
+/pkg/placement/workload-projector.go:692:4: the result of logger.V should be stored in a variable and then be used multiple times: if logger := logger.V(); logger.Enabled() { ... logger.Info ... }
+/pkg/placement/workload-projector.go:714:2: the result of logger.V should be stored in a variable and then be used multiple times: if logger := logger.V(); logger.Enabled() { ... logger.Info ... }
+/pkg/placement/workload-projector.go:890:1: A function should accept either a context or a logger, but not both. Having both makes calling the function harder because it must be defined whether the context must contain the logger and callers have to follow that.
+/pkg/placement/workload-projector.go:972:4: the result of logger.V should be stored in a variable and then be used multiple times: if logger := logger.V(); logger.Enabled() { ... logger.Info ... }

--- a/hack/logcheck.out
+++ b/hack/logcheck.out
@@ -2,8 +2,8 @@
 /cmd/kcp-watchall/main.go:103:3: Key positional arguments are expected to be inlined constant strings. Please replace &{flg Name} provided with string value.
 /cmd/mailbox-controller/main.go:198:4: Additional arguments to Info should always be Key Value pairs. Please check if there is any key or value missing.
 /cmd/mailbox-controller/main.go:91:3: Key positional arguments are expected to be inlined constant strings. Please replace &{flg Name} provided with string value.
-/cmd/placement-translator/main.go:122:3: Key positional arguments are expected to be inlined constant strings. Please replace &{flg Name} provided with string value.
-/pkg/placement/workload-projector.go:692:4: the result of logger.V should be stored in a variable and then be used multiple times: if logger := logger.V(); logger.Enabled() { ... logger.Info ... }
-/pkg/placement/workload-projector.go:714:2: the result of logger.V should be stored in a variable and then be used multiple times: if logger := logger.V(); logger.Enabled() { ... logger.Info ... }
-/pkg/placement/workload-projector.go:890:1: A function should accept either a context or a logger, but not both. Having both makes calling the function harder because it must be defined whether the context must contain the logger and callers have to follow that.
-/pkg/placement/workload-projector.go:972:4: the result of logger.V should be stored in a variable and then be used multiple times: if logger := logger.V(); logger.Enabled() { ... logger.Info ... }
+/cmd/placement-translator/main.go:120:3: Key positional arguments are expected to be inlined constant strings. Please replace &{flg Name} provided with string value.
+/pkg/placement/workload-projector.go:690:4: the result of logger.V should be stored in a variable and then be used multiple times: if logger := logger.V(); logger.Enabled() { ... logger.Info ... }
+/pkg/placement/workload-projector.go:712:2: the result of logger.V should be stored in a variable and then be used multiple times: if logger := logger.V(); logger.Enabled() { ... logger.Info ... }
+/pkg/placement/workload-projector.go:888:1: A function should accept either a context or a logger, but not both. Having both makes calling the function harder because it must be defined whether the context must contain the logger and callers have to follow that.
+/pkg/placement/workload-projector.go:970:4: the result of logger.V should be stored in a variable and then be used multiple times: if logger := logger.V(); logger.Enabled() { ... logger.Info ... }

--- a/pkg/customize/customize.go
+++ b/pkg/customize/customize.go
@@ -25,13 +25,14 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/klog/v2"
 
-	schedulingv1alpha1 "github.com/kcp-dev/kcp/pkg/apis/scheduling/v1alpha1"
-
 	edgeapi "github.com/kubestellar/kubestellar/pkg/apis/edge/v1alpha1"
 	"github.com/kubestellar/kubestellar/pkg/jsonpath"
+	//	schedulingv1alpha1 "github.com/kcp-dev/kcp/pkg/apis/scheduling/v1alpha1"
 )
 
-func Customize(logger klog.Logger, input *unstructured.Unstructured, customizer *edgeapi.Customizer, loc *schedulingv1alpha1.Location) *unstructured.Unstructured {
+//func Customize(logger klog.Logger, input *unstructured.Unstructured, customizer *edgeapi.Customizer, loc *schedulingv1alpha1.Location) *unstructured.Unstructured {
+
+func Customize(logger klog.Logger, input *unstructured.Unstructured, customizer *edgeapi.Customizer, loc *edgeapi.Location) *unstructured.Unstructured {
 	expandInput := input.GetAnnotations()[edgeapi.ParameterExpansionAnnotationKey] == "true"
 	expandCustomizer := customizer != nil && customizer.Annotations[edgeapi.ParameterExpansionAnnotationKey] == "true"
 	if customizer == nil && !expandInput {

--- a/pkg/placement/main.go
+++ b/pkg/placement/main.go
@@ -33,10 +33,10 @@ import (
 	tenancyv1a1informers "github.com/kcp-dev/kcp/pkg/client/informers/externalversions/tenancy/v1alpha1"
 	tenancyv1a1listers "github.com/kcp-dev/kcp/pkg/client/listers/tenancy/v1alpha1"
 
-	//schedulingv1a1informers "github.com/kcp-dev/kcp/pkg/client/informers/externalversions/scheduling/v1alpha1"
-
 	edgeapi "github.com/kubestellar/kubestellar/pkg/apis/edge/v1alpha1"
 	edgeclusterclientset "github.com/kubestellar/kubestellar/pkg/client/clientset/versioned/cluster"
+
+	//schedulingv1a1informers "github.com/kcp-dev/kcp/pkg/client/informers/externalversions/scheduling/v1alpha1"
 	edgev1a1informers "github.com/kubestellar/kubestellar/pkg/client/informers/externalversions/edge/v1alpha1"
 	edgev1a1listers "github.com/kubestellar/kubestellar/pkg/client/listers/edge/v1alpha1"
 )

--- a/pkg/placement/main.go
+++ b/pkg/placement/main.go
@@ -30,9 +30,10 @@ import (
 	kcpkubecorev1informers "github.com/kcp-dev/client-go/informers/core/v1"
 	kcpkubecorev1client "github.com/kcp-dev/client-go/kubernetes/typed/core/v1"
 	kcpclusterclientset "github.com/kcp-dev/kcp/pkg/client/clientset/versioned/cluster"
-	schedulingv1a1informers "github.com/kcp-dev/kcp/pkg/client/informers/externalversions/scheduling/v1alpha1"
 	tenancyv1a1informers "github.com/kcp-dev/kcp/pkg/client/informers/externalversions/tenancy/v1alpha1"
 	tenancyv1a1listers "github.com/kcp-dev/kcp/pkg/client/listers/tenancy/v1alpha1"
+
+	//schedulingv1a1informers "github.com/kcp-dev/kcp/pkg/client/informers/externalversions/scheduling/v1alpha1"
 
 	edgeapi "github.com/kubestellar/kubestellar/pkg/apis/edge/v1alpha1"
 	edgeclusterclientset "github.com/kubestellar/kubestellar/pkg/client/clientset/versioned/cluster"
@@ -69,7 +70,8 @@ type placementTranslator struct {
 func NewPlacementTranslator(
 	numThreads int,
 	ctx context.Context,
-	locationClusterPreInformer schedulingv1a1informers.LocationClusterInformer,
+	//locationClusterPreInformer schedulingv1a1informers.LocationClusterInformer,
+	locationClusterPreInformer edgev1a1informers.LocationClusterInformer,
 	// pre-informer on all SinglePlacementSlice objects, cross-workspace
 	epClusterPreInformer edgev1a1informers.EdgePlacementClusterInformer,
 	// pre-informer on all SinglePlacementSlice objects, cross-workspace

--- a/pkg/placement/main.go
+++ b/pkg/placement/main.go
@@ -36,9 +36,8 @@ import (
 	edgeapi "github.com/kubestellar/kubestellar/pkg/apis/edge/v1alpha1"
 	edgeclusterclientset "github.com/kubestellar/kubestellar/pkg/client/clientset/versioned/cluster"
 	edgev1a1informers "github.com/kubestellar/kubestellar/pkg/client/informers/externalversions/edge/v1alpha1"
-
-	//schedulingv1a1informers "github.com/kcp-dev/kcp/pkg/client/informers/externalversions/scheduling/v1alpha1"
 	edgev1a1listers "github.com/kubestellar/kubestellar/pkg/client/listers/edge/v1alpha1"
+	//schedulingv1a1informers "github.com/kcp-dev/kcp/pkg/client/informers/externalversions/scheduling/v1alpha1"
 )
 
 type placementTranslator struct {

--- a/pkg/placement/main.go
+++ b/pkg/placement/main.go
@@ -35,9 +35,9 @@ import (
 
 	edgeapi "github.com/kubestellar/kubestellar/pkg/apis/edge/v1alpha1"
 	edgeclusterclientset "github.com/kubestellar/kubestellar/pkg/client/clientset/versioned/cluster"
+	edgev1a1informers "github.com/kubestellar/kubestellar/pkg/client/informers/externalversions/edge/v1alpha1"
 
 	//schedulingv1a1informers "github.com/kcp-dev/kcp/pkg/client/informers/externalversions/scheduling/v1alpha1"
-	edgev1a1informers "github.com/kubestellar/kubestellar/pkg/client/informers/externalversions/edge/v1alpha1"
 	edgev1a1listers "github.com/kubestellar/kubestellar/pkg/client/listers/edge/v1alpha1"
 )
 

--- a/pkg/placement/workload-projector.go
+++ b/pkg/placement/workload-projector.go
@@ -45,15 +45,17 @@ import (
 	clusterdynamic "github.com/kcp-dev/client-go/dynamic"
 	kcpkubecorev1informers "github.com/kcp-dev/client-go/informers/core/v1"
 	kcpkubecorev1client "github.com/kcp-dev/client-go/kubernetes/typed/core/v1"
-	schedulingv1a1 "github.com/kcp-dev/kcp/pkg/apis/scheduling/v1alpha1"
 	tenancyv1a1 "github.com/kcp-dev/kcp/pkg/apis/tenancy/v1alpha1"
-	schedulingv1a1listers "github.com/kcp-dev/kcp/pkg/client/listers/scheduling/v1alpha1"
 	tenancyv1a1listers "github.com/kcp-dev/kcp/pkg/client/listers/tenancy/v1alpha1"
 	"github.com/kcp-dev/logicalcluster/v3"
 
 	edgeapi "github.com/kubestellar/kubestellar/pkg/apis/edge/v1alpha1"
+
+	//schedulingv1a1 "github.com/kcp-dev/kcp/pkg/apis/scheduling/v1alpha1"
 	edgeclusterclientset "github.com/kubestellar/kubestellar/pkg/client/clientset/versioned/cluster"
 	edgev1a1listers "github.com/kubestellar/kubestellar/pkg/client/listers/edge/v1alpha1"
+
+	//schedulingv1a1listers "github.com/kcp-dev/kcp/pkg/client/listers/scheduling/v1alpha1"
 	"github.com/kubestellar/kubestellar/pkg/customize"
 )
 
@@ -85,7 +87,8 @@ func NewWorkloadProjector(
 	mbwsInformer k8scache.SharedIndexInformer,
 	mbwsLister tenancyv1a1listers.WorkspaceLister,
 	locationClusterInformer kcpcache.ScopeableSharedIndexInformer,
-	locationClusterLister schedulingv1a1listers.LocationClusterLister,
+	//locationClusterLister schedulingv1a1listers.LocationClusterLister,
+	locationClusterLister edgev1a1listers.LocationClusterLister,
 	syncfgClusterInformer kcpcache.ScopeableSharedIndexInformer,
 	syncfgClusterLister edgev1a1listers.SyncerConfigClusterLister,
 	customizerClusterInformer kcpcache.ScopeableSharedIndexInformer,
@@ -304,14 +307,15 @@ var _ Runnable = &workloadProjector{}
 //
 // The fields following the Mutex should only be accessed with the Mutex locked.
 type workloadProjector struct {
-	ctx                       context.Context
-	configConcurrency         int
-	resourceModes             ResourceModes
-	delay                     time.Duration // to slow down for debugging
-	queue                     workqueue.RateLimitingInterface
-	mbwsLister                tenancyv1a1listers.WorkspaceLister
-	locationClusterInformer   kcpcache.ScopeableSharedIndexInformer
-	locationClusterLister     schedulingv1a1listers.LocationClusterLister
+	ctx                     context.Context
+	configConcurrency       int
+	resourceModes           ResourceModes
+	delay                   time.Duration // to slow down for debugging
+	queue                   workqueue.RateLimitingInterface
+	mbwsLister              tenancyv1a1listers.WorkspaceLister
+	locationClusterInformer kcpcache.ScopeableSharedIndexInformer
+	//locationClusterLister     schedulingv1a1listers.LocationClusterLister
+	locationClusterLister     edgev1a1listers.LocationClusterLister
 	syncfgClusterInformer     kcpcache.ScopeableSharedIndexInformer
 	syncfgClusterLister       edgev1a1listers.SyncerConfigClusterLister
 	customizerClusterInformer kcpcache.ScopeableSharedIndexInformer
@@ -1086,7 +1090,8 @@ func (wp *workloadProjector) customizeOrCopy(logger klog.Logger, srcCluster logi
 			expandParameters = expandParameters || customizer.Annotations[edgeapi.ParameterExpansionAnnotationKey] == "true"
 		}
 	}
-	var location *schedulingv1a1.Location
+	//var location *schedulingv1a1.Location
+	var location *edgeapi.Location
 	if expandParameters {
 		location, err = wp.locationClusterLister.Cluster(logicalcluster.Name(destSP.Cluster)).Get(destSP.LocationName)
 		if err != nil {

--- a/pkg/placement/workload-projector.go
+++ b/pkg/placement/workload-projector.go
@@ -50,13 +50,11 @@ import (
 	"github.com/kcp-dev/logicalcluster/v3"
 
 	edgeapi "github.com/kubestellar/kubestellar/pkg/apis/edge/v1alpha1"
-
-	//schedulingv1a1 "github.com/kcp-dev/kcp/pkg/apis/scheduling/v1alpha1"
 	edgeclusterclientset "github.com/kubestellar/kubestellar/pkg/client/clientset/versioned/cluster"
 	edgev1a1listers "github.com/kubestellar/kubestellar/pkg/client/listers/edge/v1alpha1"
-
-	//schedulingv1a1listers "github.com/kcp-dev/kcp/pkg/client/listers/scheduling/v1alpha1"
 	"github.com/kubestellar/kubestellar/pkg/customize"
+	//schedulingv1a1 "github.com/kcp-dev/kcp/pkg/apis/scheduling/v1alpha1"
+	//schedulingv1a1listers "github.com/kcp-dev/kcp/pkg/client/listers/scheduling/v1alpha1"
 )
 
 const SyncerConfigName = "the-one"
@@ -1090,7 +1088,6 @@ func (wp *workloadProjector) customizeOrCopy(logger klog.Logger, srcCluster logi
 			expandParameters = expandParameters || customizer.Annotations[edgeapi.ParameterExpansionAnnotationKey] == "true"
 		}
 	}
-	//var location *schedulingv1a1.Location
 	var location *edgeapi.Location
 	if expandParameters {
 		location, err = wp.locationClusterLister.Cluster(logicalcluster.Name(destSP.Cluster)).Get(destSP.LocationName)


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
pkg/placeholder/workload-projector.go needs to use Kubestellar edge.kcp.io rather than TMC scheduling.kcp.io. This should have been included in Feature 814's changes, but was overlooked.

## Related issue(s)
814
836
Fixes #
836
