### PR TITLE
🐛 Make prep-for-syncer plugin use status write hack

### DIFF
--- a/scripts/kubectl-kubestellar-prep_for_syncer
+++ b/scripts/kubectl-kubestellar-prep_for_syncer
@@ -34,7 +34,7 @@ imw=.
 espw="root:espw"
 stname=""
 output=""
-syncer_image="quay.io/kubestellar/syncer:pr-901"
+syncer_image="quay.io/kubestellar/syncer:pr-947"
 kubectl_flags=()
 silent="false"
 


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
This PR changes the prep-for-syncer plugin to use the syncer image that I built for `main` just after #947 merged into `main`.

## Related issue(s)

This partially addresses #945
