### PR TITLE
:sparkles: Syncer supports NamespacedObjects in syncerconfig

### DIFF
--- a/pkg/syncer/controller/syncerconfigmanager.go
+++ b/pkg/syncer/controller/syncerconfigmanager.go
@@ -22,7 +22,6 @@ import (
 
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/restmapper"
 	"k8s.io/klog/v2"

--- a/pkg/syncer/controller/syncerconfigmanager.go
+++ b/pkg/syncer/controller/syncerconfigmanager.go
@@ -91,7 +91,7 @@ func (s *SyncerConfigManager) upsertNamespaceScoped(syncerConfig edgev1alpha1.Sy
 	s.logger.V(3).Info("upsert namespace scoped resources as syncerConfig to syncConfigManager stores", "syncerConfigName", syncerConfig.Name, "numNamespaces", len(syncerConfig.Spec.NamespaceScope.Namespaces))
 	if lgr := s.logger.V(4); lgr.Enabled() {
 		for _, agrs := range upstreamGroupResourcesList {
-			lgr.Info("APIGroupResources", "group", agrs.Group, "bar", agrs.VersionedResources)
+			lgr.Info("APIGroupResources", "group", agrs.Group, "versionedResources", agrs.VersionedResources)
 		}
 	}
 	edgeSyncConfigResources := []edgev1alpha1.EdgeSyncConfigResource{}
@@ -180,7 +180,7 @@ func (s *SyncerConfigManager) upsertNamespacedObjects(syncerConfig edgev1alpha1.
 	s.logger.V(3).Info("upsert namespaced objects as syncerConfig to syncConfigManager stores", "syncerConfigName", syncerConfig.Name, "numNamespaces", len(requiredNamespaces))
 	if lgr := s.logger.V(4); lgr.Enabled() {
 		for _, agrs := range upstreamGroupResourcesList {
-			lgr.Info("APIGroupResources", "group", agrs.Group, "bar", agrs.VersionedResources)
+			lgr.Info("APIGroupResources", "group", agrs.Group, "versionedResources", agrs.VersionedResources)
 		}
 	}
 	edgeSyncConfigResources := []edgev1alpha1.EdgeSyncConfigResource{}
@@ -349,16 +349,18 @@ func findVersionedResourcesByGVR(group string, version string, resource string, 
 			break
 		}
 	}
-	if apiGroupResources == nil {
-		return _versionedResources
-	}
-	versionedResources := apiGroupResources.VersionedResources[version]
-	for _, versionedResource := range versionedResources {
-		if resource == versionedResource.Name {
-			_versionedResources = append(_versionedResources, versionedResource)
-		} else if resource == "*" {
-			_versionedResources = append(_versionedResources, versionedResource)
+	if apiGroupResources != nil {
+		versionedResources := apiGroupResources.VersionedResources[version]
+		for _, versionedResource := range versionedResources {
+			if resource == versionedResource.Name {
+				_versionedResources = append(_versionedResources, versionedResource)
+			} else if resource == "*" {
+				_versionedResources = append(_versionedResources, versionedResource)
+			}
 		}
+	}
+	if len(_versionedResources) == 0 {
+		logger.V(2).Info("Any versioned resource is not found from given apiGroupResources", "group", group, "version", version, "resource", resource)
 	}
 	return _versionedResources
 }

--- a/pkg/syncer/controller/syncerconfigmanager.go
+++ b/pkg/syncer/controller/syncerconfigmanager.go
@@ -132,28 +132,28 @@ func (s *SyncerConfigManager) upsertNamespaceScoped(syncerConfig edgev1alpha1.Sy
 	s.syncConfigManager.upsert(edgeSyncConfig)
 }
 
-type typeFlatNamespacedObject struct {
+type flatNamespacedObject struct {
 	APIVersion string
 	v1.GroupResource
 	Namespace string
 	Names     []string
 }
 
-type typeTableOfFlatNamespacedObject struct {
-	FlatNamespacedObjects []typeFlatNamespacedObject
+type tableOfFlatNamespacedObject struct {
+	FlatNamespacedObjects []flatNamespacedObject
 }
 
-func (t *typeTableOfFlatNamespacedObject) filter(predicate func(row typeFlatNamespacedObject) bool) *typeTableOfFlatNamespacedObject {
-	flatNamespacedObjects := []typeFlatNamespacedObject{}
+func (t *tableOfFlatNamespacedObject) filter(predicate func(row flatNamespacedObject) bool) *tableOfFlatNamespacedObject {
+	flatNamespacedObjects := []flatNamespacedObject{}
 	for _, obj := range t.FlatNamespacedObjects {
 		if predicate(obj) {
 			flatNamespacedObjects = append(flatNamespacedObjects, obj)
 		}
 	}
-	return &typeTableOfFlatNamespacedObject{FlatNamespacedObjects: flatNamespacedObjects}
+	return &tableOfFlatNamespacedObject{FlatNamespacedObjects: flatNamespacedObjects}
 }
 
-func (t *typeTableOfFlatNamespacedObject) getAllNamespaces() []string {
+func (t *tableOfFlatNamespacedObject) getAllNamespaces() []string {
 	namespaces := sets.String{}
 	for _, obj := range t.FlatNamespacedObjects {
 		namespaces.Insert(obj.Namespace)
@@ -162,10 +162,10 @@ func (t *typeTableOfFlatNamespacedObject) getAllNamespaces() []string {
 }
 
 func (s *SyncerConfigManager) upsertNamespacedObjects(syncerConfig edgev1alpha1.SyncerConfig, upstreamGroupResourcesList []*restmapper.APIGroupResources) {
-	flatNamespacedObjects := []typeFlatNamespacedObject{}
+	flatNamespacedObjects := []flatNamespacedObject{}
 	for _, nsObject := range syncerConfig.Spec.NamespacedObjects {
 		for _, obj := range nsObject.ObjectsByNamespace {
-			flatNamespacedObjects = append(flatNamespacedObjects, typeFlatNamespacedObject{
+			flatNamespacedObjects = append(flatNamespacedObjects, flatNamespacedObject{
 				APIVersion:    nsObject.APIVersion,
 				GroupResource: nsObject.GroupResource,
 				Namespace:     obj.Namespace,
@@ -173,9 +173,9 @@ func (s *SyncerConfigManager) upsertNamespacedObjects(syncerConfig edgev1alpha1.
 			})
 		}
 	}
-	namespacedObjectsTable := typeTableOfFlatNamespacedObject{FlatNamespacedObjects: flatNamespacedObjects}
+	namespacedObjectsTable := tableOfFlatNamespacedObject{FlatNamespacedObjects: flatNamespacedObjects}
 
-	requiredNamespaces := namespacedObjectsTable.filter(func(row typeFlatNamespacedObject) bool { return len(row.Names) > 0 }).getAllNamespaces()
+	requiredNamespaces := namespacedObjectsTable.filter(func(row flatNamespacedObject) bool { return len(row.Names) > 0 }).getAllNamespaces()
 
 	s.logger.V(3).Info("upsert namespaced objects as syncerConfig to syncConfigManager stores", "syncerConfigName", syncerConfig.Name, "numNamespaces", len(requiredNamespaces))
 	if lgr := s.logger.V(4); lgr.Enabled() {

--- a/test/e2e/kubestellar-syncer/common_test.go
+++ b/test/e2e/kubestellar-syncer/common_test.go
@@ -73,6 +73,18 @@ var deploymentGvr = schema.GroupVersionResource{
 	Resource: "deployments",
 }
 
+var configmapGvr = schema.GroupVersionResource{
+	Group:    "",
+	Version:  "v1",
+	Resource: "configmaps",
+}
+
+var secretGvr = schema.GroupVersionResource{
+	Group:    "",
+	Version:  "v1",
+	Resource: "secrets",
+}
+
 var policyGvr = schema.GroupVersionResource{
 	Group:    "kyverno.io",
 	Version:  "v1",

--- a/test/e2e/kubestellar-syncer/syncer_kyverno_test.go
+++ b/test/e2e/kubestellar-syncer/syncer_kyverno_test.go
@@ -34,13 +34,30 @@ import (
 )
 
 func TestKubeStellarSyncerForKyvernoWithSyncerConfig(t *testing.T) {
-
 	var syncerConfigUnst *unstructured.Unstructured
 	err := edgeframework.LoadFile("testdata/kyverno/syncer-config.yaml", embedded, &syncerConfigUnst)
 	require.NoError(t, err)
+	testKubeStellarSyncerForKyvernoWithSyncerConfig(t, syncerConfigUnst)
+}
+
+func TestKubeStellarSyncerForKyvernoWithNamespacedObjectsSyncerConfig(t *testing.T) {
+	var syncerConfigUnst *unstructured.Unstructured
+	err := edgeframework.LoadFile("testdata/kyverno/syncer-config-namespaced-objects.yaml", embedded, &syncerConfigUnst)
+	require.NoError(t, err)
+	testKubeStellarSyncerForKyvernoWithSyncerConfig(t, syncerConfigUnst)
+}
+
+func TestKubeStellarSyncerForKyvernoWithNamespacedObjectsCoexistSyncerConfig(t *testing.T) {
+	var syncerConfigUnst *unstructured.Unstructured
+	err := edgeframework.LoadFile("testdata/kyverno/syncer-config-namespaced-objects-coexist.yaml", embedded, &syncerConfigUnst)
+	require.NoError(t, err)
+	testKubeStellarSyncerForKyvernoWithSyncerConfig(t, syncerConfigUnst)
+}
+
+func testKubeStellarSyncerForKyvernoWithSyncerConfig(t *testing.T, syncerConfigUnst *unstructured.Unstructured) {
 
 	var policyReportUnst *unstructured.Unstructured
-	err = edgeframework.LoadFile("testdata/kyverno/policy-report.yaml", embedded, &policyReportUnst)
+	err := edgeframework.LoadFile("testdata/kyverno/policy-report.yaml", embedded, &policyReportUnst)
 	require.NoError(t, err)
 
 	var clusterPolicyReportUnst *unstructured.Unstructured

--- a/test/e2e/kubestellar-syncer/syncer_namespaced_objects_test.go
+++ b/test/e2e/kubestellar-syncer/syncer_namespaced_objects_test.go
@@ -1,0 +1,171 @@
+/*
+Copyright 2022 The KubeStellar Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package syncer
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	corev1 "k8s.io/api/core/v1"
+	k8serror "k8s.io/apimachinery/pkg/api/errors"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/util/wait"
+
+	"github.com/kcp-dev/kcp/test/e2e/framework"
+
+	edgeframework "github.com/kubestellar/kubestellar/test/e2e/framework"
+)
+
+func TestKubeStellarSyncerForNamespacedObjects(t *testing.T) {
+	var syncerConfigUnst *unstructured.Unstructured
+	err := edgeframework.LoadFile("testdata/namespaced-objects/syncer-config.yaml", embedded, &syncerConfigUnst)
+	require.NoError(t, err)
+	testKubeStellarSyncerForNamespacedObjects(t, syncerConfigUnst)
+}
+
+func testKubeStellarSyncerForNamespacedObjects(t *testing.T, syncerConfigUnst *unstructured.Unstructured) {
+
+	var err error
+	testDataDirectory := "testdata/namespaced-objects"
+
+	type typeUnstObjWithPath struct {
+		UnstObj *unstructured.Unstructured
+		Path    string
+	}
+	var test1cm1, test1cm2, test2cm1, test2cm2, test3cm1, test1secret, test2secret, test3secret unstructured.Unstructured
+	_test1cm1 := typeUnstObjWithPath{UnstObj: &test1cm1, Path: testDataDirectory + "/configmap-test1-cm1.yaml"}
+	_test1cm2 := typeUnstObjWithPath{UnstObj: &test1cm2, Path: testDataDirectory + "/configmap-test1-cm2.yaml"}
+	_test2cm1 := typeUnstObjWithPath{UnstObj: &test2cm1, Path: testDataDirectory + "/configmap-test2-cm1.yaml"}
+	_test2cm2 := typeUnstObjWithPath{UnstObj: &test2cm2, Path: testDataDirectory + "/configmap-test2-cm2.yaml"}
+	_test3cm1 := typeUnstObjWithPath{UnstObj: &test3cm1, Path: testDataDirectory + "/configmap-test3-cm1.yaml"}
+	_test1secret := typeUnstObjWithPath{UnstObj: &test1secret, Path: testDataDirectory + "/secret-test1.yaml"} // pragma: allowlist secret
+	_test2secret := typeUnstObjWithPath{UnstObj: &test2secret, Path: testDataDirectory + "/secret-test2.yaml"} // pragma: allowlist secret
+	_test3secret := typeUnstObjWithPath{UnstObj: &test3secret, Path: testDataDirectory + "/secret-test3.yaml"} // pragma: allowlist secret
+	for _, test := range []*typeUnstObjWithPath{&_test1cm1, &_test1cm2, &_test2cm1, &_test2cm2, &_test3cm1, &_test1secret, &_test2secret, &_test3secret} {
+		err := edgeframework.LoadFile(test.Path, embedded, &test.UnstObj)
+		require.NoError(t, err)
+	}
+	framework.Suite(t, "kubestellar-syncer")
+
+	syncerFixture := setup(t)
+	wsPath := syncerFixture.WorkspacePath
+
+	ctx, cancelFunc := context.WithCancel(context.Background())
+	t.Cleanup(cancelFunc)
+
+	upstreamDynamicClueterClient := syncerFixture.UpstreamDynamicKubeClient
+	upstreamKubeClusterClient := syncerFixture.UpstreamKubeClusterClient
+
+	t.Logf("Create a SyncerConfig for test in workspace %q.", wsPath.String())
+	_, err = upstreamDynamicClueterClient.Cluster(wsPath).Resource(syncerConfigGvr).Create(ctx, syncerConfigUnst, v1.CreateOptions{})
+	require.NoError(t, err)
+
+	t.Logf("Create namespaces for test in workspace %q.", wsPath.String())
+	test1NamespaceObj := &corev1.Namespace{
+		ObjectMeta: v1.ObjectMeta{
+			Name: "test1",
+		},
+	}
+	test2NamespaceObj := &corev1.Namespace{
+		ObjectMeta: v1.ObjectMeta{
+			Name: "test2",
+		},
+	}
+	test3NamespaceObj := &corev1.Namespace{
+		ObjectMeta: v1.ObjectMeta{
+			Name: "test3",
+		},
+	}
+	testShouldNotSyncedNamespaceObj := &corev1.Namespace{
+		ObjectMeta: v1.ObjectMeta{
+			Name: "should-not-synced",
+		},
+	}
+	for _, testNamespaceObj := range []*corev1.Namespace{test1NamespaceObj, test2NamespaceObj, test3NamespaceObj, testShouldNotSyncedNamespaceObj} {
+		t.Logf("Create namespace %q in workspace %q.", testNamespaceObj.Name, wsPath.String())
+		_, err = upstreamKubeClusterClient.Cluster(wsPath).CoreV1().Namespaces().Create(ctx, testNamespaceObj, v1.CreateOptions{})
+		require.NoError(t, err)
+	}
+
+	t.Logf("Create test configmaps in workspace %q.", wsPath.String())
+	for _, configmap := range []unstructured.Unstructured{test1cm1, test1cm2, test2cm1, test2cm2, test3cm1} {
+		_, err = upstreamDynamicClueterClient.Cluster(wsPath).Resource(configmapGvr).Namespace(configmap.GetNamespace()).Create(ctx, &configmap, v1.CreateOptions{})
+		require.NoError(t, err)
+	}
+
+	t.Logf("Create test secrets in workspace %q.", wsPath.String())
+	for _, secret := range []unstructured.Unstructured{test1secret, test2secret, test3secret} { // pragma: allowlist secret
+		_, err = upstreamDynamicClueterClient.Cluster(wsPath).Resource(secretGvr).Namespace(secret.GetNamespace()).Create(ctx, &secret, v1.CreateOptions{})
+		require.NoError(t, err)
+	}
+
+	client := syncerFixture.DownstreamKubeClient
+	dynamicClient := syncerFixture.DownstreamDynamicKubeClient
+
+	t.Logf("Wait for resources to be downsynced.")
+	framework.Eventually(t, func() (bool, string) {
+		t.Logf("  Check namespaces to be downsynced.")
+		for _, testNamespaceObj := range []*corev1.Namespace{test1NamespaceObj, test2NamespaceObj, test3NamespaceObj} {
+			_, err := client.CoreV1().Namespaces().Get(ctx, testNamespaceObj.Name, v1.GetOptions{})
+			if err != nil {
+				return false, fmt.Sprintf("Failed to get namespace %s: %v", testNamespaceObj.Name, err)
+			}
+		}
+
+		t.Logf("  Check required configmaps to be downsynced.")
+		for _, testCm := range []unstructured.Unstructured{test1cm1, test1cm2, test2cm1} {
+			_, err := dynamicClient.Resource(configmapGvr).Namespace(testCm.GetNamespace()).Get(ctx, testCm.GetName(), v1.GetOptions{})
+			if err != nil {
+				return false, fmt.Sprintf("Failed to get configmap %s: %v", testCm.GetName(), err)
+			}
+		}
+
+		t.Logf("  Check required secrets to be downsynced.")
+		for _, testSecret := range []unstructured.Unstructured{test1secret, test3secret} { // pragma: allowlist secret
+			_, err := dynamicClient.Resource(secretGvr).Namespace(testSecret.GetNamespace()).Get(ctx, testSecret.GetName(), v1.GetOptions{})
+			if err != nil {
+				return false, fmt.Sprintf("Failed to get secret %s: %v", testSecret.GetName(), err)
+			}
+		}
+		return true, ""
+	}, wait.ForeverTestTimeout, time.Second*5, "All downsynced resources haven't been propagated to downstream yet.")
+
+	t.Logf("Check should-not-synced namespace doesn't exist in downstream.")
+	_, errShoultNotSyncedNamespace := client.CoreV1().Namespaces().Get(ctx, testShouldNotSyncedNamespaceObj.Name, v1.GetOptions{})
+	assert.NotNil(t, errShoultNotSyncedNamespace)
+	assert.Equal(t, true, k8serror.IsNotFound(errShoultNotSyncedNamespace))
+
+	t.Logf("Check excluded configmaps not to be downsynced.")
+	for _, testCm := range []unstructured.Unstructured{test2cm2, test3cm1} {
+		_, err := dynamicClient.Resource(configmapGvr).Namespace(testCm.GetNamespace()).Get(ctx, testCm.GetName(), v1.GetOptions{})
+		assert.NotNil(t, err)
+		assert.Equal(t, true, k8serror.IsNotFound(err))
+	}
+
+	t.Logf("Check excluded secrets not to be downsynced.")
+	for _, testSecret := range []unstructured.Unstructured{test2secret} { // pragma: allowlist secret
+		_, err := dynamicClient.Resource(secretGvr).Namespace(testSecret.GetNamespace()).Get(ctx, testSecret.GetName(), v1.GetOptions{})
+		assert.NotNil(t, err)
+		assert.Equal(t, true, k8serror.IsNotFound(err))
+	}
+}

--- a/test/e2e/kubestellar-syncer/syncer_syncerconfig_test.go
+++ b/test/e2e/kubestellar-syncer/syncer_syncerconfig_test.go
@@ -48,6 +48,13 @@ func TestKubeStellarSyncerWithWildcardSyncerConfig(t *testing.T) {
 	testKubeStellarSyncerWithSyncerConfig(t, syncerConfigUnst)
 }
 
+func TestKubeStellarSyncerWithNamespacedObjectsSyncerConfig(t *testing.T) {
+	var syncerConfigUnst *unstructured.Unstructured
+	err := edgeframework.LoadFile("testdata/syncerconfig/syncer-config-namespaced-objects.yaml", embedded, &syncerConfigUnst)
+	require.NoError(t, err)
+	testKubeStellarSyncerWithSyncerConfig(t, syncerConfigUnst)
+}
+
 func testKubeStellarSyncerWithSyncerConfig(t *testing.T, syncerConfigUnst *unstructured.Unstructured) {
 
 	var sampleDownsyncCRDUnst *unstructured.Unstructured

--- a/test/e2e/kubestellar-syncer/testdata/kyverno/syncer-config-namespaced-objects-coexist.yaml
+++ b/test/e2e/kubestellar-syncer/testdata/kyverno/syncer-config-namespaced-objects-coexist.yaml
@@ -1,0 +1,87 @@
+apiVersion: edge.kubestellar.io/v1alpha1
+kind: SyncerConfig
+metadata:
+  name: syncer-config
+spec:
+  namespaceScope:
+    namespaces:
+    - kyverno
+    resources:
+    - apiVersion: v1
+      group: ""
+      resource: serviceaccounts
+    - apiVersion: v1
+      group: ""
+      resource: configmaps
+    - apiVersion: v1
+      group: ""
+      resource: services
+    - apiVersion: v1
+      group: apps
+      resource: deployments
+    - apiVersion: v1
+      group: rbac.authorization.k8s.io
+      resource: roles
+    - apiVersion: v1
+      group: rbac.authorization.k8s.io
+      resource: rolebindings
+
+  namespacedObjects:
+  - apiVersion: v1
+    group: kyverno.io
+    resource: policies
+    objectsByNamespace:
+    - namespace: policy
+      names:
+      - "*"
+
+  clusterScope:
+  - apiVersion: v1
+    group: apiextensions.k8s.io
+    resource: customresourcedefinitions
+    objects:
+    - admissionreports.kyverno.io
+    - backgroundscanreports.kyverno.io
+    - clusteradmissionreports.kyverno.io
+    - clusterbackgroundscanreports.kyverno.io
+    - clusterpolicies.kyverno.io
+    - clusterpolicyreports.wgpolicyk8s.io
+    - generaterequests.kyverno.io
+    - policies.kyverno.io
+    - policyreports.wgpolicyk8s.io
+    - updaterequests.kyverno.io
+  - apiVersion: v1
+    group: rbac.authorization.k8s.io
+    resource: clusterroles
+    objects:
+    - kyverno:admin-policies
+    - kyverno:admin-policyreport
+    - kyverno:admin-reports
+    - kyverno:admin-generaterequest
+    - kyverno:admin-updaterequest
+    - kyverno
+    - kyverno:userinfo
+    - kyverno:policies
+    - kyverno:view
+    - kyverno:generate
+    - kyverno:events
+    - kyverno:webhook
+  - apiVersion: v1
+    group: rbac.authorization.k8s.io
+    resource: clusterrolebindings
+    objects:
+    - kyverno
+  - apiVersion: v1
+    group: kyverno.io
+    resource: clusterpolicies
+    objects:
+    - "*"
+  upsync:
+  - apiGroup: wgpolicyk8s.io
+    resources:
+    - policyreports
+    - clusterpolicyreports
+    namespaces:
+    - policy
+    names:
+    - "*"

--- a/test/e2e/kubestellar-syncer/testdata/kyverno/syncer-config-namespaced-objects.yaml
+++ b/test/e2e/kubestellar-syncer/testdata/kyverno/syncer-config-namespaced-objects.yaml
@@ -1,0 +1,126 @@
+apiVersion: edge.kubestellar.io/v1alpha1
+kind: SyncerConfig
+metadata:
+  name: syncer-config
+spec:
+  namespacedObjects:
+  - apiVersion: v1
+    group: ""
+    resource: serviceaccounts
+    objectsByNamespace:
+    - namespace: kyverno
+      names:
+      - "*"
+    - namespace: policy
+      names:
+      - "*"
+  - apiVersion: v1
+    group: ""
+    resource: configmaps
+    objectsByNamespace:
+    - namespace: kyverno
+      names:
+      - "*"
+    - namespace: policy
+      names:
+      - "*"
+  - apiVersion: v1
+    group: ""
+    resource: services
+    objectsByNamespace:
+    - namespace: kyverno
+      names:
+      - "*"
+    - namespace: policy
+      names:
+      - "*"
+  - apiVersion: v1
+    group: apps
+    resource: deployments
+    objectsByNamespace:
+    - namespace: kyverno
+      names:
+      - "*"
+    - namespace: policy
+      names:
+      - "*"
+  - apiVersion: v1
+    group: rbac.authorization.k8s.io
+    resource: roles
+    objectsByNamespace:
+    - namespace: kyverno
+      names:
+      - "*"
+    - namespace: policy
+      names:
+      - "*"
+  - apiVersion: v1
+    group: rbac.authorization.k8s.io
+    resource: rolebindings
+    objectsByNamespace:
+    - namespace: kyverno
+      names:
+      - "*"
+    - namespace: policy
+      names:
+      - "*"
+  - apiVersion: v1
+    group: kyverno.io
+    resource: policies
+    objectsByNamespace:
+    - namespace: kyverno
+      names:
+      - "*"
+    - namespace: policy
+      names:
+      - "*"
+  clusterScope:
+  - apiVersion: v1
+    group: apiextensions.k8s.io
+    resource: customresourcedefinitions
+    objects:
+    - admissionreports.kyverno.io
+    - backgroundscanreports.kyverno.io
+    - clusteradmissionreports.kyverno.io
+    - clusterbackgroundscanreports.kyverno.io
+    - clusterpolicies.kyverno.io
+    - clusterpolicyreports.wgpolicyk8s.io
+    - generaterequests.kyverno.io
+    - policies.kyverno.io
+    - policyreports.wgpolicyk8s.io
+    - updaterequests.kyverno.io
+  - apiVersion: v1
+    group: rbac.authorization.k8s.io
+    resource: clusterroles
+    objects:
+    - kyverno:admin-policies
+    - kyverno:admin-policyreport
+    - kyverno:admin-reports
+    - kyverno:admin-generaterequest
+    - kyverno:admin-updaterequest
+    - kyverno
+    - kyverno:userinfo
+    - kyverno:policies
+    - kyverno:view
+    - kyverno:generate
+    - kyverno:events
+    - kyverno:webhook
+  - apiVersion: v1
+    group: rbac.authorization.k8s.io
+    resource: clusterrolebindings
+    objects:
+    - kyverno
+  - apiVersion: v1
+    group: kyverno.io
+    resource: clusterpolicies
+    objects:
+    - "*"
+  upsync:
+  - apiGroup: wgpolicyk8s.io
+    resources:
+    - policyreports
+    - clusterpolicyreports
+    namespaces:
+    - policy
+    names:
+    - "*"

--- a/test/e2e/kubestellar-syncer/testdata/namespaced-objects/configmap-test1-cm1.yaml
+++ b/test/e2e/kubestellar-syncer/testdata/namespaced-objects/configmap-test1-cm1.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cm1
+  namespace: test1
+data:
+  field1: value1

--- a/test/e2e/kubestellar-syncer/testdata/namespaced-objects/configmap-test1-cm2.yaml
+++ b/test/e2e/kubestellar-syncer/testdata/namespaced-objects/configmap-test1-cm2.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cm2
+  namespace: test1
+data:
+  field1: value1

--- a/test/e2e/kubestellar-syncer/testdata/namespaced-objects/configmap-test2-cm1.yaml
+++ b/test/e2e/kubestellar-syncer/testdata/namespaced-objects/configmap-test2-cm1.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cm1
+  namespace: test2
+data:
+  field1: value1

--- a/test/e2e/kubestellar-syncer/testdata/namespaced-objects/configmap-test2-cm2.yaml
+++ b/test/e2e/kubestellar-syncer/testdata/namespaced-objects/configmap-test2-cm2.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cm2
+  namespace: test2
+data:
+  field1: value1

--- a/test/e2e/kubestellar-syncer/testdata/namespaced-objects/configmap-test3-cm1.yaml
+++ b/test/e2e/kubestellar-syncer/testdata/namespaced-objects/configmap-test3-cm1.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cm1
+  namespace: test3
+data:
+  field1: value1

--- a/test/e2e/kubestellar-syncer/testdata/namespaced-objects/secret-test1.yaml
+++ b/test/e2e/kubestellar-syncer/testdata/namespaced-objects/secret-test1.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: s1
+  namespace: test1
+data:
+  field1: dmFsdWUxCg==

--- a/test/e2e/kubestellar-syncer/testdata/namespaced-objects/secret-test2.yaml
+++ b/test/e2e/kubestellar-syncer/testdata/namespaced-objects/secret-test2.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: s1
+  namespace: test2
+data:
+  field1: dmFsdWUxCg==

--- a/test/e2e/kubestellar-syncer/testdata/namespaced-objects/secret-test3.yaml
+++ b/test/e2e/kubestellar-syncer/testdata/namespaced-objects/secret-test3.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: s1
+  namespace: test3
+data:
+  field1: dmFsdWUxCg==

--- a/test/e2e/kubestellar-syncer/testdata/namespaced-objects/syncer-config.yaml
+++ b/test/e2e/kubestellar-syncer/testdata/namespaced-objects/syncer-config.yaml
@@ -1,0 +1,39 @@
+apiVersion: edge.kubestellar.io/v1alpha1
+kind: SyncerConfig
+metadata:
+  name: syncer-config
+spec:
+  namespaceScope:
+    namespaces:
+    - test1
+    resources:
+    - apiVersion: v1
+      group: ""
+      resource: configmaps
+    - apiVersion: v1
+      group: ""
+      resource: secrets
+      
+  namespacedObjects:
+  - apiVersion: v1
+    group: ""
+    resource: configmaps
+    objectsByNamespace:
+    - namespace: test2
+      names:
+      - cm1
+    - namespace: test3
+      names: []
+    - namespace: should-not-synced
+      names: []
+  - apiVersion: v1
+    group: ""
+    resource: secrets
+    objectsByNamespace:
+    - namespace: test2
+      names: []
+    - namespace: test3
+      names:
+      - s1
+    - namespace: should-not-synced
+      names: []

--- a/test/e2e/kubestellar-syncer/testdata/syncerconfig/syncer-config-namespaced-objects.yaml
+++ b/test/e2e/kubestellar-syncer/testdata/syncerconfig/syncer-config-namespaced-objects.yaml
@@ -1,0 +1,31 @@
+apiVersion: edge.kubestellar.io/v1alpha1
+kind: SyncerConfig
+metadata:
+  name: syncer-config-wildcard
+spec:
+  namespacedObjects:
+  - apiVersion: v1
+    group: ""
+    resource: configmaps
+    objectsByNamespace:
+    - namespace: test
+      names:
+      - sampleupsyncs.my.domain
+  clusterScope:
+  - apiVersion: v1
+    group: apiextensions.k8s.io
+    resource: customresourcedefinitions
+    objects:
+    - sampleupsyncs.my.domain
+    - sampledownsyncs.my.domain
+  - apiVersion: v1alpha1
+    group: my.domain
+    resource: sampledownsyncs
+    objects:
+    - "*"
+  upsync:
+  - apiGroup: my.domain
+    resources:
+    - sampleupsyncs
+    names:
+    - "*"


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

- Extend Syncer to support newly introduced namespacedObject field in SyncerConfig
  - It keeps backward compatibility and also supports the new format.
- Add test cases
  - [Existing SyncerConfig](https://github.com/yana1205/kubestellar/blob/cd9892c5abfaf910cc9a0316cc0852e65ee017d3/test/e2e/kubestellar-syncer/testdata/kyverno/syncer-config.yaml) (used namespaceScoped field) for backward compatibility
  - [New SyncerConfig](https://github.com/yana1205/kubestellar/blob/cd9892c5abfaf910cc9a0316cc0852e65ee017d3/test/e2e/kubestellar-syncer/testdata/kyverno/syncer-config-namespaced-objects.yaml) (used namespacedObject field)
  - [Union](https://github.com/yana1205/kubestellar/blob/cd9892c5abfaf910cc9a0316cc0852e65ee017d3/test/e2e/kubestellar-syncer/testdata/kyverno/syncer-config-namespaced-objects-coexist.yaml) (used both namespaceScoped and namespacedObject) just in case if both are given. Though not sure this is a real use case.
  - [Another complex case](https://github.com/yana1205/kubestellar/blob/cd9892c5abfaf910cc9a0316cc0852e65ee017d3/test/e2e/kubestellar-syncer/testdata/namespaced-objects/syncer-config.yaml) (used both namespaceScoped and namespacedObject)

#### Verification

UT passed:
```
$ make test-syncer
go test -count 1 `go list ./... | grep "/pkg/cliplugins\|/pkg/syncer"`
?       github.com/kubestellar/kubestellar/pkg/syncer   [no test files]
?       github.com/kubestellar/kubestellar/pkg/syncer/clientfactory     [no test files]
?       github.com/kubestellar/kubestellar/pkg/syncer/shared    [no test files]
?       github.com/kubestellar/kubestellar/pkg/syncer/syncers   [no test files]
ok      github.com/kubestellar/kubestellar/pkg/cliplugins/kubestellar/syncer-gen        0.394s
ok      github.com/kubestellar/kubestellar/pkg/syncer/controller        17.585s
```

E2E passed:
```
$ make e2e-test-kubestellar-syncer
...
ok      github.com/kubestellar/kubestellar/test/e2e/kubestellar-syncer  255.863s
```

Verified manual test (example1) too.

## Related issue(s)

Fixes #898
