### PR TITLE
:sparkles:Use provider config field for provider client

### DIFF
--- a/pkg/clustermanager/provider.go
+++ b/pkg/clustermanager/provider.go
@@ -58,13 +58,13 @@ type provider struct {
 }
 
 // TODO: this is termporary for stage 1. For stage 2 we expect to have a uniform interface for all informers.
-func newProviderClient(providerName string, providerType lcv1alpha1apis.ClusterProviderType, config string) clusterprovider.ProviderClient {
+func newProviderClient(providerDesc *lcv1alpha1apis.ClusterProviderDesc) clusterprovider.ProviderClient {
 	var pClient clusterprovider.ProviderClient = nil
-	switch providerType {
+	switch providerDesc.Spec.ProviderType {
 	case lcv1alpha1apis.KindProviderType:
-		pClient = kindprovider.New(providerName)
+		pClient = kindprovider.New(providerDesc.Name)
 	case lcv1alpha1apis.KubeflexProviderType:
-		pClient = kflexprovider.New(providerName)
+		pClient = kflexprovider.New(providerDesc.Name)
 	default:
 		return nil
 	}
@@ -83,7 +83,7 @@ func CreateProvider(c *controller, providerDesc *lcv1alpha1apis.ClusterProviderD
 		return nil, err
 	}
 
-	newProviderClient := newProviderClient(providerName, providerDesc.Spec.ProviderType, providerDesc.Spec.Config)
+	newProviderClient := newProviderClient(providerDesc)
 	if newProviderClient == nil {
 		return nil, errors.New("unknown provider type")
 	}

--- a/pkg/clustermanager/provider.go
+++ b/pkg/clustermanager/provider.go
@@ -58,7 +58,7 @@ type provider struct {
 }
 
 // TODO: this is termporary for stage 1. For stage 2 we expect to have a uniform interface for all informers.
-func newProviderClient(providerName string, providerType lcv1alpha1apis.ClusterProviderType) clusterprovider.ProviderClient {
+func newProviderClient(providerName string, providerType lcv1alpha1apis.ClusterProviderType, config string) clusterprovider.ProviderClient {
 	var pClient clusterprovider.ProviderClient = nil
 	switch providerType {
 	case lcv1alpha1apis.KindProviderType:
@@ -72,11 +72,10 @@ func newProviderClient(providerName string, providerType lcv1alpha1apis.ClusterP
 }
 
 // CreateProvider returns new provider client
-func CreateProvider(c *controller, providerName string, providerType lcv1alpha1apis.ClusterProviderType) (*provider, error) {
+func CreateProvider(c *controller, providerDesc *lcv1alpha1apis.ClusterProviderDesc) (*provider, error) {
+	providerName := providerDesc.Name
 	c.lock.Lock()
 	defer c.lock.Unlock()
-
-	discoveryPrefix := ""
 
 	_, exists := c.providers[providerName]
 	if exists {
@@ -84,20 +83,14 @@ func CreateProvider(c *controller, providerName string, providerType lcv1alpha1a
 		return nil, err
 	}
 
-	newProviderClient := newProviderClient(providerName, providerType)
+	newProviderClient := newProviderClient(providerName, providerDesc.Spec.ProviderType, providerDesc.Spec.Config)
 	if newProviderClient == nil {
 		return nil, errors.New("unknown provider type")
 	}
 
-	providerDescObj, found, _ := c.clusterProviderInformer.GetIndexer().GetByKey(lcKeyFunc("", providerName))
-	if found {
-		providerDesc, ok := providerDescObj.(*lcv1alpha1apis.ClusterProviderDesc)
-		if ok {
-			discoveryPrefix = providerDesc.Spec.ClusterPrefixForDiscovery
-			if discoveryPrefix == "" {
-				discoveryPrefix = "*"
-			}
-		}
+	discoveryPrefix := providerDesc.Spec.ClusterPrefixForDiscovery
+	if discoveryPrefix == "" {
+		discoveryPrefix = "*"
 	}
 
 	p := &provider{

--- a/pkg/clustermanager/reconcile_clusterprovider.go
+++ b/pkg/clustermanager/reconcile_clusterprovider.go
@@ -67,7 +67,7 @@ func (c *controller) handleAdd(providerDesc *lcv1alpha1.ClusterProviderDesc) err
 		return err
 	}
 
-	provider, err := CreateProvider(c, name, providerDesc.Spec.ProviderType)
+	provider, err := CreateProvider(c, providerDesc)
 	if err != nil {
 		// TODO: Check if the err is because the provider already exists
 		return err


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
This will allow provider client to access the provider by using config from provider description object.

## Related issue(s)

Fixes #
