### PR TITLE
:bug: Fix Syncer not to update status field

### DIFF
--- a/pkg/syncer/syncers/common.go
+++ b/pkg/syncer/syncers/common.go
@@ -180,7 +180,7 @@ func diff(logger klog.Logger, srcResourceList *unstructured.UnstructuredList, de
 		if ok {
 			srcResource.SetResourceVersion(destResource.GetResourceVersion())
 			srcResource.SetUID(destResource.GetUID())
-			srcResource.SetManagedFields(nil)
+			srcResource.SetManagedFields(destResource.GetManagedFields())
 			if hasAnnotation(destResource) {
 				setAnnotation(&srcResource)
 				updatedResources = append(updatedResources, srcResource)

--- a/pkg/syncer/syncers/common.go
+++ b/pkg/syncer/syncers/common.go
@@ -181,6 +181,11 @@ func diff(logger klog.Logger, srcResourceList *unstructured.UnstructuredList, de
 			srcResource.SetResourceVersion(destResource.GetResourceVersion())
 			srcResource.SetUID(destResource.GetUID())
 			srcResource.SetManagedFields(destResource.GetManagedFields())
+
+			// Avoid to overwrite status field. Though, not sure this workaround is required.
+			// Actually, when Syncer donwsynces, Syncer doesn't call UpdateStatus() method. Status fields at downstream side aren't updated by downsyncing.
+			setStatusFieldToDestinationStatus(logger, &srcResource, destResource)
+
 			if hasAnnotation(destResource) {
 				setAnnotation(&srcResource)
 				updatedResources = append(updatedResources, srcResource)
@@ -238,4 +243,16 @@ func setAnnotation(resource *unstructured.Unstructured, key string, value string
 func getAnnotation(resource *unstructured.Unstructured, key string) string {
 	annotations := resource.GetAnnotations()
 	return annotations[key]
+}
+
+func setStatusFieldToDestinationStatus(logger klog.Logger, srcResource *unstructured.Unstructured, destResource *unstructured.Unstructured) {
+	status, found, err := unstructured.NestedMap(destResource.Object, "status")
+	if found {
+		srcResource.Object["status"] = status
+	} else {
+		if err != nil {
+			logger.V(2).Info(fmt.Sprintf("  %v", err))
+		}
+		logger.V(2).Info(fmt.Sprintf("  failed to extract status from destination object %q. Nothing to do with status field", destResource.GetName()))
+	}
 }


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

I added a code to explicitly set `status` field and `meta.managedField` to the same value of the existing object at the destination when downsyncing objects in order to avoid overwriting the status field just in case.

## Related issue(s)

Fixes #938
