### PR TITLE
✨ Change switch-domain to take output pathname

### DIFF
--- a/docs/content/Coding Milestones/PoC2023q1/commands.md
+++ b/docs/content/Coding Milestones/PoC2023q1/commands.md
@@ -117,12 +117,12 @@ that server has to be done by concurrent processes.  The
 kcp server to start handling kubectl requests, and making an alternate
 kubeconfig file for a set of clients to use.  This command is pointed
 at an existing kubeconfig file and reads it but does not write it; the
-alternate config file is written, with the same base name, into a
-parallel directory (which this command `mkdir -p`s).  This command
-takes exactly six command line positional arguments, as follows.
+alternate config file is written (its directory must already exist and
+be writable).  This command takes exactly six command line positional
+arguments, as follows.
 
-1. Pathname (absolute or relative) of the directory holding the input kubeconfig.
-2. Filename of the input kubeconfig (just the base, no directory part).
+1. Pathname (absolute or relative) of the input kubeconfig.
+2. Pathname (absolute or relative) of the output kubeconfig.
 3. Name of the kubeconfig "context" that identifies what to replace.
 4. Domain name to put in the replacement server URLs.
 5. Port number to put in the replacement server URLs.
@@ -144,19 +144,14 @@ There will be the following two differences.
    the contents (base64 encoded, as usual) of the given CA certificate
    file.
 
-This command does a `mkdir -p` on a directory name that is the input
-kubeconfig directory name followed by a dash ("-") and the given
-domain name.  This command writes the alternate kubeconfig file into
-that directory.
-
 Following is an example of using this command and examining the
 results.  The context and port number chosen work for the kubeconfig
 file that `kcp start` (kcp release v0.11.0) creates by default.
 
 ```console
-bash-5.2$ scripts/wait-and-switch-domain .kcp admin.kubeconfig root yep.yep 6443 ${pieces[0]}
+bash-5.2$ scripts/wait-and-switch-domain .kcp/admin.kubeconfig test.yaml root yep.yep 6443 ${pieces[0]}
 
-bash-5.2$ diff -w .kcp/admin.kubeconfig .kcp-yep.yep/admin.kubeconfig 
+bash-5.2$ diff -w .kcp/admin.kubeconfig test.yaml 
 4,5c4,5
 <     certificate-authority-data: LS0...LQo=
 <     server: https://192.168.something.something:6443
@@ -189,7 +184,7 @@ identifies what to replace.
 
 This command is the second part of `wait-and-switch-domain`: the part
 of creating the alternate kubeconfig file.  It has the same inputs and
-outputs.
+outputs and concurrency considerations.
 
 ## KubeStellar Platform control
 

--- a/scripts/switch-domain
+++ b/scripts/switch-domain
@@ -9,16 +9,16 @@
 # matched that of the cluster of the given context.
 
 if [ $# != 6 ]; then
-   echo "Usage: $0 configdir configfile context domain port cacert_file" >&2
+   echo "Usage: $0 inpath outpath context domain port cacert_file" >&2
    exit 1
 fi
 
 set -o errexit
 set -o pipefail
 
-configdir="$(cd $1; pwd)"
+inpath="$1"
 shift
-configfile="$1"
+outpath="$1"
 shift
 context=$1
 shift
@@ -27,10 +27,6 @@ shift
 port=$1
 shift
 cacert_file="$1"
-
-inpath="${configdir}/${configfile}"
-outdir="${configdir}-${domain}"
-outpath="${outdir}/${configfile}"
 
 if ! cacert=$(base64 -w 0 < "$cacert_file" 2>/dev/null) ; then
     cacert=$(base64 < "$cacert_file")
@@ -45,8 +41,6 @@ if [ -z "$protocluster" ]; then
 fi
 export protocluster
 protourl=$(yq '.clusters[] | select(.name == strenv(protocluster)) | .cluster.server' "$inpath")
-
-mkdir -p "${outdir}"
 
 protocol=$(cut -d: -f1 <<<$protourl)
 authpath=$(cut -d: -f2- <<<$protourl)

--- a/scripts/wait-and-switch-domain
+++ b/scripts/wait-and-switch-domain
@@ -11,7 +11,7 @@
 # originally equaled the prefix of the cluster of the given context.
 
 if [ $# != 6 ]; then
-   echo "Usage: $0 configdir configfile context domain port cacert" >&2
+   echo "Usage: $0 inpath outpath context domain port cacert" >&2
    exit 1
 fi
 
@@ -19,9 +19,9 @@ this="$0"
 
 set -e
 
-configdir="$(cd $1; pwd)"
+inpath="$1"
 shift
-configfile="$1"
+outpath="$1"
 shift
 context="$1"
 shift
@@ -31,10 +31,8 @@ port="$1"
 shift
 cacert_file="$1"
 
-inpath="${configdir}/${configfile}"
-
 while ! kubectl --kubeconfig "$inpath" get ns &> /dev/null; do
       sleep 10
 done
 
-${this%wait-and-switch-domain}switch-domain "$configdir" "$configfile" "$context" "$domain" "$port" "$cacert_file"
+${this%wait-and-switch-domain}switch-domain "$inpath" "$outpath" "$context" "$domain" "$port" "$cacert_file"


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
This PR changes the `switch-domain` and `wait-and-switch-domain` commands to simply take an output pathname rather than compute it from other parts.  This one usage we have does not want to use the output path that was being computed.

## Related issue(s)

Fixes #
