### PR TITLE
✨ Make apiwatch package reveal definers of resources

### DIFF
--- a/docs/content/Coding Milestones/PoC2023q1/example1-subs/example1-stage-3.md
+++ b/docs/content/Coding Milestones/PoC2023q1/example1-subs/example1-stage-3.md
@@ -171,6 +171,11 @@ metadata:
 spec:
   clusterScope:
   - apiVersion: v1
+    group: apiextensions.k8s.io
+    objects:
+    - crontabs.stable.example.com
+    resource: customresourcedefinitions
+  - apiVersion: v1
     group: apiregistration.k8s.io
     objects:
     - v1090.example.my
@@ -184,6 +189,13 @@ spec:
       - commond
       namespace: commonstuff
     resource: replicasets
+  - apiVersion: v1
+    group: stable.example.com
+    objectsByNamespace:
+    - names:
+      - my-new-cron-object
+      namespace: specialstuff
+    resource: crontabs
   - apiVersion: v1
     group: apps
     objectsByNamespace:

--- a/pkg/apis/meta/v1alpha1/resources.go
+++ b/pkg/apis/meta/v1alpha1/resources.go
@@ -63,6 +63,17 @@ type APIResourceSpec struct {
 	// +listType=map
 	// +listMapKey=Name
 	SubResources []*APIResourceSpec `json:"subResources,omitempty" protobuf:"bytes,10,opt,name=subResources"`
+
+	// definers is the objects that appear to be defining this resource.
+	// Typically 0 or 1 of these.
+	// +optional
+	Definers []Definer `json:"definers,omitempty" protobuf:"bytes,11,opt,name=definers"`
+}
+
+// Definer is a reference to an object that defines a resource.
+type Definer struct {
+	Kind string `json:"kind"`
+	Name string `json:"name"`
 }
 
 // APIResourceList is the API type for a list of APIResource

