### PR TITLE
:seedling: Remove --from-cluster flag and temporally use syncer:pr-999 for transitioning to the new syncer-gen

### DIFF
--- a/pkg/cliplugins/kubestellar/syncer-gen/edgesync_test.go
+++ b/pkg/cliplugins/kubestellar/syncer-gen/edgesync_test.go
@@ -128,7 +128,6 @@ spec:
         - --from-kubeconfig=/kcp/kubeconfig
         - --sync-target-name=sync-target-name
         - --sync-target-uid=sync-target-uid
-        - --from-cluster=123456789abcdefg # TODO: --from-cluster is no longer required but keep it for backward compatibility (see PR#999)
         - --qps=123.4
         - --burst=456
         - --v=3

--- a/pkg/cliplugins/kubestellar/syncer-gen/kubestellar-syncer.yaml
+++ b/pkg/cliplugins/kubestellar/syncer-gen/kubestellar-syncer.yaml
@@ -112,7 +112,6 @@ spec:
         - --from-kubeconfig=/kcp/{{.SecretConfigKey}}
         - --sync-target-name={{.SyncTarget}}
         - --sync-target-uid={{.SyncTargetUID}}
-        - --from-cluster=123456789abcdefg # TODO: --from-cluster is no longer required but keep it for backward compatibility (see PR#999)
         - --qps={{.QPS}}
         - --burst={{.Burst}}
         - --v=3

--- a/scripts/kubectl-kubestellar-prep_for_syncer
+++ b/scripts/kubectl-kubestellar-prep_for_syncer
@@ -34,7 +34,7 @@ imw=.
 espw="root:espw"
 stname=""
 output=""
-syncer_image="quay.io/kubestellar/syncer:pr-968"
+syncer_image="quay.io/kubestellar/syncer:pr-999"
 kubectl_flags=()
 silent="false"
 


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

This is followup change for https://github.com/kubestellar/kubestellar/pull/999#issuecomment-1720389062

> * After that merges we can build a syncer image from main and start using that. We can change prep-for-syncer to default to the new syncer image.
> * At that same time or later, we change syncer-gen to not emit the --from-cluster flag.

Mike has made the latest image (syncer:pr-999) built after https://github.com/kubestellar/kubestellar/pull/999 is merged. 
The PR contains 
- remove --from-cluster flag
- switch the default image to this image

## Related issue(s)

Fixes #
