### PR TITLE
:sparkles: Makefile cleanup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -471,11 +471,10 @@ verify-go-versions:
 .PHONY: modules
 modules: ## Run go mod tidy to ensure modules are up to date
 	go mod tidy
-	cd pkg/apis; go mod tidy
 
 .PHONY: verify-modules
 verify-modules: modules  ## Verify go modules are up to date
-	@if !(git diff --quiet HEAD -- go.sum go.mod pkg/apis/go.mod pkg/apis/go.sum); then \
+	@if !(git diff --quiet HEAD -- go.sum go.mod); then \
 		git diff; \
 		echo "go module files are out of date"; exit 1; \
 	fi


### PR DESCRIPTION
Removing some leftovers from KCP. In KS we don't use different go module for pkg/api

<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

## Related issue(s)

Fixes #
