### PR TITLE
:sparkles:Change the setup scripts to create Spaces instead of workspaces

### DIFF
--- a/config/space/provider_kcp.yaml
+++ b/config/space/provider_kcp.yaml
@@ -1,0 +1,8 @@
+apiVersion: space.kubestellar.io/v1alpha1
+kind: SpaceProviderDesc
+metadata:
+  name: default
+spec:
+  ProviderType: "kcp"
+  SpacePrefixForDiscovery: "espw"
+  Config: |

--- a/docs/content/Coding Milestones/PoC2023q1/example1-subs/example1-post-kcp.md
+++ b/docs/content/Coding Milestones/PoC2023q1/example1-subs/example1-post-kcp.md
@@ -92,11 +92,66 @@ to pass the new file with `--kubeconfig` on the command lines when
 using kcp or KubeStellar.
 
 
+### Space Manager
+
+The Space Manager will use space provider to create and manage underlying cluster
+for each Space object. Space objects are created in `root:space-mgt` context
+under `spaceprovider-default` namespace.
+
+```shell
+space-manager --context root:space-mgt &
+```
+``` { .bash .no-copy }
+...
+I0829 13:35:53.848054  379407 controller.go:143] "starting manager space controller"
+controller="space-manager"
+...
+I0829 13:35:53.865272  379407 reconcile_spaceprovider.go:87] "Provider namespace cre
+ated" controller="space-manager" provider="default" namespace="spaceprovider-default"
+...
+I0829 13:35:53.870486  379407 provider.go:176] "New space was detected" space="espw"
+provider="default"
+```
+
+You can get a listing of Spaces as follows.
+
+```shell
+kubectl config use-context root:space-mgt
+kubectl get spaces -A
+```
+``` { .bash .no-copy }
+NAMESPACE               NAME   AGE
+spaceprovider-default   espw   90s
+```
+
+
 ### Create an inventory management workspace.
 ```shell
-kubectl ws root
-kubectl ws create imw-1 
+kubectl config use-context root:space-mgt
+kubectl apply -f - <<EOF
+apiVersion: space.kubestellar.io/v1alpha1
+kind: Space
+metadata:
+  name: imw-1
+  namespace: spaceprovider-default
+spec:
+  SpaceProviderDescName: default
+  Managed: true
+EOF
 ```
+``` {.bash .hide-me}
+sleep 5
+```
+
+Check out the Space status as follows.
+
+```shell
+kubectl get space imw-1 -n spaceprovider-default -o yaml | grep Phase
+```
+``` { .bash .no-copy }
+  Phase: Ready
+```
+
 ### Create SyncTarget and Location objects to represent the florin and guilder clusters
 
 Use the following two commands. They label both florin and guilder

--- a/docs/content/Coding Milestones/PoC2023q1/example1-subs/example1-stage-2.md
+++ b/docs/content/Coding Milestones/PoC2023q1/example1-subs/example1-stage-2.md
@@ -13,19 +13,12 @@ One of the workloads is called "common", because it will go to both
 edge clusters.  The other one is called "special".
 
 In this example, each workload description goes in its own workload
-management workspace (WMW).  Start by creating a common parent for
-those two workspaces, with the following commands.
+management workspace (WMW).
+Create the WMW for the common workload.  The following command
+will create it under "root:my-org" workspace.
 
 ```shell
-kubectl ws root
-kubectl ws create my-org --enter
-```
-
-Next, create the WMW for the common workload.  The following command
-will do that, if issued while "root:my-org" is the current workspace.
-
-```shell
-kubectl kubestellar ensure wmw wmw-c
+kubectl kubestellar ensure wmw root:my-org:wmw-c
 ```
 
 This is equivalent to creating that workspace and then entering it and
@@ -176,8 +169,7 @@ Use the following `kubectl` commands to create the WMW for the special
 workload.
 
 ```shell
-kubectl ws root:my-org
-kubectl kubestellar ensure wmw wmw-s
+kubectl kubestellar ensure wmw root:my-org:wmw-s
 ```
 
 Next, use `kubectl` to create the following workload objects in that workspace.

