### PR TITLE
🌱 Cleanup after EdgePlacement downsync unification

### DIFF
--- a/pkg/apis/edge/v1alpha1/report-single.go
+++ b/pkg/apis/edge/v1alpha1/report-single.go
@@ -1,0 +1,30 @@
+/*
+Copyright 2023 The KubeStellar Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha1
+
+// WantSingletonReportKey is used to request return of reported state to
+// the Workload Description Space while the number of executing copies is 1.
+// This request is indicated by a workload object having an annotation with
+// this key and the value "true".
+const WantSingletonReportKey string = "kubestellar.io/want-singleton-report"
+
+// ExecutingCountKey is used to report on the number of executing copies of
+// a workload object while it has the "kubestellar.io/want-singleton-report=true" annotation.
+// This is the key of an annotation whose value is a string representing the number of
+// executing copies of the annotated workload object.  While this annotation is
+// present with the value "1", the reported state is being returned into this workload object.
+const ExecutingCountKey string = "kubestellar.io/executing-count"

--- a/pkg/placement/apiwatch-map-provider.go
+++ b/pkg/placement/apiwatch-map-provider.go
@@ -83,8 +83,9 @@ func (awp *apiWatchProvider) AddReceivers(clusterName logicalcluster.Name,
 	wpc := MapGetAdd(awp.perCluster, clusterName, true, func(clusterName logicalcluster.Name) *apiWatchProviderPerCluster {
 		ctx := context.Background()
 		wpc := &apiWatchProviderPerCluster{
-			awp:               awp,
-			cluster:           clusterName,
+			awp:     awp,
+			cluster: clusterName,
+			// TODO: feed the groupReceivers
 			groupReceivers:    MappingReceiverHolderFork[string /*group name*/, APIGroupInfo]{},
 			resourceReceivers: MappingReceiverHolderFork[metav1.GroupResource, ResourceDetails]{},
 		}

