### PR TITLE
:sparkles:Remove the usage of workspace hierarchy

### DIFF
--- a/cmd/mailbox-controller/main.go
+++ b/cmd/mailbox-controller/main.go
@@ -70,15 +70,13 @@ func main() {
 	fs.IntVar(&concurrency, "concurrency", concurrency, "number of syncs to run in parallel")
 	fs.StringVar(&espwPath, "espw-path", espwPath, "the pathname of the edge service provider workspace")
 
-	inventoryClientOpts := clientopts.NewClientOpts("inventory", "access to APIExport view of SyncTarget objects")
-	inventoryClientOpts.SetDefaultCurrentContext("root")
+	rootClientOpts := clientopts.NewClientOpts("root", "access to the root workspace")
+	rootClientOpts.SetDefaultCurrentContext("root")
 
-	workloadClientOpts := clientopts.NewClientOpts("workload", "access to edge service provider workspace")
 	mbwsClientOpts := clientopts.NewClientOpts("mbws", "access to mailbox workspaces (really all clusters)")
 	mbwsClientOpts.SetDefaultCurrentContext("base")
 
-	inventoryClientOpts.AddFlags(fs)
-	workloadClientOpts.AddFlags(fs)
+	rootClientOpts.AddFlags(fs)
 	mbwsClientOpts.AddFlags(fs)
 
 	fs.Parse(os.Args[1:])
@@ -102,15 +100,6 @@ func main() {
 		}
 	}()
 
-	// create config for accessing TMC service provider workspace
-	inventoryClientConfig, err := inventoryClientOpts.ToRESTConfig()
-	if err != nil {
-		logger.Error(err, "failed to make inventory config")
-		os.Exit(2)
-	}
-
-	inventoryClientConfig.UserAgent = "mailbox-controller"
-
 	// create edgeSharedInformerFactory
 	options := resolveroptions.NewOptions()
 	espwRestConfig, err := options.EspwClientOpts.ToRESTConfig()
