### PR TITLE
🌱 Align default core image ref in chart with coming release

### DIFF
--- a/core-helm-chart/values.yaml
+++ b/core-helm-chart/values.yaml
@@ -16,7 +16,7 @@
 image:
   repository: quay.io/kubestellar/kubestellar
   pullPolicy: IfNotPresent
-  tag: main-mc
+  tag: release-0.9
 
 # Storage size
 storageSize: 8Gi


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
This PR updates the default core image tag in the Helm chart's `values.yaml` to be named after the coming release. The theory is that a tag naming a release branch can be advanced along backward-compatible changes to pick up improvements and bug fixes while being specific enough to insulate a user of one branch from work on the next branch.

## Related issue(s)

Fixes #
