### PR TITLE
📖 Make port number more clearly an example

### DIFF
--- a/docs/content/Coding Milestones/PoC2023q1/commands.md
+++ b/docs/content/Coding Milestones/PoC2023q1/commands.md
@@ -294,11 +294,11 @@ following, in any order.
 
 For example, to deploy to a plain Kubernetes cluster whose Ingress
 controller can be reached at
-`my-long-application-name.my-region.some.cloud.com:8443`, you would
+`my-long-application-name.my-region.some.cloud.com:1234`, you would
 issue the following command.
 
 ```shell
-kubectl kubestellar deploy --external-endpoint my-long-application-name.my-region.some.cloud.com:8443
+kubectl kubestellar deploy --external-endpoint my-long-application-name.my-region.some.cloud.com:1234
 ```
 
 ### Fetch kubeconfig for internal clients


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
This PR changes an example port number to make it more obvious that this particular bit of documentation has zero normative force regarding the port number but rather is trying to talk about how to cope with whatever port number is coming from the actual usage context.

## Related issue(s)

Fixes #

/cc @ronenkat 
@clubanderson 
/cc @dumb0002 