@@ -131,17 +120,14 @@ func main() {
 	edgeSharedInformerFactory := edgeinformers.NewSharedInformerFactoryWithOptions(edgeViewClusterClientset, resyncPeriod)
 	syncTargetClusterPreInformer := edgeSharedInformerFactory.Edge().V1alpha1().SyncTargets()
 
-	// create config for accessing edge service provider workspace
-
-	workspaceClientConfig, err := workloadClientOpts.ToRESTConfig()
+	rootRestConfig, err := rootClientOpts.ToRESTConfig()
 	if err != nil {
-		logger.Error(err, "failed to make workspaces config")
+		logger.Error(err, "failed to make root config")
 		os.Exit(8)
 	}
+	rootRestConfig.UserAgent = "mailbox-controller"
 
-	workspaceClientConfig.UserAgent = "mailbox-controller"
-
-	workspaceScopedClientset, err := kcpscopedclientset.NewForConfig(workspaceClientConfig)
+	workspaceScopedClientset, err := kcpscopedclientset.NewForConfig(rootRestConfig)
 	if err != nil {
 		logger.Error(err, "Failed to create clientset for workspaces")
 	}

--- a/docs/content/Coding Milestones/PoC2023q1/example1-subs/example1-stage-1a.md
+++ b/docs/content/Coding Milestones/PoC2023q1/example1-subs/example1-stage-1a.md
@@ -13,7 +13,7 @@ sleep 60
 ``` { .bash .no-copy }
 ...
 I0721 17:37:10.186848  189094 main.go:206] "Found APIExport view" exportName="e
-dge.kcp.io" serverURL="https://10.0.2.15:6443/services/apiexport/cseslli1ddit3s
+dge.kubestellar.io" serverURL="https://10.0.2.15:6443/services/apiexport/cseslli1ddit3s
 a5/edge.kubestellar.io"
 ...
 I0721 19:17:21.906984  189094 controller.go:300] "Created APIBinding" worker=1
@@ -38,6 +38,7 @@ normally it would run continuously.
 You can get a listing of those mailbox workspaces as follows.
 
 ```shell
+kubectl ws root
 kubectl get Workspaces
 ```
 ``` { .bash .no-copy }

--- a/docs/content/Coding Milestones/PoC2023q1/example1-subs/example1-stage-1a.md
+++ b/docs/content/Coding Milestones/PoC2023q1/example1-subs/example1-stage-1a.md
@@ -35,6 +35,7 @@ workspaces.  For this simple scenario, you do not need to keep this
 controller running after it does those things (hence the `^C` above);
 normally it would run continuously.
 
+A mailbox workspace name is distinguished by `-mb-` separator.
 You can get a listing of those mailbox workspaces as follows.
 
 ```shell
@@ -42,9 +43,12 @@ kubectl ws root
 kubectl get Workspaces
 ```
 ``` { .bash .no-copy }
-NAME                                                       TYPE        REGION   PHASE   URL                                                     AGE
-1t82bk54r6gjnzsp-mb-1a045336-8178-4026-8a56-5cd5609c0ec1   universal            Ready   https://192.168.58.123:6443/clusters/1najcltzt2nqax47   50s
-1t82bk54r6gjnzsp-mb-f0a82ab1-63f4-49ea-954d-3a41a35a9f1c   universal            Ready   https://192.168.58.123:6443/clusters/1y7wll1dz806h3sb   50s
+NAME                                                       TYPE          REGION   PHASE   URL                                                     AGE
+1t82bk54r6gjnzsp-mb-1a045336-8178-4026-8a56-5cd5609c0ec1   universal              Ready   https://192.168.58.123:6443/clusters/1najcltzt2nqax47   50s
+1t82bk54r6gjnzsp-mb-f0a82ab1-63f4-49ea-954d-3a41a35a9f1c   universal              Ready   https://192.168.58.123:6443/clusters/1y7wll1dz806h3sb   50s
+compute                                                    universal              Ready   https://172.20.144.39:6443/clusters/root:compute        6m8s
+espw                                                       organization           Ready   https://172.20.144.39:6443/clusters/root:espw           2m4s
+imw-1                                                      organization           Ready   https://172.20.144.39:6443/clusters/root:imw-1          1m9s
 ```
 
 More usefully, using custom columns you can get a listing that shows
@@ -57,6 +61,9 @@ kubectl get Workspace -o "custom-columns=NAME:.metadata.name,SYNCTARGET:.metadat
 NAME                                                       SYNCTARGET   CLUSTER
 1t82bk54r6gjnzsp-mb-1a045336-8178-4026-8a56-5cd5609c0ec1   florin       1najcltzt2nqax47
 1t82bk54r6gjnzsp-mb-f0a82ab1-63f4-49ea-954d-3a41a35a9f1c   guilder      1y7wll1dz806h3sb
+compute                                                    <none>       mqnl7r5f56hswewy
+espw                                                       <none>       2n88ugkhysjbxqp5
+imw-1                                                      <none>       4d2r9stcyy2qq5c1
 ```
 
 Also: if you ever need to look up just one mailbox workspace by

--- a/docs/content/Coding Milestones/PoC2023q1/example1-subs/example1-stage-2.md
+++ b/docs/content/Coding Milestones/PoC2023q1/example1-subs/example1-stage-2.md
@@ -13,18 +13,11 @@ One of the workloads is called "common", because it will go to both
 edge clusters.  The other one is called "special".
 
 In this example, each workload description goes in its own workload
-management workspace (WMW).  Start by creating a common parent for
-those two workspaces, with the following commands.
+management workspace (WMW).  Start by creating a WMW for the common
+workload, with the following commands.
 
 ```shell
 kubectl ws root
-kubectl ws create my-org --enter
-```
-
-Next, create the WMW for the common workload.  The following command
-will do that, if issued while "root:my-org" is the current workspace.
-
-```shell
 kubectl kubestellar ensure wmw wmw-c
 ```
 
@@ -185,7 +178,7 @@ Use the following `kubectl` commands to create the WMW for the special
 workload.
 
 ```shell
-kubectl ws root:my-org
+kubectl ws root
 kubectl kubestellar ensure wmw wmw-s
 ```
 
@@ -350,10 +343,10 @@ continually.
 Check out the SinglePlacementSlice objects as follows.
 
 ```shell
-kubectl ws root:my-org:wmw-c
+kubectl ws root:wmw-c
 ```
 ``` { .bash .no-copy }
-Current workspace is "root:my-org:wmw-c".
+Current workspace is "root:wmw-c".
 ```
 
 ```shell
@@ -392,6 +385,6 @@ metadata:
 ```
 
 Also check out the SinglePlacementSlice objects in
-`root:my-org:wmw-s`.  It should go similarly, but the `destinations`
+`root:wmw-s`.  It should go similarly, but the `destinations`
 should include only the entry for guilder.
 <!--example1-stage-2-end-->

--- a/docs/content/Coding Milestones/PoC2023q1/example1-subs/example1-stage-3.md
+++ b/docs/content/Coding Milestones/PoC2023q1/example1-subs/example1-stage-3.md
@@ -30,11 +30,18 @@ The florin cluster gets only the common workload.  Examine florin's
 `SyncerConfig` as follows.  Utilize florin's name (which you stored in Stage 1) here.
 
 ```shell
+kubectl ws root
+```
+``` { .bash .no-copy }
+Current workspace is "root".
+```
+
+```shell
 kubectl ws $FLORIN_WS
 ```
 
 ``` { .bash .no-copy }
-Current workspace is "root:espw:1t82bk54r6gjnzsp-mb-1a045336-8178-4026-8a56-5cd5609c0ec1" (type root:universal).
+Current workspace is "root:1t82bk54r6gjnzsp-mb-1a045336-8178-4026-8a56-5cd5609c0ec1" (type root:universal).
 ```
 
 ```shell
@@ -177,17 +184,17 @@ Examine guilder's `SyncerConfig` object and workloads as follows, using
 the name that you stored in Stage 1.
 
 ```shell
-kubectl ws root:espw
+kubectl ws root
 ```
 ``` { .bash .no-copy }
-Current workspace is "root:espw".
+Current workspace is "root".
 ```
 
 ```shell
 kubectl ws $GUILDER_WS
 ```
 ``` { .bash .no-copy }
-Current workspace is "root:espw:1t82bk54r6gjnzsp-mb-f0a82ab1-63f4-49ea-954d-3a41a35a9f1c" (type root:universal).
+Current workspace is "root:1t82bk54r6gjnzsp-mb-f0a82ab1-63f4-49ea-954d-3a41a35a9f1c" (type root:universal).
 ```
 
 ```shell

--- a/docs/content/Coding Milestones/PoC2023q1/example1-subs/example1-teardown.md
+++ b/docs/content/Coding Milestones/PoC2023q1/example1-subs/example1-teardown.md
@@ -1,11 +1,14 @@
-<!--teardown-the-environment-start-->
+<!--example1-teardown-start-->
 To remove the example usage, delete the IMW and WMW and kind clusters run the following commands:
 
 ``` {.bash}
 rm florin-syncer.yaml guilder-syncer.yaml || true
 kubectl ws root
-kubectl delete workspace example-imw
-kubectl kubestellar remove wmw example-wmw
+kubectl delete workspace imw-1
+kubectl delete workspace $FLORIN_WS
+kubectl delete workspace $GUILDER_WS
+kubectl kubestellar remove wmw wmw-c
+kubectl kubestellar remove wmw wmw-s
 kind delete cluster --name florin
 kind delete cluster --name guilder
 ```
@@ -34,4 +37,4 @@ With `kubectl` configured to manipulate the hosting cluster, the following comma
 helm delete kubestellar
 ```
 
-<!--teardown-the-environment-end-->
+<!--example1-teardown-end-->

--- a/docs/content/Coding Milestones/PoC2023q1/example1.md
+++ b/docs/content/Coding Milestones/PoC2023q1/example1.md
@@ -73,7 +73,7 @@ the `commond` Deployment objects in the two mailbox workspaces.
 ## Teardown the environment
 
 {%
-   include-markdown "../../common-subs/teardown-the-environment.md"
-   start="<!--teardown-the-environment-start-->"
-   end="<!--teardown-the-environment-end-->"
+   include-markdown "example1-subs/example1-teardown.md"
+   start="<!--example1-teardown-start-->"
+   end="<!--example1-teardown-end-->"
 %}

--- a/docs/content/Coding Milestones/PoC2023q1/kubestellar-syncer-subs/kubestellar-syncer-0-deploy-florin.md
+++ b/docs/content/Coding Milestones/PoC2023q1/kubestellar-syncer-subs/kubestellar-syncer-0-deploy-florin.md
@@ -12,11 +12,11 @@ mailbox workspace name = vosh9816n2xmpdwm-mb-bb47149d-52d3-4f14-84dd-7b64ac01c97
 
 Go to the mailbox workspace and run the following command to obtain yaml manifests to bootstrap KubeStellar-Syncer.
 ```shell
-kubectl ws root:espw:$mbws
+kubectl ws root:$mbws
 ./bin/kubectl-kubestellar-syncer_gen florin --syncer-image quay.io/kubestellar/syncer:v0.2.2 -o florin-syncer.yaml
 ```
 ``` { .bash .no-copy }
-Current workspace is "root:espw:vosh9816n2xmpdwm-mb-bb47149d-52d3-4f14-84dd-7b64ac01c97f".
+Current workspace is "root:vosh9816n2xmpdwm-mb-bb47149d-52d3-4f14-84dd-7b64ac01c97f".
 Creating service account "kubestellar-syncer-florin-32uaph9l"
 Creating cluster role "kubestellar-syncer-florin-32uaph9l" to give service account "kubestellar-syncer-florin-32uaph9l"
 

--- a/docs/content/Coding Milestones/PoC2023q1/kubestellar-syncer-subs/kubestellar-syncer-0-deploy-guilder.md
+++ b/docs/content/Coding Milestones/PoC2023q1/kubestellar-syncer-subs/kubestellar-syncer-0-deploy-guilder.md
@@ -16,11 +16,11 @@ mailbox workspace name = vosh9816n2xmpdwm-mb-bf1277df-0da9-4a26-b0fc-3318862b1a5
 
 Go to the mailbox workspace and run the following command to obtain yaml manifests to bootstrap KubeStellar-Syncer.
 ```shell
-kubectl ws root:espw:$mbws
+kubectl ws root:$mbws
 ./bin/kubectl-kubestellar-syncer_gen guilder --syncer-image quay.io/kubestellar/syncer:v0.2.2 -o guilder-syncer.yaml
 ```
 ``` { .bash .no-copy }
-Current workspace is "root:espw:vosh9816n2xmpdwm-mb-bf1277df-0da9-4a26-b0fc-3318862b1a5e".
+Current workspace is "root:vosh9816n2xmpdwm-mb-bf1277df-0da9-4a26-b0fc-3318862b1a5e".
 Creating service account "kubestellar-syncer-guilder-wfeig2lv"
 Creating cluster role "kubestellar-syncer-guilder-wfeig2lv" to give service account "kubestellar-syncer-guilder-wfeig2lv"
 

--- a/docs/content/Coding Milestones/PoC2023q1/mailbox-controller.md
+++ b/docs/content/Coding Milestones/PoC2023q1/mailbox-controller.md
@@ -44,19 +44,14 @@ APIExport in those workspaces; this should be a client config that is
 able to read/write in all clusters.  For example, that is in the
 kubeconfig context named `base` in the kubeconfig created by `kcp
 start`.  Finally, the controller also needs a kube client config that
-is pointed at the edge service provider workspace and is authorized to
-consume the `Workspace` objects from there.
+is pointed at the root workspace and is authorized to consume the `Workspace`
+objects from there.
 
 The command line flags, beyond the basics, are as follows.
 
 ``` { .bash .no-copy }
       --concurrency int                  number of syncs to run in parallel (default 4)
       --espw-path string                 the pathname of the edge service provider workspace (default "root:espw")
-
-      --inventory-cluster string         The name of the kubeconfig cluster to use for access to APIExport view of SyncTarget objects
-      --inventory-context string         The name of the kubeconfig context to use for access to APIExport view of SyncTarget objects (default "root")
-      --inventory-kubeconfig string      Path to the kubeconfig file to use for access to APIExport view of SyncTarget objects
-      --inventory-user string            The name of the kubeconfig user to use for access to APIExport view of SyncTarget objects
 
       --mbws-cluster string              The name of the kubeconfig cluster to use for access to mailbox workspaces (really all clusters)
       --mbws-context string              The name of the kubeconfig context to use for access to mailbox workspaces (really all clusters) (default "base")
@@ -65,10 +60,10 @@ The command line flags, beyond the basics, are as follows.
 
       --server-bind-address ipport       The IP address with port at which to serve /metrics and /debug/pprof/ (default :10203)
 
-      --workload-cluster string          The name of the kubeconfig cluster to use for access to edge service provider workspace
-      --workload-context string          The name of the kubeconfig context to use for access to edge service provider workspace
-      --workload-kubeconfig string       Path to the kubeconfig file to use for access to edge service provider workspace
-      --workload-user string             The name of the kubeconfig user to use for access to edge service provider workspace
+      --root-cluster string              The name of the kubeconfig cluster to use for access to the root workspace
+      --root-context string              The name of the kubeconfig context to use for access to the root workspace (default "root")
+      --root-kubeconfig string           Path to the kubeconfig file to use for access to the root workspace
+      --root-user string                 The name of the kubeconfig user to use for access to the root workspace
 ```
 
 ## Try out the mailbox controller
@@ -166,10 +161,10 @@ kubectl get synctargets.edge.kubestellar.io
 ```
 
 ```shell
-kubectl ws root:espw
+kubectl ws root
 ```
 ``` {.bash .no-copy }
-Current workspace is "root:espw".
+Current workspace is "root".
 ```
 
 ```shell

--- a/docs/content/Coding Milestones/PoC2023q1/placement-translator.md
+++ b/docs/content/Coding Milestones/PoC2023q1/placement-translator.md
@@ -120,6 +120,11 @@ command line parameters, then `$KUBECONFIG`, then `~/.kube/config`.
       --espw-kubeconfig string           Path to the kubeconfig file to use for access to the edge service provider workspace
       --espw-user string                 The name of the kubeconfig user to use for access to the edge service provider workspace
 
+      --root-cluster string              The name of the kubeconfig cluster to use for access to root workspace
+      --root-context string              The name of the kubeconfig context to use for access to root workspace (default "root")
+      --root-kubeconfig string           Path to the kubeconfig file to use for access to root workspace
+      --root-user string                 The name of the kubeconfig user to use for access to root workspace
+
       --server-bind-address ipport       The IP address with port at which to serve /metrics and /debug/pprof/ (default :10204)
 ```
 
@@ -209,10 +214,10 @@ to run the placement translator, or any other that is pointed at the
 edge service provider workspace. The following with switch the focus
 to mailbox workspace(s).
 
-You can get a listing of mailbox workspaces, while in the edge service
-provider workspace, as follows.
+You can get a listing of mailbox workspaces, as follows.
 
 ```shell 
+kubectl ws root
 kubectl get workspace
 ```
 ``` { .bash .no-copy }
@@ -226,10 +231,10 @@ one for the guilder cluster) and examine the `SyncerConfig` object.
 That should look like the following.
 
 ```shell
-kubectl ws $(kubectl get workspace | sed -n '2p' | awk '{print $1}')
+kubectl ws $(kubectl get Workspace -o json | jq -r '.items | .[] | .metadata | select(.annotations ["edge.kubestellar.io/sync-target-name"] == "guilder") | .name')
 ```
 ``` { .bash .no-copy }
-Current workspace is "root:espw:1xpg93182scl85te-mb-5ee1c42e-a7d5-4363-ba10-2f13fe578e19" (type root:universal).
+Current workspace is "root:1xpg93182scl85te-mb-5ee1c42e-a7d5-4363-ba10-2f13fe578e19" (type root:universal).
 ```
 
 ```shell
@@ -323,7 +328,7 @@ tweaking things.  For example, try deleting an EdgePlacement as
 follows.
 
 ```shell
