### PR TITLE
🐛 release-0.4: Update prep-for-syncer plugin to use PR 946

### DIFF
--- a/scripts/kubectl-kubestellar-prep_for_syncer
+++ b/scripts/kubectl-kubestellar-prep_for_syncer
@@ -34,7 +34,7 @@ imw=.
 espw="root:espw"
 stname=""
 output=""
-syncer_image="quay.io/kubestellar/syncer:v0.4.0"
+syncer_image="quay.io/kubestellar/syncer:pr-946"
 kubectl_flags=()
 
 while (( $# > 0 )); do


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
This PR updates the prep-for-syncer plugin in the `release-0.4` branch to use the syncer image built from #946 .

## Related issue(s)

This partially addresses #945
