### PR TITLE
✨ Improve `kubestellar init` wrt waiting for kcp

### DIFF
--- a/docs/content/Coding Milestones/PoC2023q1/commands.md
+++ b/docs/content/Coding Milestones/PoC2023q1/commands.md
@@ -219,7 +219,8 @@ kubestellar [flags] subcommand [flags]
 
 This command accepts the following command line flags, which can
 appear before and/or after the subcommand.  The `--log-folder` flag is
-only used in the `start` subcommand.
+only meaningful for the `start` subcommand. The `--local-kcp` flag is
+not meaningful for the `stop` subcommand.
 
 - `-V` or `--verbose`: calls for more verbose output.  This is a
   binary choice, not a matter of degree.
@@ -227,25 +228,30 @@ only used in the `start` subcommand.
 - `--log-folder $pathname`: says where to put the logs from the
   controllers.  Will be `mkdir -p` if absent.  Defaults to
   `${PWD}/kubestellar-logs`.
+- `--local-kcp $bool`: says whether to expect to find a local process
+  named "kcp".  Defaults to "true".
 - `-h` or `--help`: print a brief usage message and terminate.
 
 #### Kubestellar init
 
 This subcommand is used after installation to finish setup and does
-the following four things.
+the following five things.
 
-1. Ensure that the edge service provider workspace (ESPW) exists and
+1. Waits for the kcp server to be in service and the `root:compute`
+   workspace to be usable.
+
+2. Ensure that the edge service provider workspace (ESPW) exists and
 has the required contents.
 
-2. Ensure that the `root:compute` workspace has been extended with the
+3. Ensure that the `root:compute` workspace has been extended with the
 RBAC objects that enable the syncer to propagate reported state for
 downsynced objects defined by the APIExport from that workspace of a
 subset of the Kubernetes API for managing containerized workloads.
 
-3. Ensure the existence of an inventory management workspace at
+4. Ensure the existence of an inventory management workspace at
 pathname "root:imw1".
 
-4. Ensure the existence of a workload management workspace at pathname
+5. Ensure the existence of a workload management workspace at pathname
 "root:wmw1" and that it has APIBindings that import the namespaced
 Kubernetes resources (kinds of objects) for management of
 containerized workloads.

--- a/scripts/kubestellar
+++ b/scripts/kubestellar
@@ -24,6 +24,7 @@
 # Requirements:
 #    Download KubeStellar binaries
 #    KubeStellar controller binaries are on $PATH.
+#    kubectl is configured to talk to kcp server with high privilege
 
 bindir="$(dirname "$0")"
 
@@ -37,6 +38,7 @@ remove=0
 cleanup=0
 espw_name="espw"
 log_folder=$(pwd)/kubestellar-logs
+local_kcp=true
 
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 
@@ -49,6 +51,11 @@ while (( $# > 0 )); do
         then { log_folder="$2"; shift; }
         else { echo "$0: missing log folder" >&2; exit 1; }
         fi;;
+    (--local-kcp)
+        if (( $# > 1 ));
+        then { local_kcp="$2"; shift; }
+        else { echo "$0: missing log folder" >&2; exit 1; }
+        fi;;
     (--verbose|-V)
         verbosity=1
 	verbdir="";;
@@ -56,7 +63,7 @@ while (( $# > 0 )); do
 	xflag="-X"
 	set -x;;
     (-h|--help)
-        echo "Usage: $0 [init | start | stop] [--log-folder log_folder] [-V|--verbose] [-X]"
+        echo "Usage: $0 [init | start | stop] [--log-folder log_folder] [--local-kcp bool] [-V|--verbose] [-X]"
         exit 0;;
     (-*)
         echo "$0: unknown flag" >&2 ; exit 1;
@@ -73,6 +80,13 @@ if [ "$subcommand" == "" ]; then
     exit 1
 fi
 
+case "$local_kcp" in
+    (true|false) ;;
+    (*) echo "$0: --local-kcp must be given 'true' or 'false', not '${local_kcp}'" >&2
+	exit 1;;
+esac
+
+
 # Check if a given process name is running
 process_running() {
   SERVICE="$1"
@@ -83,13 +97,6 @@ process_running() {
       echo "stopped" 
   fi
 }
-
-# Check if kcp is running
-if [ $(process_running kcp) != "running" ]
-then
-    echo "kcp is not running - please start it ...."
-    exit 1
-fi
 
 function create_or_replace() { # usage: filename
     filename="$1"
@@ -103,10 +110,6 @@ function create_or_replace() { # usage: filename
     
 # current ws at start does not matter, is root:compute on return
 function ensure_root_compute_configd() {
-    if ! kubectl ws root:compute &> /dev/null ; then
-	echo "$0: Something is very wrong, unable to set current kcp workspace to root:compute" >&2
-	exit 1
-    fi
     ( cd ${SCRIPT_DIR}/../config/kube/exports/namespaced
       # Some are too big to `kubectl apply`
       for rsfn in apiresourceschema-*.yaml; do
@@ -301,6 +304,21 @@ if [ $subcommand == stop ]; then
    echo "kubestellar stopped ....."
    exit 0
 fi
+
+# Check if kcp is running
+if [ "$local_kcp" == true ] && [ $(process_running kcp) != "running" ]; then
+    echo "kcp is not running - please start it ...."
+    exit 1
+fi
+
+let tries=1
+while ! ( kubectl get workspaces && kubectl ws root:compute ); do
+    if (( ( tries & (tries-1) ) == 0 ))
+    then echo "$0: At $(date), kcp server not running yet or root:compute workspace not yet ready, waiting $(( tries * 15 )) sec..." >& 2
+    fi
+    let tries=tries+1
+    sleep 15
+done
 
 ensure_root_compute_configd
 ensure_espw


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
This PR does two things.
(1) Make waiting for a "kcp" process optional.
(2) Add non-optional waiting for the server to be fully ready.

## Related issue(s)

I think this needs to go in before #1077 so that can use this.
