### PR TITLE
:book: Add Helm to Ubuntu install instructions after rebase

### DIFF
--- a/docs/content/common-subs/required-packages.md
+++ b/docs/content/common-subs/required-packages.md
@@ -37,6 +37,13 @@
         ``` title="kubectl - https://kubernetes.io/docs/tasks/tools/ (version range expected: 1.23-1.25)"
         curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/$(dpkg --print-architecture)/kubectl" && chmod +x kubectl && sudo mv ./kubectl /usr/local/bin/kubectl
         ```
+        ``` title="helm (required when deploying as workload) - https://helm.sh/docs/intro/install/"
+        curl https://baltocdn.com/helm/signing.asc | gpg --dearmor | sudo tee /usr/share/keyrings/helm.gpg > /dev/null
+        sudo apt-get install apt-transport-https --yes
+        echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/helm.gpg] https://baltocdn.com/helm/stable/debian/ all main" | sudo tee /etc/apt/sources.list.d/helm-stable-debian.list
+        sudo apt-get update
+        sudo apt-get install helm
+        ```
     === "Debian"
         ``` title="jq - https://stedolan.github.io/jq/download/"
         sudo apt-get install jq


### PR DESCRIPTION
## Summary
PR [#1007](https://github.com/kubestellar/kubestellar/pull/1007) included the addition of Debian to the install instructions, and separately PR [#1030](https://github.com/kubestellar/kubestellar/pull/1030) added Helm to install instructions. With both being merged together, this results in missing Helm install instructions for Ubuntu (missing instructions in Debian would have been my initial guess, but this is how the merge ended up).

This PR adds the Helm instructions to Ubuntu (same instructions as Debian). 

## Related issue(s)

Fixes #