--- a/pkg/placement/declarations.go
+++ b/pkg/placement/declarations.go
@@ -156,10 +156,8 @@ type ResolvedWhat struct {
 //
 // Every WorkloadParts that appears in the interfaces here is immutable.
 //
-// Namespace objects implied by the "what predicate" are included in
-// the results of "what resolution", with IncludeNamespaceObject=false.
-// The user may explicitly request a Namespace object, in which case
-// IncludeNamespaceObject=true.
+// Namespace objects appear here only if explicitly requested in the
+// "what predicate".
 //
 // A workload may include objects of kinds that are built into
 // the edge cluster.  By built-in we mean that these kinds are both
@@ -176,15 +174,18 @@ type WorkloadPartID = Triple[metav1.GroupResource, NamespaceName, ObjectName]
 
 type ObjectName string
 
-func (objName ObjectName) String() string { return string(objName) }
+func NewObjectName(name string) ObjectName { return ObjectName(name) }
+func (objName ObjectName) String() string  { return string(objName) }
 
 // WorkloadPartDetails provides additional details about how the WorkloadPart
 // is to be included.
 type WorkloadPartDetails struct {
 	// APIVersion is version (no group) that the source workspace prefers to serve.
-	// In the case of a namespace object: this field only applies to the namespace
-	// object itself, not the namespace contents, and is the empty string if
-	// IncludeNamespaceObject is false.
+	// This is denormalized in two ways.
+	// This information is duplicated for all objects of the same kind.
+	// Since each WorkloadParts is specific to one EdgePlacement object,
+	// this information is duplicated among EdgePlacement objects that
+	// refer to the same workload object (i.e., in the same WDS).
 	APIVersion string
 }
 

--- a/pkg/placement/external-name.go
+++ b/pkg/placement/external-name.go
@@ -25,22 +25,22 @@ type ExternalName struct {
 	// Cluster identifies the cluster.  It is the one-part ID, not a path.
 	Cluster logicalcluster.Name
 
-	Name string
+	Name ObjectName
 }
 
 // NewExternalName assumes the given cluster identifier is proper
 func NewExternalName(cluster, name string) ExternalName {
-	return ExternalName{Cluster: logicalcluster.Name(cluster), Name: name}
+	return ExternalName{Cluster: logicalcluster.Name(cluster), Name: ObjectName(name)}
 }
 
 func (ExternalName) OfSPLocation(sp SinglePlacement) ExternalName {
-	return ExternalName{Cluster: logicalcluster.Name(sp.Cluster), Name: sp.LocationName}
+	return ExternalName{Cluster: logicalcluster.Name(sp.Cluster), Name: ObjectName(sp.LocationName)}
 }
 
 func (ExternalName) OfSPTarget(sp SinglePlacement) ExternalName {
-	return ExternalName{Cluster: logicalcluster.Name(sp.Cluster), Name: sp.SyncTargetName}
+	return ExternalName{Cluster: logicalcluster.Name(sp.Cluster), Name: ObjectName(sp.SyncTargetName)}
 }
 
 func (en ExternalName) String() string {
-	return en.Cluster.String() + ":" + en.Name
+	return en.Cluster.String() + ":" + en.Name.String()
 }

--- a/pkg/placement/hash-domain.go
+++ b/pkg/placement/hash-domain.go
@@ -125,15 +125,21 @@ var SliceOfStringDomain = NewSliceHashDomain[string](HashDomainString{})
 
 var HashLogicalClusterName = NewTransformHashDomain[logicalcluster.Name, string](func(name logicalcluster.Name) string { return string(name) }, HashDomainString{})
 
+var HashObjectName = NewTransformHashDomain[ObjectName, string](func(name ObjectName) string { return string(name) }, HashDomainString{})
+
 var HashClusterString = PairHashDomain[logicalcluster.Name, string](HashLogicalClusterName, HashDomainString{})
 
+var HashClusterObjectName = PairHashDomain[logicalcluster.Name, ObjectName](HashLogicalClusterName, HashObjectName)
+
 var factorExternalName = NewFactorer(
-	func(whole ExternalName) Pair[logicalcluster.Name, string] { return NewPair(whole.Cluster, whole.Name) },
-	func(parts Pair[logicalcluster.Name, string]) ExternalName {
+	func(whole ExternalName) Pair[logicalcluster.Name, ObjectName] {
+		return NewPair(whole.Cluster, whole.Name)
+	},
+	func(parts Pair[logicalcluster.Name, ObjectName]) ExternalName {
 		return ExternalName{parts.First, parts.Second}
 	})
 
-var HashExternalName = NewTransformHashDomain(factorExternalName.First, HashClusterString)
+var HashExternalName = NewTransformHashDomain(factorExternalName.First, HashClusterObjectName)
 
 type HashUpsyncSet struct{}
 

--- a/pkg/placement/rotations_test.go
+++ b/pkg/placement/rotations_test.go
@@ -88,11 +88,11 @@ func TestFactorers(t *testing.T) {
 	t.Run("factorClusterWhatWhereFullKey", exerciseFactorer(factorClusterWhatWhereFullKey,
 		gen.ClusterWhatWhereFullKey(),
 		gen.NonNamespacedDistributionTuple(),
-		gen.String()))
+		gen.ObjectName()))
 	t.Run("factorExternalName", exerciseFactorer(factorExternalName,
 		gen.ExternalName(),
 		gen.ClusterName(),
-		gen.String()))
+		gen.ObjectName()))
 	t.Run("factorNamespacedJoinKeyLessNS", exerciseFactorer(
 		factorNamespacedJoinKeyLessNS,
 		gen.NamespacedJoinKeyLessnS(),
@@ -101,7 +101,7 @@ func TestFactorers(t *testing.T) {
 	t.Run("factorNamespacedWhatWhereFullKey", exerciseFactorer(factorNamespacedWhatWhereFullKey,
 		gen.NamespacedWhatWhereFullKey(),
 		gen.NamespacedDistributionTuple(),
-		gen.String()))
+		gen.ObjectName()))
 
 	t.Run("factorNamespacedDistributionTupleForSync1", exerciseFactorer(factorNamespacedDistributionTupleForSync1,
 		gen.NamespacedDistributionTuple(),
@@ -128,7 +128,7 @@ func TestFactorers(t *testing.T) {
 	t.Run("factorNonNamespacedDistributionTupleForProj1and234", exerciseFactorer(factorNonNamespacedDistributionTupleForProj1and234,
 		gen.NonNamespacedDistributionTuple(),
 		gen.ClusterName(),
-		NewTriple(gen.GroupResource(), gen.String(), gen.SinglePlacement())))
+		NewTriple(gen.GroupResource(), gen.ObjectName(), gen.SinglePlacement())))
 
 	t.Run("factorProjectionModeKeyForSyncer", exerciseFactorer(factorProjectionModeKeyForSyncer,
 		gen.ProjectionModeKey(),
@@ -195,7 +195,7 @@ func (gen generator) ObjectName() ObjectName {
 }
 
 func (gen generator) ExternalName() ExternalName {
-	return ExternalName{gen.ClusterName(), gen.String()}
+	return ExternalName{gen.ClusterName(), gen.ObjectName()}
 }
 
 func (gen generator) ExternalNamespacedName() ExternalNamespacedName {
@@ -215,7 +215,7 @@ func (gen generator) GroupResourceNamespacedInstance() GroupResourceNamespacedIn
 }
 
 func (gen generator) GroupResourceNonNamespacedInstance() GroupResourceNonNamespacedInstance {
-	return NewPair(gen.GroupResource(), gen.String())
+	return NewPair(gen.GroupResource(), gen.ObjectName())
 }
 
 func (generator) UID() machtypes.UID {
@@ -254,7 +254,7 @@ func (gen generator) NamespacedWhatWhereFullKey() NamespacedWhatWhereFullKey {
 func (gen generator) ClusterWhatWhereFullKey() ClusterWhatWhereFullKey {
 	return ClusterWhatWhereFullKey{
 		First:  gen.ExternalName(),
-		Second: Pair[metav1.GroupResource, string]{gen.GroupResource(), gen.String()},
+		Second: Pair[metav1.GroupResource, ObjectName]{gen.GroupResource(), gen.ObjectName()},
 		Third:  gen.SinglePlacement()}
 }
 

--- a/pkg/placement/set-binder-assembly.go
+++ b/pkg/placement/set-binder-assembly.go
@@ -52,7 +52,7 @@ type setBinder struct {
 type setBindingForCluster struct {
 	*setBinder
 	cluster      logicalcluster.Name
-	perPlacement map[string]*setBindingForPlacement
+	perPlacement map[ObjectName]*setBindingForPlacement
 }
 
 type setBindingForPlacement struct {
@@ -199,14 +199,14 @@ func (sb *setBinder) getCluster(cluster logicalcluster.Name, want bool) *setBind
 		sbc = &setBindingForCluster{
 			setBinder:    sb,
 			cluster:      cluster,
-			perPlacement: map[string]*setBindingForPlacement{},
+			perPlacement: map[ObjectName]*setBindingForPlacement{},
 		}
 		sb.perCluster[cluster] = sbc
 	}
 	return sbc
 }
 
-func (sbc *setBindingForCluster) ensurePlacement(epName string) *setBindingForPlacement {
+func (sbc *setBindingForCluster) ensurePlacement(epName ObjectName) *setBindingForPlacement {
 	sbp := sbc.perPlacement[epName]
 	if sbp == nil {
 		epID := ExternalName{sbc.cluster, epName}

--- a/pkg/placement/set-binder-test.go
+++ b/pkg/placement/set-binder-test.go
@@ -96,8 +96,8 @@ func exerciseSetBinder(t *testing.T, logger klog.Logger, resourceDiscoveryReceiv
 	}
 	pmv1 := ProjectionModeVal{workloadPartDetails1.APIVersion}
 	pmv2 := ProjectionModeVal{workloadPartDetails2.APIVersion}
-	objRef1 := ExternalName{Cluster: sc1, Name: workloadPartID1.Third.String()}
-	objRef2 := ExternalName{Cluster: sc1, Name: workloadPartID2.Third.String()}
+	objRef1 := ExternalName{Cluster: sc1, Name: workloadPartID1.Third}
+	objRef2 := ExternalName{Cluster: sc1, Name: workloadPartID2.Third}
 	expectedNonNamespacedDistributions := NewMapSet(NewPair(pmk1, objRef1))
 	if !SetEqual[NonNamespacedDistributionTuple](expectedNonNamespacedDistributions, NonNamespacedDistributions) {
 		t.Fatalf("Wrong NonNamespacedDistributions; expected=%v, got=%v", expectedNonNamespacedDistributions, NonNamespacedDistributions)

--- a/pkg/placement/slices.go
+++ b/pkg/placement/slices.go
@@ -162,7 +162,7 @@ type Slice[Elt any] []Elt
 
 var _ Visitable[float64] = Slice[float64]{}
 
-func NewSlice[Elt any]() Slice[Elt] { return Slice[Elt]{} }
+func NewSlice[Elt any](elts ...Elt) Slice[Elt] { return Slice[Elt](elts) }
 
 func (slice Slice[Elt]) IsEmpty() bool    { return len(slice) == 0 }
 func (slice Slice[Elt]) Len() int         { return len(slice) }

--- a/pkg/placement/what-resolver_test.go
+++ b/pkg/placement/what-resolver_test.go
@@ -102,7 +102,7 @@ func TestWhatResolver(t *testing.T) {
 					ObjectNames: []string{"ns2"},
 				},
 			}}}
-	ep1EN := ExternalName{wds1N, ep1.Name}
+	ep1EN := ExternalName{wds1N, ObjectName(ep1.Name)}
 	edgeViewClusterClientset := fakeedge.NewSimpleClientset(ep1)
 	edgeClusterInformerFactory := edgeinformers.NewSharedInformerFactory(edgeViewClusterClientset, 0)
 	epClusterPreInformer := edgeClusterInformerFactory.Edge().V1alpha1().EdgePlacements()

--- a/pkg/placement/where-resolver.go
+++ b/pkg/placement/where-resolver.go
@@ -56,7 +56,7 @@ type queueItem struct {
 }
 
 func (qi queueItem) toExternalName() ExternalName {
-	return ExternalName{Cluster: qi.cluster, Name: qi.name}
+	return ExternalName{Cluster: qi.cluster, Name: ObjectName(qi.name)}
 }
 
 // NewWhereResolver returns a WhereResolver.

--- a/pkg/placement/where-resolver_test.go
+++ b/pkg/placement/where-resolver_test.go
@@ -51,7 +51,7 @@ func TestWhereResolver(t *testing.T) {
 		},
 		Destinations: []edgeapi.SinglePlacement{sp1},
 	}
-	ep1EN := ExternalName{wds1N, sps1.Name}
+	ep1EN := ExternalName{wds1N, ObjectName(sps1.Name)}
 	edgeViewClusterClientset := fakeedge.NewSimpleClientset(sps1)
 	edgeClusterInformerFactory := edgeinformers.NewSharedInformerFactory(edgeViewClusterClientset, 0)
 	spsClusterPreInformer := edgeClusterInformerFactory.Edge().V1alpha1().SinglePlacementSlices()


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
This PR removes a little junk and uses `ObjectName` in place of `string` more.

## Related issue(s)

Fixes #
