### PR TITLE
:bug: Use informer in KCP space provider

### DIFF
--- a/space-provider/kcp/kcp.go
+++ b/space-provider/kcp/kcp.go
@@ -18,24 +18,32 @@ package providerkcp
 
 import (
 	"context"
+	"errors"
+	"reflect"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/go-logr/logr"
 
 	k8sapierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/clientcmd"
 	api "k8s.io/client-go/tools/clientcmd/api"
+	"k8s.io/client-go/util/workqueue"
 	"k8s.io/klog/v2"
 
+	kcpcache "github.com/kcp-dev/apimachinery/v2/pkg/cache"
 	kcpcore "github.com/kcp-dev/kcp/pkg/apis/core"
 	kcpcorev1alpha1 "github.com/kcp-dev/kcp/pkg/apis/core/v1alpha1"
 	kcptenancyv1alpha1 "github.com/kcp-dev/kcp/pkg/apis/tenancy/v1alpha1"
 	kcpclientset "github.com/kcp-dev/kcp/pkg/client/clientset/versioned/cluster"
-	kcpcoreclusteredv1alpha1 "github.com/kcp-dev/kcp/pkg/client/clientset/versioned/cluster/typed/core/v1alpha1"
 	kcptenancyclusteredv1alpha1 "github.com/kcp-dev/kcp/pkg/client/clientset/versioned/cluster/typed/tenancy/v1alpha1"
+	extkcpinformers "github.com/kcp-dev/kcp/pkg/client/informers/externalversions"
 	"github.com/kcp-dev/logicalcluster/v3"
 
 	clusterprovider "github.com/kubestellar/kubestellar/pkg/space-manager/providerclient"
@@ -47,9 +55,10 @@ type KcpClusterProvider struct {
 	logger         logr.Logger
 	kcpConfig      string
 	kcpWsClientset kcptenancyclusteredv1alpha1.WorkspaceClusterInterface
-	kcpLcClientset kcpcoreclusteredv1alpha1.LogicalClusterClusterInterface
+	adminClientset *kcpclientset.ClusterClientset
 	workspaces     map[string]string
 	watch          clusterprovider.Watcher
+	lock           sync.Mutex
 }
 
 // New returns a new KcpClusterProvider
@@ -86,7 +95,7 @@ func New(kcpConfig string) (*KcpClusterProvider, error) {
 		logger:         logger,
 		kcpConfig:      kcpConfig,
 		kcpWsClientset: baseClientset.TenancyV1alpha1().Workspaces(),
-		kcpLcClientset: adminClientset.CoreV1alpha1().LogicalClusters(),
+		adminClientset: adminClientset,
 		workspaces:     make(map[string]string),
 	}
 	return c, nil
@@ -116,7 +125,7 @@ func (k *KcpClusterProvider) Delete(name string, opts clusterprovider.Options) e
 
 // ListSpacesNames is N/A for KCP
 // TODO remove it from ProviderClient interface
-func (k KcpClusterProvider) ListSpacesNames() ([]string, error) {
+func (k *KcpClusterProvider) ListSpacesNames() ([]string, error) {
 	k.logger.V(2).Info("Not implemented")
 	return []string{}, nil
 }
@@ -193,67 +202,192 @@ func (k *KcpWatcher) ResultChan() <-chan clusterprovider.WatchEvent {
 		k.wg.Add(1)
 		go func() {
 			defer k.wg.Done()
-			watcher, err := k.provider.kcpLcClientset.Watch(k.provider.ctx, metav1.ListOptions{})
-			if err == nil {
-				for {
-					select {
-					case <-ctx.Done():
-						watcher.Stop()
-						k.Stop()
-					case event, ok := <-watcher.ResultChan():
-						if !ok {
-							k.Stop()
-							return
-						}
-						lc := event.Object.(*kcpcorev1alpha1.LogicalCluster)
+			numThreads := 2
+			resyncPeriod := 30 * time.Second
+			kcpInformerFactory := extkcpinformers.NewSharedInformerFactory(k.provider.adminClientset, resyncPeriod)
+			lcInformer := kcpInformerFactory.Core().V1alpha1().LogicalClusters().Informer()
 
-						path, ok := lc.Annotations[kcpcore.LogicalClusterPathAnnotationKey]
-						if !ok || lc.Spec.Owner == nil {
-							continue
-						}
-						if event.Type == "MODIFIED" || event.Type == "ADDED" {
-							k.provider.logger.V(2).Info("KCP workspace modify/add event", "ws", path, "status", lc.Status.Phase)
-							_, ok := k.provider.workspaces[path]
-							if !ok && lc.Status.Phase == kcpcorev1alpha1.LogicalClusterPhaseReady {
-								spaceInfo, err := k.provider.Get(path)
-								if err != nil {
-									k.provider.logger.Info("Failed to get space info")
-									continue
-								}
-								k.provider.logger.V(2).Info("New KCP workspace is ready", "ws", path)
-								// add ready WS to cache and send an event
-								k.provider.workspaces[path] = string(lc.Status.Phase)
-								k.ch <- clusterprovider.WatchEvent{
-									Type:      watch.Added,
-									Name:      lc.Spec.Owner.Name,
-									SpaceInfo: spaceInfo,
-								}
-							}
-							if ok && lc.Status.Phase != kcpcorev1alpha1.LogicalClusterPhaseReady {
-								k.provider.logger.V(2).Info("KCP workspace is not ready")
-								if ok {
-									delete(k.provider.workspaces, path)
-									k.ch <- clusterprovider.WatchEvent{
-										Type: watch.Deleted,
-										Name: lc.Spec.Owner.Name,
-									}
-								}
-							}
-						}
-						if event.Type == "DELETED" {
-							k.provider.logger.V(2).Info("KCP workspace deleted", "ws", path)
-							delete(k.provider.workspaces, path)
-							k.ch <- clusterprovider.WatchEvent{
-								Type: watch.Deleted,
-								Name: lc.Spec.Owner.Name,
-							}
-						}
-					}
-				}
-			}
+			kcpInformerFactory.Start(ctx.Done())
+
+			c := NewController(ctx, k, lcInformer)
+			c.Run(numThreads)
 		}()
 	})
 	return k.ch
+}
+
+type queueItem struct {
+	key   string
+	path  string
+	owner *kcpcorev1alpha1.LogicalClusterOwner
+}
+
+type controller struct {
+	ctx        context.Context
+	logger     logr.Logger
+	watcher    *KcpWatcher
+	queue      workqueue.RateLimitingInterface
+	lcInformer kcpcache.ScopeableSharedIndexInformer
+}
+
+// NewController returns new KCP-provider controller
+func NewController(
+	ctx context.Context,
+	watcher *KcpWatcher,
+	lcInformer kcpcache.ScopeableSharedIndexInformer,
+) *controller {
+	controllerName := "KCP-provider"
+	ctx = klog.NewContext(ctx, klog.FromContext(ctx).WithValues("controller", controllerName))
+
+	c := &controller{
+		ctx:        ctx,
+		logger:     klog.FromContext(ctx),
+		watcher:    watcher,
+		queue:      workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), controllerName),
+		lcInformer: lcInformer,
+	}
+
+	lcInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc: c.enqueue,
+		UpdateFunc: func(oldObj, newObj interface{}) {
+			old := oldObj.(*kcpcorev1alpha1.LogicalCluster)
+			new := newObj.(*kcpcorev1alpha1.LogicalCluster)
+			if !reflect.DeepEqual(old, new) {
+				c.enqueue(newObj)
+			}
+		},
+		DeleteFunc: c.enqueue,
+	})
+	return c
+}
+
+func (c *controller) enqueue(obj interface{}) {
+	key, err := kcpcache.DeletionHandlingMetaClusterNamespaceKeyFunc(obj)
+	if err != nil {
+		runtime.HandleError(err)
+		return
+	}
+	lc, ok := obj.(*kcpcorev1alpha1.LogicalCluster)
+	if !ok {
+		runtime.HandleError(errors.New("unexpected object type. expected LogicalCluster"))
+		return
+	}
+	path, ok := lc.Annotations[kcpcore.LogicalClusterPathAnnotationKey]
+	if ok && lc.Spec.Owner != nil {
+		c.logger.V(4).Info("queueing LogicalCluster", "key", key)
+		c.queue.Add(
+			queueItem{
+				key:   key,
+				path:  path,
+				owner: lc.Spec.Owner,
+			},
+		)
+	}
+
+}
+
+// Run starts the controller, which stops when c.context.Done() is closed.
+func (c *controller) Run(numThreads int) {
+	defer runtime.HandleCrash()
+	defer c.queue.ShutDown()
+
+	c.logger.Info("starting KCP provider controller")
+	defer c.logger.Info("shutting down KCP provider controller")
+
+	for i := 0; i < numThreads; i++ {
+		go wait.UntilWithContext(c.ctx, c.runWorker, time.Second)
+	}
+
+	<-c.ctx.Done()
+}
+
+func (c *controller) runWorker(ctx context.Context) {
+	for c.processNextItem() {
+	}
+}
+
+func (c *controller) processNextItem() bool {
+	// Wait until there is a new item in the working queue
+	i, quit := c.queue.Get()
+	if quit {
+		return false
+	}
+	item := i.(queueItem)
+
+	// Done with this key, unblock other workers.
+	defer c.queue.Done(i)
+
+	if err := c.process(item); err != nil {
+		runtime.HandleError(err)
+		c.queue.AddRateLimited(i)
+		return true
+	}
+	c.queue.Forget(i)
+	return true
+}
+
+func (c *controller) process(item queueItem) error {
+	lc, exists, err := c.lcInformer.GetIndexer().GetByKey(item.key)
+	if err != nil {
+		return err
+	}
+	if !exists {
+		c.handleDelete(item)
+	} else {
+		c.handleAdd(lc, item)
+	}
+	return nil
+}
+
+func (c *controller) handleAdd(logicalCluster interface{}, item queueItem) {
+	lc, ok := logicalCluster.(*kcpcorev1alpha1.LogicalCluster)
+	if !ok {
+		runtime.HandleError(errors.New("unexpected object type. expected LogicalCluster"))
+		return
+	}
+	path, owner := item.path, item.owner
+	c.logger.V(2).Info("KCP workspace modify/add event", "ws", path, "status", lc.Status.Phase)
+	c.watcher.provider.lock.Lock()
+	defer c.watcher.provider.lock.Unlock()
+
+	_, ok = c.watcher.provider.workspaces[path]
+	if !ok && lc.Status.Phase == kcpcorev1alpha1.LogicalClusterPhaseReady {
+		spaceInfo, err := c.watcher.provider.Get(path)
+		if err != nil {
+			c.logger.Info("Failed to get space info")
+			return
+		}
+		c.logger.V(2).Info("New KCP workspace is ready", "ws", path)
+		// add ready WS to cache and send an event
+		c.watcher.provider.workspaces[path] = string(lc.Status.Phase)
+		c.watcher.ch <- clusterprovider.WatchEvent{
+			Type:      watch.Added,
+			Name:      owner.Name,
+			SpaceInfo: spaceInfo,
+		}
+	}
+	if ok && lc.Status.Phase != kcpcorev1alpha1.LogicalClusterPhaseReady {
+		c.logger.V(2).Info("KCP workspace is not ready")
+		if ok {
+			delete(c.watcher.provider.workspaces, path)
+			c.watcher.ch <- clusterprovider.WatchEvent{
+				Type: watch.Deleted,
+				Name: lc.Spec.Owner.Name,
+			}
+		}
+	}
+
+}
+
+func (c *controller) handleDelete(item queueItem) {
+	c.logger.V(2).Info("KCP workspace deleted", "ws", item.path)
+	c.watcher.provider.lock.Lock()
+	defer c.watcher.provider.lock.Unlock()
+	delete(c.watcher.provider.workspaces, item.path)
+	c.watcher.ch <- clusterprovider.WatchEvent{
+		Type: watch.Deleted,
+		Name: item.owner.Name,
+	}
 }
 
 func buildRawConfig(baseRaw api.Config, spaceName string) api.Config {


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
This PR will change KCP space provider to use LogicalCluster informer instead of `watch` API call which is unstable. 
## Related issue(s)

Fixes #
https://github.com/kubestellar/kubestellar/issues/964