### PR TITLE
🌱 Make bootstrap script able to not deploy

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -73,10 +73,8 @@ script](bootstrap/bootstrap-kubestellar.sh) from the main branch of
 the main repo; if you want to contribute a change to that script then
 you will need to test your changed version.  Just run your local copy
 (perhaps in a special testing directory, just to be safe) and be sure
-to add the downloaded `bin` at the _front_ of your `$PATH` (contrary
-to [what the scripting currently tells
-you](bootstrap/install-kubestellar.sh)) so that your `git clone`'s
-`bin` does not shadow the one being tested.
+to add the downloaded `bin` at the _front_ of your `$PATH` so that
+your `git clone`'s `bin` does not shadow the one being tested.
 
 Note that changes to the bootstrap script start being used by users as
 soon as your PR merges.  Since this script can only fetch a released

--- a/bootstrap/bootstrap-kubestellar.sh
+++ b/bootstrap/bootstrap-kubestellar.sh
@@ -19,7 +19,7 @@
 # This script installs kcp and Kubestellar binaries to a folder of choice
 #
 # Arguments:
-# [--deploy bool] control whether platform deployment is included
+# [--deploy bool] indicate if kubestellar (and kcp) will be deployed
 # [--kcp-version release] set a specific kcp release version, default: latest
 # [--kubestellar-version release] set a specific KubeStellar release version, default: latest
 # [--os linux|darwin] set a specific OS type, default: autodetect

--- a/bootstrap/bootstrap-kubestellar.sh
+++ b/bootstrap/bootstrap-kubestellar.sh
@@ -19,6 +19,7 @@
 # This script installs kcp and Kubestellar binaries to a folder of choice
 #
 # Arguments:
+# [--deploy bool] control whether platform deployment is included
 # [--kcp-version release] set a specific kcp release version, default: latest
 # [--kubestellar-version release] set a specific KubeStellar release version, default: latest
 # [--os linux|darwin] set a specific OS type, default: autodetect
