### PR TITLE
🐛 Fix stupid typos

### DIFF
--- a/pkg/placement/workload-projector.go
+++ b/pkg/placement/workload-projector.go
@@ -1140,7 +1140,7 @@ func (wp *workloadProjector) xformForDestination(sourceCluster logicalcluster.Na
 	logger := klog.FromContext(wp.ctx).WithValues(
 		"sourceCluster", sourceCluster,
 		"destSP", destSP,
-		"destGVK", srcObjU.GroupVersionKind,
+		"destGVK", srcObjU.GroupVersionKind(),
 		"namespace", srcObj.GetNamespace(),
 		"name", srcObj.GetName())
 	srcObjU = wp.customizeOrCopy(logger, sourceCluster, srcObjU, destSP, true)
@@ -1169,7 +1169,7 @@ func (wp *workloadProjector) genericObjectMerge(sourceCluster logicalcluster.Nam
 	logger := klog.FromContext(wp.ctx).WithValues(
 		"sourceCluster", sourceCluster,
 		"destSP", destSP,
-		"destGVK", srcObjU.GroupVersionKind,
+		"destGVK", srcObjU.GroupVersionKind(),
 		"namespace", srcObj.GetNamespace(),
 		"name", srcObj.GetName())
 	srcObjU = wp.customizeOrCopy(logger, sourceCluster, srcObjU, destSP, false)


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
This PR fixes a couple of typos that cause log messages to hold the hex value of a function rather than the (intended) result of calling the function.

## Related issue(s)

Fixes #
