### PR TITLE
✨ Create generic command to execute a go template

### DIFF
--- a/cmd/go-template-execute/README.md
+++ b/cmd/go-template-execute/README.md
@@ -1,0 +1,36 @@
+# Go template execute
+
+This command simply parses a go template and some JSON and/or YAML
+data and executes that template with that data.
+
+This command requires exactly one positional argument, the pathname of
+a file holding the input template.
+
+This command accepts the following flags that supply data.  The data
+starts out as an empty JSON object and is augmented by data read
+according to these flags.
+
+- `--data-json $spec` - parse a JSON object
+- `--data-yaml $spec` - parse a YAML object
+- `--data-field-json fieldName=$spec` - parses JSON data to add as the
+  value of the given field. Can be given more than once.
+- `--data-field-yaml fieldName=$spec` - parses YAML data to add as the
+  value of the given field. Can be given more than once.
+
+A `$spec` can be one of the following.
+- `-`, meaning to read stdin.  Nothing good will come of using this
+  twice in one command.
+- `@` + pathname of a file whose contents are to be read.
+- a literal to be read.
+
+Following is an example invocation.
+
+```shell
+go-template-execute my-tmpl.txt --data-json '{"fieldx": 42}' --data-field-yaml Values=@valsfile.yaml
+```
+
+This will read data from the YAML object stored the file named
+`valsfile.yaml` and add it as the value of the field named "Values".
+Then it will parse the given JSON literal, adding to the top-level
+object.  The template will be parsed from the file `my-tmpl.txt`.
+

--- a/cmd/go-template-execute/go.mod
+++ b/cmd/go-template-execute/go.mod
@@ -1,0 +1,8 @@
+module github.com/kubestellar/kubestellar/cmd/go-template-execute
+
+go 1.19
+
+require (
+	github.com/spf13/pflag v1.0.5
+	gopkg.in/yaml.v3 v3.0.1
+)

--- a/cmd/go-template-execute/go.sum
+++ b/cmd/go-template-execute/go.sum
@@ -1,0 +1,6 @@
+github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=
+github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/cmd/go-template-execute/main.go
+++ b/cmd/go-template-execute/main.go
@@ -1,0 +1,133 @@
+/*
+Copyright 2022 The KubeStellar Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+	"text/template"
+
+	flag "github.com/spf13/pflag"
+	"gopkg.in/yaml.v3"
+)
+
+type Decoder interface {
+	Decode(val interface{}) error
+}
+
+func main() {
+	var dataYAML, dataJSON string
+	dataFieldsYAML := []string{}
+	dataFieldsJSON := []string{}
+	flag.StringVar(&dataYAML, "data-yaml", dataYAML, "YAML data to read, literal or '-' for stdin or '@pathname' for file contents")
+	flag.StringVar(&dataJSON, "data-json", dataJSON, "JSON data to read, literal or '-' for stdin or '@pathname' for file contents")
+	flag.StringArrayVar(&dataFieldsYAML, "data-field-yaml", dataFieldsYAML, "TopField=data (literal or dash or @pathname)")
+	flag.StringArrayVar(&dataFieldsJSON, "data-field-json", dataFieldsJSON, "TopField=data (literal or dash or @pathname)")
+	flag.Parse()
+
+	if flag.NArg() != 1 {
+		fmt.Fprintln(os.Stderr, "A template pathname must appear on the command line")
+		os.Exit(1)
+	}
+
+	templatePath := flag.Arg(0)
+	var err error
+	data := map[string]any{}
+	err = readFields(yaml.NewDecoder, dataFieldsYAML, data)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err.Error())
+		os.Exit(20)
+	}
+	err = readFields(json.NewDecoder, dataFieldsJSON, data)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err.Error())
+		os.Exit(21)
+	}
+	if dataJSON != "" {
+		err = readData(json.NewDecoder, dataJSON, &data)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Failed to read a JSON data object from %q: %v\n", dataJSON, err)
+			os.Exit(31)
+		}
+	}
+	if dataYAML != "" {
+		err = readData(yaml.NewDecoder, dataYAML, &data)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Failed to read a YAML data object from %q: %v\n", dataYAML, err)
+			os.Exit(31)
+		}
+	}
+	tmpl, err := template.ParseFiles(templatePath)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Failed to parse template file %q: %v\n", templatePath, err)
+		os.Exit(60)
+	}
+	err = tmpl.Execute(os.Stdout, data)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Failed to execute template %q on %v: %v\n", templatePath, data, err)
+		os.Exit(80)
+	}
+}
+
+var errEmpty = errors.New("empty data spec")
+
+func readFields[ADecoder Decoder](decoderFactory func(io.Reader) ADecoder, dataFields []string, dest map[string]any) error {
+	for _, dataSection := range dataFields {
+		splitPos := strings.Index(dataSection, "=")
+		if splitPos < 0 {
+			return fmt.Errorf("no equals sign in data field %q", dataSection)
+		}
+		sectionName := dataSection[:splitPos]
+		sectionPath := dataSection[splitPos+1:]
+		var sectionData any
+		err := readData(decoderFactory, sectionPath, &sectionData)
+		if err != nil {
+			return fmt.Errorf("failed to read data field %q: %w", dataSection, err)
+		}
+		dest[sectionName] = sectionData
+	}
+	return nil
+}
+
+func readData[ADecoder Decoder](decoderFactory func(io.Reader) ADecoder, dataArg string, dest interface{}) error {
+	return openData(dataArg, func(reader io.Reader) error {
+		decoder := decoderFactory(reader)
+		return decoder.Decode(dest)
+	})
+}
+
+func openData(dataArg string, kont func(io.Reader) error) error {
+	if len(dataArg) == 0 {
+		return errEmpty
+	} else if dataArg == "-" {
+		return kont(os.Stdin)
+	} else if dataArg[0] == '@' {
+		dataPath := dataArg[1:]
+		dataFile, err := os.Open(dataPath)
+		if err != nil {
+			return err
+		}
+		defer dataFile.Close()
+		return kont(dataFile)
+	} else {
+		return kont(strings.NewReader(dataArg))
+	}
+}


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
This PR adds a utility command that simply executes a given go template with some given data.

It can be helpful in developing Helm charts, and can be used in preliminary development before there is an actual Helm chart.  It can remove the need to make many variants of one config file.

## Related issue(s)

Fixes #