@@ -154,6 +155,7 @@ ensure_folder() {
 KCP_REQUIRED_VERSION="v0.11.0"
 kcp_version=""
 kubestellar_version=""
+deploy="true"
 os_type=""
 arch_type=""
 folder=""
@@ -177,6 +179,11 @@ while (( $# > 0 )); do
         if (( $# > 1 ));
         then { kubestellar_version="$2"; shift; }
         else { echo "$0: missing release version" >&2; exit 1; }
+        fi;;
+    (--deploy)
+        if (( $# > 1 ));
+        then { deploy="$2"; shift; }
+        else { echo "$0: missing value for --deploy" >&2; exit 1; }
         fi;;
     (--os)
         if (( $# > 1 ));
@@ -214,7 +221,7 @@ while (( $# > 0 )); do
 	set -x
 	flagx="-X";;
     (-h|--help)
-        echo "Usage: $0 [--kcp-version release_version] [--kubestellar-version release_version] [--os linux|darwin] [--arch amd64|arm64] [--ensure-folder installation_folder] [-V|--verbose] [-X]"
+        echo "Usage: $0 [--kcp-version release_version] [--kubestellar-version release_version] [--deploy bool] [--os linux|darwin] [--arch amd64|arm64] [--ensure-folder installation_folder] [-V|--verbose] [-X]"
         exit 0;;
     (-*)
         echo "$0: unknown flag" >&2
@@ -246,6 +253,13 @@ if [ "$folder" == "" ]; then
     folder="$PWD"
 fi
 
+case "$deploy" in
+    (true|false) ;;
+    (*) echo "$0: --deploy value must be 'true' or 'false'" >&2
+	exit 1;;
+esac
+
+
 # Ensure kcp is installed
 echo "< Ensure kcp is installed >----------------------"
 if [ "$(kcp_installed)" == "true" ]; then
@@ -271,51 +285,54 @@ else
     fi
 fi
 
-# Ensure kcp is running
-echo "< Ensure kcp is running >-----------------------"
-if [ "$(kcp_running)" == "true" ]; then
-    echo "kcp process is running already: pid=$(pgrep kcp) ... skip running."
-    if [ "$(kubeconfig_valid)" == "false" ]; then
-        echo "KUBECONFIG environment variable is not set correctly: KUBECONFIG='$KUBECONFIG' ... exiting!"
-        exit 3
-    fi
-    echo "Using 'KUBECONFIG=$KUBECONFIG'"
-    echo "Waiting for kcp to be ready... it may take a while"
-    until $(kcp_ready)
-    do
-        sleep 1
-    done
-    if [ "$(kcp_version)" != "$kcp_version" ]; then
-        echo "kcp running version $(kcp_version) does not match the desired version $kcp_version ... exiting!"
-        exit 4
+if [ "$deploy" == true ]; then
+    # Ensure kcp is running
+    echo "< Ensure kcp is running >-----------------------"
+    if [ "$(kcp_running)" == "true" ]; then
+	echo "kcp process is running already: pid=$(pgrep kcp) ... skip running."
+	if [ "$(kubeconfig_valid)" == "false" ]; then
+            echo "KUBECONFIG environment variable is not set correctly: KUBECONFIG='$KUBECONFIG' ... exiting!"
+            exit 3
+	fi
+	echo "Using 'KUBECONFIG=$KUBECONFIG'"
+	echo "Waiting for kcp to be ready... it may take a while"
+	until $(kcp_ready)
+	do
+            sleep 1
+	done
+	if [ "$(kcp_version)" != "$kcp_version" ]; then
+            echo "kcp running version $(kcp_version) does not match the desired version $kcp_version ... exiting!"
+            exit 4
+	else
+            echo "kcp version $(kcp_version) ... ok"
+	fi
     else
-        echo "kcp version $(kcp_version) ... ok"
+	if [ "$kcp_address" == "" ]; then
+            echo "Running kcp... logfile=$PWD/kcp_log.txt"
+            kcp start >& kcp_log.txt &
+	else
+            echo "Running kcp bound to address $kcp_address... logfile=$PWD/kcp_log.txt"
+            kcp start --bind-address $kcp_address >& kcp_log.txt &
+	fi
+	export KUBECONFIG="$PWD/.kcp/admin.kubeconfig"
+	echo "Waiting for kcp to be ready... it may take a while"
+	sleep 10
+	until $(kcp_ready)
+	do
+            sleep 1
+	done
+	sleep 10
+	if [ "$(kcp_version)" != "$KCP_REQUIRED_VERSION" ]; then
+            echo "kcp version $(kcp_version) is not supported, KubeStellar requires kcp $KCP_REQUIRED_VERSION ... exiting!"
+            exit 4
+	else
+            echo "kcp version $(kcp_version) ... ok"
+	fi
+	echo "Export KUBECONFIG environment variable: export KUBECONFIG=\"$KUBECONFIG\""
+	user_exports="$user_exports"$'\n'"export KUBECONFIG=\"$KUBECONFIG\""
     fi
-else
-    if [ "$kcp_address" == "" ]; then
-        echo "Running kcp... logfile=$PWD/kcp_log.txt"
-        kcp start >& kcp_log.txt &
-    else
-        echo "Running kcp bound to address $kcp_address... logfile=$PWD/kcp_log.txt"
-        kcp start --bind-address $kcp_address >& kcp_log.txt &
-    fi
-    export KUBECONFIG="$PWD/.kcp/admin.kubeconfig"
-    echo "Waiting for kcp to be ready... it may take a while"
-    sleep 10
-    until $(kcp_ready)
-    do
-        sleep 1
-    done
-    sleep 10
-    if [ "$(kcp_version)" != "$KCP_REQUIRED_VERSION" ]; then
-        echo "kcp version $(kcp_version) is not supported, KubeStellar requires kcp $KCP_REQUIRED_VERSION ... exiting!"
-        exit 4
-    else
-        echo "kcp version $(kcp_version) ... ok"
-    fi
-    echo "Export KUBECONFIG environment variable: export KUBECONFIG=\"$KUBECONFIG\""
-    user_exports="$user_exports"$'\n'"export KUBECONFIG=\"$KUBECONFIG\""
 fi
+
 
 # Ensure KubeStellar is installed
 echo "< Ensure KubeStellar is installed >-------------"
@@ -342,23 +359,25 @@ else
     fi
 fi
 
-# Ensure KubeStellar is running
-echo "< Ensure KubeStellar is running >---------------"
-kubectl ws root > /dev/null
-if [ "$(kubestellar_running)" == "true" ]; then
-    echo "KubeStellar processes are running ... ok"
-    if ! kubectl get workspaces.tenancy.kcp.io espw &> /dev/null ; then
-        echo "KubeStellar ESPW does not exists ... run 'kubestellar stop' first ... exiting!"
-        exit 6
+if [ "$deploy" == true ]; then
+    # Ensure KubeStellar is running
+    echo "< Ensure KubeStellar is running >---------------"
+    kubectl ws root > /dev/null
+    if [ "$(kubestellar_running)" == "true" ]; then
+	echo "KubeStellar processes are running ... ok"
+	if ! kubectl get workspaces.tenancy.kcp.io espw &> /dev/null ; then
+            echo "KubeStellar ESPW does not exists ... run 'kubestellar stop' first ... exiting!"
+            exit 6
+	else
+            echo "KubeStellar ESPW found ... ok"
+	fi
     else
-        echo "KubeStellar ESPW found ... ok"
-    fi
-else
-    echo "Starting or restarting KubeStellar..."
-    if [ $verbose == "true" ]; then
-        kubestellar start -V
-    else
-        kubestellar start
+	echo "Starting or restarting KubeStellar..."
+	if [ $verbose == "true" ]; then
+            kubestellar start -V
+	else
+            kubestellar start
+	fi
     fi
 fi
 
@@ -367,9 +386,9 @@ if [ "$kubestellar_imw" != "" ]; then
     echo "Ensuring IMW \"$kubestellar_imw\"..."
     if ! kubectl ws $kubestellar_imw &> /dev/null ; then
         if [ "$verbose" != "" ]; then
-            kubectl ws create $kubestellar_imw
+	    kubectl ws create $kubestellar_imw
         else
-            kubectl ws create $kubestellar_imw > /dev/null
+	    kubectl ws create $kubestellar_imw > /dev/null
         fi
     fi
 fi
@@ -387,11 +406,13 @@ if [ "$kubestellar_wmw" != "" ]; then
 fi
 
 
-if [ "$verbose" == "true" ]; then
-    kubectl ws root
-    kubectl ws tree
-else
-    kubectl ws root > /dev/null
+if [ "$deploy" == true ]; then
+    if [ "$verbose" == "true" ]; then
+	kubectl ws root
+	kubectl ws tree
+    else
+	kubectl ws root > /dev/null
+    fi
 fi
 
 echo "< KubeStellar bootstrap completed successfully >-"

--- a/docs/content/Coding Milestones/PoC2023q1/commands.md
+++ b/docs/content/Coding Milestones/PoC2023q1/commands.md
@@ -1,16 +1,21 @@
 ---
 short_name: commands
 ---
-This PoC includes two sorts of commands for users to use.  Most are
-executables delivered in the `bin` directory.  The other sort of
-command for users is a `bash` script that is designed to be fetched
-from github and fed directly into `bash`.
 
-# Executables
+This PoC includes two sorts of commands for users to use. Most are
+executables designed to be accessed in the usual ways: by appearing in
+a directory on the user's `$PATH` or by the user writing a pathname
+for the executable on the command line. The one exception is [the
+bootstrap script](#bootstrap), which is designed to be fetched from
+github and fed directly into `bash`.
 
-The command lines exhibited below presume that you have added the
-`bin` directory to your `$PATH`.  Alternatively: these executables can
-be invoked directly using any pathname (not in your `$PATH`).
+Most of these executables require that the kcp server be running and
+that `kubectl` is configured to use the kubeconfig file produced by
+`kcp start`. That is: either `$KUBECONFIG` holds the pathname of that
+kubeconfig file, its contents appear at `~/.kube/config`, or
+`--kubeconfig $pathname` appears on the command line.  The exceptions
+are the bootstrap script and [the kcp control script that runs before
+starting the kcp server](#kubestellar-ensure-kcp-server-creds).
 
 **NOTE**: all of the kubectl plugin usages described here certainly or
 potentially change the setting of which kcp workspace is "current" in
@@ -28,9 +33,12 @@ server can bind its socket to.  The key idea is using the
 server to respond with a bespoke server certificate in TLS handshakes
 in which the client addresses the server by a given domain name.
 
-These commands are designed so that they can be used multiple times if
-there are multiple sets of clients that need to use a distinct domain
-name.
+These commands are used separately from starting the kcp server and
+are designed so that they can be used multiple times if there are
+multiple sets of clients that need to use a distinct domain name.
+Starting the kcp server is not described here, beyond the particular
+consideration needed for the `--tls-sni-cert-key` flag, because it is
+otherwise ordinary.
 
 ### kubestellar-ensure-kcp-server-creds
 
@@ -712,9 +720,7 @@ Current workspace is "root:my-org".
 kubectl kubestellar remove wmw demo1
 ```
 
-# Web-to-bash
-
-## Quick Setup
+## Bootstrap
 
 This is a combination of some installation and setup steps, for use in
 [the
@@ -769,62 +775,3 @@ the shell running the script.  Of course, if you run the script in a
 sub-shell then those environment effects terminate with that
 sub-shell; this script also prints out messages showing how to update
 the environment in another shell.
-
-## Install kcp and its kubectl plugins
-
-This script is directly available at [{{ config.repo_url }}/blob/{{ config.ks_branch }}/bootstrap/install-kubestellar.sh]({{ config.repo_url }}/blob/{{ config.ks_branch }}/bootstrap/install-kcp-with-plugins.sh) and does the following things.
-
-- Fetch and install the `kcp` server executable.
-- Fetch and install the kubectl plugins of kcp.
-
-This script accepts the following command line flags; all are
-optional.
-
-- `--version $version`: specifies the kcp release to use.  The default
-  is the latest.
-- `--OS $OS`: specifies the operating system to use in selecting the
-  executables to fetch and install.  Choices are `darwin` and `linux`.
-  Auto-detected if omitted.
-- `--arch $ARCH`: specifies the instruction set architecture to use in
-  selecting the executables to fetch and install.  Choices are `arm64`
-  and `amd64`.  Auto-detected if omitted.
-- `--ensure-folder $install_parent_dir`: specifies where to install
-  to.  This will be `mkdir -p`.  The default is `./kcp`.
-- `-V` or `--verbose`: increases the verbosity of output.  This is a
-  binary thing, not a matter of degree.
-- `-X`: makes the script `set -x` internally, for debugging.
-- `-h` or `--help`: print brief usage message and exit.
-
-Here install means only to unpack the downloaded archives, creating
-`$install_parent_dir/bin`.  If `$install_parent_dir/bin` is not
-already on your `$PATH` then this script will print out a message
-telling you to add it.
-
-## Install KubeStellar
-
-This script is directly available at
-[{{ config.repo_url }}/blob/{{ config.ks_branch }}/bootstrap/install-kubestellar.sh]({{ config.repo_url }}/blob/{{ config.ks_branch }}/bootstrap/install-kubestellar.sh)
-and will download and install KubeStellar.
-
-This script accepts the following command line arguments; all are
-optional.
-
-- `--version $version`: specifies the release of KubeStellar to use.
-  Defaults to the latest regular release.
-- `--OS $OS`: specifies the operating system to use in selecting the
-  executables to fetch and install.  Choices are `darwin` and `linux`.
-  Auto-detected if omitted.
-- `--arch $ARCH`: specifies the instruction set architecture to use in
-  selecting the executables to fetch and install.  Choices are `arm64`
-  and `amd64`.  Auto-detected if omitted.
-- `--ensure-folder $install_parent_dir`: specifies where to install
-  to.  This will be `mkdir -p`.  The default is `./kubestellar`.
-- `-V` or `--verbose`: increases the verbosity of output.  This is a
-  binary thing, not a matter of degree.
-- `-X`: makes the script `set -x` internally, for debugging.
-- `-h` or `--help`: print brief usage message and exit.
-
-Here install means only to unpack the downloaded archive, creating
-`$install_parent_dir/bin`.  If `$install_parent_dir/bin` is not
-already on your `$PATH` then this script will print out a message
-telling you to add it.

--- a/docs/content/Getting-Started/quickstart-subs/quickstart-1-install-and-run-kubestellar.md
+++ b/docs/content/Getting-Started/quickstart-subs/quickstart-1-install-and-run-kubestellar.md
@@ -1,6 +1,6 @@
 <!--quickstart-1-install-and-run-kubestellar-start-->
 
-KubeStellar works in the context of kcp, so to use KubeStellar you also need kcp. Download the kcp and **KubeStellar** binaries and scripts into a `kubestellar` subfolder in your current working directory using the following command:
+KubeStellar works in the context of kcp, so to use KubeStellar you also need kcp. The following commands will download the kcp and **KubeStellar** executables into subdirectories of your current working directory, deploy (i.e., start and configure) kcp and KubeStellar, and configure your shell to use kcp and KubeStellar.  If you want to suppress the deployment part then add `--deploy false` to the first command's flags (e.g., after the specification of the KubeStellar version); for the deployment-only part, once the executable have been fecthed, see [kcp control](../../../Coding Milestones/PoC2023q1/commands/#kcp-control) and [KubeStellar platform control](../../../Coding Milestones/PoC2023q1/commands/#kubestellar-platform-control).
 
 ```shell
 bash <(curl -s {{ config.repo_raw_url }}/{{ config.ks_branch }}/bootstrap/bootstrap-kubestellar.sh) --kubestellar-version {{ config.ks_tag }}


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
This PR adds an option to the bootstrap script to skip deploying kcp and KubeStellar, to focus only on fetching them.

This PR also updates the commands doc to make all the headings get indexed and remove documentation of the curl-to-bash scripts that we are no longer recommending to users.

This is an alternative to #856 

## Related issue(s)

Fixes #
