### PR TITLE
📖 Improve wording on getting KubeStellar

### DIFF
--- a/docs/content/Coding Milestones/PoC2023q1/example1-subs/example1-post-kcp.md
+++ b/docs/content/Coding Milestones/PoC2023q1/example1-subs/example1-post-kcp.md
@@ -1,36 +1,40 @@
 <!--example1-post-kcp-start-->
-### Use the root workspace.
-
-Use the following commands.
-
-```shell
-kubectl ws root
-```
-
 ### Get and build or install KubeStellar
 
-Contributors interested in running the Continuous Integration scripts
-locally, or from an existing git development branch, should skip the Fetch step
-and resume reading at the Build step.
+You will need a local copy of KubeStellar.  You can either use the
+pre-built archive (containing executables and config files) from a
+release or get any desired version from GitHub and build.
 
-For new users, download and build, or install, <a href="{{config.repo_url}}">KubeStellar</a>,
-according to your preference.  That is, either (a) `git clone` the
-repo and then `make build` to populate its `bin` directory, or (b)
-fetch the binary archive appropriate for your machine from a release
-and unpack it (creating a `bin` directory).  The commands exhibited
-just below assume that the repo has been fetched but not yet built.
+#### Use pre-built archive
 
-Fetch step:
+Fetch the archive for your operating system and instruction set
+architecture as follows, in which `$kubestellar_version` is your
+chosen release of KubeStellar (see
+https://github.com/kubestellar/kubestellar/releases) and `$os_type`
+and `$arch_type` are chosen according to the list of "assets" for your
+chosen release.
 
 ```{.base}
-git clone -b {{ config.ks_branch }} {{ config.repo_url }}
+curl -SL -o kubestellar.tar.gz "https://github.com/kubestellar/kubestellar/releases/download/${kubestellar_version}/kubestellar_${kubestellar_version}_${os_type}_${arch_type}.tar.gz
+tar xzf kubestellar.tar.gz
+export PATH=$PWD/bin:$PATH
+```
+
+#### Get from GitHub
+
+You can get the latest version from GitHub with the following command,
+which will get you the default branch (which is named "main"); add `-b
+$branch` to get a different one.
+
+```{.base}
+git clone {{ config.repo_url }}
 cd kubestellar
 ```
 
-Build step:
+Use the following commands to build and add the executables to your
+`$PATH`.
 
 ```shell
-echo "current path is $PWD"
 make build
 export PATH=$(pwd)/bin:$PATH
 ```

--- a/docs/content/Coding Milestones/PoC2023q1/example1-subs/example1-stage-1a.md
+++ b/docs/content/Coding Milestones/PoC2023q1/example1-subs/example1-stage-1a.md
@@ -7,7 +7,7 @@ here.
 
 ```shell
 kubectl ws root:espw
-go run ./cmd/mailbox-controller -v=2 &
+mailbox-controller -v=2 &
 sleep 60
 ```
 ``` { .bash .no-copy }

--- a/docs/content/Coding Milestones/PoC2023q1/example1-subs/example1-stage-2.md
+++ b/docs/content/Coding Milestones/PoC2023q1/example1-subs/example1-stage-2.md
@@ -313,7 +313,7 @@ kubectl ws root:espw
 Current workspace is "root:espw".
 ```
 ```shell
-go run ./cmd/kubestellar-where-resolver &
+kubestellar-where-resolver &
 sleep 45
 ```
 ``` { .bash .no-copy }

--- a/docs/content/Coding Milestones/PoC2023q1/example1-subs/example1-stage-3.md
+++ b/docs/content/Coding Milestones/PoC2023q1/example1-subs/example1-stage-3.md
@@ -19,7 +19,7 @@ kubectl ws root:espw
 Current workspace is "root:espw".
 ```
 ```shell
-go run ./cmd/placement-translator &
+placement-translator &
 sleep 120
 ```
 ``` { .bash .no-copy }

--- a/docs/content/Coding Milestones/PoC2023q1/example1-subs/example1-start-kcp.md
+++ b/docs/content/Coding Milestones/PoC2023q1/example1-subs/example1-start-kcp.md
@@ -27,10 +27,10 @@ make build
 export PATH=$(pwd)/bin:$PATH
 ```
 
-run kcp (kcp will spit out tons of information and stay running in this terminal window)
+Run the kcp server in a forked shell.  Even though the subcommand is "start", it does not just launch the server, it continues with running the server.
 ```shell
 export KUBECONFIG=$(pwd)/.kcp/admin.kubeconfig
-kcp start &> /dev/null &
+kcp start &> /tmp/kcp.log &
 popd
 sleep 30 
 ```


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
This PR hopefully improves the wording in example1 about how to get (and build if necessary) a local copy of KubeStellar.  This includes ending the use of `go run` (which was precluding the use of pre-built archives).

## Related issue(s)

Fixes #