--- a/scripts/kubectl-kubestellar-ensure-wmw
+++ b/scripts/kubectl-kubestellar-ensure-wmw
@@ -17,10 +17,12 @@
 # Purpose: ensure that a workload management workspace exists and has
 # the needed APIBindings.
 
-# Usage: kubectl ws parent; $0 ($kubectl_flag | --with-kube boolean)* wmw_name
+# Usage: $0 ($kubectl_flag | --with-kube boolean)* wmw_path
 
 want_kube=true
 wmw_name=""
+space_mgt="root:space-mgt"
+spaceprovider_ns="spaceprovider-default"
 
 while (( $# > 0 )); do
     case "$1" in
@@ -35,7 +37,7 @@ while (( $# > 0 )); do
 	(--*=*|-?=*)
 	    kubectl_flags[${#kubectl_flags[*]}]="$1";;
 	(-h)
-	    echo "Usage: kubectl ws parent; kubectl kubestellar ensure wmw (\$kubectl_flag | --with-kube boolean)* wm_workspace_name"
+	    echo "Usage: kubectl kubestellar ensure wmw (\$kubectl_flag | --with-kube boolean)* wm_workspace_path"
 	    exit 0;;
 	(--*|-?)
 	    if (( $# > 1 ))
@@ -58,7 +60,7 @@ while (( $# > 0 )); do
 done
 
 if [ "$wmw_name" == "" ]; then
-    echo "$0: workload management workspace name not specified" >&2
+    echo "$0: workload management workspace path not specified" >&2
     exit 1
 fi
 
@@ -70,20 +72,57 @@ esac
 
 set -e
 
-original_ws=$(kubectl ws "${kubectl_flags[@]}" . --short)
+IFS=':' read -ra ws_array <<< "$wmw_name"
+first_item="true"
+parent=""
+kubectl config use-context $space_mgt
 
-if [ "$original_ws" != root ]; then
-    kubectl ws "${kubectl_flags[@]}" ..
-    if kubectl "${kubectl_flags[@]}" get workspaces.tenancy.kcp.io "$wmw_name" &> /dev/null; then
-	echo "Warning: parent has a child with the given WMW name; are you sure the right workspace is current?" >&2
-	sleep 15 # give a chance for ^C
-    fi
-    kubectl ws "${kubectl_flags[@]}" -
-fi
+create_space() {
+    kubectl "${kubectl_flags[@]}" apply -f - <<EOF
+apiVersion: space.kubestellar.io/v1alpha1
+kind: Space
+metadata:
+  name: $item
+  namespace: $spaceprovider_ns
+  annotations:
+    kubestellar.io/space-path: $parent
+spec:
+  SpaceProviderDescName: default
+  Managed: true
+EOF
+}
 
-if kubectl "${kubectl_flags[@]}" get workspaces.tenancy.kcp.io "$wmw_name" &> /dev/null
-then kubectl ws "${kubectl_flags[@]}" "$wmw_name"
-else kubectl ws "${kubectl_flags[@]}" create "$wmw_name" --enter
+for item in "${ws_array[@]}"; do
+    case "$item" in
+    (root)
+        if [ "$first_item" == "true" ]; then
+            parent=$item
+        else
+            echo "\"root\" workspace can only be used at the beginning"
+            exit 2
+        fi;;
+    (*)
+        if [ "$verbose" == "true" ]; then
+            if [[ -z "$(kubectl get space $item -n $spaceprovider_ns --ignore-not-found)" ]] ; then
+                echo "Space "$item" does not exist. Creating"
+                create_space
+                sleep 3
+            fi
+        else
+            if [[ -z "$(kubectl get space $item -n $spaceprovider_ns --ignore-not-found)" ]] ; then
+                create_space 1> /dev/null
+                sleep 3
+            fi
+        fi
+        parent=$parent":"$item;;
+    esac
+    first_item="false"
+done
+
+if ! kubectl ws "${kubectl_flags[@]}" "$wmw_name"
+then
+    echo "Can't access workspace ""$wmw_name"".Check space exist and ready"
+    exit 3
 fi
 
 if ! kubectl "${kubectl_flags[@]}" get APIBinding bind-espw &> /dev/null; then

--- a/scripts/kubestellar
+++ b/scripts/kubestellar
@@ -255,10 +255,10 @@ function ensure_space_mgt() {
     fi
     kubectl ws create-context --overwrite
     # create space CRDs
-    eval kubectl create -f "$SCRIPT_DIR/../config/crds/space.kubestellar.io_spaces.yaml" $verbdir
-    eval kubectl create -f "$SCRIPT_DIR/../config/crds/space.kubestellar.io_spaceproviderdescs.yaml" $verbdir
+    eval kubectl apply -f "$SCRIPT_DIR/../config/crds/space.kubestellar.io_spaces.yaml" $verbdir
+    eval kubectl apply -f "$SCRIPT_DIR/../config/crds/space.kubestellar.io_spaceproviderdescs.yaml" $verbdir
     # deploy KCP provider
-    eval kubectl create -f "$SCRIPT_DIR/../config/space/provider_kcp.yaml" $verbdir
+    eval kubectl apply -f "$SCRIPT_DIR/../config/space/provider_kcp.yaml" $verbdir
     echo "Finished populating the space-mgt with kubestellar apiexports"
 }
 

--- a/scripts/kubestellar
+++ b/scripts/kubestellar
@@ -34,6 +34,7 @@ verbdir="&> /dev/null"
 remove=0
 cleanup=0
 espw_name="espw"
+space_mgt_name="space-mgt"
 log_folder=$(pwd)/kubestellar-logs
 
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
@@ -243,6 +244,25 @@ EOF
     echo "Finished augmenting root:compute for KubeStellar"
 }
 
+function ensure_space_mgt() {
+    echo "space-mgt workspace setup" #TODO remove
+    kubectl ws root &> /dev/null
+    $SCRIPT_DIR/space-provider-config "$KUBECONFIG" "$SCRIPT_DIR/../config/space/provider_kcp.yaml"
+    if kubectl get Workspace "$space_mgt_name" &> /dev/null; then
+	echo "space-mgt workspace already exists -- using it:"
+	kubectl ws "$space_mgt_name"
+    else
+        kubectl ws create "$space_mgt_name" --enter
+    fi
+    kubectl ws create-context --overwrite
+    # create space CRDs
+    eval kubectl create -f "$SCRIPT_DIR/../config/crds/space.kubestellar.io_spaces.yaml" $verbdir
+    eval kubectl create -f "$SCRIPT_DIR/../config/crds/space.kubestellar.io_spaceproviderdescs.yaml" $verbdir
+    # deploy KCP provider
+    eval kubectl create -f "$SCRIPT_DIR/../config/space/provider_kcp.yaml" $verbdir
+    echo "Finished populating the space-mgt with kubestellar apiexports"
+}
+
 # current ws at start does not matter, is ESPW on return
 function ensure_espw() {
     kubectl ws root &> /dev/null
@@ -258,8 +278,16 @@ function ensure_espw() {
 
 if [ "$subcommand" == init ]; then
     ensure_root_compute_configd
+    ensure_space_mgt
     ensure_espw
     exit
+fi
+
+# Check space-manager is already running
+if [ $(process_running space-manager) == "running" ]
+then
+    echo "An older deployment of space-manager is already running - terminating it ...."
+    pkill -f space-manager
 fi
 
 # Check mailbox-controller is already running
@@ -289,6 +317,7 @@ if [ $subcommand == stop ]; then
 fi
 
 ensure_root_compute_configd
+ensure_space_mgt
 ensure_espw
 
 wait_for_process(){
@@ -323,6 +352,17 @@ if [[ ! -d $log_folder ]]; then
     mkdir -p $log_folder
 fi
 
+space-manager -context "root:"$space_mgt_name -v=2 >> $log_folder/space-manager-log.txt 2>&1 &
+run_status=$(wait_for_process space-manager)
+if [ $run_status -eq 0 ]; then
+    echo " space-manager is running (log file: $log_folder/space-manager-log.txt)"
+else
+    echo " space-manager failed to start ..... exiting"
+    sleep 2
+    exit 1
+fi
+
+sleep 3
 mailbox-controller -v=2 >> $log_folder/mailbox-controller-log.txt 2>&1 &
 
 run_status=$(wait_for_process mailbox-controller)

--- a/scripts/kubestellar
+++ b/scripts/kubestellar
@@ -245,7 +245,6 @@ EOF
 }
 
 function ensure_space_mgt() {
-    echo "space-mgt workspace setup" #TODO remove
     kubectl ws root &> /dev/null
     $SCRIPT_DIR/space-provider-config "$KUBECONFIG" "$SCRIPT_DIR/../config/space/provider_kcp.yaml"
     if kubectl get Workspace "$space_mgt_name" &> /dev/null; then

--- a/scripts/remove-kubestellar
+++ b/scripts/remove-kubestellar
@@ -35,6 +35,7 @@ done
 
 
 pkill -f kcp
+pkill -f space-manager
 pkill -f mailbox-controller
 pkill -f placement-translator
 pkill -f kubestellar-where-resolver

--- a/scripts/space-provider-config
+++ b/scripts/space-provider-config
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+
+# Copyright 2023 The KubeStellar Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -e
+
+# Check if two parameters are provided
+if [ $# -ne 2 ]; then
+    echo "Usage: $0 <config file> <provider yaml>"
+    exit 1
+fi
+
+config="$1"
+provider="$2"
+
+# Check if config file exists
+if [ ! -f "$config" ]; then
+    echo "Error: $config does not exist."
+    exit 1
+fi
+
+# Check if provider file exists
+if [ ! -f "$provider" ]; then
+    echo "Error: $provider does not exist."
+    exit 1
+fi
+
+# Define the specConfig string
+specConfig="  Config: |"
+
+# Check if config field exists in the provider yaml file and remove text after it
+if grep -q "$specConfig" "$provider"; then
+    sed -i "/$specConfig/,\$d" "$provider"
+fi
+
+# Add the field string to the provider file
+echo "$specConfig" >> "$provider"
+
+# Append the content of the config file to the provider file
+sed 's/^/    /' "$config" >> "$provider"
+
+echo "Config has been added to the provider yaml."

--- a/scripts/space-provider-config
+++ b/scripts/space-provider-config
@@ -29,14 +29,14 @@ config="$1"
 provider="$2"
 
 # Check if config file exists
-if [ ! -f "$config" ]; then
-    echo "Error: $config does not exist."
+if [ ! -r "$config" ]; then
+    echo "Error: $config does not exist or not readable."
     exit 1
 fi
 
 # Check if provider file exists
-if [ ! -f "$provider" ]; then
-    echo "Error: $provider does not exist."
+if [ ! -w "$provider" ]; then
+    echo "Error: $provider does not exist or not writable."
     exit 1
 fi
 
@@ -45,13 +45,14 @@ specConfig="  Config: |"
 
 # Check if config field exists in the provider yaml file and remove text after it
 if grep -q "$specConfig" "$provider"; then
-    sed -i "/$specConfig/,\$d" "$provider"
+    awk -v placeholder="$specConfig" '$0 == placeholder {exit} {print}' "$provider" > "$provider.temp"
+    mv "$provider.temp" "$provider"
 fi
 
 # Add the field string to the provider file
 echo "$specConfig" >> "$provider"
 
 # Append the content of the config file to the provider file
-sed 's/^/    /' "$config" >> "$provider"
+awk '{print "    " $0}' "$config" >> "$provider"
 
 echo "Config has been added to the provider yaml."

--- a/scripts/space-provider-config
+++ b/scripts/space-provider-config
@@ -16,6 +16,9 @@
 
 set -e
 
+# This is a helper script to set the space provider access from config file
+# as Config value in space provider yaml.
+
 # Check if two parameters are provided
 if [ $# -ne 2 ]; then
     echo "Usage: $0 <config file> <provider yaml>"


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
1. Create workspace for space management and deploy needed CRDs.
2. Start space-manager controller.
3. Use kubectl to create spaces instead of workspaces.

## Related issue(s)
https://github.com/kubestellar/kubestellar/issues/852

Fixes #
