### PR TITLE
🐛 Filter out system objects earlier in placement translator

### DIFF
--- a/pkg/placement/what-resolver.go
+++ b/pkg/placement/what-resolver.go
@@ -617,6 +617,9 @@ func (od *objectDetails) setByMatch(logger klog.Logger, wsd *workspaceDetails, s
 // The first returned bool indicates whether there is a match.
 // The second indicates whether an accurate answer was found.
 func whatMatches(logger klog.Logger, wsd *workspaceDetails, spec *edgeapi.EdgePlacementSpec, whatResource string, whatObj mrObject) (bool, bool) {
+	if ObjectIsSystem(whatObj) {
+		return false, true
+	}
 	gvk := whatObj.GetObjectKind().GroupVersionKind()
 	objNS := whatObj.GetNamespace()
 	objName := whatObj.GetName()

--- a/pkg/placement/workload-projector.go
+++ b/pkg/placement/workload-projector.go
@@ -1452,7 +1452,7 @@ func (wps *wpPerSource) enqueueSourceObject(gr metav1.GroupResource, namespaced 
 	if namespaced {
 		namespace = objm.GetNamespace()
 	}
-	if ObjectIsSystem(objm) {
+	if false /* filtering now done in what resolver */ && ObjectIsSystem(objm) {
 		wps.logger.V(4).Info("Ignoring system object", "groupResource", gr, "namespace", namespace, "name", objm.GetName(), "action", action)
 		return
 	}
@@ -1473,7 +1473,7 @@ func (wpd *wpPerDestination) enqueueDestinationObject(gr metav1.GroupResource, n
 	if namespaced {
 		namespace = objm.GetNamespace()
 	}
-	if ObjectIsSystem(objm) {
+	if false /* filtering now done in what resolver */ && ObjectIsSystem(objm) {
 		wpd.logger.V(4).Info("Ignoring system object", "groupResource", gr, "namespace", namespace, "name", objm.GetName(), "action", action)
 		return
 	}

--- a/scripts/kubectl-kubestellar-deploy
+++ b/scripts/kubectl-kubestellar-deploy
@@ -20,7 +20,7 @@
 
 KSDIR=$(cd $(dirname ${BASH_SOURCE[0]}); cd ..; pwd)
 
-image_tag=git-1b243dab3-clean
+image_tag=git-dd86b310c-clean
 
 external_endpoint=""
 openshift=false


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
This PR changes the placement translator to do the filtering out of the system objects in the what resolver rather than in the workload projector because in the part of the latter that deals with SyncerConfig there is not enough information to filter accurately.

## Related issue(s)

Fixes #1068
