### PR TITLE
🐛 Add helm chart to platform archive

### DIFF
--- a/hack/make-release-platform-archive.sh
+++ b/hack/make-release-platform-archive.sh
@@ -37,11 +37,11 @@ srcdir=$(dirname "$0")
 cd "$srcdir/.."
 
 rm -rf bin/*
-make build OS="$target_os" ARCH="$target_arch" WHAT="./cmd/kubestellar-where-resolver ./cmd/mailbox-controller ./cmd/placement-translator ./cmd/kubectl-kubestellar-syncer_gen"
+make build OS="$target_os" ARCH="$target_arch" WHAT="./cmd/kubectl-kubestellar-syncer_gen ./cmd/kubestellar-version ./cmd/kubestellar-where-resolver ./cmd/mailbox-controller ./cmd/placement-translator"
 echo $'#!/usr/bin/env bash\necho' ${kcpe_version@Q} > bin/kubestellar-release
 chmod a+x bin/kubestellar-release
 mkdir -p build/release
-tar czf "build/release/$archname" --exclude bin/.gitignore bin config README.md LICENSE
+tar czf "build/release/$archname" --exclude bin/.gitignore bin config user/helm-chart README.md LICENSE
 cd build/release
 touch checksums256.txt
 grep -vw "$archname" checksums256.txt > /tmp/$$.txt || true


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
This PR adds the Helm chart to the stuff put into a platform archive, because the `kubectl kubestellar deploy` command uses it.

## Related issue(s)

Fixes #

/cc @ronenkat 
/cc @dumb0002 
@clubanderson 
@francostellari 
