### PR TITLE
✨ Add command to fetch central process log

### DIFF
--- a/docs/content/Coding Milestones/PoC2023q1/commands.md
+++ b/docs/content/Coding Milestones/PoC2023q1/commands.md
@@ -257,6 +257,8 @@ the ESPW.
 These commands administer a deployment of the central components ---
 the kcp server, PKI, and the central KubeStellar components --- in a
 Kubernetes cluster that will be referred to as "the hosting cluster".
+These are framed as "kubectl plugins" and thus need to be explicitly
+or implicitly given a kubeconfig file for the hosting cluster.
 
 ### Deploy to cluster
 
@@ -317,6 +319,31 @@ on the command line.
 - `-o $output_pathname`, saying where to write the kubeconfig. This
   must appear exactly once on the command line.
 - a `kubectl` command line flag, for accessing the hosting cluster.
+
+### Fetch a log from a central process
+
+The `kubectl kubestellar get-log` command will fetch the log from one
+of the central process of kcp or KubeStellar.  This command requires
+one positional argument, identifying the process.  The accepted
+identifiers are as follows.
+
+- `kcp`
+- `mailbox-controller`
+- `where-resolver`
+- `placement-translator`
+
+This command accepts some optional flags, which may appear before
+and/or after the positional argument.  The optional flags are as
+follows.
+
+- `-h`: print a brief usage message and exit successfully.
+- `-n $lines`: the log is extracted with the Linux `tail` command, and
+  this optional flag will be passed along to `tail` if given; the
+  usual syntax and semantics of the `-n` flag for `tail` apply.  If
+  not given then `tail` will be told `-n +0` to fetch the whole log.
+- `-f`: tells `tail` to "follow".
+- a `kubectl` command line flag, for accessing the hosting cluster.
+- `-X`: for debugging, `set -x` in the script that implements this command.
 
 ## KubeStellar platform user commands
 

--- a/scripts/kubectl-kubestellar-get_log
+++ b/scripts/kubectl-kubestellar-get_log
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+
+# Copyright 2023 The KubeStellar Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Purpose: Get the log output from a central KubeStellar or kcp process
+
+# Usage: $0 (-f | -n <integer>[multiplier] | -X | kubectl_flag)* which
+
+follow=""
+lines="-n +0"
+which=""
+kubectl_flags=()
+
+while (( $# > 0 )); do
+    case "$1" in
+	(-X) set -x;;
+	(-h)
+	    echo "Usage: kubectl kubestellar get-log (\$kubectl_flag | -f | -n \$lines | -X)* \$which"
+	    exit 0;;
+	(-f) follow="-f";;
+	(-n)
+	    if (( $# >1 ))
+	    then lines="-n $2"; shift
+	    else echo "$0: missing -n value" >&2; exit 1
+	    fi;;
+	(--*=*|-?=*)
+	    kubectl_flags[${#kubectl_flags[*]}]="$1";;
+	(--*|-?)
+	    if (( $# > 1 ))
+	    then kubectl_flags[${#kubectl_flags[*]}]="$1"
+		 kubectl_flags[${#kubectl_flags[*]}]="$2"
+		 shift
+	    else echo "$0: missing value for long flag $1" >&2; exit 1
+	    fi;;
+	(-*)
+	    echo "$0: flag syntax error" >&2
+	    exit 1;;
+	(*) if [ -n "$which" ]
+	    then echo "$0: exactly one positional argument accepted" >&2
+		 exit 1
+	    else
+		which="$1"
+	    fi
+    esac
+    shift
+done
+
+case "$which" in
+    ("")  echo "$0: must be given exactly one positional argument" >&2
+	  exit 1;;
+    (kcp)                  logfile=kcp.log;;
+    (where-resolver)       logfile=kubestellar-where-resolver-log.txt;;
+    (mailbox-controller)   logfile=mailbox-controller-log.txt;;
+    (placement-translator) logfile=placement-translator-log.txt;;
+    (*) echo "$0: argument 1 must be one of: kcp, where-resolver, mailbox-controller, placement-translator" >&2
+	exit 1;;
+esac
+
+set -e
+
+while ! server_pod=$(kubectl "${kubectl_flags[@]}" get pods -n kubestellar -l app=kubestellar-server -o jsonpath='{.items[0].metadata.name}' 2> /dev/null); do
+    sleep 10
+done
+
+while ! kubectl "${kubectl_flags[@]}" exec -n kubestellar $server_pod -- ls /home/kubestellar/ready &> /dev/null; do
+    sleep 10
+done
+
+kubectl "${kubectl_flags[@]}" exec -n kubestellar $server_pod -- tail kubestellar-logs/$logfile $follow $lines


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
This PR adds a command for use by the KubeStellar platform administrator when the central KubeStellar components are deployed as workload in a hosting Kubernetes cluster.

## Related issue(s)

Fixes #