--- a/pkg/apiwatch/apibindings.go
+++ b/pkg/apiwatch/apibindings.go
@@ -1,0 +1,39 @@
+/*
+Copyright 2023 The KubeStellar Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package apiwatch
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	apisv1alpha1 "github.com/kcp-dev/kcp/pkg/apis/apis/v1alpha1"
+)
+
+type APIBindingAnalyzer struct {
+	ObjectNotifier
+}
+
+func (aba APIBindingAnalyzer) EnumerateDefinedResources(obj any) ResourceDefinitionEnumerator {
+	ab := obj.(*apisv1alpha1.APIBinding)
+	return func(consumer func(metav1.GroupVersionResource)) {
+		for _, bar := range ab.Status.BoundResources {
+			for _, version := range bar.StorageVersions {
+				gvr := metav1.GroupVersionResource{Group: bar.Group, Version: version, Resource: bar.Resource}
+				consumer(gvr)
+			}
+		}
+	}
+}

--- a/pkg/apiwatch/crds.go
+++ b/pkg/apiwatch/crds.go
@@ -1,0 +1,36 @@
+/*
+Copyright 2023 The KubeStellar Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package apiwatch
+
+import (
+	apiext "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+type CRDAnalyzer struct {
+	ObjectNotifier
+}
+
+func (crda CRDAnalyzer) EnumerateDefinedResources(obj any) ResourceDefinitionEnumerator {
+	crd := obj.(*apiext.CustomResourceDefinition)
+	return func(consumer func(metav1.GroupVersionResource)) {
+		for _, version := range crd.Spec.Versions {
+			gvr := metav1.GroupVersionResource{Group: crd.Spec.Group, Version: version.Name, Resource: crd.Status.AcceptedNames.Plural}
+			consumer(gvr)
+		}
+	}
+}

--- a/pkg/apiwatch/definition-tracking.go
+++ b/pkg/apiwatch/definition-tracking.go
@@ -1,0 +1,58 @@
+/*
+Copyright 2023 The KubeStellar Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package apiwatch
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func (rlw *resourcesListWatcher) setDefinerLocked(oid objectID, enumr ResourceDefinitionEnumerator) {
+	oldRscs := ensureMap(rlw.definerToRscs[oid])
+	newRscs := map[metav1.GroupVersionResource]Empty{}
+	rlw.logger.V(4).Info("Start setDefinerLocked", "oid", oid, "oldRscs", oldRscs)
+	enumr(func(gvr metav1.GroupVersionResource) {
+		newRscs[gvr] = Empty{}
+		if _, had := oldRscs[gvr]; !had {
+			definers := ensureMap(rlw.rscToDefiners[gvr])
+			definers[oid] = Empty{}
+			rlw.rscToDefiners[gvr] = definers
+			rlw.logger.V(4).Info("Adding definition", "gvr", gvr, "oid", oid)
+		}
+	})
+	for oldRsc := range oldRscs {
+		if _, have := newRscs[oldRsc]; !have {
+			definers := rlw.rscToDefiners[oldRsc]
+			rlw.logger.V(4).Info("Removing definition", "oldRsc", oldRsc, "oid", oid)
+			delete(definers, oid)
+			if len(definers) == 0 {
+				delete(rlw.rscToDefiners, oldRsc)
+				rlw.logger.V(4).Info("No more definers", "oldRsc", oldRsc)
+			} else {
+				rlw.rscToDefiners[oldRsc] = definers
+			}
+		}
+	}
+	rlw.definerToRscs[oid] = newRscs
+	rlw.logger.V(4).Info("Finish setDefinerLocked", "oid", oid, "newRscs", newRscs)
+}
+
+func ensureMap[Key comparable, Val any](in map[Key]Val) map[Key]Val {
+	if in != nil {
+		return in
+	}
+	return map[Key]Val{}
+}

--- a/pkg/placement/apiwatch-map-provider.go
+++ b/pkg/placement/apiwatch-map-provider.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"sync"
 
+	apiextinformers "k8s.io/apiextensions-apiserver/pkg/client/kcp/informers/externalversions/apiextensions/v1"
 	k8sapierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
@@ -29,7 +30,7 @@ import (
 	"k8s.io/klog/v2"
 
 	clusterdiscovery "github.com/kcp-dev/client-go/discovery"
-	kcpinformers "github.com/kcp-dev/client-go/informers"
+	bindinginformers "github.com/kcp-dev/kcp/pkg/client/informers/externalversions/apis/v1alpha1"
 	"github.com/kcp-dev/logicalcluster/v3"
 
 	ksmetav1a1 "github.com/kubestellar/kubestellar/pkg/apis/meta/v1alpha1"
@@ -41,8 +42,8 @@ import (
 func NewAPIWatchMapProvider(ctx context.Context,
 	numThreads int,
 	discoveryClusterClient clusterdiscovery.DiscoveryClusterInterface,
-	crdClusterPreInformer kcpinformers.GenericClusterInformer,
-	bindingClusterPreInformer kcpinformers.GenericClusterInformer,
+	crdClusterPreInformer apiextinformers.CustomResourceDefinitionClusterInformer,
+	bindingClusterPreInformer bindinginformers.APIBindingClusterInformer,
 ) APIWatchMapProvider {
 	awp := &apiWatchProvider{
 		context:                   ctx,
@@ -65,8 +66,8 @@ type apiWatchProvider struct {
 	context                   context.Context
 	numThreads                int
 	discoveryClusterClient    clusterdiscovery.DiscoveryClusterInterface
-	crdClusterPreInformer     kcpinformers.GenericClusterInformer
-	bindingClusterPreInformer kcpinformers.GenericClusterInformer
+	crdClusterPreInformer     apiextinformers.CustomResourceDefinitionClusterInformer
+	bindingClusterPreInformer bindinginformers.APIBindingClusterInformer
 	queue                     workqueue.RateLimitingInterface
 
 	sync.Mutex


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
This PR extends the apiwatch package so that it can reveal what object(s) define a given resource, when the definer is a CRD or APIBinding.  This PR modifies the cluster-watchall command to exercise the extended functionality.

## Related issue(s)

This lays a foundation for addressing #1064 and #1080
