### PR TITLE
🐛 Update openshift quickstart to authorize workload on OpenShift

### DIFF
--- a/docs/content/Getting-Started/user-quickstart-kind.md
+++ b/docs/content/Getting-Started/user-quickstart-kind.md
@@ -150,9 +150,9 @@ manifest_name: 'docs/content/Getting-Started/user-quickstart-kind.md'
 !!! tip ""
     === "deploy"
          {%
-           include-markdown "../common-subs/kubestellar-apply-apache.md"
-           start="<!--kubestellar-apply-apache-start-->"
-           end="<!--kubestellar-apply-apache-end-->"
+           include-markdown "../common-subs/kubestellar-apply-apache-kind.md"
+           start="<!--kubestellar-apply-apache-kind-start-->"
+           end="<!--kubestellar-apply-apache-kind-end-->"
          %}
 
 #### 6. View the Apache Web Server running on ks-edge-cluster1 and ks-edge-cluster2
@@ -244,9 +244,9 @@ how to create, but not overrite/update a synchronized resource
 !!! tip ""
     === "deploy"
          {%
-           include-markdown "../common-subs/kubestellar-apply-apache.md"
-           start="<!--kubestellar-apply-apache-start-->"
-           end="<!--kubestellar-apply-apache-end-->"
+           include-markdown "../common-subs/kubestellar-apply-apache-kind.md"
+           start="<!--kubestellar-apply-apache-kind-start-->"
+           end="<!--kubestellar-apply-apache-kind-end-->"
          %}
 
 #### 4. View the Apache Web Server running on ks-edge-cluster1 and ks-edge-cluster2

--- a/docs/content/Getting-Started/user-quickstart-openshift.md
+++ b/docs/content/Getting-Started/user-quickstart-openshift.md
@@ -110,9 +110,9 @@ manifest_name: 'docs/content/Getting-Started/user-quickstart-openshift.md'
 !!! tip ""
     === "deploy"
          {%
-           include-markdown "../common-subs/kubestellar-apply-apache.md"
-           start="<!--kubestellar-apply-apache-start-->"
-           end="<!--kubestellar-apply-apache-end-->"
+           include-markdown "../common-subs/kubestellar-apply-apache-openshift.md"
+           start="<!--kubestellar-apply-apache-openshift-start-->"
+           end="<!--kubestellar-apply-apache-openshift-end-->"
          %}
 
 #### 6. View the Apache Web Server running on ks-edge-cluster1 and ks-edge-cluster2
@@ -190,9 +190,9 @@ how to create, but not overrite/update a synchronized resource
 !!! tip ""
     === "deploy"
          {%
-           include-markdown "../common-subs/kubestellar-apply-apache.md"
-           start="<!--kubestellar-apply-apache-start-->"
-           end="<!--kubestellar-apply-apache-end-->"
+           include-markdown "../common-subs/kubestellar-apply-apache-openshift.md"
+           start="<!--kubestellar-apply-apache-openshift-start-->"
+           end="<!--kubestellar-apply-apache-openshift-end-->"
          %}
 
 #### 4. View the Apache Web Server running on ks-edge-cluster1 and ks-edge-cluster2

--- a/docs/content/common-subs/kubestellar-apply-apache-kind.md
+++ b/docs/content/common-subs/kubestellar-apply-apache-kind.md
@@ -1,4 +1,4 @@
-<!--kubestellar-apply-apache-start-->
+<!--kubestellar-apply-apache-kind-start-->
 KubeStellar's helm chart automatically creates a Workload Management
 Workspace (WMW) for you to store kubernetes workload descriptions and KubeStellar control objects in. The automatically created WMW is at `root:wmw1`.
 
