### PR TITLE
✨ Generalize bootstrap wrt namespace in hosting cluster

### DIFF
--- a/bootstrap/bootstrap-kubestellar.sh
+++ b/bootstrap/bootstrap-kubestellar.sh
@@ -31,6 +31,7 @@
 # [--bind-address address] bind kcp to a specific ip address
 # [--ensure-imw name] create a Inventory Management Workspace (IMW)
 # [--ensure-wmw name] create a Workload Management Workspace (WMW)
+# [--host-ns namespace] specify namespace in hosting cluster that gets chart
 # [-V|--verbose] verbose output
 # [-X] `set -x`
 
@@ -174,6 +175,7 @@ flagx=""
 user_exports=""
 external_endpoint=""
 openshift=false
+host_ns="kubestellar"
 
 echo "< KubeStellar bootstrap started >----------------"
 
@@ -234,13 +236,18 @@ while (( $# > 0 )); do
         then { openshift="$2"; shift; }
         else { echo "$0: missing openshift setting" >&2; exit 1; }
         fi;;
+    (--host-ns)
+        if (( $# > 1 ));
+        then { host_ns="$2"; shift; }
+        else { echo "$0: missing host-ns setting" >&2; exit 1; }
+        fi;;
     (--verbose|-V)
         verbose="true";;
     (-X)
 	set -x
 	flagx="-X";;
     (-h|--help)
-        echo "Usage: $0 [--kcp-version release_version] [--kubestellar-version release_version] [--deploy bool] [--os linux|darwin] [--arch amd64|arm64] [--ensure-folder installation_folder] [--ensure-imw imw-list] [--ensure-wmw wmw-list] [-V|--verbose] [-X]"
+        echo "Usage: $0 [--kcp-version release_version] [--kubestellar-version release_version] [--deploy bool] [--os linux|darwin] [--arch amd64|arm64] [--ensure-folder installation_folder] [--ensure-imw imw-list] [--ensure-wmw wmw-list] [--host-ns namespace-in-hosting-cluster] [-V|--verbose] [-X]"
         exit 0;;
     (-*)
         echo "$0: unknown flag" >&2
@@ -284,6 +291,11 @@ case "$openshift" in
     (*) echo "$0: --openshift value must be 'true' or 'false'" >&2
 	exit 1;;
 esac
+
+if [ $(wc -w <<<"$host_ns") != 1 ]; then
+    echo "$0: --host-ns value must be one word, not '$host_ns'" >&2
+    exit 1
+fi
 
 deploy_style=bare
 deploy_flags=()
@@ -430,10 +442,11 @@ elif [ "$deploy_style" == bare ]; then
 	fi
     fi
 else
-    echo "< Deploy kcp and KubeStellar into Kubernetes >---------------"
-    kubectl kubestellar deploy "${deploy_flags[@]}"
+    echo "< Deploy kcp and KubeStellar into Kubernetes, namespace=$host_ns >---------------"
+    kubectl get ns $host_ns || kubectl create ns $host_ns
+    kubectl kubestellar deploy "${deploy_flags[@]}" -n $host_ns
     echo "< Waiting for startup and fetching $folder/kubestellar.kubeconfig >---------------"
-    kubectl kubestellar get-external-kubeconfig -o "$folder"/kubestellar.kubeconfig
+    kubectl kubestellar get-external-kubeconfig -n $host_ns -o "$folder"/kubestellar.kubeconfig
     export KUBECONFIG="$folder/kubestellar.kubeconfig"
     echo "Export KUBECONFIG environment variable: export KUBECONFIG=\"$KUBECONFIG\""
     user_exports="$user_exports"$'\n'"export KUBECONFIG=\"$KUBECONFIG\""

--- a/docs/content/Coding Milestones/PoC2023q1/commands.md
+++ b/docs/content/Coding Milestones/PoC2023q1/commands.md
@@ -949,6 +949,9 @@ This script accepts the following command line flags; all are optional.  The `--
   working directory.  The download of kcp, if any, will go in
   `$install_parent_dir/kcp`.  The download of KubeStellar will go in
   `$install_parent_dir/kubestellar`.
+- `--host-ns $namespace_in_hosting_cluster`: specifies the namespace
+  in the hosting cluster where the core will be deployed. Defaults to
+  "kubestellar".
 - `-V` or `--verbose`: increases the verbosity of output.  This is a
   binary thing, not a matter of degree.
 - `-X`: makes the script `set -x` internally, for debugging.


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
This PR generalizes the bootstrap script to enable control over the hosting cluster namespace where the core gets installed. This includes changing the default to match what the quickstart says to expect. This is the release-0.8 version of #1144 and #1145 .

## Related issue(s)

Fixes #
