### PR TITLE
🐛Change the way entry.sh determine if the kcp container has completed …

### DIFF
--- a/core-container/entry.sh
+++ b/core-container/entry.sh
@@ -28,12 +28,12 @@ function wait_kcp_ready() {
     echo "Waiting for kcp to be ready... this may take a while."
     (
         KUBECONFIG=
-        # while ! kubectl exec $(kubectl get pod --selector=app=kubestellar -o jsonpath='{.items[0].metadata.name}') -c kcp -- ls /home/kubestellar/ready &> /dev/null; do
-        #     sleep 10
-        # done
-        until [ "$(kubectl logs $(kubectl get pod --selector=app=kubestellar -o jsonpath='{.items[0].metadata.name}') -c kcp | grep '***READY***')" != "" ]; do
+        while ! kubectl exec $(kubectl get pod --selector=app=kubestellar -o jsonpath='{.items[0].metadata.name}') -c kcp -- ls /home/kubestellar/ready &> /dev/null; do
             sleep 10
         done
+        # until [ "$(kubectl logs $(kubectl get pod --selector=app=kubestellar -o jsonpath='{.items[0].metadata.name}') -c kcp | grep '***READY***')" != "" ]; do
+        #    sleep 10
+        # done
     )
     echo "Success!"
     echo "Copying the admin.kubeconfig from kubestellar seret..."


### PR DESCRIPTION
## Summary

To fix #1213 we revert back to check on the existence of file `ready` in `kcp` container instead of flag `***READY***` in `kcp` container log, which may overflow

## Related issue(s)

Fixes #
#1213