### PR TITLE
✨ Make get-internal-kubeconfig fetch mid-level kubeconfig

### DIFF
--- a/outer-scripts/kubectl-kubestellar-get_internal_kubeconfig
+++ b/outer-scripts/kubectl-kubestellar-get_internal_kubeconfig
@@ -24,7 +24,7 @@ kubectl_flags=()
 while (( $# > 0 )); do
     case "$1" in
 	(-h|--help)
-	    echo "Usage: kubectl kubestellar get-external-kubeconfig (\$kubectl_flag | -o \$ouptut_pathname)*"
+	    echo "Usage: kubectl kubestellar get-internal-kubeconfig (\$kubectl_flag | -o \$ouptut_pathname)*"
 	    exit 0;;
 	(-o)
 	    if (( $# >1 ))
@@ -65,4 +65,4 @@ while ! kubectl "${kubectl_flags[@]}" exec $server_pod -c init -- ls /home/kubes
     sleep 10
 done
 
-kubectl "${kubectl_flags[@]}" get secrets kubestellar -o jsonpath='{.data.admin\.kubeconfig}' | base64 -d > $output_pathname
+kubectl "${kubectl_flags[@]}" get secrets kubestellar -o jsonpath='{.data.cluster\.kubeconfig}' | base64 -d > $output_pathname


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
This PR updates the `kubectl kubestellar get-internal-kubeconfig` command to fetch the mid-level kubeconfig --- the one using the kubestellar service name rather than the core Pod IP address. This is more broadly useful, while still being consistent with what the documentation says (vaguely, sigh). This is a backward-compatible change.

This PR also fixes a bug in the help message.

## Related issue(s)

Fixes #
