### PR TITLE
:bug: Cleanup and refactoring syncer e2e related parts

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "go.sum|docs/package-lock.json|cmd/kube-watchall/go.sum|docs/config.toml|docs/resources/_gen|docs/static|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2023-09-14T15:02:41Z",
+  "generated_at": "2023-10-02T09:21:43Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -110,7 +110,7 @@
         "hashed_secret": "4d55af37dbbb6a42088d917caa1ca25428ec42c9",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 353,
+        "line_number": 345,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/Makefile
+++ b/Makefile
@@ -428,9 +428,9 @@ kcp/bin/kcp:
 .PHONY: e2e-test-kubestellar-syncer
 e2e-test-kubestellar-syncer: WORK_DIR ?= $(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
 e2e-test-kubestellar-syncer: TEST_ARGS ?= 
-e2e-test-kubestellar-syncer: KIND_CLUSTER_NAME ?= e2e-kubestellar
-e2e-test-kubestellar-syncer: export PATH := $(PWD)/kcp/bin:$(PATH)
-e2e-test-kubestellar-syncer: e2e-test-kubestellar-syncer-cleanup bin/kubestellar kcp/bin/kcp
+e2e-test-kubestellar-syncer: PATH := $(PWD)/kcp/bin:$(PATH)
+e2e-test-kubestellar-syncer: e2e-test-kubestellar-syncer-cleanup kcp/bin/kcp
+	mkdir -p $(WORK_DIR)/.kcp && \
 	kcp start --root-directory=$(WORK_DIR)/.kcp > $(WORK_DIR)/.kcp/kcp.log 2>&1 & PID=$$! && echo "PID $$PID" && \
 	trap 'kill -TERM $$PID' TERM INT EXIT && \
 	while [ ! -f "$(WORK_DIR)/.kcp/admin.kubeconfig" ]; do sleep 1; echo "kcp is not ready. wait for 1s...";done && \

--- a/Makefile
+++ b/Makefile
@@ -423,18 +423,23 @@ endif
 # 	$(if $(value WAIT),|| { echo "Terminated with $$?"; wait "$$PID"; },)
 
 kcp/bin/kcp:
-	bash ./bootstrap/install-kcp-with-plugins.sh
+	bash ./bootstrap/bootstrap-kubestellar.sh --deploy false
 
 .PHONY: e2e-test-kubestellar-syncer
 e2e-test-kubestellar-syncer: WORK_DIR ?= $(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
 e2e-test-kubestellar-syncer: TEST_ARGS ?= 
 e2e-test-kubestellar-syncer: KIND_CLUSTER_NAME ?= e2e-kubestellar
-e2e-test-kubestellar-syncer: e2e-test-kubestellar-syncer-cleanup kcp/bin/kcp
-	export PATH=$(PWD)/kcp/bin:$$PATH && \
+e2e-test-kubestellar-syncer: export PATH := $(PWD)/kcp/bin:$(PATH)
+e2e-test-kubestellar-syncer: e2e-test-kubestellar-syncer-cleanup bin/kubestellar kcp/bin/kcp
 	kcp start --root-directory=$(WORK_DIR)/.kcp > $(WORK_DIR)/.kcp/kcp.log 2>&1 & PID=$$! && echo "PID $$PID" && \
 	trap 'kill -TERM $$PID' TERM INT EXIT && \
 	while [ ! -f "$(WORK_DIR)/.kcp/admin.kubeconfig" ]; do sleep 1; echo "kcp is not ready. wait for 1s...";done && \
-	echo 'Starting test(s)' && \
+	echo 'kcp is ready. Wait for Workspace API to be ready' && \
+	export KUBECONFIG=$(WORK_DIR)/.kcp/admin.kubeconfig && \
+	while ! kubectl get workspaces &> /dev/null; do sleep 1; echo "Workspace API is not ready. wait for 1s...";done && \
+	echo 'Workspace API is ready. Setup root:compute workspace by kubestellar init' && \
+	./scripts/kubestellar init && \
+	echo 'Starting test(s). To add TEST_ARGS=-v option to Make command if displaying the detail logs' && \
 	NO_GORUN=1 GOOS=$(OS) GOARCH=$(ARCH) \
 		$(GO_TEST) -race $(COUNT_ARG) ./test/e2e/kubestellar-syncer/... $(TEST_ARGS) \
 		--kcp-kubeconfig $(WORK_DIR)/.kcp/admin.kubeconfig --suites kubestellar-syncer \

--- a/test/e2e/framework/kubestellar_syncer.go
+++ b/test/e2e/framework/kubestellar_syncer.go
@@ -123,8 +123,6 @@ type kubeStellarSyncerFixture struct {
 func (sf *kubeStellarSyncerFixture) CreateEdgeSyncTargetAndApplyToDownstream(t *testing.T) *appliedKubeStellarSyncerFixture {
 	t.Helper()
 
-	useDeployedSyncer := len(framework.TestConfig.PClusterKubeconfig()) > 0
-
 	// Write the upstream logical cluster config to disk for the workspace plugin
 	upstreamRawConfig, err := sf.upstreamServer.RawConfig()
 	require.NoError(t, err)
@@ -132,20 +130,14 @@ func (sf *kubeStellarSyncerFixture) CreateEdgeSyncTargetAndApplyToDownstream(t *
 
 	var downstreamConfig *rest.Config
 	var downstreamKubeconfigPath string
-	syncerImage := framework.TestConfig.SyncerImage()
 
-	if useDeployedSyncer {
-		// Test code is not implemented yet
-		require.NotZero(t, len(syncerImage), "--syncer-image must be specified if testing with a deployed syncer")
-	} else {
-		// The syncer will target a logical cluster that is a child of the current workspace. A
-		// logical server provides as a lightweight approximation of a pcluster for tests that
-		// don't need to validate running workloads or interaction with kube controllers.
-		downstreamServer := framework.NewFakeWorkloadServer(t, sf.upstreamServer, sf.edgeSyncTargetPath, sf.edgeSyncTargetName)
-		downstreamConfig = downstreamServer.BaseConfig(t)
-		downstreamKubeconfigPath = downstreamServer.KubeconfigPath()
-		syncerImage = "not-a-valid-image"
-	}
+	// The syncer will target a logical cluster that is a child of the current workspace. A
+	// logical server provides as a lightweight approximation of a pcluster for tests that
+	// don't need to validate running workloads or interaction with kube controllers.
+	downstreamServer := framework.NewFakeWorkloadServer(t, sf.upstreamServer, sf.edgeSyncTargetPath, sf.edgeSyncTargetName)
+	downstreamConfig = downstreamServer.BaseConfig(t)
+	downstreamKubeconfigPath = downstreamServer.KubeconfigPath()
+	syncerImage := "not-a-valid-image"
 
 	// Modify root:compute so that Syncer can update deployment.status
 	modifyRootCompute(t, upstreamRawConfig)


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
Originally this change is to address errors at Syncer E2E tests along with the works for moving to kcp 0.20.0(https://github.com/kubestellar/kubestellar/pull/1070). The original PR of this change is https://github.com/MikeSpreitzer/kcp-edge-mc/pull/2. This change results in some kind of cleanup of unused methods and scripts, which is benefit for maintenance. So, I would like to open this PR to main branch.

What's changes:
- Remove unused code paths in syncer e2e setup (test/e2e/framework/kubestellar_syncer.go)
- Fix Makefile
  - to setup root:compute workspace by `kubestellar init`
  - to use bootstrap-kubestellar.sh instead of install-kcp-with-plugins.sh for kcp installation
    - install-kcp-with-plugins.sh is no longer referred by any code so the issue [#971](https://github.com/kubestellar/kubestellar/issues/971) may be closed by removing install-kcp-with-plugins.sh.  

## Related issue(s)

Fixes: