### PR TITLE
🐛 Update default core image ref to build of current main

### DIFF
--- a/scripts/kubectl-kubestellar-deploy
+++ b/scripts/kubectl-kubestellar-deploy
@@ -20,7 +20,7 @@
 
 KSDIR=$(cd $(dirname ${BASH_SOURCE[0]}); cd ..; pwd)
 
-image_tag=git-8259fa7c7-clean
+image_tag=git-ce9cc894a-clean
 
 external_endpoint=""
 openshift=false


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
This PR updates the default reference to the core image to refer to a build of the `main` branch as it is right now, just after merging #1031 . An update to the default should have been part of that PR, but I forgot.

## Related issue(s)

Fixes #
