### PR TITLE
✨ Ensure IMWs and WMWs across all scripts

### DIFF
--- a/bootstrap/bootstrap-kubestellar.sh
+++ b/bootstrap/bootstrap-kubestellar.sh
@@ -167,8 +167,8 @@ os_type=""
 arch_type=""
 folder=""
 kcp_address=""
-kubestellar_imw=""
-kubestellar_wmw=""
+kubestellar_imw="imw1"
+kubestellar_wmw="wmw1"
 verbose="false"
 flagx=""
 user_exports=""
@@ -240,7 +240,7 @@ while (( $# > 0 )); do
 	set -x
 	flagx="-X";;
     (-h|--help)
-        echo "Usage: $0 [--kcp-version release_version] [--kubestellar-version release_version] [--deploy bool] [--os linux|darwin] [--arch amd64|arm64] [--ensure-folder installation_folder] [-V|--verbose] [-X]"
+        echo "Usage: $0 [--kcp-version release_version] [--kubestellar-version release_version] [--deploy bool] [--os linux|darwin] [--arch amd64|arm64] [--ensure-folder installation_folder] [--ensure-imw imw-list] [--ensure-wmw wmw-list] [-V|--verbose] [-X]"
         exit 0;;
     (-*)
         echo "$0: unknown flag" >&2
@@ -424,9 +424,9 @@ elif [ "$deploy_style" == bare ]; then
     else
 	echo "Starting or restarting KubeStellar..."
 	if [ $verbose == "true" ]; then
-            kubestellar start -V
+            kubestellar start --ensure-imw $kubestellar_imw --ensure-wmw $kubestellar_wmw -V
 	else
-            kubestellar start
+            kubestellar start --ensure-imw $kubestellar_imw --ensure-wmw $kubestellar_wmw
 	fi
     fi
 else
@@ -438,31 +438,6 @@ else
     echo "Export KUBECONFIG environment variable: export KUBECONFIG=\"$KUBECONFIG\""
     user_exports="$user_exports"$'\n'"export KUBECONFIG=\"$KUBECONFIG\""
 fi
-
-# Ensure imw
-if [ "$kubestellar_imw" != "" ]; then
-    echo "Ensuring IMW \"$kubestellar_imw\"..."
-    if ! kubectl ws $kubestellar_imw &> /dev/null ; then
-        if [ "$verbose" != "" ]; then
-	    kubectl ws create $kubestellar_imw
-        else
-	    kubectl ws create $kubestellar_imw > /dev/null
-        fi
-    fi
-fi
-
-# Ensure wmw
-if [ "$kubestellar_wmw" != "" ]; then
-    echo "Ensuring WMW \"$kubestellar_wmw\"..."
-    if ! kubectl ws $kubestellar_imw &> /dev/null ; then
-        if [ "$verbose" != "" ]; then
-            kubectl kubestellar ensure wmw $kubestellar_wmw
-        else
-            kubectl kubestellar ensure wmw $kubestellar_wmw > /dev/null
-        fi
-    fi
-fi
-
 
 if [ "$deploy" == true ]; then
     if [ "$verbose" == "true" ]; then

--- a/bootstrap/install-kcp-with-plugins.sh
+++ b/bootstrap/install-kcp-with-plugins.sh
@@ -54,7 +54,7 @@ get_arch_type() {
 }
 
 get_latest_version() {
-    curl -sL https://github.com/kcp-dev/kcp/releases/latest | grep "</h1>" | head -n 1 | sed -e 's/<[^>]*>//g' | xargs
+    curl -sL https://github.com/kcp-dev/kcp/releases/latest | grep "</h1>" | tail -n 1 | sed -e 's/<[^>]*>//g' | xargs
 }
 
 get_full_path() {

--- a/bootstrap/install-kubestellar.sh
+++ b/bootstrap/install-kubestellar.sh
@@ -54,7 +54,7 @@ get_arch_type() {
 }
 
 get_latest_version() {
-    curl -sL https://github.com/kubestellar/kubestellar/releases/latest | grep "</h1>" | head -n 1 | sed -e 's/<[^>]*>//g' | xargs
+    curl -sL https://github.com/kubestellar/kubestellar/releases/latest | grep "</h1>" | tail -n 1 | sed -e 's/<[^>]*>//g' | xargs
 }
 
 get_full_path() {

--- a/docs/content/Coding Milestones/PoC2023q1/commands.md
+++ b/docs/content/Coding Milestones/PoC2023q1/commands.md
@@ -230,6 +230,8 @@ not meaningful for the `stop` subcommand.
   `${PWD}/kubestellar-logs`.
 - `--local-kcp $bool`: says whether to expect to find a local process
   named "kcp".  Defaults to "true".
+- `--ensure-imw`: provide a comma separated list of fully qualified inventory workspaces, _e.g._ "root:imw1,root:test:imw2". Defaults to "root:imw1". To prevet the creation of any inventory workspace, then pass "".
+- `--ensure-wmw`: provide a comma separated list of fully qualified workload management workspaces, _e.g._ "root:org:wmw1,root:org:imw2". Defaults to "root:wmw1". To prevet the creation of any workload management workspace, then pass "".
 - `-h` or `--help`: print a brief usage message and terminate.
 
 #### Kubestellar init

--- a/docs/content/Coding Milestones/PoC2023q1/commands.md
+++ b/docs/content/Coding Milestones/PoC2023q1/commands.md
@@ -220,7 +220,8 @@ kubestellar [flags] subcommand [flags]
 This command accepts the following command line flags, which can
 appear before and/or after the subcommand.  The `--log-folder` flag is
 only meaningful for the `start` subcommand. The `--local-kcp` flag is
-not meaningful for the `stop` subcommand.
+not meaningful for the `stop` subcommand. The `--ensure-imw` and 
+`--ensure-wmw` flags are only meaningful for the `start` or `init` subcommands.
 
 - `-V` or `--verbose`: calls for more verbose output.  This is a
   binary choice, not a matter of degree.
@@ -230,8 +231,8 @@ not meaningful for the `stop` subcommand.
   `${PWD}/kubestellar-logs`.
 - `--local-kcp $bool`: says whether to expect to find a local process
   named "kcp".  Defaults to "true".
-- `--ensure-imw`: provide a comma separated list of fully qualified inventory workspaces, _e.g._ "root:imw1,root:test:imw2". Defaults to "root:imw1". To prevet the creation of any inventory workspace, then pass "".
-- `--ensure-wmw`: provide a comma separated list of fully qualified workload management workspaces, _e.g._ "root:org:wmw1,root:org:imw2". Defaults to "root:wmw1". To prevet the creation of any workload management workspace, then pass "".
+- `--ensure-imw`: provide a comma separated list of pathnames for inventory workspaces, _e.g._ "root:imw1,root:imw2". Defaults to "root:imw1". To prevent the creation of any inventory workspace, then pass "".
+- `--ensure-wmw`: provide a comma separated list of pathnames for workload management workspaces, _e.g._ "root:wmw1,root:imw2". Defaults to "root:wmw1". To prevent the creation of any workload management workspace, then pass "".
 - `-h` or `--help`: print a brief usage message and terminate.
 
 #### Kubestellar init
@@ -250,16 +251,16 @@ RBAC objects that enable the syncer to propagate reported state for
 downsynced objects defined by the APIExport from that workspace of a
 subset of the Kubernetes API for managing containerized workloads.
 
-4. Ensure the existence of an inventory management workspace at
-pathname "root:imw1".
+4. Ensure the existence of zero, one, or more inventory management workspaces
+depending on the value of `--ensure-imw` flag. Default is one inventory management
+workspaces at pathname "root:imw1".
 
-5. Ensure the existence of a workload management workspace at pathname
-"root:wmw1" and that it has APIBindings that import the namespaced
-Kubernetes resources (kinds of objects) for management of
-containerized workloads.
-
-At the completion of `kubestellar init` the current workspace will be
-"root:wmw1".
+5. Ensure the existence of zero, one, or more workload management workspaces 
+depending on the value of `--ensure-wmw` flag. Default is one workload management
+workspaces at pathname "root:wmw1". The workload management workspaceshace APIBindings
+that import the namespaced Kubernetes resources (kinds of objects) for management of
+containerized workloads. At the completion of `kubestellar init` the current workspace will be
+"root".
 
 #### KubeStellar start
 

--- a/scripts/kubestellar
+++ b/scripts/kubestellar
@@ -76,7 +76,7 @@ function ensure_imws() {
             if [ "$i" == "" ] ; then
                 continue
             fi
-            echo "Ensuring INV: $i"
+            echo "Ensuring IMW: $i"
             ensure_imw "$i"
             kubectl ws use $initial_ws &> /dev/null # go back to the initial state
         done

--- a/scripts/kubestellar
+++ b/scripts/kubestellar
@@ -50,25 +50,6 @@ function echoerr() {
 }
 
 
-function ensure_imw() {
-    while IFS=':' read -ra items; do
-        for i in "${items[@]}"; do
-            if [ "$i" == "" ] ; then
-                break
-            fi
-            if ! kubectl ws "$i" &> /dev/null ; then #
-                if ! kubectl ws create "$i" --enter &> /dev/null ; then
-                    echoerr 'unable to create "$i"!'
-                    break
-                fi
-            fi
-        done
-    done <<< "$1"
-    if ! kubectl get apibinding "edge.kubestellar.io" &> /dev/null; then
-    	kubectl kcp bind apiexport root:espw:edge.kubestellar.io
-    fi
-}
-
 function ensure_imws() {
     initial_ws=$(kubectl ws . --short)
     while IFS=',' read -ra items; do
@@ -76,37 +57,21 @@ function ensure_imws() {
             if [ "$i" == "" ] ; then
                 continue
             fi
-            echo "Ensuring IMW: $i"
-            ensure_imw "$i"
-            kubectl ws use $initial_ws &> /dev/null # go back to the initial state
-        done
-    done <<< "$1"
-    kubectl ws use $initial_ws &> /dev/null
-}
-
-
-function ensure_wmw() {
-    while IFS=':' read -ra items; do
-        len=${#items[@]}
-        if [[ ${len} -eq 0 ]]; then
-            break # nothing to do
-        fi
-        # separate the last item
-        last_item=${items[$len-1]}
-        unset items[$len-1]
-        for i in "${items[@]}"; do
-            if [ "$i" == "" ] ; then
-                break
-            fi
-            if ! kubectl ws "$i" &> /dev/null ; then #
-                if ! kubectl ws create "$i" --enter &> /dev/null ; then
-                    echoerr 'unable to create "$i"!'
+            imw=${i#"root:"}
+            echo "Ensuring IMW: $imw"
+            kubectl ws root &> /dev/null
+            if ! kubectl ws "$imw" &> /dev/null ; then #
+                if ! kubectl ws create "$imw" --enter &> /dev/null ; then
+                    echoerr 'unable to create "$imw"!'
                     break
                 fi
             fi
+            if ! kubectl get apibinding "edge.kubestellar.io" &> /dev/null; then
+                kubectl kcp bind apiexport root:espw:edge.kubestellar.io
+            fi
         done
-        ${bindir}/kubectl-kubestellar-ensure-wmw $last_item $xflag --with-kube true &> /dev/null
     done <<< "$1"
+    kubectl ws use $initial_ws &> /dev/null # go back to the initial state
 }
 
 
@@ -117,12 +82,13 @@ function ensure_wmws() {
             if [ "$i" == "" ] ; then
                 continue
             fi
-            echo "Ensuring WMW: $i"
-            ensure_wmw "$i"
-            kubectl ws use $initial_ws &> /dev/null # go back to the initial state
+            wmw=${i#"root:"}
+            echo "Ensuring WMW: $wmw"
+            kubectl ws root &> /dev/null
+            ${bindir}/kubectl-kubestellar-ensure-wmw $wmw $xflag --with-kube true &> /dev/null
         done
     done <<< "$1"
-    kubectl ws use $initial_ws &> /dev/null
+    kubectl ws use $initial_ws &> /dev/null # go back to the initial state
 }
 
 
@@ -403,10 +369,9 @@ done
 
 ensure_root_compute_configd
 ensure_espw
-# ensure_imw1
-kubectl ws root &> /dev/null
 ensure_imws $imws
 ensure_wmws $wmws
+kubectl ws root &> /dev/null
 
 if [ $subcommand == init ]; then
     exit 0

--- a/scripts/kubestellar
+++ b/scripts/kubestellar
@@ -39,8 +39,92 @@ cleanup=0
 espw_name="espw"
 log_folder=$(pwd)/kubestellar-logs
 local_kcp=true
+imws="root:imw1"
+wmws="root:wmw1"
 
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+
+
+function echoerr() {
+   echo "ERROR: $1" >&2
+}
+
+
+function ensure_imw() {
+    while IFS=':' read -ra items; do
+        for i in "${items[@]}"; do
+            if [ "$i" == "" ] ; then
+                break
+            fi
+            if ! kubectl ws "$i" &> /dev/null ; then #
+                if ! kubectl ws create "$i" --enter &> /dev/null ; then
+                    echoerr 'unable to create "$i"!'
+                    break
+                fi
+            fi
+        done
+    done <<< "$1"
+    if ! kubectl get apibinding "edge.kubestellar.io" &> /dev/null; then
+    	kubectl kcp bind apiexport root:espw:edge.kubestellar.io
+    fi
+}
+
+function ensure_imws() {
+    initial_ws=$(kubectl ws . --short)
+    while IFS=',' read -ra items; do
+        for i in "${items[@]}"; do
+            if [ "$i" == "" ] ; then
+                continue
+            fi
+            echo "Ensuring INV: $i"
+            ensure_imw "$i"
+            kubectl ws use $initial_ws &> /dev/null # go back to the initial state
+        done
+    done <<< "$1"
+    kubectl ws use $initial_ws &> /dev/null
+}
+
+
+function ensure_wmw() {
+    while IFS=':' read -ra items; do
+        len=${#items[@]}
+        if [[ ${len} -eq 0 ]]; then
+            break # nothing to do
+        fi
+        # separate the last item
+        last_item=${items[$len-1]}
+        unset items[$len-1]
+        for i in "${items[@]}"; do
+            if [ "$i" == "" ] ; then
+                break
+            fi
+            if ! kubectl ws "$i" &> /dev/null ; then #
+                if ! kubectl ws create "$i" --enter &> /dev/null ; then
+                    echoerr 'unable to create "$i"!'
+                    break
+                fi
+            fi
+        done
+        ${bindir}/kubectl-kubestellar-ensure-wmw $last_item $xflag --with-kube true &> /dev/null
+    done <<< "$1"
+}
+
+
+function ensure_wmws() {
+    initial_ws=$(kubectl ws . --short)
+    while IFS=',' read -ra items; do
+        for i in "${items[@]}"; do
+            if [ "$i" == "" ] ; then
+                continue
+            fi
+            echo "Ensuring WMW: $i"
+            ensure_wmw "$i"
+            kubectl ws use $initial_ws &> /dev/null # go back to the initial state
+        done
+    done <<< "$1"
+    kubectl ws use $initial_ws &> /dev/null
+}
+
 
 while (( $# > 0 )); do
     case "$1" in
@@ -59,11 +143,21 @@ while (( $# > 0 )); do
     (--verbose|-V)
         verbosity=1
 	verbdir="";;
+    (--ensure-imw)
+        if (( $# > 1 ));
+        then { imws="$2"; shift; }
+        else { echo "$0: missing comma separated list of IMWs" >&2; exit 1; }
+        fi;;
+    (--ensure-wmw)
+        if (( $# > 1 ));
+        then { wmws="$2"; shift; }
+        else { echo "$0: missing comma separated list of WMWs" >&2; exit 1; }
+        fi;;
     (-X)
-	xflag="-X"
-	set -x;;
+        xflag="-X"
+        set -x;;
     (-h|--help)
-        echo "Usage: $0 [init | start | stop] [--log-folder log_folder] [--local-kcp bool] [-V|--verbose] [-X]"
+        echo "Usage: $0 [init | start | stop] [--log-folder log_folder] [--local-kcp bool] [--ensure-imw imw-list] [--ensure-wmw wmw-list] [-V|--verbose] [-X]"
         exit 0;;
     (-*)
         echo "$0: unknown flag" >&2 ; exit 1;
@@ -94,7 +188,7 @@ process_running() {
   then
       echo "running"
   else
-      echo "stopped" 
+      echo "stopped"
   fi
 }
 
@@ -107,7 +201,7 @@ function create_or_replace() { # usage: filename
     else eval kubectl create -f "$filename" $verbdir
     fi
 }
-    
+
 # current ws at start does not matter, is root:compute on return
 function ensure_root_compute_configd() {
     ( cd ${SCRIPT_DIR}/../config/kube/exports/namespaced
@@ -255,52 +349,39 @@ function ensure_espw() {
     if kubectl get Workspace "$espw_name" &> /dev/null; then
 	echo "espw workspace already exists -- using it:"
 	kubectl ws "$espw_name"
-    else 
+    else
         kubectl ws create "$espw_name" --enter
     fi
     eval kubectl apply -f "$SCRIPT_DIR/../config/exports" $verbdir
-    echo "Finished populating the espw with kubestellar apiexports"   
-}
-
-# current ws at start does not matter, is imw1 on return
-function ensure_imw1() {
-    kubectl ws root &> /dev/null
-    if kubectl get ws imw1 &> /dev/null
-    then kubectl ws imw1 &> /dev/null
-    else kubectl ws create imw1 --enter &> /dev/null
-    fi
-    
-    if ! kubectl get apibinding "edge.kubestellar.io" &> /dev/null; then
-	kubectl kcp bind apiexport root:espw:edge.kubestellar.io
-    fi
+    echo "Finished populating the espw with kubestellar apiexports"
 }
 
 if [ "$subcommand" != init ]; then
-    
+
     # Check mailbox-controller is already running
     if [ $(process_running mailbox-controller) == "running" ]
     then
 	echo "An older deployment of mailbox-controller is already running - terminating it ...."
 	pkill -f mailbox-controller
     fi
-    
+
     # Check kubestellar-where-resolver is already running
     if [ $(process_running "kubestellar-where-resolver") == "running" ]
     then
 	echo "An older deployment of kubestellar-where-resolver is already running - terminating it ...."
 	pkill -f "kubestellar-where-resolver"
     fi
-    
+
     # Check placement-translator is already running
     if [ $(process_running placement-translator) == "running" ]
     then
 	echo "An older deployment of placement-translator is already running - terminating it ...."
 	pkill -f placement-translator
     fi
-    
+
 fi
 
-if [ $subcommand == stop ]; then    
+if [ $subcommand == stop ]; then
    echo "kubestellar stopped ....."
    exit 0
 fi
@@ -322,9 +403,10 @@ done
 
 ensure_root_compute_configd
 ensure_espw
-ensure_imw1
+# ensure_imw1
 kubectl ws root &> /dev/null
-${bindir}/kubectl-kubestellar-ensure-wmw wmw1 $xflag --with-kube true
+ensure_imws $imws
+ensure_wmws $wmws
 
 if [ $subcommand == init ]; then
     exit 0
@@ -385,7 +467,7 @@ else
     echo " where-resolver failed to start ..... exiting"
     exit 1
 fi
- 
+
 # Start the Placement Translator
 sleep 3
 placement-translator --allclusters-context  "system:admin" -v=2 >> $log_folder/placement-translator-log.txt 2>&1 &


### PR DESCRIPTION
## Summary

Create a consistent experience to ensure IMWs and WMWs across all scripts.
- update `kubestellar init` to accept `--ensure-imw "imw-list"`  and `--ensure-wnw "wmw-list"`, where the list are comma separated and accept fully qualified kcp paths (default is `imw1` and `wmw1` to respect current behavior, use "" to create nothing)
- update `bootstrap-kubestellar` to leverage the above `kubestellar init` code instead of its own copy of the code
- update container `entry.sh`  to leverage the above `kubestellar init` code instead of its own copy of the code

## Related issue(s)

Fixes #
#1098