### PR TITLE
📖 Update example1 and user quickstarts to use new command

### DIFF
--- a/docs/content/Getting-Started/user-quickstart-kind.md
+++ b/docs/content/Getting-Started/user-quickstart-kind.md
@@ -274,9 +274,11 @@ how to create, but not overrite/update a synchronized resource
 
 ## 5. Check the status of your Apache Server on ks-edge-cluster1 and ks-edge-cluster2
 
-```
-TODO
-```
+{%
+           include-markdown "../common-subs/kubestellar-list-syncing.md"
+           start="<!--kubestellar-list-syncing-start-->"
+           end="<!--kubestellar-list-syncing-end-->"
+%}
 
 <br>
 ---

--- a/docs/content/Getting-Started/user-quickstart-openshift.md
+++ b/docs/content/Getting-Started/user-quickstart-openshift.md
@@ -213,6 +213,8 @@ how to create, but not overrite/update a synchronized resource
 
 ## 5. Check the status of your Apache Server on ks-edge-cluster1 and ks-edge-cluster2
 
-```
-TODO
-```
+{%
+           include-markdown "../common-subs/kubestellar-list-syncing.md"
+           start="<!--kubestellar-list-syncing-start-->"
+           end="<!--kubestellar-list-syncing-end-->"
+%}

--- a/docs/content/common-subs/kubestellar-list-syncing.md
+++ b/docs/content/common-subs/kubestellar-list-syncing.md
@@ -1,0 +1,56 @@
+<!--kubestellar-list-syncing-start-->
+
+Every object subject to downsync or upsync has a full per-WEC copy in
+the core. These include reported state from the WECs. If you are using
+release 0.10 or later of KubeStellar then you can list these copies of
+your httpd `Deployment` objects with the following command.
+
+``` { .bash .no-copy }
+kubestellar-list-syncing-objects --api-group apps --api-kind Deployment
+```
+
+``` { .bash .no-copy }
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations:
+    ... (lots of other details) ...
+  name: my-first-kubestellar-deployment
+  namespace: my-namespace
+spec:
+  ... (the spec) ...
+status:
+  availableReplicas: 1
+  conditions:
+  - lastTransitionTime: "2023-10-27T07:00:19Z"
+    lastUpdateTime: "2023-10-27T07:00:19Z"
+    message: Deployment has minimum availability.
+    reason: MinimumReplicasAvailable
+    status: "True"
+    type: Available
+  - lastTransitionTime: "2023-10-27T07:00:19Z"
+    lastUpdateTime: "2023-10-27T07:00:19Z"
+    message: ReplicaSet "my-first-kubestellar-deployment-76f6fc4cfc" has successfully progressed.
+    reason: NewReplicaSetAvailable
+    status: "True"
+    type: Progressing
+  observedGeneration: 618
+  readyReplicas: 1
+  replicas: 1
+  updatedReplicas: 1
+
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations:
+    ... (lots of other details) ...
+  name: my-first-kubestellar-deployment
+  namespace: my-namespace
+spec:
+  ... (the spec) ...
+status:
+  ... (another happy status) ...
+```
+<!--kubestellar-list-syncing-end-->


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
This PR updates the example1 and user quickstarts to show the use of the new `kubestellar-list-syncing-objects` command.

This also fixes the command shown in example1 to wait for the placement translator to do its job to _only_ wait on that much.

## Related issue(s)

Fixes #
