### PR TITLE
🌱 Also tag center KS image with git commit

### DIFF
--- a/center.Dockerfile
+++ b/center.Dockerfile
@@ -44,7 +44,7 @@ ADD hack/		hack/
 ADD monitoring/		monitoring/
 ADD pkg/		pkg/
 ADD scripts/		scripts/
-ADD space-provider/	space-provider/
+ADD space-framework/	space-framework/
 ADD test/		test/
 ADD .git/		.git/
 ADD .gitattributes Makefile Makefile.venv go.mod go.sum .


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
This PR updates the Makefile so that building the central container image now applies two tags, rather than just the previous one; the new tag identifies the git commit, while the old tag identifies the build time.  Adding this information helps with understandability of the produced artifacts, while keeping it out of the image contents avoids an offense against making the image depend only on its _functional_ input.

This PR also fixes a bug in the center.Dockerfile that was introduced in a recent space PR.

## Related issue(s)

Fixes #