-kubectl ws root:my-org:wmw-c
+kubectl ws root:wmw-c
 ```
 ``` { .bash .no-copy }
 Current workspace is "root:work-c"
@@ -346,17 +351,17 @@ After that, the SyncerConfig in the florin mailbox should be empty, as
 in the following (you mailbox workspace names may be different).
 
 ```shell
-kubectl ws root:espw
+kubectl ws root
 ```
 ``` { .bash .no-copy }
-Current workspace is "root:espw".
+Current workspace is "root".
 ```
 
 ```shell
-kubectl ws $(kubectl get workspace | sed -n '2p' | awk '{print $1}')
+kubectl ws $(kubectl get Workspace -o json | jq -r '.items | .[] | .metadata | select(.annotations ["edge.kubestellar.io/sync-target-name"] == "florin") | .name')
 ```
 ``` { .bash .no-copy }
-Current workspace is "root:espw:2lplrryirmv4xug3-mb-89c08764-01ae-4117-8fb0-6b752e76bc2f" (type root:universal).
+Current workspace is "root:2lplrryirmv4xug3-mb-89c08764-01ae-4117-8fb0-6b752e76bc2f" (type root:universal).
 ```
 
 ```shell
@@ -383,11 +388,11 @@ only the special workload.  That would look something like the
 following.
 
 ```shell
