### PR TITLE
:bug:fix syncer bootstrap manifests to change names like container name from kcp to kubestellar

### DIFF
--- a/pkg/cliplugins/kubestellar/syncer-gen/edgesync_test.go
+++ b/pkg/cliplugins/kubestellar/syncer-gen/edgesync_test.go
@@ -33,22 +33,22 @@ metadata:
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: kcp-syncer-sync-target-name-34b23c4k
+  name: kubestellar-syncer-sync-target-name-34b23c4k
   namespace: kubestellar-syncer-sync-target-name-34b23c4k
 ---
 apiVersion: v1
 kind: Secret
 metadata:
-  name: kcp-syncer-sync-target-name-34b23c4k-token
+  name: kubestellar-syncer-sync-target-name-34b23c4k-token
   namespace: kubestellar-syncer-sync-target-name-34b23c4k
   annotations:
-    kubernetes.io/service-account.name: kcp-syncer-sync-target-name-34b23c4k
+    kubernetes.io/service-account.name: kubestellar-syncer-sync-target-name-34b23c4k
 type: kubernetes.io/service-account-token
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: kcp-syncer-sync-target-name-34b23c4k
+  name: kubestellar-syncer-sync-target-name-34b23c4k
 rules:
 - apiGroups:
   - "rbac.authorization.k8s.io"
@@ -67,20 +67,20 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: kcp-syncer-sync-target-name-34b23c4k
+  name: kubestellar-syncer-sync-target-name-34b23c4k
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: kcp-syncer-sync-target-name-34b23c4k
+  name: kubestellar-syncer-sync-target-name-34b23c4k
 subjects:
 - kind: ServiceAccount
-  name: kcp-syncer-sync-target-name-34b23c4k
+  name: kubestellar-syncer-sync-target-name-34b23c4k
   namespace: kubestellar-syncer-sync-target-name-34b23c4k
 ---
 apiVersion: v1
 kind: Secret
 metadata:
-  name: kcp-syncer-sync-target-name-34b23c4k
+  name: kubestellar-syncer-sync-target-name-34b23c4k
   namespace: kubestellar-syncer-sync-target-name-34b23c4k
 stringData:
   kubeconfig: |
@@ -95,7 +95,7 @@ stringData:
     - name: default-context
       context:
         cluster: default-cluster
-        namespace: kcp-namespace
+        namespace: kubestellar-namespace
         user: default-user
     current-context: default-context
     users:
@@ -106,7 +106,7 @@ stringData:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: kcp-syncer-sync-target-name-34b23c4k
+  name: kubestellar-syncer-sync-target-name-34b23c4k
   namespace: kubestellar-syncer-sync-target-name-34b23c4k
 spec:
   replicas: 1
@@ -114,18 +114,18 @@ spec:
     type: Recreate
   selector:
     matchLabels:
-      app: kcp-syncer-sync-target-name-34b23c4k
+      app: kubestellar-syncer-sync-target-name-34b23c4k
   template:
     metadata:
       labels:
-        app: kcp-syncer-sync-target-name-34b23c4k
+        app: kubestellar-syncer-sync-target-name-34b23c4k
     spec:
       containers:
-      - name: kcp-syncer
+      - name: kubestellar-syncer
         command:
         - /ko-app/syncer
         args:
-        - --from-kubeconfig=/kcp/kubeconfig
+        - --from-kubeconfig=/kubestellar/kubeconfig
         - --sync-target-name=sync-target-name
         - --sync-target-uid=sync-target-uid
         - --qps=123.4
@@ -140,14 +140,14 @@ spec:
         imagePullPolicy: IfNotPresent
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
-        - name: kcp-config
-          mountPath: /kcp/
+        - name: kubestellar-config
+          mountPath: /kubestellar/
           readOnly: true
-      serviceAccountName: kcp-syncer-sync-target-name-34b23c4k
+      serviceAccountName: kubestellar-syncer-sync-target-name-34b23c4k
       volumes:
-        - name: kcp-config
+        - name: kubestellar-config
           secret:
