### PR TITLE
:bug: fix Get function in kflex provider

### DIFF
--- a/space-framework/space-provider/kubeflex/kubeflex.go
+++ b/space-framework/space-provider/kubeflex/kubeflex.go
@@ -97,7 +97,7 @@ func (k KflexClusterProvider) ListSpacesNames() ([]string, error) {
 // Get: obtains the kubeconfig for the given lcName cluster.
 // TODO: switch from cli to kube directives
 func (k KflexClusterProvider) Get(lcName string) (clusterprovider.SpaceInfo, error) {
-	cmd := "kubectl --context kind-kubeflex get secrets -n lc3-system admin-kubeconfig -o jsonpath='{.data.*}' | base64 -d"
+	cmd := "kubectl --context kind-kubeflex get secrets -n " + lcName + " admin-kubeconfig -o jsonpath='{.data.*}' | base64 -d"
 	cfg, err := exec.Command("bash", "-c", cmd).Output()
 	if err != nil {
 		return clusterprovider.SpaceInfo{}, err
@@ -180,6 +180,8 @@ func (k *KflexWatcher) ResultChan() <-chan clusterprovider.WatchEvent {
 					for _, name := range newSetClusters.Difference(setClusters).UnsortedList() {
 						logger.V(2).Info("Processing KubeFlex cluster", "name", name)
 						spaceInfo, err := k.provider.Get(name)
+						logger.Error(err, "kflex Added")
+						logger.Error(err, name)
 						if err != nil {
 							logger.V(2).Info("KubeFlex cluster is not ready. Retrying", "cluster", name)
 							// Can't get the cluster info, so let's discover it again

--- a/space-framework/test/e2e-sh-tests/space-kflex1.yaml
+++ b/space-framework/test/e2e-sh-tests/space-kflex1.yaml
@@ -1,0 +1,8 @@
+apiVersion: space.kubestellar.io/v1alpha1
+kind: Space
+metadata:
+  name: kflex2
+  namespace: "spaceprovider-default"
+spec:
+  SpaceProviderDescName: "default"
+  Type: "managed"

--- a/space-framework/test/e2e-sh-tests/spaceproviderdesc-kflex.yaml
+++ b/space-framework/test/e2e-sh-tests/spaceproviderdesc-kflex.yaml
@@ -1,0 +1,7 @@
+apiVersion: space.kubestellar.io/v1alpha1
+kind: SpaceProviderDesc
+metadata:
+  name: default
+spec:
+  ProviderType: "kubeflex"
+  SpacePrefixForDiscovery: "ks-"


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
The Get() function in the kubeflex provider somehow lost the space name usage.

## Related issue(s)

Fixes #
