### PR TITLE
🐛 Make server cert filename depend on domain name

### DIFF
--- a/docs/content/Coding Milestones/PoC2023q1/commands.md
+++ b/docs/content/Coding Milestones/PoC2023q1/commands.md
@@ -92,10 +92,10 @@ bash-5.2$ echo ${pieces[0]}
 /Users/mspreitz/go/src/github.com/kubestellar/kubestellar/pki/ca.crt
 
 bash-5.2$ echo ${pieces[1]}
-/Users/mspreitz/go/src/github.com/kubestellar/kubestellar/pki/issued/kcp-server.crt
+/Users/mspreitz/go/src/github.com/kubestellar/kubestellar/pki/issued/kcp-DNS-yep.yep.crt
 
 bash-5.2$ echo ${pieces[2]}
-/Users/mspreitz/go/src/github.com/kubestellar/kubestellar/pki/private/kcp-server.key
+/Users/mspreitz/go/src/github.com/kubestellar/kubestellar/pki/private/kcp-DNS-yep.yep.key
 ```
 
 Following is an example of using those results in launching the kcp

--- a/scripts/kubestellar-ensure-kcp-server-creds
+++ b/scripts/kubestellar-ensure-kcp-server-creds
@@ -38,8 +38,8 @@ export EASYRSA_PKI=${PWD}/pki
 need=true
 
 cacert="${PWD}/pki/ca.crt"
-svrcert="${PWD}/pki/issued/kcp-server.crt"
-svrkey="${PWD}/pki/private/kcp-server.key"
+svrcert="${PWD}/pki/issued/kcp-DNS-$domain.crt"
+svrkey="${PWD}/pki/private/kcp-DNS-$domain.key"
 
 if [ -r "$svrcert" ] && [ -r "$svrkey" ]; then
     if oldsan=$(easyrsa show-cert kcp-server |

--- a/scripts/kubestellar-make-kcp-server-cert
+++ b/scripts/kubestellar-make-kcp-server-cert
@@ -15,12 +15,12 @@ fi
 
 SAN="${1#--subject-alt-names=}"
 
-SERVERNAME=kcp-server
+FILE_NAME_BASE="kcp-${SAN//:/-}"
 
 export EASYRSA_PKI=${PWD}/pki
 
-rm -f ${EASYRSA_PKI}/reqs/${SERVERNAME}.req ${EASYRSA_PKI}/issued/${SERVERNAME}.crt ${EASYRSA_PKI}/private/${SERVERNAME}.key
-easyrsa --batch --use-algo=ed --curve=ed25519 \
+rm -f "${EASYRSA_PKI}/reqs/${FILE_NAME_BASE}.req" "${EASYRSA_PKI}/issued/${FILE_NAME_BASE}.crt" "${EASYRSA_PKI}/private/${FILE_NAME_BASE}.key"
+easyrsa --batch --use-algo=ec \
     --subject-alt-name="$SAN" \
     --days=10000 \
-    build-server-full $SERVERNAME nopass
+    build-server-full "$FILE_NAME_BASE" nopass


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
This PR updates `scripts/kubestellar-make-kcp-server-cert` to make the name of the file that holds the server certificate depend on the domain name in the certificate, so that certs for different domain names can coexist at the same time.

## Related issue(s)

Fixes #
