### PR TITLE
📖 Document teardown of deployment to Kubernetes

### DIFF
--- a/docs/content/Coding Milestones/PoC2023q1/commands.md
+++ b/docs/content/Coding Milestones/PoC2023q1/commands.md
@@ -354,6 +354,21 @@ follows.
 - a `kubectl` command line flag, for accessing the hosting cluster.
 - `-X`: for debugging, `set -x` in the script that implements this command.
 
+### Remove deployment to a Kubernetes cluster
+
+The deployent of kcp and KubeStellar as a Kubernetes workload is done
+by making a "release" (this is a [technical term in
+Helm](https://helm.sh/docs/intro/cheatsheet/#basic-interpretationscontext)
+whose meaning might surprise you) of a Helm chart.  This release is
+named "kubestellar".  To undo the deployment, just use the Helm
+command to delete that release.
+
+```shell
+helm delete kubestellar
+```
+
+**NOTE**: this is a detail that might change in the future.
+
 ## KubeStellar platform user commands
 
 The remainder of the commands in this document are for users rather


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
This PR documents how to undo deployment of kcp+KubeStellar as a workload in a Kubernetes cluster.

## Related issue(s)

Fixes #

/cc @clubanderson 
/cc @dumb0002 
/cc @ronenkat 
@francostellari 
