### PR TITLE
✨ Allow IP address instead of domain name as external hostname

### DIFF
--- a/inner-scripts/kubestellar-ensure-kcp-server-creds
+++ b/inner-scripts/kubestellar-ensure-kcp-server-creds
@@ -3,9 +3,11 @@
 # Usage: $0 dns-name
 
 # This makes a TLS server certificate and private key.
-# The uses, creating if necessary, a PKI and CA at $PWD/pki.
-# The cert has one SubjectAlternativeName: a DNS form one
-# using the given domain name.
+# This uses, creating if necessary, a PKI and CA at $PWD/pki.
+# The cert has one SubjectAlternativeName, taken from the command line
+# in openssl syntax (e.g., "IP:1.2.3.4").
+# If there is no scheme part in the given name then it is assumed to be
+# a domain name and "DNS:" is implicitly added.
 # This script prints one line that parses as three bash words:
 # the first holds the absolute pathname of the CA's public cert,
 # the second holds the absolute pathname of the server cert,
@@ -13,7 +15,7 @@
 # Join the last two with a comma and give that value to the `--tls-sni-cert-key`
 # command line flag of a kcp or plain kube apiserver.
 # Also edit the dns-name and CA cert into kube client config,
-# to make that client connect to that domain name and verify
+# to make that client connect to that subject name and verify
 # the server's cert against that CA.
 
 if [ $# != 1 ]; then
@@ -25,10 +27,14 @@ set -e
 set -o pipefail
 
 this="$0"
-domain="$1"
+SAN="$1"
 
-if [ $(wc -w <<<$domain) != 1 ]; then
-    echo "$0: the given domain name must be one word" >&2
+if ! [[ "$SAN" =~ .*:.* ]]; then
+	SAN="DNS:$SAN"
+fi
+
+if [ $(wc -w <<<$SAN) != 1 ]; then
+    echo "$0: the given SubjectAlternativeName must be one word" >&2
     exit 2
 fi
 
@@ -38,12 +44,11 @@ export EASYRSA_PKI=${PWD}/pki
 
 need=true
 
-if ! domhash=$(sha256sum <<<"$domain" 2> /dev/null | awk '{ print $1 }')
-then domhash=$(shasum -a 256 <<<"$domain" | awk '{ print $1 }')
+if ! sanhash=$(sha256sum <<<"$SAN" 2> /dev/null | awk '{ print $1 }')
+then sanhash=$(shasum -a 256 <<<"$SAN" | awk '{ print $1 }')
 fi
 
-#FILE_NAME_BASE="kcp-DNS-$domain"
-FILE_NAME_BASE="kcp-server-${domhash:1:33}"
+FILE_NAME_BASE="kcp-server-${sanhash:1:33}"
 
 cacert="${PWD}/pki/ca.crt"
 svrcert="${PWD}/pki/issued/${FILE_NAME_BASE}.crt"
@@ -54,16 +59,16 @@ if [ -r "$svrcert" ] && [ -r "$svrkey" ]; then
     if oldsan=$(easyrsa show-cert $FILE_NAME_BASE |
 		    grep -A1 'X509v3 Subject Alternative Name' |
 		    tail -1 | awk '{ print $1 }'); then
-	if [ "$oldsan" == "DNS:$domain" ]
-	then echo Accepting existing credentials >&2
+		if [ "$oldsan" == "$SAN" ]
+		then echo Accepting existing credentials >&2
 	     need=false
-	else echo Rejecting existing credentials with SAN ${oldsan@Q} >&2
-	fi
+		else echo Rejecting existing credentials with SAN ${oldsan@Q} >&2
+		fi
     fi
 fi
 
 if [ "$need" == "true" ];
-then ${this%ensure-kcp-server-creds}make-kcp-server-cert "$FILE_NAME_BASE" "DNS:$domain" >&2
+then ${this%ensure-kcp-server-creds}make-kcp-server-cert "$FILE_NAME_BASE" "$SAN" >&2
 fi
 
 echo ${cacert@Q} ${svrcert@Q} ${svrkey@Q}

--- a/inner-scripts/switch-domain
+++ b/inner-scripts/switch-domain
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# Usage: $0 inpath outpath context domain port
+# Usage: $0 inpath outpath context host port cacert_file
 
 # Reads a kubeconfig file from $inpath and writes a modified
 # kubeconfig file on $outpath.
@@ -9,7 +9,7 @@
 # matched that of the cluster of the given context.
 
 if [ $# != 6 ]; then
-   echo "Usage: $0 inpath outpath context domain port cacert_file" >&2
+   echo "Usage: $0 inpath outpath context host port cacert_file" >&2
    exit 1
 fi
 
@@ -22,7 +22,7 @@ outpath="$1"
 shift
 context=$1
 shift
-domain=$1
+host=$1
 shift
 port=$1
 shift
@@ -46,7 +46,7 @@ protocol=$(cut -d: -f1 <<<$protourl)
 authpath=$(cut -d: -f2- <<<$protourl)
 authority=${protocol}:$(cut -d/ -f1-3 <<<$authpath)
 authpat="^"$(sed 's/\./\\./g' <<<$authority)
-replacement="${protocol}://${domain}:${port}"
+replacement="${protocol}://${host}:${port}"
 
 export authpat replacement cacert
 

--- a/inner-scripts/wait-and-switch-domain
+++ b/inner-scripts/wait-and-switch-domain
@@ -1,9 +1,7 @@
 #!/usr/bin/env bash
 
 # Waits for kube server to be running then produces an alternate kubeconfig.
-# The alternate kubeconfig goes in a directory whose name equals
-# the name of the original's directory extended with a dash and
-# the given domain name.
+# The input and output pathnames are the first two arguments.
 # The alternate kubeconfig equals the given kubeconfig except for
 # the replacement of the protocol://host:port prefix of some
 # `server` fields in some `cluster` values.
@@ -11,7 +9,7 @@
 # originally equaled the prefix of the cluster of the given context.
 
 if [ $# != 6 ]; then
-   echo "Usage: $0 inpath outpath context domain port cacert" >&2
+   echo "Usage: $0 inpath outpath context host port cacert" >&2
    exit 1
 fi
 
@@ -25,7 +23,7 @@ outpath="$1"
 shift
 context="$1"
 shift
-domain="$1"
+host="$1"
 shift
 port="$1"
 shift
@@ -35,4 +33,4 @@ while ! kubectl --kubeconfig "$inpath" get ns &> /dev/null; do
       sleep 10
 done
 
-${this%wait-and-switch-domain}switch-domain "$inpath" "$outpath" "$context" "$domain" "$port" "$cacert_file"
+${this%wait-and-switch-domain}switch-domain "$inpath" "$outpath" "$context" "$host" "$port" "$cacert_file"

--- a/outer-scripts/kubectl-kubestellar-deploy
+++ b/outer-scripts/kubectl-kubestellar-deploy
@@ -16,7 +16,7 @@
 
 # Purpose: deploy the KubeStellar Helm chart
 
-# Usage: $0 (--external-endpoint $domain_name:$port | --openshift $bool | -X | kubectl_flag)*
+# Usage: $0 (--external-endpoint $host:$port | --openshift $bool | -X | kubectl_flag)*
 
 KSDIR=$(cd -- $(dirname $(realpath ${BASH_SOURCE[0]})); cd ..; pwd)
 
@@ -29,7 +29,7 @@ helm_flags=()
 while (( $# > 0 )); do
     case "$1" in
 	(-h|--help)
-	    echo "Usage: kubectl kubestellar deploy (\$kubectl_flag | --external_endpoint \$domain_name:$port | --openshift \$boolean)*"
+	    echo "Usage: kubectl kubestellar deploy (\$kubectl_flag | --external_endpoint \$host:$port | --openshift \$boolean)*"
 	    exit 0;;
 	(--external-endpoint)
 	    if (( $# >1 ))


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
This PR generalizes the generation of external kubeconfigs to allow for the possibility of using an IP address rather than a domain name to identify where the hosting cluster's Ingress controller is listening.

This PR also does a few updates that should have been done a long time ago.

## Related issue(s)

Fixes #