-kubectl ws root:espw
-kubectl ws $(kubectl get workspace | sed -n '2p' | awk '{print $1}')
+kubectl ws root
+kubectl ws $(kubectl get Workspace -o json | jq -r '.items | .[] | .metadata | select(.annotations ["edge.kubestellar.io/sync-target-name"] == "guilder") | .name')
 ```
 ``` { .bash .no-copy }
-Current workspace is "root:espw:1xpg93182scl85te-mb-5ee1c42e-a7d5-4363-ba10-2f13fe578e19" (type root:universal).
+Current workspace is "root:1xpg93182scl85te-mb-5ee1c42e-a7d5-4363-ba10-2f13fe578e19" (type root:universal).
 ```
 
 ```shell

--- a/docs/content/Getting-Started/quickstart-subs/quickstart-2-apache-example-deployment-b-create-imw-and-wmw.md
+++ b/docs/content/Getting-Started/quickstart-subs/quickstart-2-apache-example-deployment-b-create-imw-and-wmw.md
@@ -12,11 +12,10 @@ kubectl ws root
 kubectl ws create example-imw
 ```
 
-WMWs are used by KubeStellar to store workload descriptions and `EdgePlacement` objects. Create an WMW named `example-wmw` in a `my-org` workspace with the following commands:
+WMWs are used by KubeStellar to store workload descriptions and `EdgePlacement` objects. Create an WMW named `example-wmw` with the following commands:
 
 ```shell
 kubectl ws root
