### PR TITLE
:bug: Fix arch detection for Mac arm in install-kcp-with-plugins.sh

### DIFF
--- a/bootstrap/install-kcp-with-plugins.sh
+++ b/bootstrap/install-kcp-with-plugins.sh
@@ -48,6 +48,7 @@ get_arch_type() {
   case "$HOSTTYPE" in
       x86_64*)  echo "amd64" ;;
       aarch64*) echo "arm64" ;;
+      arm64*)   echo "arm64" ;;
       *)        echo "Unsupported architecture type: $HOSTTYPE" >&2 ; exit 1 ;;
   esac
 }

--- a/bootstrap/install-kubestellar.sh
+++ b/bootstrap/install-kubestellar.sh
@@ -48,6 +48,7 @@ get_arch_type() {
   case "$HOSTTYPE" in
       x86_64*)  echo "amd64" ;;
       aarch64*) echo "arm64" ;;
+      arm64*)   echo "arm64" ;;
       *)        echo "Unsupported architecture type: $HOSTTYPE" >&2 ; exit 1 ;;
   esac
 }


### PR DESCRIPTION
## Summary

Improve automatic arch detection to include the $HOSTTYPE reported by arm-based Macs

## Related issue(s)
#971
#979

Fixes #
#979