### PR TITLE
:seedling: Remove the dependency of core.kcp.io/v1alpha1/logicalclusters from Syncer

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "go.sum|docs/package-lock.json|cmd/kube-watchall/go.sum|docs/config.toml|docs/resources/_gen|docs/static|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2023-06-11T03:51:35Z",
+  "generated_at": "2023-09-14T15:02:41Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -92,7 +92,7 @@
         "hashed_secret": "4f151c44a6783667af6cedaa3d12560f8af2f38a",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 499,
+        "line_number": 481,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -100,7 +100,7 @@
         "hashed_secret": "eba2ae817b95fdb713f3af658a6ae1821e452264",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 605,
+        "line_number": 585,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/cmd/syncer/main.go
+++ b/cmd/syncer/main.go
@@ -28,8 +28,6 @@ import (
 	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/klog/v2"
 
-	"github.com/kcp-dev/logicalcluster/v3"
-
 	synceroptions "github.com/kubestellar/kubestellar/cmd/syncer/options"
 	"github.com/kubestellar/kubestellar/pkg/syncer"
 )
@@ -76,7 +74,6 @@ func main() {
 	syncerConfig := &syncer.SyncerConfig{
 		UpstreamConfig:   upstreamConfig,
 		DownstreamConfig: downstreamConfig,
-		SyncTargetPath:   logicalcluster.NewPath(options.FromClusterPath),
 		SyncTargetName:   options.SyncTargetName,
 		SyncTargetUID:    options.SyncTargetUID,
 	}

--- a/cmd/syncer/options/options.go
+++ b/cmd/syncer/options/options.go
@@ -24,15 +24,14 @@ import (
 )
 
 type Options struct {
-	QPS             float32
-	Burst           int
-	FromKubeconfig  string
-	FromContext     string
-	FromClusterPath string
-	ToKubeconfig    string
-	ToContext       string
-	SyncTargetName  string
-	SyncTargetUID   string
+	QPS            float32
+	Burst          int
+	FromKubeconfig string
+	FromContext    string
+	ToKubeconfig   string
+	ToContext      string
+	SyncTargetName string
+	SyncTargetUID  string
 }
 
 func NewOptions() *Options {
@@ -47,7 +46,6 @@ func (options *Options) AddFlags(fs *pflag.FlagSet) {
 	fs.IntVar(&options.Burst, "burst", options.Burst, "Burst to use when talking to API servers.")
 	fs.StringVar(&options.FromKubeconfig, "from-kubeconfig", options.FromKubeconfig, "Kubeconfig file for -from cluster.")
 	fs.StringVar(&options.FromContext, "from-context", options.FromContext, "Context to use in the Kubeconfig file for -from cluster, instead of the current context.")
-	fs.StringVar(&options.FromClusterPath, "from-cluster", options.FromClusterPath, "Path of the -from logical cluster.")
 	fs.StringVar(&options.ToKubeconfig, "to-kubeconfig", options.ToKubeconfig, "Kubeconfig file for -to cluster. If not set, the InCluster configuration will be used.")
 	fs.StringVar(&options.ToContext, "to-context", options.ToContext, "Context to use in the Kubeconfig file for -to cluster, instead of the current context.")
 	fs.StringVar(&options.SyncTargetName, "sync-target-name", options.SyncTargetName,
@@ -60,9 +58,6 @@ func (options *Options) Complete() error {
 }
 
 func (options *Options) Validate() error {
-	if options.FromClusterPath == "" {
-		return errors.New("--from-cluster is required")
-	}
 	if options.FromKubeconfig == "" {
 		return errors.New("--from-kubeconfig is required")
 	}

--- a/docs/content/Coding Milestones/PoC2023q1/kubestellar-syncer-subs/kubestellar-syncer-1-syncer-gen-plugin.md
+++ b/docs/content/Coding Milestones/PoC2023q1/kubestellar-syncer-subs/kubestellar-syncer-1-syncer-gen-plugin.md
@@ -90,10 +90,6 @@ b. Syncer image
 ```shell
 image="quay.io/kubestellar/syncer:v0.2.2"
 ```
-c. Logical cluster name
-```shell
-cluster_name=`kubectl get logicalclusters.core.kcp.io cluster -o custom-columns=":.metadata.annotations.kcp\.io\/cluster" --no-headers`
-```
 
 Download manifest template.
 ```shell
@@ -102,7 +98,7 @@ curl -LO {{ config.repo_raw_url }}/main/pkg/syncer/scripts/kubestellar-syncer-bo
 
 Generate manifests to bootstrap KubeStellar-Syncer.
 ```shell
-syncer_id=$syncer_id cacrt=$cacrt token=$token server_url=$server_url downstream_namespace=$downstream_namespace image=$image cluster_name=$cluster_name envsubst < kubestellar-syncer-bootstrap.template.yaml
+syncer_id=$syncer_id cacrt=$cacrt token=$token server_url=$server_url downstream_namespace=$downstream_namespace image=$image envsubst < kubestellar-syncer-bootstrap.template.yaml
 ```
 ```
 ---

--- a/pkg/cliplugins/kubestellar/syncer-gen/edgesync.go
+++ b/pkg/cliplugins/kubestellar/syncer-gen/edgesync.go
@@ -53,10 +53,8 @@ import (
 	"k8s.io/client-go/restmapper"
 	"k8s.io/klog/v2"
 
-	kcpclient "github.com/kcp-dev/kcp/pkg/client/clientset/versioned"
 	"github.com/kcp-dev/kcp/pkg/cliplugins/base"
 	"github.com/kcp-dev/kcp/pkg/cliplugins/helpers"
-	"github.com/kcp-dev/logicalcluster/v3"
 )
 
 //go:embed *.yaml
@@ -235,9 +233,8 @@ func (o *EdgeSyncOptions) Run(ctx context.Context) error {
 		KCPNamespace: o.KCPNamespace,
 		Namespace:    o.DownstreamNamespace,
 
-		SyncTargetPath: logicalcluster.From(edgeSyncTarget).Path().String(),
-		SyncTarget:     o.SyncTargetName,
-		SyncTargetUID:  string(edgeSyncTarget.UID),
+		SyncTarget:    o.SyncTargetName,
+		SyncTargetUID: string(edgeSyncTarget.UID),
 
 		Image:    o.SyncerImage,
 		Replicas: o.Replicas,
@@ -267,28 +264,18 @@ func getKubeStellarSyncerID(edgeSyncTarget *typeEdgeSyncTarget) string {
 }
 
 type typeEdgeSyncTarget struct {
-	UID         types.UID
-	Name        string
-	Annotations map[string]string
+	UID  types.UID
+	Name string
 }
 
-func (o *typeEdgeSyncTarget) GetAnnotations() map[string]string {
-	return o.Annotations
-}
-
-func (o *EdgeSyncOptions) applyEdgeSyncTarget(ctx context.Context, kcpClient kcpclient.Interface, edgeSyncTargetName string, labels map[string]string) (*typeEdgeSyncTarget, error) {
-	logicalCluster, err := kcpClient.CoreV1alpha1().LogicalClusters().Get(ctx, "cluster", metav1.GetOptions{})
-	if err != nil {
-		return nil, fmt.Errorf("failed to get default logical cluster %q: %w", edgeSyncTargetName, err)
-	}
+func (o *EdgeSyncOptions) applyEdgeSyncTarget(ctx context.Context, edgeSyncTargetName string, labels map[string]string) (*typeEdgeSyncTarget, error) {
 	uuid, err := uuid.NewUUID()
 	if err != nil {
 		return nil, fmt.Errorf("failed to generate UUID %q: %w", edgeSyncTargetName, err)
 	}
 	edgeSyncTarget := typeEdgeSyncTarget{
-		UID:         types.UID(uuid.String()),
-		Name:        edgeSyncTargetName,
-		Annotations: logicalCluster.Annotations,
+		UID:  types.UID(uuid.String()),
+		Name: edgeSyncTargetName,
 	}
 	return &edgeSyncTarget, nil
 }
@@ -297,12 +284,7 @@ func (o *EdgeSyncOptions) applyEdgeSyncTarget(ctx context.Context, kcpClient kcp
 // account for the syncer in the given namespace. The expectation is that the provided config is
 // for a logical cluster (workspace). Returns the token the syncer will use to connect to kcp.
 func (o *EdgeSyncOptions) enableSyncerForWorkspace(ctx context.Context, config *rest.Config, edgeSyncTargetName, namespace string, labels map[string]string) (saToken string, syncerID string, edgeSyncTarget *typeEdgeSyncTarget, err error) {
-	kcpClient, err := kcpclient.NewForConfig(config)
-	if err != nil {
-		return "", "", nil, fmt.Errorf("failed to create kcp client: %w", err)
-	}
-
-	edgeSyncTarget, err = o.applyEdgeSyncTarget(ctx, kcpClient, edgeSyncTargetName, labels)
+	edgeSyncTarget, err = o.applyEdgeSyncTarget(ctx, edgeSyncTargetName, labels)
 	if err != nil {
 		return "", "", nil, fmt.Errorf("failed to apply synctarget %q: %w", edgeSyncTargetName, err)
 	}
@@ -542,8 +524,6 @@ type templateInputForEdge struct {
 	KCPNamespace string
 	// Namespace is the name of the syncer namespace on the pcluster
 	Namespace string
-	// SyncTargetPath is the qualified kcp logical cluster name the syncer will sync from
-	SyncTargetPath string
 	// SyncTarget is the name of the sync target the syncer will use to
 	// communicate its status and read configuration from
 	SyncTarget string

--- a/pkg/cliplugins/kubestellar/syncer-gen/edgesync_test.go
+++ b/pkg/cliplugins/kubestellar/syncer-gen/edgesync_test.go
@@ -128,7 +128,6 @@ spec:
         - --from-kubeconfig=/kcp/kubeconfig
         - --sync-target-name=sync-target-name
         - --sync-target-uid=sync-target-uid
-        - --from-cluster=root:default:foo
         - --qps=123.4
         - --burst=456
         - --v=3
@@ -153,18 +152,17 @@ spec:
 `
 
 	actualYAML, err := renderKubeStellarSyncerResources(templateInputForEdge{
-		ServerURL:      "server-url",
-		Token:          "token",
-		CAData:         "ca-data",
-		KCPNamespace:   "kcp-namespace",
-		Namespace:      "kubestellar-syncer-sync-target-name-34b23c4k",
-		SyncTargetPath: "root:default:foo",
-		SyncTarget:     "sync-target-name",
-		SyncTargetUID:  "sync-target-uid",
-		Image:          "image",
-		Replicas:       1,
-		QPS:            123.4,
-		Burst:          456,
+		ServerURL:     "server-url",
+		Token:         "token",
+		CAData:        "ca-data",
+		KCPNamespace:  "kcp-namespace",
+		Namespace:     "kubestellar-syncer-sync-target-name-34b23c4k",
+		SyncTarget:    "sync-target-name",
+		SyncTargetUID: "sync-target-uid",
+		Image:         "image",
+		Replicas:      1,
+		QPS:           123.4,
+		Burst:         456,
 	}, "kcp-syncer-sync-target-name-34b23c4k")
 	require.NoError(t, err)
 	require.Empty(t, cmp.Diff(expectedYAML, string(actualYAML)))

--- a/pkg/cliplugins/kubestellar/syncer-gen/edgesync_test.go
+++ b/pkg/cliplugins/kubestellar/syncer-gen/edgesync_test.go
@@ -128,6 +128,7 @@ spec:
         - --from-kubeconfig=/kcp/kubeconfig
         - --sync-target-name=sync-target-name
         - --sync-target-uid=sync-target-uid
+        - --from-cluster=123456789abcdefg # TODO: --from-cluster is no longer required but keep it for backward compatibility (see PR#999)
         - --qps=123.4
         - --burst=456
         - --v=3

--- a/pkg/cliplugins/kubestellar/syncer-gen/kubestellar-syncer.yaml
+++ b/pkg/cliplugins/kubestellar/syncer-gen/kubestellar-syncer.yaml
@@ -112,7 +112,6 @@ spec:
         - --from-kubeconfig=/kcp/{{.SecretConfigKey}}
         - --sync-target-name={{.SyncTarget}}
         - --sync-target-uid={{.SyncTargetUID}}
-        - --from-cluster={{.SyncTargetPath}}
         - --qps={{.QPS}}
         - --burst={{.Burst}}
         - --v=3

--- a/pkg/cliplugins/kubestellar/syncer-gen/kubestellar-syncer.yaml
+++ b/pkg/cliplugins/kubestellar/syncer-gen/kubestellar-syncer.yaml
@@ -112,6 +112,7 @@ spec:
         - --from-kubeconfig=/kcp/{{.SecretConfigKey}}
         - --sync-target-name={{.SyncTarget}}
         - --sync-target-uid={{.SyncTargetUID}}
+        - --from-cluster=123456789abcdefg # TODO: --from-cluster is no longer required but keep it for backward compatibility (see PR#999)
         - --qps={{.QPS}}
         - --burst={{.Burst}}
         - --v=3

--- a/pkg/syncer/scripts/kubestellar-syncer-bootstrap.template.yaml
+++ b/pkg/syncer/scripts/kubestellar-syncer-bootstrap.template.yaml
@@ -102,7 +102,6 @@ spec:
         - --from-kubeconfig=/kcp/kubeconfig
         - --sync-target-name=${syncer_id}
         - --sync-target-uid=${syncer_id}
-        - --from-cluster=${cluster_name}
         - --qps=30
         - --burst=30
         - --v=3

--- a/pkg/syncer/syncer.go
+++ b/pkg/syncer/syncer.go
@@ -28,8 +28,6 @@ import (
 	"k8s.io/client-go/rest"
 	"k8s.io/klog/v2"
 
-	"github.com/kcp-dev/logicalcluster/v3"
-
 	edgev1alpha1 "github.com/kubestellar/kubestellar/pkg/apis/edge/v1alpha1"
 	edgeclientset "github.com/kubestellar/kubestellar/pkg/client/clientset/versioned"
 	edgeinformers "github.com/kubestellar/kubestellar/pkg/client/informers/externalversions"
@@ -41,7 +39,6 @@ import (
 type SyncerConfig struct {
 	UpstreamConfig   *rest.Config
 	DownstreamConfig *rest.Config
-	SyncTargetPath   logicalcluster.Path
 	SyncTargetName   string
 	SyncTargetUID    string
 	Interval         time.Duration

--- a/test/e2e/framework/kubestellar_syncer.go
+++ b/test/e2e/framework/kubestellar_syncer.go
@@ -367,7 +367,6 @@ func syncerConfigFromCluster(t *testing.T, downstreamConfig *rest.Config, namesp
 	return &syncer.SyncerConfig{
 		UpstreamConfig:   upstreamConfig,
 		DownstreamConfig: downstreamConfigWithToken,
-		SyncTargetPath:   logicalcluster.NewPath(""),
 		SyncTargetName:   "",
 		SyncTargetUID:    "",
 		Interval:         time.Second * 3,


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

This is the PR for #874.

#### What's the changed

- Remove the dependency of kcp logical cluster function from Syncer

I reviewed Syncer code whether Syncer really depends on logical cluster id or not and concluded it's not required. I have removed the dependent codes on the logical cluster stuff from Syncer. As a result, Syncer does no longer require `--from-cluster` option.

#### Verification

UT passed
```
$ make test-syncer COUNT=1
go test -count 1 `go list ./... | grep "/pkg/cliplugins\|/pkg/syncer"`
?       github.com/kubestellar/kubestellar/pkg/syncer   [no test files]
?       github.com/kubestellar/kubestellar/pkg/syncer/clientfactory     [no test files]
?       github.com/kubestellar/kubestellar/pkg/syncer/shared    [no test files]
?       github.com/kubestellar/kubestellar/pkg/syncer/syncers   [no test files]
ok      github.com/kubestellar/kubestellar/pkg/cliplugins/kubestellar/syncer-gen        0.952s
ok      github.com/kubestellar/kubestellar/pkg/syncer/controller        18.689s
```

E2E passed
```
$ make e2e-test-kubestellar-syncer                                                                                       
rm -rf /Users/yana/git/trl/kcp/kcp-edge-mc/.kcp/etcd-server
rm -rf /Users/yana/git/trl/kcp/kcp-edge-mc/.kcp/.admin-token-store /Users/yana/git/trl/kcp/kcp-edge-mc/.kcp/admin.kubeconfig
rm -rf /Users/yana/git/trl/kcp/kcp-edge-mc/.kcp/apiserver.* /Users/yana/git/trl/kcp/kcp-edge-mc/.kcp/sa.key
export PATH=/Users/yana/git/trl/kcp/kcp-edge-mc/kcp/bin:$PATH && \
        kcp start --root-directory=/Users/yana/git/trl/kcp/kcp-edge-mc/.kcp > /Users/yana/git/trl/kcp/kcp-edge-mc/.kcp/kcp.log 2>&1 & PID=$! && echo "PID $PID" && \
        trap 'kill -TERM $PID' TERM INT EXIT && \
        while [ ! -f "/Users/yana/git/trl/kcp/kcp-edge-mc/.kcp/admin.kubeconfig" ]; do sleep 1; echo "kcp is not ready. wait for 1s...";done && \
        echo 'Starting test(s)' && \
        NO_GORUN=1 GOOS=darwin GOARCH=arm64 \
                go test -race  ./test/e2e/kubestellar-syncer/...  \
                --kcp-kubeconfig /Users/yana/git/trl/kcp/kcp-edge-mc/.kcp/admin.kubeconfig --suites kubestellar-syncer \

PID 6248
kcp is not ready. wait for 1s...
kcp is not ready. wait for 1s...
kcp is not ready. wait for 1s...
Starting test(s)
ok      github.com/kubestellar/kubestellar/test/e2e/kubestellar-syncer  258.144s
```

I also verified that a manual test (example1.md) passed with the Syncer image built by this branch

## Related issue(s)

Fixes #874
