### PR TITLE
🐛 Fix file name issues in kubestellar-ensure-kcp-server-creds

### DIFF
--- a/scripts/kubestellar-ensure-kcp-server-creds
+++ b/scripts/kubestellar-ensure-kcp-server-creds
@@ -22,6 +22,7 @@ if [ $# != 1 ]; then
 fi
 
 set -e
+set -o pipefail
 
 this="$0"
 domain="$1"
@@ -37,12 +38,20 @@ export EASYRSA_PKI=${PWD}/pki
 
 need=true
 
+if ! domhash=$(sha256sum <<<"$domain" 2> /dev/null | awk '{ print $1 }')
+then domhash=$(shasum -a 256 <<<"$domain" | awk '{ print $1 }')
+fi
+
+#FILE_NAME_BASE="kcp-DNS-$domain"
+FILE_NAME_BASE="kcp-server-${domhash:1:33}"
+
 cacert="${PWD}/pki/ca.crt"
-svrcert="${PWD}/pki/issued/kcp-DNS-$domain.crt"
-svrkey="${PWD}/pki/private/kcp-DNS-$domain.key"
+svrcert="${PWD}/pki/issued/${FILE_NAME_BASE}.crt"
+svrkey="${PWD}/pki/private/${FILE_NAME_BASE}.key"
+
 
 if [ -r "$svrcert" ] && [ -r "$svrkey" ]; then
-    if oldsan=$(easyrsa show-cert kcp-server |
+    if oldsan=$(easyrsa show-cert $FILE_NAME_BASE |
 		    grep -A1 'X509v3 Subject Alternative Name' |
 		    tail -1 | awk '{ print $1 }'); then
 	if [ "$oldsan" == "DNS:$domain" ]
@@ -54,7 +63,7 @@ if [ -r "$svrcert" ] && [ -r "$svrkey" ]; then
 fi
 
 if [ "$need" == "true" ];
-then ${this%ensure-kcp-server-creds}make-kcp-server-cert --subject-alt-names="DNS:$domain" >&2
+then ${this%ensure-kcp-server-creds}make-kcp-server-cert "$FILE_NAME_BASE" "DNS:$domain" >&2
 fi
 
 echo ${cacert@Q} ${svrcert@Q} ${svrkey@Q}

--- a/scripts/kubestellar-make-kcp-server-cert
+++ b/scripts/kubestellar-make-kcp-server-cert
@@ -1,21 +1,23 @@
 #!/usr/bin/env bash
 
-# Usage: $0 --subject-alt-names=$names
+# Usage: $0 $FILE_NAME_BASE $subject_alt_names
 
 # Assumes easy-rsa PKI with CA is at $PWD/pki.
 # Creates server public cert and private key at
-# pki/kcp-server.crt and pki/kcp-server.key.
-# Creates an ed25519 key.
+# pki/${FILE_NAME_BASE}.crt and pki/${FILE_NAME_BASE}.key.
+# Creates an elliptic curve key.
 # Makes a cert good for 10000 days.
 
-if [ $# != 1 ] || [[ "$1" != --subject-alt-names=?* ]]; then
-    echo "Usage: $0 --subject-alt-names=\$names" >&2
+if [ $# != 2 ] ; then
+    echo "Usage: $0 \$FILE_NAME_BASE \$subject_alt_names" >&2
     exit 1
 fi
 
-SAN="${1#--subject-alt-names=}"
+set -e
 
-FILE_NAME_BASE="kcp-${SAN//:/-}"
+FILE_NAME_BASE="$1"
+shift
+SAN="$1"
 
 export EASYRSA_PKI=${PWD}/pki
 


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
This PR changes the `kubestellar-ensure-kcp-server-creds` and `kubestellar-make-kcp-server-cert` scripts to work around the fact that EasyRSA does not want to work with long filenames.  It also fixes a bug in the idempotency logic in `kubestellar-ensure-kcp-server-creds`.

## Related issue(s)

Fixes #