-            secretName: kcp-syncer-sync-target-name-34b23c4k
+            secretName: kubestellar-syncer-sync-target-name-34b23c4k
             optional: false
 `
 
@@ -155,7 +155,7 @@ spec:
 		ServerURL:     "server-url",
 		Token:         "token",
 		CAData:        "ca-data",
-		KCPNamespace:  "kcp-namespace",
+		KCPNamespace:  "kubestellar-namespace",
 		Namespace:     "kubestellar-syncer-sync-target-name-34b23c4k",
 		SyncTarget:    "sync-target-name",
 		SyncTargetUID: "sync-target-uid",
@@ -163,7 +163,7 @@ spec:
 		Replicas:      1,
 		QPS:           123.4,
 		Burst:         456,
-	}, "kcp-syncer-sync-target-name-34b23c4k")
+	}, "kubestellar-syncer-sync-target-name-34b23c4k")
 	require.NoError(t, err)
 	require.Empty(t, cmp.Diff(expectedYAML, string(actualYAML)))
 }

--- a/pkg/cliplugins/kubestellar/syncer-gen/kubestellar-syncer.yaml
+++ b/pkg/cliplugins/kubestellar/syncer-gen/kubestellar-syncer.yaml
@@ -105,11 +105,11 @@ spec:
         app: {{.DeploymentApp}}
     spec:
       containers:
-      - name: kcp-syncer
+      - name: kubestellar-syncer
         command:
         - /ko-app/syncer
         args:
-        - --from-kubeconfig=/kcp/{{.SecretConfigKey}}
+        - --from-kubeconfig=/kubestellar/{{.SecretConfigKey}}
         - --sync-target-name={{.SyncTarget}}
         - --sync-target-uid={{.SyncTargetUID}}
         - --qps={{.QPS}}
@@ -124,12 +124,12 @@ spec:
         imagePullPolicy: IfNotPresent
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
-        - name: kcp-config
-          mountPath: /kcp/
+        - name: kubestellar-config
+          mountPath: /kubestellar/
           readOnly: true
       serviceAccountName: {{.ServiceAccount}}
       volumes:
-        - name: kcp-config
+        - name: kubestellar-config
           secret:
             secretName: {{.Secret}}
             optional: false

--- a/pkg/syncer/scripts/kubestellar-syncer-bootstrap.template.yaml
+++ b/pkg/syncer/scripts/kubestellar-syncer-bootstrap.template.yaml
@@ -95,11 +95,11 @@ spec:
         app: ${syncer_id}
     spec:
       containers:
-      - name: kcp-syncer
+      - name: kubestellar-syncer
         command:
         - /ko-app/syncer
         args:
-        - --from-kubeconfig=/kcp/kubeconfig
+        - --from-kubeconfig=/kubestellar/kubeconfig
         - --sync-target-name=${syncer_id}
         - --sync-target-uid=${syncer_id}
         - --qps=30
@@ -114,12 +114,12 @@ spec:
         imagePullPolicy: IfNotPresent
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
-        - name: kcp-config
-          mountPath: /kcp/
+        - name: kubestellar-config
+          mountPath: /kubestellar/
           readOnly: true
       serviceAccountName: ${syncer_id}
       volumes:
-        - name: kcp-config
+        - name: kubestellar-config
           secret:
             secretName: ${syncer_id}
             optional: false


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

Old name is still used in the syncer bootstrap manifest (e.g. container name). I fixed it to display the name as "kubestellar".  

## Verification

Before:
- "kcp" appears somewhere (`name: kcp-syncer` is the field for container name)
    ```
    $ KUBECONFIG=~/.kube/config kubectl --context kind-florin get pod -n kubestellar-syncer-florin-q8lheni0 kubestellar-syncer-florin-q8lheni0-599855f7c4-t5jq7 -o yaml | grep kcp
        - --from-kubeconfig=/kcp/kubeconfig
        name: kcp-syncer
        - mountPath: /kcp/
          name: kcp-config
      - name: kcp-config
    ```

After
- no longer appears
    ```
    $ KUBECONFIG=~/.kube/config kubectl --context kind-florin get pod -n kubestellar-syncer-florin-1zgupzpd kubestellar-syncer-florin-1zgupzpd-5c77df59fc-nwn69 -o yaml | grep kcp
    ```

- the container name
    ```
    $ KUBECONFIG=~/.kube/config kubectl --context kind-florin get pod -n kubestellar-syncer-florin-1zgupzpd kubestellar-syncer-florin-1zgupzpd-5c77df59fc-nwn69 -o json | jq '.spec.containers[0].name'
    "kubestellar-syncer"
    ```

#### No regression
I verified no regression by executing the regular workflow (example1.md). Everything to be synced are properly synced.

```
$ KUBECONFIG=~/.kube/config kubectl --context kind-florin get pod,rs -A | grep -v kube-system
NAMESPACE                            NAME                                                      READY   STATUS    RESTARTS   AGE
commonstuff                          pod/commond-mmbv8                                         1/1     Running   0          3m53s
kubestellar-syncer-florin-1zgupzpd   pod/kubestellar-syncer-florin-1zgupzpd-5c77df59fc-nwn69   1/1     Running   0          4m24s
local-path-storage                   pod/local-path-provisioner-6bc4bddd6b-k7n2x               1/1     Running   0          6m54s

NAMESPACE                            NAME                                                            DESIRED   CURRENT   READY   AGE
commonstuff                          replicaset.apps/commond                                         1         1         1       3m53s
kubestellar-syncer-florin-1zgupzpd   replicaset.apps/kubestellar-syncer-florin-1zgupzpd-5c77df59fc   1         1         1       4m24s
local-path-storage                   replicaset.apps/local-path-provisioner-6bc4bddd6b               1         1         1       6m55s
```

```
$ KUBECONFIG=~/.kube/config kubectl --context kind-guilder get pod,rs -A | grep -v kube-system
NAMESPACE                             NAME                                                       READY   STATUS    RESTARTS   AGE
commonstuff                           pod/commond-dccxw                                          1/1     Running   0          73s
kubestellar-syncer-guilder-2bu4c79u   pod/kubestellar-syncer-guilder-2bu4c79u-7b4b7d8f4c-6sxfl   1/1     Running   0          108s
local-path-storage                    pod/local-path-provisioner-6bc4bddd6b-dwt7h                1/1     Running   0          6m18s
specialstuff                          pod/speciald-76f6fc4cfc-4lwr6                              1/1     Running   0          90s

NAMESPACE                             NAME                                                             DESIRED   CURRENT   READY   AGE
commonstuff                           replicaset.apps/commond                                          1         1         1       73s
kubestellar-syncer-guilder-2bu4c79u   replicaset.apps/kubestellar-syncer-guilder-2bu4c79u-7b4b7d8f4c   1         1         1       108s
local-path-storage                    replicaset.apps/local-path-provisioner-6bc4bddd6b                1         1         1       6m18s
specialstuff                          replicaset.apps/speciald-76f6fc4cfc                              1         1         1       90s
```
## Related issue(s)

Fixes #1189