-kubectl ws create my-org --enter
 kubectl kubestellar ensure wmw example-wmw
 ```
 

--- a/docs/content/Getting-Started/quickstart-subs/quickstart-2-apache-example-deployment-d-create-and-deploy-apache-into-clusters.md
+++ b/docs/content/Getting-Started/quickstart-subs/quickstart-2-apache-example-deployment-d-create-and-deploy-apache-into-clusters.md
@@ -4,7 +4,7 @@ Create the `EdgePlacement` object for your workload. Its “where predicate” (
 In the `example-wmw` workspace create the following `EdgePlacement` object: 
   
 ```shell linenums="1"
-kubectl ws root:my-org:example-wmw
+kubectl ws root:example-wmw
 
 kubectl apply -f - <<EOF
 apiVersion: edge.kubestellar.io/v1alpha1

--- a/pkg/placement/main.go
+++ b/pkg/placement/main.go
@@ -78,7 +78,7 @@ func NewPlacementTranslator(
 	syncfgClusterPreInformer edgev1a1informers.SyncerConfigClusterInformer,
 
 	customizerClusterPreInformer edgev1a1informers.CustomizerClusterInformer,
-	// pre-informer on Workspaces objects in the ESPW
+	// pre-informer on Workspaces objects
 	mbwsPreInformer tenancyv1a1informers.WorkspaceInformer,
 	// all-cluster clientset for kcp APIs,
 	// needed to manipulate TMC objects in mailbox workspaces

--- a/scripts/kubectl-kubestellar-prep_for_syncer
+++ b/scripts/kubectl-kubestellar-prep_for_syncer
@@ -31,6 +31,7 @@ if ! [ -x "$bindir/kubectl-kubestellar-syncer_gen" ]; then
 fi
 
 imw=.
+rootws="root"
 espw="root:espw"
 stname=""
 output=""
@@ -142,6 +143,12 @@ fi
 if ! kubectl "${kubectl_flags[@]}" get APIExport edge.kubestellar.io &> /dev/null ; then
     echo "$0: it looks like ${espw@Q} is not the edge service provider workspace" >&2
     exit 2
+fi
+
+if [ "$silent" == "true" ]; then
+    kubectl ws "${kubectl_flags[@]}" "$rootws" > /dev/null
+else
+    kubectl ws "${kubectl_flags[@]}" "$rootws"
 fi
 
 if ! kubectl "${kubectl_flags[@]}" get Workspace "$mbwsname" &> /dev/null; then


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
This PR will remove the usage of space hierarchy and all KubeStellar spaces will be created at the same level under root.
This includes the mailbox spaces, previously resided under core space. 

## Related issue(s)
https://github.com/kubestellar/kubestellar/issues/976

Fixes #
