### PR TITLE
:sparkles:Initial replacement of KCP-bind with kube-bind

### DIFF
--- a/cmd/mailbox-controller/main.go
+++ b/cmd/mailbox-controller/main.go
@@ -26,34 +26,28 @@ package main
 import (
 	"context"
 	"flag"
-	"fmt"
 	"net/http"
 	"os"
 	"time"
 
 	"github.com/spf13/pflag"
 
-	k8sapierrors "k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apiserver/pkg/server/mux"
 	"k8s.io/apiserver/pkg/server/routes"
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
-	"k8s.io/client-go/rest"
 	"k8s.io/component-base/metrics/legacyregistry"
 	_ "k8s.io/component-base/metrics/prometheus/clientgo"
 	"k8s.io/klog/v2"
 	utilflag "k8s.io/kubernetes/pkg/util/flag"
 
-	apisv1alpha1 "github.com/kcp-dev/kcp/pkg/apis/apis/v1alpha1"
-	"github.com/kcp-dev/kcp/pkg/apis/third_party/conditions/util/conditions"
 	kcpscopedclientset "github.com/kcp-dev/kcp/pkg/client/clientset/versioned"
-	kcpclusterclientset "github.com/kcp-dev/kcp/pkg/client/clientset/versioned/cluster"
 	kcpinformers "github.com/kcp-dev/kcp/pkg/client/informers/externalversions"
 	"github.com/kcp-dev/logicalcluster/v3"
 
 	resolveroptions "github.com/kubestellar/kubestellar/cmd/mailbox-controller/options"
 	clientopts "github.com/kubestellar/kubestellar/pkg/client-options"
-	edgeclientset "github.com/kubestellar/kubestellar/pkg/client/clientset/versioned/cluster"
+
+	edgeclientset "github.com/kubestellar/kubestellar/pkg/client/clientset/versioned"
 	edgeinformers "github.com/kubestellar/kubestellar/pkg/client/informers/externalversions"
 )
 
