### PR TITLE
🐛 Set ks_tag to v0.9.0 in docs/mkdocs.yml

### DIFF
--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -8,7 +8,7 @@ docs_url: https://docs.kubestellar.io
 repo_raw_url: https://raw.githubusercontent.com/kubestellar/kubestellar
 edit_uri: edit/main/docs/content
 ks_branch: 'main'
-ks_tag: 'latest'
+ks_tag: 'v0.9.0'
 
 # Site content
 docs_dir: 'content'


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
This PR changes that setting. This var seems to need to hold a release semver. Right now, before this fix, the quickstart docs-ecutable is failing in the `main` branch.

## Related issue(s)
