### PR TITLE
🌱 Update default core image tag to build of PR 1111

### DIFF
--- a/scripts/kubectl-kubestellar-deploy
+++ b/scripts/kubectl-kubestellar-deploy
@@ -20,7 +20,7 @@
 
 KSDIR=$(cd $(dirname ${BASH_SOURCE[0]}); cd ..; pwd)
 
-image_tag=git-dd86b310c-clean
+image_tag=v0.9.0-alpha.9.42d07da-clean
 
 external_endpoint=""
 openshift=false

--- a/scripts/kubectl-kubestellar-deploy
+++ b/scripts/kubectl-kubestellar-deploy
@@ -20,7 +20,7 @@
 
 KSDIR=$(cd $(dirname ${BASH_SOURCE[0]}); cd ..; pwd)
 
-image_tag=v0.9.0-alpha.9.42d07da-clean
+image_tag=v0.8.0-alpha.9.42d07da-clean
 
 external_endpoint=""
 openshift=false


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
This PR updates the core image tag used by `kubectl kubestellar deploy` to a build of the latest (as of now) core code.

## Related issue(s)

This picks up the changes in #1111 .
