### PR TITLE
✨ Change how kubectl-kubestellar-deploy determine the container tag

### DIFF
--- a/scripts/kubectl-kubestellar-deploy
+++ b/scripts/kubectl-kubestellar-deploy
@@ -20,7 +20,10 @@
 
 KSDIR=$(cd $(dirname ${BASH_SOURCE[0]}); cd ..; pwd)
 
-image_tag=b23-09-15-04-52-13
+image_tag=$(kubestellar-release 2> /dev/null)
+if [ "$image_tag" == "" ]; then
+	image_tag=stable
+fi
 
 external_endpoint=""
 openshift=false


### PR DESCRIPTION
## Summary

I think that the plugin should select the tag image based on the plugin release version, or default to stable.

## Related issue(s)

Fixes #
