### PR TITLE
🐛 Fix display of initial spaces after deploy in kube

### DIFF
--- a/docs/content/Getting-Started/quickstart-subs/quickstart-1-install-and-run-kubestellar.md
+++ b/docs/content/Getting-Started/quickstart-subs/quickstart-1-install-and-run-kubestellar.md
@@ -115,7 +115,9 @@ which should yield:
 .
 └── root
     ├── compute
-    └── espw
+    ├── espw
+    ├── imw1
+    └── wmw1
 ```
 
 <!--quickstart-1-install-and-run-kubestellar-end-->


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
This PR fixes the display in the quickstart of the initial load of spaces after deploying the core as workload in a Kube cluster.

## Related issue(s)

Fixes #1142
