### PR TITLE
✨ Update kubectl-kubestellar-deploy to latest KS ctr image

### DIFF
--- a/scripts/kubectl-kubestellar-deploy
+++ b/scripts/kubectl-kubestellar-deploy
@@ -20,7 +20,7 @@
 
 KSDIR=$(cd $(dirname ${BASH_SOURCE[0]}); cd ..; pwd)
 
-image_tag=b23-08-18-21-58-09
+image_tag=b23-09-15-04-52-13
 
 external_endpoint=""
 openshift=false


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
This PR updates the `kubectl kubestellar deploy` command to use the container image built from the latest sources.  This picks up the API change in #884 and the syncer CLI change in #999 and #1003 (although I expect the syncer change is not relevant to the contents of the center container image).

## Related issue(s)

Fixes #
