### PR TITLE
🐛 Stop using nil from failed Update

### DIFF
--- a/pkg/placement/workload-projector.go
+++ b/pkg/placement/workload-projector.go
@@ -956,7 +956,7 @@ func (wp *workloadProjector) syncSourceToDestLocked(ctx context.Context, logger 
 			time.Sleep(wp.delay)
 			asUpdated, err := rscClient.Update(ctx, revisedDestObj, metav1.UpdateOptions{FieldManager: FieldManager})
 			if err != nil {
-				logger.Error(err, "Failed to update object in mailbox workspace", "resourceVersion", asUpdated.GetResourceVersion())
+				logger.V(2).Info("Failed to update object in mailbox workspace", "resourceVersion", revisedDestObj.GetResourceVersion(), "err", err)
 				return true
 			}
 			if logger.V(5).Enabled() {


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
This PR fixes a nil pointer fault that happens when reporting a failure to update a downsynced object in the mailbox workspace.
This PR also fixes the severity of the log message: this could be a transient condition that will be healed soon.

## Related issue(s)

This fixes the appearance of #1076 in the `main` branch; the problem was experienced in v0.7.0.
