### PR TITLE
✨ cleanup cluster-watchall and apiwatch

### DIFF
--- a/cmd/cluster-watchall/README.md
+++ b/cmd/cluster-watchall/README.md
@@ -1,18 +1,20 @@
 # cluster-watchall
 
 This is a demonstration of a way to monitor all objects in all
-workspaces in a kcp server.  A little more carefully: the objects
-monitored are those of kinds that support informers --- that is, they
-support the `list` and `watch` verbs.  This demonstration only reports
-object creations.  Note also that it is workspaces, not other kinds of
-logical clusters, that matter here.
+workspaces in a kcp server.  This is: a demonstration of how to use
+`pkg/apiwatch`, a demonstration of how to monitor objects, and a
+utility to investigate what API resources are actually defined in a
+kcp server (more precisely than `kubectl api-resources`).
+
+This demonstration only reports object creations.  Note also that it
+is workspaces, not other kinds of logical clusters, that matter here.
 
 This demonstrates, among other things, use of the informer on "API
 resources" in [pkg/apiwatch](../../pkg/apiwatch).
 
-The notable command line flags are as follows.
+The command line flags include all the usual ones for `kubectl` (see [the kubectl common flags doc](https://v1-24.docs.kubernetes.io/docs/reference/kubectl/kubectl/); I am not sure whether [the in-cluster overrides](https://v1-24.docs.kubernetes.io/docs/reference/kubectl/#in-cluster-authentication-and-namespace-overrides) is also relevant), of which a few prominent ones are shown below, plus one for configuring the metrics & debug endpoint.
 
-```
+```console
       --kubeconfig string                Path to the kubeconfig file to use for CLI requests
       --context string                   The name of the kubeconfig context to use
       --server-bind-address ipport       The IP address with port at which to serve /metrics and /debug/pprof/ (default :10203)
@@ -29,14 +31,14 @@ all-cluster operations; typically this is the context named
 Thus, a typical minimal invocation might be something like the
 following.
 
-```
+```shell
 cluster-watchall --context system:admin
 ```
 
 This demo outputs what it discovered as three interleaved CSV tables.
 The tables have rows of the following formats.
 
-```
+```console
 CLUSTER,$clusterName
 RESOURCE,$clusterName,$apiGroup,$apiVersion,$kind,$informable
 OBJECT,$clusterName,$apiGroupVersion,$kind,$namespace,$name
@@ -44,7 +46,7 @@ OBJECT,$clusterName,$apiGroupVersion,$kind,$namespace,$name
 
 Following is some sample output.
 
-```
+```console
 CLUSTER,kvdk2spgmbix
 RESOURCE,1p4q3bat75x35ez3,,v1,ConfigMap,true
 RESOURCE,root,authentication.k8s.io,v1,TokenReview,false

--- a/pkg/apiwatch/resources.go
+++ b/pkg/apiwatch/resources.go
@@ -79,7 +79,6 @@ func NewAPIResourceInformer(ctx context.Context, clusterName string, client upst
 		ctx:              ctx,
 		logger:           logger,
 		clusterName:      clusterName,
-		client:           client,
 		cache:            cachediscovery.NewMemCacheClient(client),
 		resourceVersionI: 1,
 	}
@@ -132,7 +131,6 @@ type resourcesListWatcher struct {
 	ctx         context.Context
 	logger      klog.Logger
 	clusterName string
-	client      upstreamdiscovery.DiscoveryInterface
 	cache       upstreamdiscovery.CachedDiscoveryInterface
 
 	mutex            sync.Mutex


### PR DESCRIPTION
Also fix doc nits and remove unused client.

<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
This PR does a little cleanup in preparation for bigger things. The one does the following.

1. Switch the cluster-watchall command to use the library for kubectl options.
2. Add missing fenced code block tags in the README for cluster-watchall.
3. Remove an unused internal field in pkg/apiwatch.

## Related issue(s)

Believe it or not, this is part of working on #772 .  The placement-translator is going to need to know whether to update a status "subresource" or a plain field (#945).
