### PR TITLE
✨ Avoid empty cluster IDs

### DIFF
--- a/hack/logcheck.out
+++ b/hack/logcheck.out
@@ -3,7 +3,7 @@
 /cmd/mailbox-controller/main.go:198:4: Additional arguments to Info should always be Key Value pairs. Please check if there is any key or value missing.
 /cmd/mailbox-controller/main.go:91:3: Key positional arguments are expected to be inlined constant strings. Please replace &{flg Name} provided with string value.
 /cmd/placement-translator/main.go:120:3: Key positional arguments are expected to be inlined constant strings. Please replace &{flg Name} provided with string value.
-/pkg/placement/workload-projector.go:687:4: the result of logger.V should be stored in a variable and then be used multiple times: if logger := logger.V(); logger.Enabled() { ... logger.Info ... }
-/pkg/placement/workload-projector.go:709:2: the result of logger.V should be stored in a variable and then be used multiple times: if logger := logger.V(); logger.Enabled() { ... logger.Info ... }
-/pkg/placement/workload-projector.go:885:1: A function should accept either a context or a logger, but not both. Having both makes calling the function harder because it must be defined whether the context must contain the logger and callers have to follow that.
-/pkg/placement/workload-projector.go:967:4: the result of logger.V should be stored in a variable and then be used multiple times: if logger := logger.V(); logger.Enabled() { ... logger.Info ... }
+/pkg/placement/workload-projector.go:1009:4: the result of logger.V should be stored in a variable and then be used multiple times: if logger := logger.V(); logger.Enabled() { ... logger.Info ... }
+/pkg/placement/workload-projector.go:728:4: the result of logger.V should be stored in a variable and then be used multiple times: if logger := logger.V(); logger.Enabled() { ... logger.Info ... }
+/pkg/placement/workload-projector.go:750:2: the result of logger.V should be stored in a variable and then be used multiple times: if logger := logger.V(); logger.Enabled() { ... logger.Info ... }
+/pkg/placement/workload-projector.go:927:1: A function should accept either a context or a logger, but not both. Having both makes calling the function harder because it must be defined whether the context must contain the logger and callers have to follow that.

--- a/scripts/kubestellar
+++ b/scripts/kubestellar
@@ -323,7 +323,7 @@ if [[ ! -d $log_folder ]]; then
     mkdir -p $log_folder
 fi
 
-mailbox-controller -v=2 &>> $log_folder/mailbox-controller-log.txt &
+mailbox-controller -v=2 >> $log_folder/mailbox-controller-log.txt 2>&1 &
 
 run_status=$(wait_for_process mailbox-controller)
 if [ $run_status -eq 0 ]; then
@@ -337,7 +337,7 @@ fi
 
 # Start the kubestellar where-resolver
 sleep 3
-kubestellar-where-resolver -v 2 &>> $log_folder/kubestellar-where-resolver-log.txt &
+kubestellar-where-resolver -v 2 >> $log_folder/kubestellar-where-resolver-log.txt 2>&1 &
 
 run_status=$(wait_for_process "kubestellar-where-resolver")
 if [ $run_status -eq 0 ]; then
@@ -349,7 +349,7 @@ fi
  
 # Start the Placement Translator
 sleep 3
-placement-translator --allclusters-context  "system:admin" -v=2 &>> $log_folder/placement-translator-log.txt &
+placement-translator --allclusters-context  "system:admin" -v=2 >> $log_folder/placement-translator-log.txt 2>&1 &
 
 run_status=$(wait_for_process placement-translator)
 if [ $run_status -eq 0 ]; then

--- a/scripts/kubestellar
+++ b/scripts/kubestellar
@@ -100,7 +100,10 @@ function create_or_replace() { # usage: filename
     
 # current ws at start does not matter, is root:compute on return
 function ensure_root_compute_configd() {
-    kubectl ws root:compute &> /dev/null
+    if ! kubectl ws root:compute &> /dev/null ; then
+	echo "$0: Something is very wrong, unable to set current kcp workspace to root:compute" >&2
+	exit 1
+    fi
     ( cd ${SCRIPT_DIR}/../config/kube/exports/namespaced
       # Some are too big to `kubectl apply`
       for rsfn in apiresourceschema-*.yaml; do


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
This PR fixes the logic in the placement translator to avoid processing Workspace objects while they are still being set up, and adds error checking for empty cluster IDs in other places.

This PR also updates the logic in `kubestellar init` to print an explanatory message if the first attempt to use the kcp server fails.

This PR also changes the `kubestellar` script to eschew `&>>` redirection in favor of `>> file 2>&1` because bash on the Mac is astonishingly back-level.

## Related issue(s)

Fixes #935 
Fixes #936
