### PR TITLE
🐛 Adopt hack for OpenShift vs amd64/v2 problem

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ GIT_COMMIT := $(shell git rev-parse --short HEAD || echo 'local')
 GIT_DIRTY := $(shell [ $$(git status --porcelain=v2 | wc -l) == 0 ] && echo 'clean' || echo 'dirty')
 GIT_VERSION := $(shell go mod edit -json | jq '.Require[] | select(.Path == "k8s.io/kubernetes") | .Version' --raw-output)+kcp-$(shell git describe --tags --match='v*' --abbrev=14 "$(GIT_COMMIT)^{commit}" 2>/dev/null || echo v0.0.0-$(GIT_COMMIT))
 
-CORE_PLATFORMS ?= linux/amd64/v2,linux/arm64,linux/ppc64le # kcp does not support linux/s390x
+CORE_PLATFORMS ?= linux/amd64,linux/arm64,linux/ppc64le # kcp does not support linux/s390x
 CORE_IMAGE_REPO ?= quay.io/kubestellar/kubestellar
 BUILD_TIME_TAG := $(shell date -u +b%y-%m-%d-%H-%M-%S)
 GIT_TAG = git-${GIT_COMMIT}-${GIT_DIRTY}

--- a/docs/content/Coding Milestones/PoC2023q1/commands.md
+++ b/docs/content/Coding Milestones/PoC2023q1/commands.md
@@ -275,6 +275,16 @@ nginx](../environments/dev-env/#hosting-kubestellar-in-a-kind-cluster). You
 will need to know the port number at which the Ingress controller is
 listening for HTTPS connections.
 
+**IF** your Kubernetes cluster has any worker nodes --- real or
+virtual --- with the x86_64 instruction set, they need to support the
+extended instruction set known as "x64-64-v2". If using hardware
+bought in the last 10 years, you can assume that is true. If using
+emulation, you need to make sure that your emulator is emulating that
+extended instruction set --- some emulators do not do this by
+default. See [QEMU configuration
+recommendations](https://www.qemu.org/docs/master/system/i386/cpu.html),
+for example.
+
 You will need a domain name that, on each of your clients, resolves to
 an IP address that gets to the Ingress controller's listening socket.
 

--- a/docs/content/Contribution guidelines/CONTRIBUTING.md
+++ b/docs/content/Contribution guidelines/CONTRIBUTING.md
@@ -89,6 +89,35 @@ below before trying this.
 make kubestellar-image
 ```
 
+The set of target platforms can be specified by setting the
+`CORE_PLATFORMS` variable. The following command is equivalent to the
+default behavior.
+
+```bash
+make kubestellar-image CORE_PLATFORMS=linux/amd64,linux/arm64,linux/ppc64le
+```
+
+**NOTE VERY SHARP AND BURIED EDGE**: IF the target platforms include
+  `linux/amd64` --- either because you explicitly set that or you let
+  the default setting apply --- then you MUST issue this command on a
+  machine (real or virtual) with the x86-64-v2
+  instructions. "x86-64-v2" is a shorthand for a bundle of instruction
+  set features that have been appearing in x86 chips for many years
+  now (any real machine that you are likely to use today has them) but
+  still do not all appear by default in some common emulators. See
+  [QEMU configuration
+  recommendations](https://www.qemu.org/docs/master/system/i386/cpu.html),
+  for example. If the machine lacks the v2 instructions then the build
+  will fail when it tries to use the glibc in the redhat/ubi9
+  image. Cross-platform building when the builder is NOT x86 and the
+  target IS x86 is beyond the ken of modern technology (see
+  [here](https://github.com/docker/buildx/issues/2028) and
+  [here](https://github.com/multiarch/qemu-user-static#supported-host-architectures)). If
+  you somehow succeed to build for the target platform
+  `linux/amd64/v2` and successfully test on real x86 hardware you
+  still are not done: when you try to use this image in OpenShift on
+  x86 you may get inexplicable failures to pull the image.
+
 The command shown above will only succeed if you have done `docker
 login` to quay.io with credentials authorized to write to the
 `kubestellar/kubestellar` repository. Look on quay.io to find the


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
This PR stupidifies the built images to not mention that v2 of the x86-64 ISA is required, because OpenShift nodes refuse to pull images that _do_ say they are built for that (even when run on a machine that has those instructions). This PR also adds a note to the building instructions about this.

## Related issue(s)

Fixes #
