### PR TITLE
✨ Document -X and -h for new commands

### DIFF
--- a/docs/content/Coding Milestones/PoC2023q1/commands.md
+++ b/docs/content/Coding Milestones/PoC2023q1/commands.md
@@ -286,6 +286,9 @@ following, in any order.
   chart (currently "kubestellar-route-kubestellar") and continue with
   "." and then the ingress domain name for the cluster.
 - a command line flag for the `helm upgrade` command.
+- `-X` turns on debug echoing of all the commands in the script that
+  implements this command.
+- `-h` prints a brief usage message and terminates with success.
 
 For example, to deploy to a plain Kubernetes cluster whose Ingress
 controller can be reached at
@@ -305,6 +308,9 @@ takes the following on the command line.
 - `-o $output_pathname`, saying where to write the kubeconfig. This
   must appear exactly once on the command line.
 - a `kubectl` command line flag, for accessing the hosting cluster.
+- `-X` turns on debug echoing of all the commands in the script that
+  implements this command.
+- `-h` prints a brief usage message and terminates with success.
 
 ### Fetch kubeconfig for external clients
 
@@ -317,6 +323,9 @@ on the command line.
 - `-o $output_pathname`, saying where to write the kubeconfig. This
   must appear exactly once on the command line.
 - a `kubectl` command line flag, for accessing the hosting cluster.
+- `-X` turns on debug echoing of all the commands in the script that
+  implements this command.
+- `-h` prints a brief usage message and terminates with success.
 
 ## KubeStellar platform user commands
 


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
This PR documents the fact that `kubectl kubestellar deploy`, `kubectl kubestellar get-internal-kubeconfig`, and `kubectl kubestellar get-external-kubeconfig` accept `-X` and `-h` on the command line.

This should have been included from the start but was overlooked.

## Related issue(s)

Fixes #

/cc @ronenkat 
/cc @dumb0002 
@clubanderson 