### PR TITLE
🐛 Choose update status method according to API group

### DIFF
--- a/pkg/syncer/syncers/downsyncer.go
+++ b/pkg/syncer/syncers/downsyncer.go
@@ -19,6 +19,7 @@ package syncers
 import (
 	"errors"
 	"fmt"
+	"strings"
 	"sync"
 
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
@@ -203,7 +204,7 @@ func (ds *DownSyncer) BackStatusOne(resource edgev1alpha1.EdgeSyncConfigResource
 	}
 	upstreamResource.Object["status"] = status
 	applyConversion(upstreamResource, resourceForUp)
-	if _, err := upstreamClient.UpdateStatus(resourceForUp, upstreamResource); err != nil {
+	if _, err := updateStatusByResource(upstreamClient, resourceForUp, upstreamResource); err != nil {
 		ds.logger.Error(err, fmt.Sprintf("failed to update resource on upstream %q", resourceToString(resourceForUp)))
 		return err
 	}
@@ -315,13 +316,25 @@ func (ds *DownSyncer) BackStatusMany(resource edgev1alpha1.EdgeSyncConfigResourc
 			resourceForUp := convertToUpstream(resource, conversions)
 			upstreamResource.Object["status"] = status
 			applyConversion(upstreamResource, resourceForUp)
-			if _, err := upstreamClient.UpdateStatus(resourceForUp, upstreamResource); err != nil {
+			if _, err := updateStatusByResource(upstreamClient, resourceForUp, upstreamResource); err != nil {
 				ds.logger.Error(err, fmt.Sprintf("failed to update resource on upstream %q", resourceToString(resourceForUp)))
 				return err
 			}
 		}
 	}
 	return nil
+}
+
+func updateStatusByResource(upstreamClient *Client, resourceForUp edgev1alpha1.EdgeSyncConfigResource, upstreamResource *unstructured.Unstructured) (*unstructured.Unstructured, error) {
+	// TODO: make a more informed choice
+	if isKubeResource(resourceForUp) {
+		return upstreamClient.UpdateStatus(resourceForUp, upstreamResource)
+	}
+	return upstreamClient.Update(resourceForUp, upstreamResource)
+}
+
+func isKubeResource(rsc edgev1alpha1.EdgeSyncConfigResource) bool {
+	return strings.HasSuffix(rsc.Group, ".k8s.io") || !strings.Contains(rsc.Group, ".")
 }
 
 func findWithObject(target unstructured.Unstructured, resourceList *unstructured.UnstructuredList) (*unstructured.Unstructured, bool) {


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
This PR updates the syncer to make it choose how to update the status of an upstream object based on the API group. This is better than the previous code but not fully correct; the correct code would somehow depend on whether the resource actually has a status subresource.

## Related issue(s)

This partially addresses #945 .