@@ -72,12 +66,7 @@ func main() {
 
 	rootClientOpts := clientopts.NewClientOpts("root", "access to the root workspace")
 	rootClientOpts.SetDefaultCurrentContext("root")
-
-	mbwsClientOpts := clientopts.NewClientOpts("mbws", "access to mailbox workspaces (really all clusters)")
-	mbwsClientOpts.SetDefaultCurrentContext("base")
-
 	rootClientOpts.AddFlags(fs)
-	mbwsClientOpts.AddFlags(fs)
 
 	fs.Parse(os.Args[1:])
 
@@ -107,17 +96,14 @@ func main() {
 		logger.Error(err, "failed to create config from flags")
 		os.Exit(3)
 	}
-	edgeViewConfig, err := configForViewOfExport(ctx, espwRestConfig, "edge.kubestellar.io")
-	if err != nil {
-		logger.Error(err, "failed to create config for view of edge exports")
-		os.Exit(4)
-	}
-	edgeViewClusterClientset, err := edgeclientset.NewForConfig(edgeViewConfig)
+
+	edgeClientset, err := edgeclientset.NewForConfig(espwRestConfig)
 	if err != nil {
 		logger.Error(err, "failed to create clientset for view of edge exports")
 		os.Exit(6)
 	}
-	edgeSharedInformerFactory := edgeinformers.NewSharedInformerFactoryWithOptions(edgeViewClusterClientset, resyncPeriod)
+
+	edgeSharedInformerFactory := edgeinformers.NewSharedScopedInformerFactoryWithOptions(edgeClientset, resyncPeriod)
 	syncTargetClusterPreInformer := edgeSharedInformerFactory.Edge().V2alpha1().SyncTargets()
 
 	rootRestConfig, err := rootClientOpts.ToRESTConfig()
@@ -135,21 +121,8 @@ func main() {
 	workspaceScopedInformerFactory := kcpinformers.NewSharedScopedInformerFactoryWithOptions(workspaceScopedClientset, resyncPeriod)
 	workspaceScopedPreInformer := workspaceScopedInformerFactory.Tenancy().V1alpha1().Workspaces()
 
-	mbwsClientConfig, err := mbwsClientOpts.ToRESTConfig()
-	if err != nil {
-		logger.Error(err, "failed to make all-cluster config")
-		os.Exit(20)
-	}
-	mbwsClientConfig.UserAgent = "mailbox-controller"
-	mbwsClientset, err := kcpclusterclientset.NewForConfig(mbwsClientConfig)
-	if err != nil {
-		logger.Error(err, "Failed to create all-cluster clientset")
-		os.Exit(24)
-	}
-
 	ctl := newMailboxController(ctx, espwPath, syncTargetClusterPreInformer, workspaceScopedPreInformer,
 		workspaceScopedClientset.TenancyV1alpha1().Workspaces(),
-		mbwsClientset.ApisV1alpha1().APIBindings(),
 	)
 
 	doneCh := ctx.Done()
@@ -160,48 +133,4 @@ func main() {
 	ctl.Run(concurrency)
 
 	logger.Info("Time to stop")
-}
-
-func configForViewOfExport(ctx context.Context, providerConfig *rest.Config, exportName string) (*rest.Config, error) {
-	providerClient, err := kcpscopedclientset.NewForConfig(providerConfig)
-	if err != nil {
-		return nil, fmt.Errorf("error creating client for service provider workspace: %w", err)
-	}
-	apiExportClient := providerClient.ApisV1alpha1().APIExports()
-	logger := klog.FromContext(ctx)
-	var apiExport *apisv1alpha1.APIExport
-	for {
-		apiExport, err = apiExportClient.Get(ctx, exportName, metav1.GetOptions{})
-		if err != nil {
-			if k8sapierrors.IsNotFound(err) {
-				logger.V(2).Info("Pause because APIExport not found", "exportName", exportName)
-				time.Sleep(time.Second * 15)
-				continue
-			}
-			return nil, fmt.Errorf("error reading APIExport %s: %w", exportName, err)
-		}
-		if isAPIExportReady(logger, apiExport) {
-			logger.V(2).Info(" ### export is ready, exportName: ", exportName)
-			break
-		}
-		logger.V(2).Info("Pause because APIExport not ready", "exportName", exportName)
-		time.Sleep(time.Second * 15)
-	}
-	viewConfig := rest.CopyConfig(providerConfig)
-	serverURL := apiExport.Status.VirtualWorkspaces[0].URL
-	logger.V(2).Info("Found APIExport view", "exportName", exportName, "serverURL", serverURL)
-	viewConfig.Host = serverURL
-	return viewConfig, nil
-}
-
-func isAPIExportReady(logger klog.Logger, apiExport *apisv1alpha1.APIExport) bool {
-	if !conditions.IsTrue(apiExport, apisv1alpha1.APIExportVirtualWorkspaceURLsReady) {
-		logger.V(2).Info("APIExport virtual workspace URLs are not ready", "APIExport", apiExport.Name)
-		return false
-	}
-	if len(apiExport.Status.VirtualWorkspaces) == 0 {
-		logger.V(2).Info("APIExport does not have any virtual workspace URLs", "APIExport", apiExport.Name)
-		return false
-	}
-	return true
 }

--- a/cmd/mailbox-controller/main.go
+++ b/cmd/mailbox-controller/main.go
@@ -46,7 +46,6 @@ import (
 
 	resolveroptions "github.com/kubestellar/kubestellar/cmd/mailbox-controller/options"
 	clientopts "github.com/kubestellar/kubestellar/pkg/client-options"
-
 	edgeclientset "github.com/kubestellar/kubestellar/pkg/client/clientset/versioned"
 	edgeinformers "github.com/kubestellar/kubestellar/pkg/client/informers/externalversions"
 )

--- a/cmd/placement-translator/main.go
+++ b/cmd/placement-translator/main.go
@@ -26,7 +26,6 @@ package main
 import (
 	"context"
 	"flag"
-	"fmt"
 	"net/http"
 	"os"
 	"time"
@@ -35,8 +34,6 @@ import (
 
 	apiextclient "k8s.io/apiextensions-apiserver/pkg/client/kcp/clientset/versioned"
 	apiextinfactory "k8s.io/apiextensions-apiserver/pkg/client/kcp/informers/externalversions"
-	k8sapierrors "k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apiserver/pkg/server/mux"
 	"k8s.io/apiserver/pkg/server/routes"
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
@@ -52,13 +49,13 @@ import (
 	clusterdynamicinformer "github.com/kcp-dev/client-go/dynamic/dynamicinformer"
 	kcpkubeinformers "github.com/kcp-dev/client-go/informers"
 	kcpkubeclient "github.com/kcp-dev/client-go/kubernetes"
-	apisv1alpha1 "github.com/kcp-dev/kcp/pkg/apis/apis/v1alpha1"
-	"github.com/kcp-dev/kcp/pkg/apis/third_party/conditions/util/conditions"
+
 	kcpscopedclientset "github.com/kcp-dev/kcp/pkg/client/clientset/versioned"
 	kcpclusterclientset "github.com/kcp-dev/kcp/pkg/client/clientset/versioned/cluster"
 	kcpinformers "github.com/kcp-dev/kcp/pkg/client/informers/externalversions"
 	tenancyv1a1informers "github.com/kcp-dev/kcp/pkg/client/informers/externalversions/tenancy/v1alpha1"
 
+	ksclientset "github.com/kubestellar/kubestellar/pkg/client/clientset/versioned"
 	emcclusterclientset "github.com/kubestellar/kubestellar/pkg/client/clientset/versioned/cluster"
 	emcinformers "github.com/kubestellar/kubestellar/pkg/client/informers/externalversions"
 	edgev1a1informers "github.com/kubestellar/kubestellar/pkg/client/informers/externalversions/edge/v2alpha1"
@@ -156,17 +153,10 @@ func main() {
 		os.Exit(25)
 	}
 
-	// Get client config for view of APIExport of edge API
-	edgeViewConfig, err := configForViewOfExport(ctx, espwRestConfig, "edge.kubestellar.io")
+	edgeClientset, err := ksclientset.NewForConfig(espwRestConfig)
 	if err != nil {
-		logger.Error(err, "Failed to create client config for view of edge APIExport")
+		logger.Error(err, "failed to create provider clientset from config")
 		os.Exit(30)
-	}
-
-	edgeViewClusterClientset, err := emcclusterclientset.NewForConfig(edgeViewConfig)
-	if err != nil {
-		logger.Error(err, "Failed to create cluster clientset for view of edge APIExport")
-		os.Exit(40)
 	}
 
 	apiextClusterClient, err := apiextclient.NewForConfig(baseRestConfig)
@@ -187,12 +177,12 @@ func main() {
 	kubeClusterInformerFactory := kcpkubeinformers.NewSharedInformerFactory(kubeClusterClient, 0)
 	nsClusterPreInformer := kubeClusterInformerFactory.Core().V1().Namespaces()
 
-	edgeInformerFactory := emcinformers.NewSharedInformerFactoryWithOptions(edgeViewClusterClientset, resyncPeriod)
-	epClusterPreInformer := edgeInformerFactory.Edge().V2alpha1().EdgePlacements()
-	spsClusterPreInformer := edgeInformerFactory.Edge().V2alpha1().SinglePlacementSlices()
-	syncfgClusterPreInformer := edgeInformerFactory.Edge().V2alpha1().SyncerConfigs()
-	customizerClusterPreInformer := edgeInformerFactory.Edge().V2alpha1().Customizers()
-	var _ edgev1a1informers.SinglePlacementSliceClusterInformer = spsClusterPreInformer
+	edgeInformerFactory := emcinformers.NewSharedScopedInformerFactoryWithOptions(edgeClientset, resyncPeriod)
+	epPreInformer := edgeInformerFactory.Edge().V2alpha1().EdgePlacements()
+	spsPreInformer := edgeInformerFactory.Edge().V2alpha1().SinglePlacementSlices()
+	syncfgPreInformer := edgeInformerFactory.Edge().V2alpha1().SyncerConfigs()
+	customizerPreInformer := edgeInformerFactory.Edge().V2alpha1().Customizers()
+	var _ edgev1a1informers.SinglePlacementSliceInformer = spsPreInformer
 
 	rootClientset, err := kcpscopedclientset.NewForConfig(rootRestConfig)
 	if err != nil {
@@ -204,8 +194,8 @@ func main() {
 	mbwsPreInformer := rootInformerFactory.Tenancy().V1alpha1().Workspaces()
 	var _ tenancyv1a1informers.WorkspaceInformer = mbwsPreInformer
 
-	locationClusterPreInformer := edgeInformerFactory.Edge().V2alpha1().Locations()
-	var _ edgev1a1informers.LocationClusterInformer = locationClusterPreInformer
+	locationPreInformer := edgeInformerFactory.Edge().V2alpha1().Locations()
+	var _ edgev1a1informers.LocationInformer = locationPreInformer
 
 	kcpClusterClientset, err := kcpclusterclientset.NewForConfig(baseRestConfig)
 	if err != nil {
@@ -232,7 +222,7 @@ func main() {
 
 	doneCh := ctx.Done()
 	// TODO: more
-	pt := placement.NewPlacementTranslator(concurrency, ctx, locationClusterPreInformer, epClusterPreInformer, spsClusterPreInformer, syncfgClusterPreInformer, customizerClusterPreInformer,
+	pt := placement.NewPlacementTranslator(concurrency, ctx, locationPreInformer, epPreInformer, spsPreInformer, syncfgPreInformer, customizerPreInformer,
 		mbwsPreInformer, kcpClusterClientset, discoveryClusterClient, crdClusterPreInformer, bindingClusterPreInformer,
 		dynamicClusterClient, edgeClusterClientset, nsClusterPreInformer, nsClusterClient)
 
@@ -244,47 +234,4 @@ func main() {
 	kcpClusterInformerFactory.Start(doneCh)
 	pt.Run()
 	logger.Info("Time to stop")
-}
-
-func configForViewOfExport(ctx context.Context, providerConfig *rest.Config, exportName string) (*rest.Config, error) {
-	providerScopedClient, err := kcpscopedclientset.NewForConfig(providerConfig)
-	if err != nil {
-		return nil, fmt.Errorf("error creating client for service provider workspace: %w", err)
-	}
-	apiExportClient := providerScopedClient.ApisV1alpha1().APIExports()
-	logger := klog.FromContext(ctx)
-	var apiExport *apisv1alpha1.APIExport
-	for {
-		apiExport, err = apiExportClient.Get(ctx, exportName, metav1.GetOptions{})
-		if err != nil {
-			if k8sapierrors.IsNotFound(err) {
-				logger.V(2).Info("Pause because APIExport not found", "exportName", exportName)
-				time.Sleep(time.Second * 15)
-				continue
-			}
-			return nil, fmt.Errorf("error reading APIExport %s: %w", exportName, err)
-		}
-		if isAPIExportReady(logger, apiExport) {
-			break
-		}
-		logger.V(2).Info("Pause because APIExport not ready", "exportName", exportName)
-		time.Sleep(time.Second * 15)
-	}
-	viewConfig := rest.CopyConfig(providerConfig)
-	serverURL := apiExport.Status.VirtualWorkspaces[0].URL
-	logger.V(2).Info("Found APIExport view", "exportName", exportName, "serverURL", serverURL)
-	viewConfig.Host = serverURL
-	return viewConfig, nil
-}
-
-func isAPIExportReady(logger klog.Logger, apiExport *apisv1alpha1.APIExport) bool {
-	if !conditions.IsTrue(apiExport, apisv1alpha1.APIExportVirtualWorkspaceURLsReady) {
-		logger.V(2).Info("APIExport virtual workspace URLs are not ready", "APIExport", apiExport.Name)
-		return false
-	}
-	if len(apiExport.Status.VirtualWorkspaces) == 0 {
-		logger.V(2).Info("APIExport does not have any virtual workspace URLs", "APIExport", apiExport.Name)
-		return false
-	}
-	return true
 }

--- a/cmd/placement-translator/main.go
+++ b/cmd/placement-translator/main.go
@@ -49,7 +49,6 @@ import (
 	clusterdynamicinformer "github.com/kcp-dev/client-go/dynamic/dynamicinformer"
 	kcpkubeinformers "github.com/kcp-dev/client-go/informers"
 	kcpkubeclient "github.com/kcp-dev/client-go/kubernetes"
-
 	kcpscopedclientset "github.com/kcp-dev/kcp/pkg/client/clientset/versioned"
 	kcpclusterclientset "github.com/kcp-dev/kcp/pkg/client/clientset/versioned/cluster"
 	kcpinformers "github.com/kcp-dev/kcp/pkg/client/informers/externalversions"

--- a/core.Dockerfile
+++ b/core.Dockerfile
@@ -37,6 +37,19 @@ RUN mkdir -p .kcp && \
     git config --global --add safe.directory /home/kubestellar && \
     mkdir -p bin
 
+RUN git clone https://github.com/kube-bind/kube-bind.git && \
+    pushd kube-bind && \
+    IGNORE_GO_VERSION=1 make build && \
+    popd && \
+    git clone -b autobind https://github.com/waltforme/kube-bind.git kube-bind-autobind && \
+    pushd kube-bind-autobind && \
+    IGNORE_GO_VERSION=1 go build -o ../kube-bind/bin/kubectl-bind cmd/kubectl-bind/main.go && \
+    popd && \
+    git clone https://github.com/dexidp/dex.git && \
+    pushd dex && \
+    IGNORE_GO_VERSION=1 make build && \
+    popd
+
 ENV PATH=$PATH:/root/go/bin
 
 ADD cmd/             cmd/
@@ -64,13 +77,18 @@ RUN dnf install -y jq procps && \
     mkdir -p .kcp
 
 # copy binaries from the builder image
-COPY --from=builder /home/kubestellar/easy-rsa        easy-rsa/
-COPY --from=builder /root/go/bin                      /usr/local/bin/
-COPY --from=builder /usr/local/bin/kubectl            /usr/local/bin/kubectl
-COPY --from=builder /home/kubestellar/kcp/bin         kcp/bin/
-COPY --from=builder /home/kubestellar/kcp-plugins/bin kcp/bin/
-COPY --from=builder /home/kubestellar/bin             bin/
-COPY --from=builder /home/kubestellar/config          config/
+COPY --from=builder /home/kubestellar/easy-rsa                           easy-rsa/
+COPY --from=builder /root/go/bin                                         /usr/local/bin/
+COPY --from=builder /usr/local/bin/kubectl                               /usr/local/bin/kubectl
+COPY --from=builder /home/kubestellar/kcp/bin                            kcp/bin/
+COPY --from=builder /home/kubestellar/kcp-plugins/bin                    kcp/bin/
+COPY --from=builder /home/kubestellar/bin                                bin/
+COPY --from=builder /home/kubestellar/config                             config/
+COPY --from=builder /home/kubestellar/kube-bind/bin                      kube-bind/bin/
+COPY --from=builder /home/kubestellar/kube-bind/deploy/crd               kube-bind/deploy/crd
+COPY --from=builder /home/kubestellar/kube-bind/deploy/examples          kube-bind/deploy/examples
+COPY --from=builder /home/kubestellar/dex/bin                            dex/bin/
+COPY --from=builder /home/kubestellar/kube-bind/hack/dex-config-dev.yaml dex/dex-config-dev.yaml
 
 # add entry script
 ADD core-container/entry.sh entry.sh
@@ -79,7 +97,7 @@ RUN chown -R kubestellar:0 /home/kubestellar && \
     chmod -R g=u /home/kubestellar
 
 # setup the environment variables
-ENV PATH=/home/kubestellar/bin:/home/kubestellar/kcp/bin:/home/kubestellar/easy-rsa:$PATH
+ENV PATH=/home/kubestellar/bin:/home/kubestellar/kcp/bin:/home/kubestellar/kube-bind/bin:/home/kubestellar/dex/bin:/home/kubestellar/easy-rsa:$PATH
 ENV KUBECONFIG=/home/kubestellar/.kcp/admin.kubeconfig
 ENV EXTERNAL_HOSTNAME=""
 ENV EXTERNAL_PORT=""

--- a/hack/logcheck.out
+++ b/hack/logcheck.out
@@ -1,11 +1,10 @@
-/cmd/cluster-watchall/main.go:80:3: Key positional arguments are expected to be inlined constant strings. Please replace &{flg Name} provided with string value.
+/cmd/cluster-watchall/main.go:85:3: Key positional arguments are expected to be inlined constant strings. Please replace &{flg Name} provided with string value.
 /cmd/kcp-watchall/main.go:103:3: Key positional arguments are expected to be inlined constant strings. Please replace &{flg Name} provided with string value.
-/cmd/mailbox-controller/main.go:184:4: Additional arguments to Info should always be Key Value pairs. Please check if there is any key or value missing.
-/cmd/mailbox-controller/main.go:89:3: Key positional arguments are expected to be inlined constant strings. Please replace &{flg Name} provided with string value.
-/cmd/placement-translator/main.go:120:3: Key positional arguments are expected to be inlined constant strings. Please replace &{flg Name} provided with string value.
-/pkg/placement/workload-projector.go:1053:4: the result of logger.V should be stored in a variable and then be used multiple times: if logger := logger.V(); logger.Enabled() { ... logger.Info ... }
-/pkg/placement/workload-projector.go:1073:1: A function should accept either a context or a logger, but not both. Having both makes calling the function harder because it must be defined whether the context must contain the logger and callers have to follow that.
-/pkg/placement/workload-projector.go:1101:1: A function should accept either a context or a logger, but not both. Having both makes calling the function harder because it must be defined whether the context must contain the logger and callers have to follow that.
-/pkg/placement/workload-projector.go:708:4: the result of logger.V should be stored in a variable and then be used multiple times: if logger := logger.V(); logger.Enabled() { ... logger.Info ... }
-/pkg/placement/workload-projector.go:730:2: the result of logger.V should be stored in a variable and then be used multiple times: if logger := logger.V(); logger.Enabled() { ... logger.Info ... }
-/pkg/placement/workload-projector.go:961:1: A function should accept either a context or a logger, but not both. Having both makes calling the function harder because it must be defined whether the context must contain the logger and callers have to follow that.
+/cmd/mailbox-controller/main.go:77:3: Key positional arguments are expected to be inlined constant strings. Please replace &{flg Name} provided with string value.
+/cmd/placement-translator/main.go:117:3: Key positional arguments are expected to be inlined constant strings. Please replace &{flg Name} provided with string value.
+/pkg/placement/workload-projector.go:1052:4: the result of logger.V should be stored in a variable and then be used multiple times: if logger := logger.V(); logger.Enabled() { ... logger.Info ... }
+/pkg/placement/workload-projector.go:1072:1: A function should accept either a context or a logger, but not both. Having both makes calling the function harder because it must be defined whether the context must contain the logger and callers have to follow that.
+/pkg/placement/workload-projector.go:1100:1: A function should accept either a context or a logger, but not both. Having both makes calling the function harder because it must be defined whether the context must contain the logger and callers have to follow that.
+/pkg/placement/workload-projector.go:707:4: the result of logger.V should be stored in a variable and then be used multiple times: if logger := logger.V(); logger.Enabled() { ... logger.Info ... }
+/pkg/placement/workload-projector.go:729:2: the result of logger.V should be stored in a variable and then be used multiple times: if logger := logger.V(); logger.Enabled() { ... logger.Info ... }
+/pkg/placement/workload-projector.go:960:1: A function should accept either a context or a logger, but not both. Having both makes calling the function harder because it must be defined whether the context must contain the logger and callers have to follow that.

--- a/pkg/placement/main.go
+++ b/pkg/placement/main.go
@@ -43,9 +43,9 @@ import (
 type placementTranslator struct {
 	context                context.Context
 	apiProvider            APIWatchMapProvider
-	spsClusterInformer     kcpcache.ScopeableSharedIndexInformer
-	syncfgClusterInformer  kcpcache.ScopeableSharedIndexInformer
-	syncfgClusterLister    edgev1a1listers.SyncerConfigClusterLister
+	spsInformer            k8scache.SharedIndexInformer
+	syncfgInformer         k8scache.SharedIndexInformer
+	syncfgLister           edgev1a1listers.SyncerConfigLister
 	mbwsInformer           k8scache.SharedIndexInformer
 	mbwsLister             tenancyv1a1listers.WorkspaceLister
 	kcpClusterClientset    kcpclusterclientset.ClusterInterface
@@ -69,16 +69,15 @@ type placementTranslator struct {
 func NewPlacementTranslator(
 	numThreads int,
 	ctx context.Context,
-	//locationClusterPreInformer schedulingv1a1informers.LocationClusterInformer,
-	locationClusterPreInformer edgev1a1informers.LocationClusterInformer,
+	locationPreInformer edgev1a1informers.LocationInformer,
 	// pre-informer on all SinglePlacementSlice objects, cross-workspace
-	epClusterPreInformer edgev1a1informers.EdgePlacementClusterInformer,
+	epPreInformer edgev1a1informers.EdgePlacementInformer,
 	// pre-informer on all SinglePlacementSlice objects, cross-workspace
-	spsClusterPreInformer edgev1a1informers.SinglePlacementSliceClusterInformer,
+	spsPreInformer edgev1a1informers.SinglePlacementSliceInformer,
 	// pre-informer on syncer config objects, should be in mailbox workspaces
-	syncfgClusterPreInformer edgev1a1informers.SyncerConfigClusterInformer,
+	syncfgPreInformer edgev1a1informers.SyncerConfigInformer,
 
-	customizerClusterPreInformer edgev1a1informers.CustomizerClusterInformer,
+	customizerPreInformer edgev1a1informers.CustomizerInformer,
 	// pre-informer on Workspaces objects
 	mbwsPreInformer tenancyv1a1informers.WorkspaceInformer,
 	// all-cluster clientset for kcp APIs,
@@ -104,9 +103,9 @@ func NewPlacementTranslator(
 	pt := &placementTranslator{
 		context:                ctx,
 		apiProvider:            amp,
-		spsClusterInformer:     spsClusterPreInformer.Informer(),
-		syncfgClusterInformer:  syncfgClusterPreInformer.Informer(),
-		syncfgClusterLister:    syncfgClusterPreInformer.Lister(),
+		spsInformer:            spsPreInformer.Informer(),
+		syncfgInformer:         syncfgPreInformer.Informer(),
+		syncfgLister:           syncfgPreInformer.Lister(),
 		mbwsInformer:           mbwsPreInformer.Informer(),
 		mbwsLister:             mbwsPreInformer.Lister(),
 		kcpClusterClientset:    kcpClusterClientset,
@@ -117,14 +116,14 @@ func NewPlacementTranslator(
 		edgeClusterClientset:   edgeClusterClientset,
 		nsClusterPreInformer:   nsClusterPreInformer,
 		nsClusterClient:        nsClusterClient,
-		whatResolver: NewWhatResolver(ctx, epClusterPreInformer, discoveryClusterClient,
+		whatResolver: NewWhatResolver(ctx, epPreInformer, discoveryClusterClient,
 			crdClusterPreInformer, bindingClusterPreInformer, dynamicClusterClient, numThreads),
-		whereResolver: NewWhereResolver(ctx, spsClusterPreInformer, numThreads),
+		whereResolver: NewWhereResolver(ctx, spsPreInformer, numThreads),
 	}
 	pt.workloadProjector = NewWorkloadProjector(ctx, numThreads, DefaultResourceModes, pt.mbwsInformer, pt.mbwsLister,
-		locationClusterPreInformer.Informer(), locationClusterPreInformer.Lister(),
-		pt.syncfgClusterInformer, pt.syncfgClusterLister,
-		customizerClusterPreInformer.Informer(), customizerClusterPreInformer.Lister(),
+		locationPreInformer.Informer(), locationPreInformer.Lister(),
+		pt.syncfgInformer, pt.syncfgLister,
+		customizerPreInformer.Informer(), customizerPreInformer.Lister(),
 		edgeClusterClientset, dynamicClusterClient,
 		nsClusterPreInformer, nsClusterClient)
 
@@ -136,11 +135,11 @@ func (pt *placementTranslator) Run() {
 	logger := klog.FromContext(ctx)
 
 	doneCh := ctx.Done()
-	if !(k8scache.WaitForNamedCacheSync("placement-translator(sps)", doneCh, pt.spsClusterInformer.HasSynced) &&
+	if !(k8scache.WaitForNamedCacheSync("placement-translator(sps)", doneCh, pt.spsInformer.HasSynced) &&
 		k8scache.WaitForNamedCacheSync("placement-translator(mbws)", doneCh, pt.mbwsInformer.HasSynced) &&
 		k8scache.WaitForNamedCacheSync("placement-translator(crds)", doneCh, pt.crdClusterInformer.HasSynced) &&
 		k8scache.WaitForNamedCacheSync("placement-translator(bind)", doneCh, pt.bindingClusterInformer.HasSynced) &&
-		k8scache.WaitForNamedCacheSync("placement-translator(sync)", doneCh, pt.syncfgClusterInformer.HasSynced) &&
+		k8scache.WaitForNamedCacheSync("placement-translator(sync)", doneCh, pt.syncfgInformer.HasSynced) &&
 		true) {
 		logger.Error(nil, "Informer syncs not achieved")
 		os.Exit(100)

--- a/pkg/placement/what-resolver.go
+++ b/pkg/placement/what-resolver.go
@@ -57,8 +57,8 @@ type whatResolver struct {
 	queue      workqueue.RateLimitingInterface
 	receiver   MappingReceiver[ExternalName, ResolvedWhat]
 
-	edgePlacementInformer kcpcache.ScopeableSharedIndexInformer
-	edgePlacementLister   edgev2alpha1listers.EdgePlacementClusterLister
+	edgePlacementInformer upstreamcache.SharedIndexInformer
+	edgePlacementLister   edgev2alpha1listers.EdgePlacementLister
 
 	discoveryClusterClient    clusterdiscovery.DiscoveryClusterInterface
 	crdClusterPreInformer     apiextkcpinformers.CustomResourceDefinitionClusterInformer
@@ -113,7 +113,7 @@ type objectDetails struct {
 // invoke that function after the namespace informer has synced.
 func NewWhatResolver(
 	ctx context.Context,
-	edgePlacementPreInformer edgev2alpha1informers.EdgePlacementClusterInformer,
+	edgePlacementPreInformer edgev2alpha1informers.EdgePlacementInformer,
 	discoveryClusterClient clusterdiscovery.DiscoveryClusterInterface,
 	crdClusterPreInformer apiextkcpinformers.CustomResourceDefinitionClusterInformer,
 	bindingClusterPreInformer bindinginformers.APIBindingClusterInformer,
@@ -462,7 +462,7 @@ func (wr *whatResolver) processResource(ctx context.Context, cluster logicalclus
 // process returns true on success or unrecoverable error, false to retry
 func (wr *whatResolver) processEdgePlacement(ctx context.Context, cluster logicalcluster.Name, epName ObjectName) bool {
 	logger := klog.FromContext(ctx)
-	ep, err := wr.edgePlacementLister.Cluster(cluster).Get(string(epName))
+	ep, err := wr.edgePlacementLister.Get(string(epName))
 	if err != nil {
 		if !k8sapierrors.IsNotFound(err) {
 			logger.Error(err, "Failed to fetch EdgePlacement from local cache")

--- a/pkg/placement/what-resolver_test.go
+++ b/pkg/placement/what-resolver_test.go
@@ -42,7 +42,7 @@ import (
 	"github.com/kcp-dev/logicalcluster/v3"
 
 	edgeapi "github.com/kubestellar/kubestellar/pkg/apis/edge/v2alpha1"
-	fakeedge "github.com/kubestellar/kubestellar/pkg/client/clientset/versioned/cluster/fake"
+	fakeedge "github.com/kubestellar/kubestellar/pkg/client/clientset/versioned/fake"
 	edgeinformers "github.com/kubestellar/kubestellar/pkg/client/informers/externalversions"
 )
 
@@ -121,8 +121,8 @@ func TestWhatResolver(t *testing.T) {
 		}}
 	ep1EN := ExternalName{wds1N, ObjectName(ep1.Name)}
 	edgeViewClusterClientset := fakeedge.NewSimpleClientset(ep1)
-	edgeClusterInformerFactory := edgeinformers.NewSharedInformerFactory(edgeViewClusterClientset, 0)
-	epClusterPreInformer := edgeClusterInformerFactory.Edge().V2alpha1().EdgePlacements()
+	edgeInformerFactory := edgeinformers.NewSharedScopedInformerFactoryWithOptions(edgeViewClusterClientset, 0)
+	epPreInformer := edgeInformerFactory.Edge().V2alpha1().EdgePlacements()
 	fakeKubeClusterClientset := fakekube.NewSimpleClientset(ns1, cm1)
 	k8sCoreGroupVersion := metav1.GroupVersion{Version: "v1"}
 	usualVerbs := []string{"get", "list", "watch"}
@@ -149,8 +149,8 @@ func TestWhatResolver(t *testing.T) {
 	apiExtClusterFactory := apiextinfact.NewSharedInformerFactory(fakeApiExtClusterClientset, 0)
 	crdClusterPreInformer := apiExtClusterFactory.Apiextensions().V1().CustomResourceDefinitions()
 
-	whatResolver := NewWhatResolver(ctx, epClusterPreInformer, fcd, crdClusterPreInformer, bindingClusterPreInformer, fakeDynamicClusterClientset, 3)
-	edgeClusterInformerFactory.Start(ctx.Done())
+	whatResolver := NewWhatResolver(ctx, epPreInformer, fcd, crdClusterPreInformer, bindingClusterPreInformer, fakeDynamicClusterClientset, 3)
+	edgeInformerFactory.Start(ctx.Done())
 	dynamicClusterInformerFactory.Start(ctx.Done())
 	rcvr := NewMapMap[ExternalName, ResolvedWhat](nil)
 	runnable := whatResolver(rcvr)

--- a/pkg/placement/where-resolver.go
+++ b/pkg/placement/where-resolver.go
@@ -42,8 +42,8 @@ type whereResolver struct {
 	numThreads int
 	queue      workqueue.RateLimitingInterface
 
-	spsInformer kcpcache.ScopeableSharedIndexInformer
-	spsLister   edgev2alpha1listers.SinglePlacementSliceClusterLister
+	spsInformer upstreamcache.SharedIndexInformer
+	spsLister   edgev2alpha1listers.SinglePlacementSliceLister
 
 	// resolutions maps EdgePlacement name to its ResolvedWhere
 	resolutions RelayMap[ExternalName, ResolvedWhere]
@@ -62,7 +62,7 @@ func (qi queueItem) toExternalName() ExternalName {
 // NewWhereResolver returns a WhereResolver.
 func NewWhereResolver(
 	ctx context.Context,
-	spsPreInformer edgev2alpha1informers.SinglePlacementSliceClusterInformer,
+	spsPreInformer edgev2alpha1informers.SinglePlacementSliceInformer,
 	numThreads int,
 ) WhereResolver {
 	return func(receiver MappingReceiver[ExternalName, ResolvedWhere]) Runnable {
@@ -171,7 +171,7 @@ func (wr *whereResolver) process(ctx context.Context, item queueItem) bool {
 	cluster := item.cluster
 	epName := item.name
 	objName := item.toExternalName()
-	sps, err := wr.spsLister.Cluster(cluster).Get(epName)
+	sps, err := wr.spsLister.Get(epName)
 	if err != nil && !k8sapierrors.IsNotFound(err) {
 		logger.Error(err, "Failed to fetch SinglePlacementSlice from local cache", "cluster", cluster, "epName", epName)
 		return true // I think these errors are not transient

--- a/pkg/placement/where-resolver_test.go
+++ b/pkg/placement/where-resolver_test.go
@@ -28,7 +28,7 @@ import (
 	"github.com/kcp-dev/logicalcluster/v3"
 
 	edgeapi "github.com/kubestellar/kubestellar/pkg/apis/edge/v2alpha1"
-	fakeedge "github.com/kubestellar/kubestellar/pkg/client/clientset/versioned/cluster/fake"
+	fakeedge "github.com/kubestellar/kubestellar/pkg/client/clientset/versioned/fake"
 	edgeinformers "github.com/kubestellar/kubestellar/pkg/client/informers/externalversions"
 )
 
@@ -53,11 +53,11 @@ func TestWhereResolver(t *testing.T) {
 	}
 	ep1EN := ExternalName{wds1N, ObjectName(sps1.Name)}
 	edgeViewClusterClientset := fakeedge.NewSimpleClientset(sps1)
-	edgeClusterInformerFactory := edgeinformers.NewSharedInformerFactory(edgeViewClusterClientset, 0)
-	spsClusterPreInformer := edgeClusterInformerFactory.Edge().V2alpha1().SinglePlacementSlices()
+	edgeInformerFactory := edgeinformers.NewSharedScopedInformerFactoryWithOptions(edgeViewClusterClientset, 0)
+	spsClusterPreInformer := edgeInformerFactory.Edge().V2alpha1().SinglePlacementSlices()
 	spsClusterPreInformer.Informer() // get the informer created so that it will start
 	whereResolver := NewWhereResolver(ctx, spsClusterPreInformer, 3)
-	edgeClusterInformerFactory.Start(ctx.Done())
+	edgeInformerFactory.Start(ctx.Done())
 	rcvr := NewMapMap[ExternalName, ResolvedWhere](nil)
 	runnable := whereResolver(rcvr)
 	go runnable.Run(ctx)

--- a/pkg/where-resolver/controller.go
+++ b/pkg/where-resolver/controller.go
@@ -59,26 +59,26 @@ type controller struct {
 
 	edgeClusterClient edgeclientset.ClusterInterface
 
-	singlePlacementSliceLister  edgev2alpha1listers.SinglePlacementSliceClusterLister
+	singlePlacementSliceLister  edgev2alpha1listers.SinglePlacementSliceLister
 	singlePlacementSliceIndexer cache.Indexer
 
-	edgePlacementLister  edgev2alpha1listers.EdgePlacementClusterLister
+	edgePlacementLister  edgev2alpha1listers.EdgePlacementLister
 	edgePlacementIndexer cache.Indexer
 
-	locationLister  edgev2alpha1listers.LocationClusterLister
+	locationLister  edgev2alpha1listers.LocationLister
 	locationIndexer cache.Indexer
 
-	synctargetLister  edgev2alpha1listers.SyncTargetClusterLister
+	synctargetLister  edgev2alpha1listers.SyncTargetLister
 	synctargetIndexer cache.Indexer
 }
 
 func NewController(
 	context context.Context,
 	edgeClusterClient edgeclientset.ClusterInterface,
-	edgePlacementAccess edgev2alpha1informers.EdgePlacementClusterInformer,
-	singlePlacementSliceAccess edgev2alpha1informers.SinglePlacementSliceClusterInformer,
-	locationAccess edgev2alpha1informers.LocationClusterInformer,
-	syncTargetAccess edgev2alpha1informers.SyncTargetClusterInformer,
+	edgePlacementAccess edgev2alpha1informers.EdgePlacementInformer,
+	singlePlacementSliceAccess edgev2alpha1informers.SinglePlacementSliceInformer,
+	locationAccess edgev2alpha1informers.LocationInformer,
+	syncTargetAccess edgev2alpha1informers.SyncTargetInformer,
 ) (*controller, error) {
 	context = klog.NewContext(context, klog.FromContext(context).WithValues("controller", ControllerName))
 	queue := workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), ControllerName)

--- a/pkg/where-resolver/reconcile_on_edgeplacement.go
+++ b/pkg/where-resolver/reconcile_on_edgeplacement.go
@@ -57,7 +57,7 @@ func (c *controller) reconcileOnEdgePlacement(ctx context.Context, epKey string)
 	store.l.Lock()
 	defer store.l.Unlock() // TODO(waltforme): Is it safe to shorten the critical section?
 
-	ep, err := c.edgePlacementLister.Cluster(epws).Get(epName)
+	ep, err := c.edgePlacementLister.Get(epName)
 	if err != nil {
 		if errors.IsNotFound(err) {
 			logger.V(1).Info("EdgePlacement not found")
@@ -86,7 +86,7 @@ func (c *controller) reconcileOnEdgePlacement(ctx context.Context, epKey string)
 	for _, loc := range locsFilteredByEp {
 		// 2)
 		lws := logicalcluster.From(loc)
-		stsInLws, err := c.synctargetLister.Cluster(lws).List(labels.Everything())
+		stsInLws, err := c.synctargetLister.List(labels.Everything())
 		if err != nil {
 			logger.Error(err, "failed to list SyncTargets in Location workspace", "locationWorkspace", lws.String())
 			return err
@@ -114,7 +114,7 @@ func (c *controller) reconcileOnEdgePlacement(ctx context.Context, epKey string)
 	}
 
 	// 4)
-	currentSPS, err := c.singlePlacementSliceLister.Cluster(epws).Get(epName)
+	currentSPS, err := c.singlePlacementSliceLister.Get(epName)
 	if err != nil {
 		if errors.IsNotFound(err) { // create
 			logger.V(1).Info("creating SinglePlacementSlice")

--- a/pkg/where-resolver/reconcile_on_location.go
+++ b/pkg/where-resolver/reconcile_on_location.go
@@ -66,7 +66,7 @@ func (c *controller) reconcileOnLocation(ctx context.Context, locKey string) err
 	defer store.l.Unlock() // TODO(waltforme): Is it safe to shorten the critical section?
 
 	locDeleted := false
-	loc, err := c.locationLister.Cluster(lws).Get(lName)
+	loc, err := c.locationLister.Get(lName)
 	if err != nil {
 		if errors.IsNotFound(err) {
 			logger.V(1).Info("Location not found")
@@ -83,7 +83,7 @@ func (c *controller) reconcileOnLocation(ctx context.Context, locKey string) err
 	// 2a)
 	stsFilteredByLoc := []*edgev2alpha1.SyncTarget{}
 	if !locDeleted {
-		stsInLws, err := c.synctargetLister.Cluster(lws).List(labels.Everything())
+		stsInLws, err := c.synctargetLister.List(labels.Everything())
 		if err != nil {
 			logger.Error(err, "failed to list SyncTargets")
 			return err
@@ -148,7 +148,7 @@ func (c *controller) reconcileOnLocation(ctx context.Context, locKey string) err
 				logger.Error(err, "invalid EdgePlacement key")
 				return err
 			}
-			currentSPS, err := c.singlePlacementSliceLister.Cluster(ws).Get(name)
+			currentSPS, err := c.singlePlacementSliceLister.Get(name)
 			if err != nil {
 				logger.Error(err, "failed to get SinglePlacementSlice", "workloadWorkspace", ws, "singlePlacementSlice", name)
 				return err
@@ -173,7 +173,7 @@ func (c *controller) reconcileOnLocation(ctx context.Context, locKey string) err
 				logger.Error(err, "invalid EdgePlacement key")
 				return err
 			}
-			currentSPS, err := c.singlePlacementSliceLister.Cluster(ws).Get(name)
+			currentSPS, err := c.singlePlacementSliceLister.Get(name)
 			if err != nil {
 				logger.Error(err, "failed to get SinglePlacementSlice", "workloadWorkspace", ws, "singlePlacementSlice", name)
 				return err
@@ -203,7 +203,7 @@ func (c *controller) reconcileOnLocation(ctx context.Context, locKey string) err
 				logger.Error(err, "invalid EdgePlacement key")
 				return err
 			}
-			currentSPS, err := c.singlePlacementSliceLister.Cluster(ws).Get(name)
+			currentSPS, err := c.singlePlacementSliceLister.Get(name)
 			if err != nil {
 				logger.Error(err, "failed to get SinglePlacementSlice", "workloadWorkspace", ws, "singlePlacementSlice", name)
 				return err

--- a/pkg/where-resolver/reconcile_on_synctarget.go
+++ b/pkg/where-resolver/reconcile_on_synctarget.go
@@ -64,7 +64,7 @@ func (c *controller) reconcileOnSyncTarget(ctx context.Context, stKey string) er
 	defer store.l.Unlock() // TODO(waltforme): Is it safe to shorten the critical section?
 
 	stDeleted := false
-	st, err := c.synctargetLister.Cluster(stws).Get(stName)
+	st, err := c.synctargetLister.Get(stName)
 	if err != nil {
 		if errors.IsNotFound(err) {
 			logger.V(1).Info("SyncTarget not found")
@@ -81,7 +81,7 @@ func (c *controller) reconcileOnSyncTarget(ctx context.Context, stKey string) er
 	// 2a)
 	locsFilteredBySt := []*edgev2alpha1.Location{}
 	if !stDeleted {
-		locsInStws, err := c.locationLister.Cluster(stws).List(labels.Everything())
+		locsInStws, err := c.locationLister.List(labels.Everything())
 		if err != nil {
 			logger.Error(err, "failed to list Locations")
 			return err
@@ -126,7 +126,7 @@ func (c *controller) reconcileOnSyncTarget(ctx context.Context, stKey string) er
 				logger.Error(err, "invalid EdgePlacement key")
 				return err
 			}
-			currentSPS, err := c.singlePlacementSliceLister.Cluster(ws).Get(name)
+			currentSPS, err := c.singlePlacementSliceLister.Get(name)
 			if err != nil {
 				logger.Error(err, "failed to get SinglePlacementSlice", "workloadWorkspace", ws, "singlePlacementSlice", name)
 				return err
@@ -152,14 +152,14 @@ func (c *controller) reconcileOnSyncTarget(ctx context.Context, stKey string) er
 				logger.Error(err, "invalid EdgePlacement key")
 				return err
 			}
-			currentSPS, err := c.singlePlacementSliceLister.Cluster(ws).Get(name)
+			currentSPS, err := c.singlePlacementSliceLister.Get(name)
 			if err != nil {
 				logger.Error(err, "failed to get SinglePlacementSlice", "workloadWorkspace", ws, "singlePlacementSlice", name)
 				return err
 			}
 			nextSPS := cleanSPSBySt(currentSPS, stws.String(), stName)
 
-			epObj, err := c.edgePlacementLister.Cluster(ws).Get(name)
+			epObj, err := c.edgePlacementLister.Get(name)
 			if err != nil {
 				logger.Error(err, "failed to get EdgePlacement", "workloadWorkspace", ws, "edgePlacement", name)
 				return err
@@ -193,14 +193,14 @@ func (c *controller) reconcileOnSyncTarget(ctx context.Context, stKey string) er
 				logger.Error(err, "invalid EdgePlacement key")
 				return err
 			}
-			currentSPS, err := c.singlePlacementSliceLister.Cluster(ws).Get(name)
+			currentSPS, err := c.singlePlacementSliceLister.Get(name)
 			if err != nil {
 				logger.Error(err, "failed to get SinglePlacementSlice", "workloadWorkspace", ws, "singlePlacementSlice", name)
 				return err
 			}
 			nextSPS := cleanSPSBySt(currentSPS, stws.String(), stName)
 
-			epObj, err := c.edgePlacementLister.Cluster(ws).Get(name)
+			epObj, err := c.edgePlacementLister.Get(name)
 			if err != nil {
 				logger.Error(err, "failed to get EdgePlacement", "workloadWorkspace", ws, "edgePlacement", name)
 				return err


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
Initial replacement of KCP APIExport/APIBinding for view of exports with kube-bind in KubeStellar controllers

## Related issue(s)

Fixes #
