### PR TITLE
✨ Introduce kubestellar-list-syncing-objects

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -114,7 +114,7 @@ ldflags:
 require-%:
 	@if ! command -v $* 1> /dev/null 2>&1; then echo "$* not found in \$$PATH"; exit 1; fi
 
-build: WHAT ?= ./cmd/kubectl-kubestellar-syncer_gen ./cmd/kubestellar-version ./cmd/kubestellar-where-resolver ./cmd/mailbox-controller ./cmd/placement-translator
+build: WHAT ?= ./cmd/kubectl-kubestellar-syncer_gen ./cmd/kubestellar-version ./cmd/kubestellar-where-resolver ./cmd/mailbox-controller ./cmd/placement-translator ./cmd/kubestellar-list-syncing-objects
 build: require-jq require-go require-git verify-go-versions ## Build all executables
 	GOOS=$(OS) GOARCH=$(ARCH) CGO_ENABLED=0 go build $(BUILDFLAGS) -ldflags="$(LDFLAGS)" -o bin $(WHAT)
 	cp outer-scripts/* bin/
@@ -122,7 +122,7 @@ build: require-jq require-go require-git verify-go-versions ## Build all executa
 	cp inner-scripts/* bin/
 .PHONY: build
 
-userbuild: WHAT ?= ./cmd/kubectl-kubestellar-syncer_gen ./cmd/kubestellar-version
+userbuild: WHAT ?= ./cmd/kubectl-kubestellar-syncer_gen ./cmd/kubestellar-version ./cmd/kubestellar-list-syncing-objects
 userbuild: require-jq require-go require-git verify-go-versions ## Build executables needed by users outside the core image
 	GOOS=$(OS) GOARCH=$(ARCH) CGO_ENABLED=0 go build $(BUILDFLAGS) -ldflags="$(LDFLAGS)" -o bin $(WHAT)
 	cp outer-scripts/* bin/

--- a/cmd/kubestellar-list-syncing-objects/README.md
+++ b/cmd/kubestellar-list-syncing-objects/README.md
@@ -1,0 +1,74 @@
+# kubestellar-list-syncing-objects
+
+This is a simple utility and demo that exercises the mailboxwatch
+package to make and use an informer on a given kind of objects in
+the mailbox workspaces.
+
+This utility/demo can either do a one-shot listing or watch indefinitely.
+When doing a watch, a field is added to each object to indicate the kind
+of notification being presented; the field is named "Action" and its value
+will be either "add", "update", or "delete".
+
+This utility/demo normally outputs YAML but can alternatively output
+JSON, one line per object.
+
+This utility/demo is given two Kubernetes client configurations.
+One, called "all", is for reading the chosen objects from all workspaces.
+The other, called "parent", is for reading the mailbox Workspace objects
+from their parent Workspace.
+
+Aside from the usual, the command line arguments are as follows.
+
+```console
+$ go run ./cmd/kubestellar-list-syncing-objects -h
+Usage of kubestellar-list-syncing-objects:
+...
+      --api-group string                 API group of objects to watch (default is Kubernetes core group)
+      --api-kind string                  kind of objects to watch
+      --api-resource string              API resource (lowercase plural) of objects to watch (defaults to lowercase(kind)+'s')
+      --api-version string               API version (just version, no group) of objects to watch (default "v1")
+      --json                             indicates whether to output as lines of JSON rather than YAML
+      --watch                            indicates whether to inform rather than just list
+...
+      --all-cluster string               The name of the kubeconfig cluster to use for access to the chosen objects in all clusters
+      --all-context string               The name of the kubeconfig context to use for access to the chosen objects in all clusters (default "system:admin")
+      --all-kubeconfig string            Path to the kubeconfig file to use for access to the chosen objects in all clusters
+      --all-user string                  The name of the kubeconfig user to use for access to the chosen objects in all clusters
+...
+      --parent-cluster string              The name of the kubeconfig cluster to use for access to the parent of mailbox workspaces
+      --parent-context string            The name of the kubeconfig context to use for access to the parent of mailbox workspaces (default "root")
+      --parent-kubeconfig string           Path to the kubeconfig file to use for access to the parent of mailbox workspaces
+      --parent-user string                 The name of the kubeconfig user to use for access to the parent of mailbox workspaces
+...
+pflag: help requested
+exit status 2
+```
+
+Following is an example of its usage.
+
+```console
+$ go run ./cmd/kubestellar-list-syncing-objects --api-group apps --api-kind ReplicaSet
+---
+apiVersion: apps/v1
+kind: ReplicaSet
+metadata:
+...
+status:
+  availableReplicas: 1
+  fullyLabeledReplicas: 1
+  observedGeneration: 1
+  readyReplicas: 1
+  replicas: 1
+
+---
+apiVersion: apps/v1
+kind: ReplicaSet
+metadata:
+...
+status:
+  availableReplicas: 1
+  fullyLabeledReplicas: 1
+  observedGeneration: 1
+  readyReplicas: 1
+  replicas: 1
+```

--- a/cmd/kubestellar-list-syncing-objects/main.go
+++ b/cmd/kubestellar-list-syncing-objects/main.go
@@ -1,0 +1,180 @@
+/*
+Copyright 2023 The KubeStellar Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+// Import of k8s.io/client-go/plugin/pkg/client/auth ensures
+// that all in-tree Kubernetes client auth plugins
+// (e.g. Azure, GCP, OIDC, etc.)  are available.
+
+import (
+	"context"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"os"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/spf13/pflag"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	machschema "k8s.io/apimachinery/pkg/runtime/schema"
+	k8sdynamic "k8s.io/client-go/dynamic"
+	_ "k8s.io/client-go/plugin/pkg/client/auth"
+	upstreamcache "k8s.io/client-go/tools/cache"
+	_ "k8s.io/component-base/metrics/prometheus/clientgo"
+	"k8s.io/klog/v2"
+	"sigs.k8s.io/yaml"
+
+	kcpdynamic "github.com/kcp-dev/client-go/dynamic"
+	kcpscopedclient "github.com/kcp-dev/kcp/pkg/client/clientset/versioned"
+	kcpinformers "github.com/kcp-dev/kcp/pkg/client/informers/externalversions"
+
+	clientopts "github.com/kubestellar/kubestellar/pkg/client-options"
+	"github.com/kubestellar/kubestellar/pkg/mailboxwatch"
+)
+
+const mainName = "kubestellar-list-syncing-objects"
+
+var watch bool
+var outputJson bool
+
+func main() {
+	fs := pflag.NewFlagSet(mainName, pflag.ExitOnError)
+	gvr := machschema.GroupVersionResource{Version: "v1"}
+	var kind string
+	klog.InitFlags(flag.CommandLine)
+	fs.AddGoFlagSet(flag.CommandLine)
+
+	fs.StringVar(&gvr.Group, "api-group", gvr.Group, "API group of objects to watch (default is Kubernetes core group)")
+	fs.StringVar(&gvr.Version, "api-version", gvr.Version, "API version (just version, no group) of objects to watch")
+	fs.StringVar(&gvr.Resource, "api-resource", gvr.Resource, "API resource (lowercase plural) of objects to watch (defaults to lowercase(kind)+'s')")
+	fs.StringVar(&kind, "api-kind", kind, "kind of objects to watch")
+	fs.BoolVar(&watch, "watch", watch, "indicates whether to inform rather than just list")
+	fs.BoolVar(&outputJson, "json", outputJson, "indicates whether to output as lines of JSON rather than YAML")
+
+	parentClientOpts := clientopts.NewClientOpts("parent", "access to the parent of mailbox workspaces")
+	parentClientOpts.SetDefaultCurrentContext("root")
+	parentClientOpts.AddFlags(fs)
+
+	allClientOpts := clientopts.NewClientOpts("all", "access to the chosen objects in all clusters")
+	allClientOpts.SetDefaultCurrentContext("system:admin")
+	allClientOpts.AddFlags(fs)
+
+	fs.Parse(os.Args[1:])
+
+	ctx := context.Background()
+	logger := klog.Background()
+	ctx = klog.NewContext(ctx, logger)
+
+	if len(kind) == 0 {
+		logger.Error(nil, "The --kind must not be the empty string")
+	}
+	if len(gvr.Resource) == 0 {
+		gvr.Resource = strings.ToLower(kind) + "s"
+	}
+
+	parentClientConfig, err := parentClientOpts.ToRESTConfig()
+	if err != nil {
+		logger.Error(err, "failed to make parent client config")
+		os.Exit(2)
+	}
+	parentClientConfig.UserAgent = mainName
+
+	parentClient := kcpscopedclient.NewForConfigOrDie(parentClientConfig)
+
+	allClientConfig, err := allClientOpts.ToRESTConfig()
+	if err != nil {
+		logger.Error(err, "failed to make all-cluster client config")
+		os.Exit(2)
+	}
+	allClientConfig.UserAgent = mainName
+
+	dynamicClusterClientset, err := kcpdynamic.NewForConfig(allClientConfig)
+	if err != nil {
+		logger.Error(err, "failed to make all-cluster dynamic client")
+		os.Exit(3)
+	}
+	dynamicClusterResource := dynamicClusterClientset.Resource(gvr)
+
+	listGVK := machschema.GroupVersionKind{Group: gvr.Group,
+		Version: gvr.Version,
+		Kind:    kind + "List"}
+
+	exampleObj := &unstructured.Unstructured{}
+	exampleObj.SetAPIVersion(gvr.GroupVersion().String())
+	exampleObj.SetKind(kind)
+
+	parentInformerFactory := kcpinformers.NewSharedScopedInformerFactory(parentClient, 0, "")
+	mbPreInformer := parentInformerFactory.Tenancy().V1alpha1().Workspaces()
+
+	informer := mailboxwatch.NewSharedInformer[k8sdynamic.NamespaceableResourceInterface, *unstructured.UnstructuredList](ctx, listGVK, mbPreInformer, dynamicClusterResource, exampleObj, 0, upstreamcache.Indexers{})
+
+	informer.AddEventHandler(upstreamcache.ResourceEventHandlerFuncs{
+		AddFunc:    func(obj any) { log(logger, "add", obj) },
+		UpdateFunc: func(oldObj, newObj any) { log(logger, "update", newObj) },
+		DeleteFunc: func(obj any) { log(logger, "delete", obj) },
+	})
+	parentInformerFactory.Start(ctx.Done())
+	upstreamcache.WaitForCacheSync(ctx.Done(), mbPreInformer.Informer().HasSynced)
+	go informer.Run(ctx.Done())
+	logger.V(2).Info("Running", "group", gvr.Group, "version", gvr.Version, "resource", gvr.Resource, "kind", kind)
+	if watch {
+		<-ctx.Done()
+	} else {
+		if !upstreamcache.WaitForCacheSync(ctx.Done(),
+			informer.HasSynced) {
+			logger.Error(nil, "Impossible")
+		}
+		time.Sleep(15 * time.Second)
+	}
+}
+
+var logmu sync.Mutex
+
+func log(logger klog.Logger, action string, obj any) {
+	objU := obj.(*unstructured.Unstructured)
+	logmu.Lock()
+	defer logmu.Unlock()
+	objData := objU.UnstructuredContent()
+	outData := objData
+	if watch {
+		outData = map[string]any{"Action": action}
+		for key, val := range objData {
+			outData[key] = val
+		}
+	}
+	objJ, err := json.Marshal(outData)
+	if err != nil {
+		logger.Error(err, "Failed to marshal as JSON", "outData", outData)
+		return
+	}
+	if outputJson {
+		objJS := string(objJ)
+		fmt.Println(objJS)
+		return
+	}
+	objY, err := yaml.JSONToYAML(objJ)
+	if err != nil {
+		logger.Error(err, "Failed to convert JSON to YAML", "objJ", objJ)
+		return
+	}
+	fmt.Println("---")
+	objYS := string(objY)
+	fmt.Println(objYS)
+}

--- a/docs/content/Coding Milestones/PoC2023q1/commands.md
+++ b/docs/content/Coding Milestones/PoC2023q1/commands.md
@@ -927,6 +927,83 @@ kubectl kubestellar remove wmw demo1
 Current workspace is "root".
 ```
 
+## kubestellar-list-syncing-objects
+
+The `kubestellar-list-syncing-objects` command will list or watch one
+kind of objects in the mailbox spaces. These are full (not summarized)
+workload objects in the intermediate place between WDSes and WECs,
+participating in downsync or upsync. The user of this command is not
+very exposed to the mailbox spaces themselves; the command is directed
+at the whole of this intermediate place and lists all of the requested
+kind of objects there. The kind of objects to list/watch is given by
+command line flags. In general the user has to also give the
+"resource" that is roughly equivalent to the "kind", but that can be
+defaulted in the easy case.
+
+The output is suitable for piping to `jq` or `yq`. In the JSON case,
+the output is one object per line (not pretty-printed). The default is
+to output YAML.
+
+This command will either do a one-shot listing or an ongoing
+list+watch. In the latter case each object is extended with a field
+named `Action` having a value of either `add`, `update`, or `delete`.
+
+This command is given two Kubernetes client configurations.  One,
+called "all", is for reading the chosen objects from all workspaces.
+The other, called "parent", is for reading the mailbox Workspace
+objects from their parent Workspace.
+
+Following are the command line flags beyond the baseline golang flags.
+
+```shell
+      --api-group string                 API group of objects to watch (default is Kubernetes core group)
+      --api-kind string                  kind of objects to watch
+      --api-resource string              API resource (lowercase plural) of objects to watch (defaults to lowercase(kind)+'s')
+      --api-version string               API version (just version, no group) of objects to watch (default "v1")
+      --json                             indicates whether to output as lines of JSON rather than YAML
+      --watch                            indicates whether to inform rather than just list
+...
+      --all-cluster string               The name of the kubeconfig cluster to use for access to the chosen objects in all clusters
+      --all-context string               The name of the kubeconfig context to use for access to the chosen objects in all clusters (default "system:admin")
+      --all-kubeconfig string            Path to the kubeconfig file to use for access to the chosen objects in all clusters
+      --all-user string                  The name of the kubeconfig user to use for access to the chosen objects in all clusters
+...
+      --parent-cluster string              The name of the kubeconfig cluster to use for access to the parent of mailbox workspaces
+      --parent-context string            The name of the kubeconfig context to use for access to the parent of mailbox workspaces (default "root")
+      --parent-kubeconfig string           Path to the kubeconfig file to use for access to the parent of mailbox workspaces
+      --parent-user string                 The name of the kubeconfig user to use for access to the parent of mailbox workspaces
+```
+
+Following is an example of its usage; the elipses show where this
+document omits many lines for brevity.
+
+```console
+$ kubestellar-list-syncing-objects --api-group apps --api-kind ReplicaSet
+---
+apiVersion: apps/v1
+kind: ReplicaSet
+metadata:
+...
+status:
+  availableReplicas: 1
+  fullyLabeledReplicas: 1
+  observedGeneration: 1
+  readyReplicas: 1
+  replicas: 1
+
+---
+apiVersion: apps/v1
+kind: ReplicaSet
+metadata:
+...
+status:
+  availableReplicas: 1
+  fullyLabeledReplicas: 1
+  observedGeneration: 1
+  readyReplicas: 1
+  replicas: 1
+```
+
 ## Bootstrap
 
 This is a combination of some installation and setup steps, for use in


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
This PR adds a demo/utility command that lists or watches the objects of a given kind in the mailbox workspaces.

Example usage:
```
kubestellar-list-mid-dynamic --api-group apps --api-kind ReplicaSet
```

## Related issue(s)

Fixes #
