### PR TITLE
🐛 Armor syncer ownership annotations against some copying

### DIFF
--- a/pkg/syncer/syncers/common.go
+++ b/pkg/syncer/syncers/common.go
@@ -235,11 +235,7 @@ func setAnnotation(resource *unstructured.Unstructured, key string, value string
 	resource.SetAnnotations(annotations)
 }
 
-func hasAnnotation(resource *unstructured.Unstructured, key string) bool {
+func getAnnotation(resource *unstructured.Unstructured, key string) string {
 	annotations := resource.GetAnnotations()
-	if annotations == nil {
-		return false
-	}
-	_, ok := annotations[key]
-	return ok
+	return annotations[key]
 }

--- a/pkg/syncer/syncers/upsyncer.go
+++ b/pkg/syncer/syncers/upsyncer.go
@@ -282,12 +282,15 @@ func (us *UpSyncer) getNamespaces() ([]string, error) {
 	return namespaces, nil
 }
 
+const upsyncKey = "edge.kcp.io/upsynced"
+
 func setUpsyncAnnotation(resource *unstructured.Unstructured) {
-	setAnnotation(resource, "edge.kcp.io/upsynced", "true")
+	setAnnotation(resource, upsyncKey, makeOwnedValue(resource))
 }
 
 func hasUpsyncAnnotation(resource *unstructured.Unstructured) bool {
-	return hasAnnotation(resource, "edge.kcp.io/upsynced")
+	ownedValue := makeOwnedValue(resource)
+	return getAnnotation(resource, upsyncKey) == ownedValue
 }
 
 func (us *UpSyncer) BackStatusOne(resource edgev1alpha1.EdgeSyncConfigResource, conversions []edgev1alpha1.EdgeSynConversion) error {


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
This PR makes the annotations that the syncer uses to indicate that it owns an object more specific to the individual object, so that copying by, e.g. the Deployment controller, will not be confusing.

This PR also improves some of the debug logging in the syncer.

## Related issue(s)

Fixes #900

/cc @yana1205 
/cc @clubanderson 
/cc @waltforme 
@dumb0002 
@ronenkat 
