### PR TITLE
🐛 Remove some sharp edges from kubectl plugins

### DIFF
--- a/outer-scripts/kubectl-kubestellar
+++ b/outer-scripts/kubectl-kubestellar
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+
+# Copyright 2023 The KubeStellar Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+cat <<EOF
+Usage:
+  kubectl kubestellar [command]
+
+Available commands:
+  deploy                  Deploy KubeStellar core in a Kubernetes cluster
+  ensure                  Make sure a given thing exists and is setup
+  get-internal-kubeconfig Fetch kubeconfig for using core from same namespace
+  get-external-kubeconfig Fetch kubeconfig for using core from outside cluster
+  prep-for-cluster        Ensure location and prep-for-syncer
+  prep-for-syncer         First step in bootstrapping a WEC
+  remove                  Make sure a given thing does not exist
+EOF

--- a/outer-scripts/kubectl-kubestellar-deploy
+++ b/outer-scripts/kubectl-kubestellar-deploy
@@ -28,6 +28,9 @@ helm_flags=()
 
 while (( $# > 0 )); do
     case "$1" in
+	(-h|--help)
+	    echo "Usage: kubectl kubestellar deploy (\$kubectl_flag | --external_endpoint \$domain_name:$port | --openshift \$boolean)*"
+	    exit 0;;
 	(--external-endpoint)
 	    if (( $# >1 ))
 	    then external_endpoint="$2"; shift
@@ -41,21 +44,17 @@ while (( $# > 0 )); do
 	(--*=*|-?=*)
 	    helm_flags[${#helm_flags[*]}]="$1";;
 	(-X) set -x;;
-	(-h)
-	    echo "Usage: kubectl kubestellar deploy (\$kubectl_flag | --external_endpoint \$domain_name:$port | --openshift \$boolean)*"
-	    exit 0;;
 	(--*|-?)
-	    if (( $# > 1 ))
-	    then helm_flags[${#helm_flags[*]}]="$1"
+	    helm_flags[${#helm_flags[*]}]="$1"
+	    if (( $# > 1 )); then 
 		 helm_flags[${#helm_flags[*]}]="$2"
 		 shift
-	    else echo "$0: missing value for long flag $1" >&2; exit 1
 	    fi;;
 	(-*)
 	    echo "$0: flag syntax error" >&2
 	    exit 1;;
 	(*)
-	    echo "$0: no positional arguments accepted" >&2
+	    echo "$0: no positional arguments are allowed" >&2
 	    exit 1
     esac
     shift

--- a/outer-scripts/kubectl-kubestellar-ensure
+++ b/outer-scripts/kubectl-kubestellar-ensure
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+
+# Copyright 2023 The KubeStellar Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+cat <<EOF
+Usage:
+  kubectl kubestellar ensure subcommand
+
+Available subcommands:
+  location Ensure existence and configuration of an inventory listing for a WEC
+  wmw      Ensure existence and configuration of a Workload Description Space (WDS, formerly WMW)
+EOF

--- a/outer-scripts/kubectl-kubestellar-ensure-location
+++ b/outer-scripts/kubectl-kubestellar-ensure-location
@@ -54,6 +54,9 @@ function add_label() {
 
 while (( $# > 0 )); do
     case "$1" in
+	(-h|--help)
+	    echo "Usage: kubectl kubestellar ensure location (\$kubectl_flag | --imw ws_path | -X)* objname labelname=labelvalue ..."
+	    exit 0;;
 	(-X) set -o xtrace;;
 	(--imw)
 	    if (( $# >1 ))
@@ -65,15 +68,11 @@ while (( $# > 0 )); do
 	    echo "$0: --context flag not supported" >&2; exit 1;;
 	(--*=*|-?=*)
 	    kubectl_flags[${#kubectl_flags[*]}]="$1";;
-	(-h)
-	    echo "Usage: kubectl kubestellar ensure location (\$kubectl_flag | --imw ws_path | -X)* objname labelname=labelvalue ..."
-	    exit 0;;
 	(--*|-?)
-	    if (( $# > 1 ))
-	    then kubectl_flags[${#kubectl_flags[*]}]="$1"
+	    kubectl_flags[${#kubectl_flags[*]}]="$1"
+	    if (( $# > 1 )); then 
 		 kubectl_flags[${#kubectl_flags[*]}]="$2"
 		 shift
-	    else echo "$0: missing value for long flag $1" >&2; exit 1
 	    fi;;
 	(-*)
 	    echo "$0: flag syntax error" >&2

--- a/outer-scripts/kubectl-kubestellar-get_external_kubeconfig
+++ b/outer-scripts/kubectl-kubestellar-get_external_kubeconfig
@@ -23,6 +23,9 @@ kubectl_flags=()
 
 while (( $# > 0 )); do
     case "$1" in
+	(-h|--help)
+	    echo "Usage: kubectl kubestellar get-external-kubeconfig (\$kubectl_flag | -o \$ouptut_pathname)*"
+	    exit 0;;
 	(-o)
 	    if (( $# >1 ))
 	    then output_pathname="$2"; shift
@@ -31,15 +34,11 @@ while (( $# > 0 )); do
 	(--*=*|-?=*)
 	    kubectl_flags[${#kubectl_flags[*]}]="$1";;
 	(-X) set -x;;
-	(-h)
-	    echo "Usage: kubectl kubestellar get-external-kubeconfig (\$kubectl_flag | -o \$ouptut_pathname)*"
-	    exit 0;;
 	(--*|-?)
-	    if (( $# > 1 ))
-	    then kubectl_flags[${#kubectl_flags[*]}]="$1"
+	    kubectl_flags[${#kubectl_flags[*]}]="$1"
+	    if (( $# > 1 )); then 
 		 kubectl_flags[${#kubectl_flags[*]}]="$2"
 		 shift
-	    else echo "$0: missing value for long flag $1" >&2; exit 1
 	    fi;;
 	(-*)
 	    echo "$0: flag syntax error" >&2

--- a/outer-scripts/kubectl-kubestellar-get_internal_kubeconfig
+++ b/outer-scripts/kubectl-kubestellar-get_internal_kubeconfig
@@ -23,6 +23,9 @@ kubectl_flags=()
 
 while (( $# > 0 )); do
     case "$1" in
+	(-h|--help)
+	    echo "Usage: kubectl kubestellar get-external-kubeconfig (\$kubectl_flag | -o \$ouptut_pathname)*"
+	    exit 0;;
 	(-o)
 	    if (( $# >1 ))
 	    then output_pathname="$2"; shift
@@ -31,15 +34,11 @@ while (( $# > 0 )); do
 	(--*=*|-?=*)
 	    kubectl_flags[${#kubectl_flags[*]}]="$1";;
 	(-X) set -x;;
-	(-h)
-	    echo "Usage: kubectl kubestellar get-external-kubeconfig (\$kubectl_flag | -o \$ouptut_pathname)*"
-	    exit 0;;
 	(--*|-?)
-	    if (( $# > 1 ))
-	    then kubectl_flags[${#kubectl_flags[*]}]="$1"
+	    kubectl_flags[${#kubectl_flags[*]}]="$1"
+	    if (( $# > 1 )); then 
 		 kubectl_flags[${#kubectl_flags[*]}]="$2"
 		 shift
-	    else echo "$0: missing value for long flag $1" >&2; exit 1
 	    fi;;
 	(-*)
 	    echo "$0: flag syntax error" >&2

--- a/outer-scripts/kubectl-kubestellar-prep_for_cluster
+++ b/outer-scripts/kubectl-kubestellar-prep_for_cluster
@@ -30,6 +30,9 @@ silent="false"
 
 while (( $# > 0 )); do
     case "$1" in
+    (-h|--help)
+        echo "Usage: kubectl kubestellar prep-for-cluster (\$kubectl_flag | --imw ws_path | --espw ws_path | --syncer-image image_ref | -o filename | -s | -X)* synctarget_name labelname=labelvalue..."
+        exit 0;;
     (-X)
          set -o xtrace
          flags[${#prep_flags[*]}]="$1";;
@@ -65,15 +68,11 @@ while (( $# > 0 )); do
         echo "$0: --context flag not supported" >&2; exit 1;;
     (--*=*|-?=*)
         kubectl_flags[${#kubectl_flags[*]}]="$1";;
-    (-h)
-        echo "Usage: kubectl kubestellar prep-for-cluster (\$kubectl_flag | --imw ws_path | --espw ws_path | --syncer-image image_ref | -o filename | -s | -X)* synctarget_name labelname=labelvalue..."
-        exit 0;;
     (--*|-?)
-        if (( $# > 1 ))
-        then kubectl_flags[${#kubectl_flags[*]}]="$1"
-         kubectl_flags[${#kubectl_flags[*]}]="$2"
-         shift
-        else echo "$0: missing value for long flag $1" >&2; exit 1
+        kubectl_flags[${#kubectl_flags[*]}]="$1";
+	if (( $# > 1 )); then 
+            kubectl_flags[${#kubectl_flags[*]}]="$2"
+            shift
         fi;;
     (-*)
         echo "$0: flag syntax error" >&2

--- a/outer-scripts/kubectl-kubestellar-prep_for_syncer
+++ b/outer-scripts/kubectl-kubestellar-prep_for_syncer
@@ -41,6 +41,9 @@ silent="false"
 
 while (( $# > 0 )); do
     case "$1" in
+	(-h|--help)
+	    echo "Usage: kubectl kubestellar prep-for-syncer (\$kubectl_flag | --imw ws_path | --espw ws_path | --syncer-image image_ref | -o filename | -s | -X)* synctarget_name"
+	    exit 0;;
 	(-X) set -o xtrace;;
 	(--imw)
 	    if (( $# >1 ))
@@ -69,15 +72,11 @@ while (( $# > 0 )); do
 	    echo "$0: --context flag not supported" >&2; exit 1;;
 	(--*=*|-?=*)
 	    kubectl_flags[${#kubectl_flags[*]}]="$1";;
-	(-h)
-	    echo "Usage: kubectl kubestellar prep-for-syncer (\$kubectl_flag | --imw ws_path | --espw ws_path | --syncer-image image_ref | -o filename | -s | -X)* synctarget_name"
-	    exit 0;;
 	(--*|-?)
-	    if (( $# > 1 ))
-	    then kubectl_flags[${#kubectl_flags[*]}]="$1"
+	    kubectl_flags[${#kubectl_flags[*]}]="$1";
+	    if (( $# > 1 )); then 
 		 kubectl_flags[${#kubectl_flags[*]}]="$2"
 		 shift
-	    else echo "$0: missing value for long flag $1" >&2; exit 1
 	    fi;;
 	(-*)
 	    echo "$0: flag syntax error" >&2

--- a/outer-scripts/kubectl-kubestellar-remove
+++ b/outer-scripts/kubectl-kubestellar-remove
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+
+# Copyright 2023 The KubeStellar Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+cat <<EOF
+Usage:
+  kubectl kubestellar remove subcommand
+
+Available subcommands:
+  location Delete, if present, an inventory entry for a given WEC
+  wmw      Delete, if present, a Workload Description Space (WDS, formerly WMW)
+EOF

--- a/outer-scripts/kubectl-kubestellar-remove-location
+++ b/outer-scripts/kubectl-kubestellar-remove-location
@@ -24,6 +24,9 @@ kubectl_flags=()
 
 while (( $# > 0 )); do
     case "$1" in
+	(-h|--help)
+	    echo "Usage: kubectl kubestellar remove location (\$kubectl_flag | --imw ws_path | -X)* objname"
+	    exit 0;;
 	(-X) set -o xtrace;;
 	(--imw)
 	    if (( $# >1 ))
@@ -35,15 +38,11 @@ while (( $# > 0 )); do
 	    echo "$0: --context flag not supported" >&2; exit 1;;
 	(--*=*|-?=*)
 	    kubectl_flags[${#kubectl_flags[*]}]="$1";;
-	(-h)
-	    echo "Usage: kubectl kubestellar remove location (\$kubectl_flag | --imw ws_path | -X)* objname"
-	    exit 0;;
 	(--*|-?)
-	    if (( $# > 1 ))
-	    then kubectl_flags[${#kubectl_flags[*]}]="$1"
+	    kubectl_flags[${#kubectl_flags[*]}]="$1";
+	    if (( $# > 1 )); then 
 		 kubectl_flags[${#kubectl_flags[*]}]="$2"
 		 shift
-	    else echo "$0: missing value for long flag $1" >&2; exit 1
 	    fi;;
 	(-*)
 	    echo "$0: flag syntax error" >&2

--- a/outer-scripts/kubectl-kubestellar-remove-wmw
+++ b/outer-scripts/kubectl-kubestellar-remove-wmw
@@ -23,21 +23,20 @@ wmw_name=""
 
 while (( $# > 0 )); do
     case "$1" in
+	(-h|--help)
+	    echo "Usage: kubectl ws parent; kubectl kubestellar remove wmw [-X] kubectl_flag... wm_workspace_name"
+	    exit 0;;
 	(-X) set -o xtrace;;
 	(--context*)
 	    # TODO: support --context
 	    echo "$0: --context flag not supported" >&2; exit 1;;
 	(--*=*|-?=*)
 	    kubectl_flags[${#kubectl_flags[*]}]="$1";;
-	(-h)
-	    echo "Usage: kubectl ws parent; kubectl kubestellar remove wmw [-X] kubectl_flag... wm_workspace_name"
-	    exit 0;;
 	(--*|-?)
-	    if (( $# > 1 ))
-	    then kubectl_flags[${#kubectl_flags[*]}]="$1"
+	    kubectl_flags[${#kubectl_flags[*]}]="$1"
+	    if (( $# > 1 )); then 
 		 kubectl_flags[${#kubectl_flags[*]}]="$2"
 		 shift
-	    else echo "$0: missing value for long flag $1" >&2; exit 1
 	    fi;;
 	(-*)
 	    echo "$0: flag syntax error" >&2

--- a/overlap-scripts/kubectl-kubestellar-ensure-wmw
+++ b/overlap-scripts/kubectl-kubestellar-ensure-wmw
@@ -24,6 +24,9 @@ wmw_name=""
 
 while (( $# > 0 )); do
     case "$1" in
+	(-h|--help)
+	    echo "Usage: kubectl ws parent; kubectl kubestellar ensure wmw (\$kubectl_flag | --with-kube boolean | -X)* wm_workspace_name"
+	    exit 0;;
 	(-X) set -o xtrace;;
 	(--with-kube)
 	    if (( $# >1 ))
@@ -35,15 +38,11 @@ while (( $# > 0 )); do
 	    echo "$0: --context flag not supported" >&2; exit 1;;
 	(--*=*|-?=*)
 	    kubectl_flags[${#kubectl_flags[*]}]="$1";;
-	(-h)
-	    echo "Usage: kubectl ws parent; kubectl kubestellar ensure wmw (\$kubectl_flag | --with-kube boolean | -X)* wm_workspace_name"
-	    exit 0;;
 	(--*|-?)
-	    if (( $# > 1 ))
-	    then kubectl_flags[${#kubectl_flags[*]}]="$1"
+	    kubectl_flags[${#kubectl_flags[*]}]="$1";
+	    if (( $# > 1 )); then 
 		 kubectl_flags[${#kubectl_flags[*]}]="$2"
 		 shift
-	    else echo "$0: missing value for long flag $1" >&2; exit 1
 	    fi;;
 	(-*)
 	    echo "$0: flag syntax error" >&2


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
This PR makes some usability improvements to the kubectl plugins.

1. They accept `--help` as well as `-h`.
2. The missing interior nodes in the command tree have been added.
3. kubectl flag gathering is expanded to allow one parameter-less flag at the end of the command line (this is better than allowing nowhere at all, we will wait for #414 to get a fully good answer here).

## Related issue(s)

Fixes #1119
