### PR TITLE
✨ Make syncer image not depend on commit ID

### DIFF
--- a/docs/content/Coding Milestones/PoC2023q1/kubestellar-syncer.md
+++ b/docs/content/Coding Milestones/PoC2023q1/kubestellar-syncer.md
@@ -91,7 +91,7 @@ KubeStellar-Syncer is deployed on an Edge cluster easily by the following steps.
     kubectl plugin that includes the implementation of the functionality needed
     here.  This variant, under the special name shown here, is a normal part of
     the `bin` of KubeStellar.
-    For the KubeStellar-Syncer image, please select an official image from https://quay.io/repository/kubestellar/syncer?tab=tags. For example, `--syncer-image quay.io/kubestellar/syncer:v0.2.2`. You can also create a syncer image from the source following [Build KubeStellar-Syncer Image](#build-kubestellar-syncer-image).
+    For the KubeStellar-Syncer image, please select an official image from https://quay.io/repository/kubestellar/syncer?tab=tags. For example, `--syncer-image quay.io/kubestellar/syncer:git-08289ea05-clean`. You can also create a syncer image from the source following [Build KubeStellar-Syncer Image](#build-kubestellar-syncer-image).
 4. Deploy KubeStellar-Syncer on an Edge cluster
 5. Syncer starts to run on the Edge cluster
     - KubeStellar-Syncer starts watching and consuming SyncerConfig
@@ -253,11 +253,26 @@ image=`make build-kubestellar-syncer-image-local`
 ```
 
 ### How to build the image with multiple architectures and push it to Docker registry
-1. `make build-kubestellar-syncer-image DOCKER_REPO=ghcr.io/yana1205/kubestellar/syncer IMAGE_TAG=dev-2023-04-24-x ARCHS=linux/amd64,linux/arm64`
+
+1. `make build-kubestellar-syncer-image`
+
+The behavior can be modified with some make variables; their default values are what get used in a normal build.  The variables are as follows.
+
+- `DOCKER_REPO`, `IMAGE_TAG`: the built multi-platform manifest will
+  be pushed to `$DOCKER_REPO:$IMAGE_TAG`.  The default for
+  `DOCKER_REPO` is `quay.io/kubestellar/syncer`.  The default for
+  `IMAGE_TAG` is the concatenation of: "git-", a short ID of the
+  current git commit, "-", and either "clean" or "dirty" depending on
+  what `git status` has to say about it.
+- `SYNCER_PLATFORMS`: a
+  comma-separated list of `docker build` "platforms".  The default is
+  "linux/amd64,linux/arm64,linux/s390x".
+- `ADDITIONAL_ARGS`: a word that will be added into the `ko build` command line.
+  The default is the empty string.
 
 For example
 ```
-$ make build-kubestellar-syncer-image DOCKER_REPO=ghcr.io/yana1205/kubestellar/syncer IMAGE_TAG=dev-2023-04-24-x ARCHS=linux/amd64,linux/arm64
+$ make build-kubestellar-syncer-image DOCKER_REPO=ghcr.io/yana1205/kubestellar/syncer IMAGE_TAG=dev-2023-04-24-x SYNCER_PLATFORMS=linux/amd64,linux/arm64
 2023/04/24 11:50:16 Using base distroless.dev/static:latest@sha256:81018475098138883b80dcc9c1242eb02b53465297724b18e88591a752d2a49c for github.com/{{ config.repo_short_name }}/cmd/syncer
 2023/04/24 11:50:17 Building github.com/{{ config.repo_short_name }}/cmd/syncer for linux/arm64
 2023/04/24 11:50:17 Building github.com/{{ config.repo_short_name }}/cmd/syncer for linux/amd64


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
This PR changes the command that builds the syncer image so that the image depends only on the code and other functional stuff that goes into it, to support managing the image references in a functional style without self-reference problems.

This PR also updates the Makefile variables relevant to building the syncer image, so that their default values match what we normally want.  This also includes renaming the variable "ARCHS" to "SYNCER_PLATFORMS" because (a) its usage is specific to building the syncer image and (b) "platform" is the word used in in the documentation about this sort of building.

## Related issue(s)

Fixes #
