### PR TITLE
🐛 Enable unconfusion regarding git tree state

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ SHELL := /usr/bin/env bash -e
 KUBE_MAJOR_VERSION := $(shell go mod edit -json | jq '.Require[] | select(.Path == "k8s.io/kubernetes") | .Version' --raw-output | sed 's/v\([0-9]*\).*/\1/')
 KUBE_MINOR_VERSION := $(shell go mod edit -json | jq '.Require[] | select(.Path == "k8s.io/kubernetes") | .Version' --raw-output | sed "s/v[0-9]*\.\([0-9]*\).*/\1/")
 GIT_COMMIT := $(shell git rev-parse --short HEAD || echo 'local')
-GIT_DIRTY := $(shell [ $$(git status --porcelain=v2 | wc -l) == 0 ] && echo 'clean' || echo 'dirty')
+GIT_DIRTY ?= $(shell [ $$(git status --porcelain=v2 | wc -l) == 0 ] && echo 'clean' || echo 'dirty')
 GIT_VERSION := $(shell go mod edit -json | jq '.Require[] | select(.Path == "k8s.io/kubernetes") | .Version' --raw-output)+kcp-$(shell git describe --tags --match='v*' --abbrev=14 "$(GIT_COMMIT)^{commit}" 2>/dev/null || echo v0.0.0-$(GIT_COMMIT))
 
 CORE_PLATFORMS ?= linux/amd64,linux/arm64,linux/ppc64le # kcp does not support linux/s390x
@@ -131,11 +131,11 @@ build-all:
 .PHONY: kubestellar-image
 kubestellar-image:
 	if ! docker buildx inspect kubestellar &> /dev/null; then docker buildx create --name kubestellar --platform $(CORE_PLATFORMS); fi
-	if [ -n "$(EXTRA_CORE_TAG)" ]; then extra="--tag $(CORE_IMAGE_REPO):$(EXTRA_CORE_TAG)"; else extra=""; fi; eval docker buildx --builder kubestellar build --push --sbom=true --platform $(CORE_PLATFORMS) --tag $(CORE_IMAGE_REPO):$(BUILD_TIME_TAG) --tag $(CORE_IMAGE_REPO):$(GIT_TAG) $$extra -f core.Dockerfile .
+	if [ -n "$(EXTRA_CORE_TAG)" ]; then extra="--tag $(CORE_IMAGE_REPO):$(EXTRA_CORE_TAG)"; else extra=""; fi; eval docker buildx --builder kubestellar build --push --sbom=true --platform $(CORE_PLATFORMS) --tag $(CORE_IMAGE_REPO):$(BUILD_TIME_TAG) --tag $(CORE_IMAGE_REPO):$(GIT_TAG) $$extra -f core.Dockerfile --build-arg "GIT_DIRTY=$(GIT_DIRTY)" .
 
 .PHONY: kubestellar-image-local
 kubestellar-image-local:
-	if [ -n "$(EXTRA_CORE_TAG)" ]; then extra="--tag $(CORE_IMAGE_REPO):$(EXTRA_CORE_TAG)"; else extra=""; fi; case "$$HOSTTYPE" in (aarch64*|arm64*) extoo="--platform linux/arm64";; esac; eval docker build --tag $(CORE_IMAGE_REPO):$(BUILD_TIME_TAG) --tag $(CORE_IMAGE_REPO):$(GIT_TAG) $$extra -f core.Dockerfile $$extoo .
+	if [ -n "$(EXTRA_CORE_TAG)" ]; then extra="--tag $(CORE_IMAGE_REPO):$(EXTRA_CORE_TAG)"; else extra=""; fi; case "$$HOSTTYPE" in (aarch64*|arm64*) extoo="--platform linux/arm64";; esac; eval docker build --tag $(CORE_IMAGE_REPO):$(BUILD_TIME_TAG) --tag $(CORE_IMAGE_REPO):$(GIT_TAG) $$extra -f core.Dockerfile $$extoo --build-arg "GIT_DIRTY=$(GIT_DIRTY)" .
 
 # .PHONY: build-kind-images
 # build-kind-images-ko: require-ko

--- a/core.Dockerfile
+++ b/core.Dockerfile
@@ -6,6 +6,7 @@ FROM redhat/ubi9 AS builder
 ARG TARGETOS
 ARG TARGETARCH
 ARG TARGETPLATFORM
+ARG GIT_DIRTY=dirty
 
 RUN groupadd kubestellar && useradd -g kubestellar kubestellar
 
@@ -52,7 +53,7 @@ ADD .gitattributes Makefile Makefile.venv go.mod go.sum .
 # Avoid self-reference
 RUN rm scripts/kubectl-kubestellar-deploy
 
-RUN make build
+RUN make build GIT_DIRTY=$GIT_DIRTY
 
 FROM redhat/ubi9
 


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
This PR fixes a bug in the current dance for building the core image, in which the `core.Dockerfile` creates a git working tree that appears to be dirty but in reality just contains the needed subset of a clean tree.

## Related issue(s)

Fixes #
