### PR TITLE
🐛 Restore progress on moving SyncTarget to KubeStellar repo

### DIFF
--- a/scripts/kubectl-kubestellar-prep_for_syncer
+++ b/scripts/kubectl-kubestellar-prep_for_syncer
@@ -130,7 +130,7 @@ else
     kubectl ws "${kubectl_flags[@]}" "$imw"
 fi
 
-mbwsname=$(kubectl "${kubectl_flags[@]}" get SyncTarget "$stname" -o jsonpath="{.metadata.annotations['kcp\.io/cluster']}-mb-{.metadata.uid}")
+mbwsname=$(kubectl "${kubectl_flags[@]}" get synctargets.edge.kcp.io "$stname" -o jsonpath="{.metadata.annotations['kcp\.io/cluster']}-mb-{.metadata.uid}")
 
 if [ "$silent" == "true" ]; then
     kubectl ws "${kubectl_flags[@]}" "$espw" > /dev/null


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
This PR undoes the regression noted in https://github.com/kubestellar/kubestellar/pull/823#pullrequestreview-1553979529 

## Related issue(s)

