### PR TITLE
✨ introduce a Type for the space object

### DIFF
--- a/space-framework/config/crds/space.kubestellar.io_spaces.yaml
+++ b/space-framework/config/crds/space.kubestellar.io_spaces.yaml
@@ -37,16 +37,6 @@ spec:
           spec:
             description: '`spec` describes a cluster.'
             properties:
-              Managed:
-                default: true
-                description: Managed identifies whether a cluster is managed (true)
-                  or unmanaged (false). Currently this is immutable. A space can be
-                  created through the ClusterManager (managed) or discovered/imported
-                  (unmanaged).
-                type: boolean
-                x-kubernetes-validations:
-                - message: Managed is immutable
-                  rule: self == oldSelf
               SpaceProviderDescName:
                 description: SpaceProviderDescName is a reference to a SpaceProviderDesc
                   resource
@@ -54,9 +44,18 @@ spec:
                 x-kubernetes-validations:
                 - message: SpaceProviderDescName is immutable
                   rule: self == oldSelf
+              Type:
+                default: managed
+                description: Type identifies the space type. A space can be created
+                  through the ClusterManager (managed), discovered (unmanaged), or
+                  imported.
+                enum:
+                - managed
+                - unmanaged
+                - imported
+                type: string
             required:
-            - Managed
-            - SpaceProviderDescName
+            - Type
             type: object
           status:
             description: '`status` describes the status of the cluster object.'

--- a/space-framework/config/exports/apiresourceschema-spaces.space.kubestellar.io.yaml
+++ b/space-framework/config/exports/apiresourceschema-spaces.space.kubestellar.io.yaml
@@ -33,16 +33,6 @@ spec:
         spec:
           description: '`spec` describes a cluster.'
           properties:
-            Managed:
-              default: true
-              description: Managed identifies whether a cluster is managed (true)
-                or unmanaged (false). Currently this is immutable. A space can be
-                created through the ClusterManager (managed) or discovered/imported
-                (unmanaged).
-              type: boolean
-              x-kubernetes-validations:
-              - message: Managed is immutable
-                rule: self == oldSelf
             SpaceProviderDescName:
               description: SpaceProviderDescName is a reference to a SpaceProviderDesc
                 resource
@@ -50,9 +40,17 @@ spec:
               x-kubernetes-validations:
               - message: SpaceProviderDescName is immutable
                 rule: self == oldSelf
+            Type:
+              default: managed
+              description: Type identifies the space type. A space can be created
+                through the ClusterManager (managed), discovered (unmanaged), or imported.
+              enum:
+              - managed
+              - unmanaged
+              - imported
+              type: string
           required:
-          - Managed
-          - SpaceProviderDescName
+          - Type
           type: object
         status:
           description: '`status` describes the status of the cluster object.'

--- a/space-framework/pkg/apis/space/v1alpha1/space.go
+++ b/space-framework/pkg/apis/space/v1alpha1/space.go
@@ -42,23 +42,30 @@ type Space struct {
 	Status SpaceStatus `json:"status"`
 }
 
+// SpaceType identifies the type of the space (managed, unmanaged, imported)
+// +kubebuilder:validation:Enum=managed;unmanaged;imported
+type SpaceType string
+
+const (
+	SpaceTypeManaged   SpaceType = "managed"
+	SpaceTypeUnmanaged SpaceType = "unmanaged"
+	SpaceTypeImported  SpaceType = "imported"
+)
+
 // SpaceSpec describes a cluster.
 type SpaceSpec struct {
 	// SpaceProviderDescName is a reference to a SpaceProviderDesc resource
 	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="SpaceProviderDescName is immutable"
+	// +optional
 	SpaceProviderDescName string `json:"SpaceProviderDescName"`
 
-	// Managed identifies whether a cluster is managed (true) or unmanaged (false).
-	// Currently this is immutable.
-	// A space can be created through the ClusterManager (managed) or
-	// discovered/imported (unmanaged).
-	// +kubebuilder:default=true
-	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="Managed is immutable"
-	Managed bool `json:"Managed"`
+	// Type identifies the space type.
+	// A space can be created through the ClusterManager (managed), discovered (unmanaged), or imported.
+	// +kubebuilder:default=managed
+	Type SpaceType `json:"Type"`
 }
 
 // SpacePhaseType is the type of the current phase of the cluster.
-//
 // +kubebuilder:validation:Enum=Initializing;NotReady;Ready
 type SpacePhaseType string
 

--- a/space-framework/pkg/space-manager/reconcile_spaceprovider.go
+++ b/space-framework/pkg/space-manager/reconcile_spaceprovider.go
@@ -116,7 +116,7 @@ func (c *controller) handleDelete(providerName string) error {
 	for _, spaceObj := range spaces {
 		space := spaceObj.(*spacev1alpha1.Space)
 		if space.Namespace == ns {
-			if space.Spec.Managed {
+			if space.Spec.Type == spacev1alpha1.SpaceTypeManaged {
 				space.Status.Phase = spacev1alpha1.SpacePhaseNotReady
 				_, err := c.clientset.SpaceV1alpha1().Spaces(ns).Update(c.ctx, space, metav1.UpdateOptions{})
 				if err != nil {

--- a/space-framework/test/e2e-sh-tests/space1.yaml
+++ b/space-framework/test/e2e-sh-tests/space1.yaml
@@ -5,4 +5,4 @@ metadata:
   namespace: "spaceprovider-default"
 spec:
   SpaceProviderDescName: "default"
-  Managed: true
+  Type: "managed"

--- a/space-framework/test/e2e-sh-tests/space2.yaml
+++ b/space-framework/test/e2e-sh-tests/space2.yaml
@@ -2,7 +2,26 @@ apiVersion: space.kubestellar.io/v1alpha1
 kind: Space
 metadata:
   name: space2
-  namespace: "spaceprovider-default"
 spec:
-  SpaceProviderDescName: "default"
-  Managed: true
+  Type: imported
+status:
+  ClusterConfig: |
+    apiVersion: v1
+    clusters:
+    - cluster:
+        certificate-authority-data: your-data-goes-here
+        server: https://127.0.0.1:33625
+      name: kind-import1
+    contexts:
+    - context:
+        cluster: kind-import1
+        user: kind-import1
+      name: kind-import1
+    current-context: kind-import1
+    kind: Config
+    preferences: {}
+    users:
+    - name: kind-import1
+      user:
+        client-certificate-data: your-data-goes-here
+        client-key-data: your-data-goes-here


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
Introduce a Type for the space object.  The type can be: managed, unmanaged, or imported.  Where imported implies a space without a provider object.  An imported space can be a space residing on a regular kubernetes cluster which does not enable creation of multiple spaces.

## Related issue(s)

Fixes #