@@ -99,4 +99,4 @@ KUBECONFIG=ks-core.kubeconfig kubectl get deployments/my-first-kubestellar-deplo
 KUBECONFIG=ks-core.kubeconfig kubectl get deployments,cm -n my-namespace
 ```
 
-<!--kubestellar-apply-apache-end-->
+<!--kubestellar-apply-apache-kind-end-->

--- a/docs/content/common-subs/kubestellar-apply-apache-openshift.md
+++ b/docs/content/common-subs/kubestellar-apply-apache-openshift.md
@@ -1,0 +1,123 @@
+<!--kubestellar-apply-apache-openshift-start-->
+KubeStellar's helm chart automatically creates a Workload Management
+Workspace (WMW) for you to store kubernetes workload descriptions and KubeStellar control objects in. The automatically created WMW is at `root:wmw1`.
+
+Create an EdgePlacement control object to direct where your workload runs using the 'location-group=edge' label selector. This label selector's value ensures your workload is directed to both clusters, as they were labeled with 'location-group=edge' when you issued the 'kubestellar prep-for-cluster' command above.
+
+This EdgePlacement includes downsync of a `RoleBinding` that grants
+privileges that let the httpd pod run in an OpenShift cluster.
+
+In the `root:wmw1` workspace create the following `EdgePlacement` object: 
+```shell hl_lines="9 10 14 18 19"
+KUBECONFIG=ks-core.kubeconfig kubectl ws root:wmw1
+
+KUBECONFIG=ks-core.kubeconfig kubectl apply -f - <<EOF
+apiVersion: edge.kubestellar.io/v2alpha1
+kind: EdgePlacement
+metadata:
+  name: my-first-edge-placement
+spec:
+  locationSelectors:
+  - matchLabels: {"location-group":"edge"}
+  downsync:
+  - apiGroup: ""
+    resources: [ configmaps ]
+    namespaces: [ my-namespace ]
+    objectNames: [ "*" ]
+  - apiGroup: apps
+    resources: [ deployments ]
+    namespaces: [ my-namespace ]
+    objectNames: [ my-first-kubestellar-deployment ]
+  - apiGroup: apis.kcp.io
+    resources: [ apibindings ]
+    namespaceSelectors: []
+    objectNames: [ "bind-kubernetes", "bind-apps" ]
+  - apiGroup: rbac.authorization.k8s.io
+    resources: [ rolebindings ]
+    namespaces: [ my-namespace ]
+    objectNames: [ let-it-be ]
+EOF
+```
+
+check if your edgeplacement was applied to the **ks-core** `kubestellar` namespace correctly
+```shell
+KUBECONFIG=ks-core.kubeconfig kubectl ws root:wmw1
+KUBECONFIG=ks-core.kubeconfig kubectl get edgeplacements -n kubestellar -o yaml
+```
+
+Now, apply the HTTP server workload definition into the WMW on **ks-core**. Note the namespace label matches the label in the namespaceSelector for the EdgePlacement (`my-first-edge-placement`) object created above. 
+```shell hl_lines="5 10 24 25"
+KUBECONFIG=ks-core.kubeconfig kubectl apply -f - <<EOF
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: my-namespace
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  namespace: my-namespace
+  name: httpd-htdocs
+data:
+  index.html: |
+    <!DOCTYPE html>
+    <html>
+      <body>
+        This web site is hosted on ks-edge-cluster1 and ks-edge-cluster2.
+      </body>
+    </html>
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  namespace: my-namespace
+  name: my-first-kubestellar-deployment
+spec:
+  selector: {matchLabels: {app: common} }
+  template:
+    metadata:
+      labels: {app: common}
+    spec:
+      containers:
+      - name: httpd
+        image: library/httpd:2.4
+        ports:
+        - name: http
+          containerPort: 80
+          hostPort: 8081
+          protocol: TCP
+        volumeMounts:
+        - name: htdocs
+          readOnly: true
+          mountPath: /usr/local/apache2/htdocs
+      volumes:
+      - name: htdocs
+        configMap:
+          name: httpd-htdocs
+          optional: false
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: let-it-be
+  namespace: my-namespace
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:openshift:scc:privileged
+subjects:
+- kind: ServiceAccount
+  name: default
+  namespace: my-namespace
+EOF
+```
+
+check if your configmap and deployment was applied to the **ks-core** `my-namespace` namespace correctly
+```shell
+
+KUBECONFIG=ks-core.kubeconfig kubectl ws root:wmw1
+KUBECONFIG=ks-core.kubeconfig kubectl get deployments/my-first-kubestellar-deployment -n my-namespace -o yaml
+KUBECONFIG=ks-core.kubeconfig kubectl get deployments,cm -n my-namespace
+```
+
+<!--kubestellar-apply-apache-openshift-end-->


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
This PR updates the openshift quickstart to add a RoleBinding that authorizes the httpd Pod to run. It probably grants more privilege than necessary, but I found that granting only `anyuid` is not enough --- that led to complaints about using a host port.

## Related issue(s)

Fixes #
