### PR TITLE
🐛 Stop checking quickstart on dev work

### DIFF
--- a/.github/workflows/docs-ecutable-qs.yml
+++ b/.github/workflows/docs-ecutable-qs.yml
@@ -5,29 +5,6 @@ on:
   workflow_call:
   # So we can trigger manually if needed
   workflow_dispatch:
-  # To confirm any changes to docs build successfully, without deploying them
-  pull_request:
-    branches:
-      - main
-      - "release-*"
-    paths:
-      - "docs/content/Getting-Started/quickstart.md"
-      - "docs/content/Getting-Started/quickstart-subs/**"
-      - "docs/content/Coding Milestones/PoC2023q1/common-subs/**"
-      - ".github/workflows/docs-ecutable-qs.yml"
-      - "docs/scripts/docs-ecutable.sh"
-  push:
-    branches:
-      - main
-      - "release-*"
-    paths:
-      - "docs/content/Getting-Started/quickstart.md"
-      - "docs/content/Getting-Started/quickstart-subs/**"
-      - "docs/content/Coding Milestones/PoC2023q1/common-subs/**"
-      - ".github/workflows/docs-ecutable-qs.yml"
-      - "docs/scripts/docs-ecutable.sh"
-    tags:
-      - 'v*'
       
 env:
   docs-ecutable-filename: qs


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
This PR removes triggering events related to development activity from those of the quickstart docs-ecutable.  This is appropriate because the quickstart docs-ecutable in the `main` branch can not be expected to stay consistent with the last release (e.g., #901).

## Related issue(s)

Fixes #
