### PR TITLE
✨ Make the syncer more assertive

### DIFF
--- a/pkg/syncer/syncers/common.go
+++ b/pkg/syncer/syncers/common.go
@@ -186,12 +186,12 @@ func diff(logger klog.Logger, srcResourceList *unstructured.UnstructuredList, de
 			// Actually, when Syncer donwsynces, Syncer doesn't call UpdateStatus() method. Status fields at downstream side aren't updated by downsyncing.
 			setStatusFieldToDestinationStatus(logger, &srcResource, destResource)
 
-			if hasAnnotation(destResource) {
-				setAnnotation(&srcResource)
-				updatedResources = append(updatedResources, srcResource)
-			} else {
-				logger.V(2).Info(fmt.Sprintf("  ignore adding %s to updatedResources since annotation is not set.", destResource.GetName()))
-			}
+			// if hasAnnotation(destResource) {
+			setAnnotation(&srcResource)
+			updatedResources = append(updatedResources, srcResource)
+			// } else {
+			// logger.V(2).Info(fmt.Sprintf("  ignore adding %s to updatedResources since annotation is not set.", destResource.GetName()))
+			// }
 		} else {
 			srcResource.SetResourceVersion("")
 			srcResource.SetUID("")

--- a/pkg/syncer/syncers/downsyncer.go
+++ b/pkg/syncer/syncers/downsyncer.go
@@ -123,7 +123,7 @@ func (ds *DownSyncer) SyncOne(resource edgev1alpha1.EdgeSyncConfigResource, conv
 			if !isDeleted {
 				// update
 				ds.logger.V(3).Info(fmt.Sprintf("  update %q in downstream since it's found", resourceToString(resourceForDown)))
-				if hasDownsyncAnnotation(downstreamResource) {
+				if true || hasDownsyncAnnotation(downstreamResource) {
 					upstreamResource.SetResourceVersion(downstreamResource.GetResourceVersion())
 					upstreamResource.SetUID(downstreamResource.GetUID())
 					setDownsyncAnnotation(upstreamResource)

--- a/scripts/kubectl-kubestellar-prep_for_syncer
+++ b/scripts/kubectl-kubestellar-prep_for_syncer
@@ -34,7 +34,7 @@ imw=.
 espw="root:espw"
 stname=""
 output=""
-syncer_image="quay.io/kubestellar/syncer:v0.7.0"
+syncer_image="quay.io/kubestellar/syncer:pr-1103"
 kubectl_flags=()
 silent="false"
 


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
This makes the syncer modify existing objects in the WEC regardless of whether they have the annotation that the syncer applies. This is because Thanos expects such rough play. Hopefully this will not break anything!

## Related issue(s)

This is intended to address #1102 in the `release-0.7` branch.
