### PR TITLE
✨ Add implicit selection of CRDs, APIBindings

### DIFF
--- a/docs/content/Coding Milestones/PoC2023q1/example1-subs/example1-stage-2.md
+++ b/docs/content/Coding Milestones/PoC2023q1/example1-subs/example1-stage-2.md
@@ -150,9 +150,6 @@ spec:
   - apiGroup: apps
     resources: [ replicasets ]
     namespaces: [ commonstuff ]
-  - apiGroup: apis.kcp.io
-    resources: [ apibindings ]
-    objectNames: [ "bind-kubernetes", "bind-apps" ]
   wantSingletonReportedState: true
   upsync:
   - apiGroup: "group1.test"
@@ -365,16 +362,9 @@ spec:
     namespaceSelectors:
     - matchLabels: {"special":"yes"}
     objectNames: [ speciald ]
-  - apiGroup: apis.kcp.io
-    resources: [ apibindings ]
-    namespaceSelectors: []
-    objectNames: [ bind-kubernetes, bind-apps, bind-apiregistration.k8s.io ]
   - apiGroup: apiregistration.k8s.io
     resources: [ apiservices ]
     objectNames: [ v1090.example.my ]
-  - apiGroup: apiextensions.k8s.io
-    resources: [ customresourcedefinitions ]
-    objectNames: [ crontabs.stable.example.com ]
   - apiGroup: stable.example.com
     resources: [ crontabs ]
     namespaces: [ specialstuff ]

--- a/docs/content/Coding Milestones/PoC2023q1/example1-subs/example1-stage-3.md
+++ b/docs/content/Coding Milestones/PoC2023q1/example1-subs/example1-stage-3.md
@@ -106,6 +106,30 @@ status:
   ... (may be filled in by the time you look) ...
 ```
 
+That display should show objects in two different mailbox workspaces;
+the following command checks that.
+
+```shell
+test $(kubestellar-list-syncing-objects --api-group apps --api-kind ReplicaSet | grep "^ *kcp.io/cluster: [0-9a-z]*$" | sort | uniq | wc -l) -ge 2
+```
+
+The various APIBinding and CustomResourceDefinition objects involved
+should also appear in the mailbox workspaces.
+
+```shell
+test $(kubestellar-list-syncing-objects --api-group apis.kcp.io --api-version v1alpha1 --api-kind APIBinding | grep -cw "name: bind-apps") -ge 2
+kubestellar-list-syncing-objects --api-group apis.kcp.io --api-version v1alpha1 --api-kind APIBinding | grep -w "name: bind-kubernetes"
+kubestellar-list-syncing-objects --api-group apiextensions.k8s.io --api-kind CustomResourceDefinition | fgrep -w "name: crontabs.stable.example.com"
+```
+
+The `APIService` of the special workload should also appear, along
+with some error messages about `APIService` not being known in the
+other mailbox workspaces.
+
+```shell
+kubestellar-list-syncing-objects --api-group apiregistration.k8s.io --api-kind APIService 2>&1 | grep -v "APIService.*the server could not find the requested resource" | fgrep -w "name: v1090.example.my"
+```
+
 The florin cluster gets only the common workload.  Examine florin's
 `SyncerConfig` as follows.  Utilize the name of the mailbox workspace
 for florin (which you stored in Stage 1) here.

--- a/docs/content/Coding Milestones/PoC2023q1/example1-subs/example1-stage-4.md
+++ b/docs/content/Coding Milestones/PoC2023q1/example1-subs/example1-stage-4.md
@@ -59,8 +59,8 @@ NAMESPACE                            NAME                                       
 commonstuff                          replicaset.apps/commond                                         1         1         1       13m
 ```
 
-Examine the guilder cluster.  Find both workload namespaces and both
-Deployments.
+Examine the guilder cluster.  Find both workload namespaces, the
+Deployment, and both ReplicaSets.
 
 ``` {.bash .hide-me}
 sleep 15
@@ -95,6 +95,16 @@ KUBECONFIG=~/.kube/config kubectl --context kind-guilder get apiservices | grep 
 ```
 ``` {.bash .no-copy }
 v1090.example.my                       my-example/my-service   False (ServiceNotFound)   2m39s
+```
+
+See the crontab in the guilder cluster.
+
+```shell
+KUBECONFIG=~/.kube/config kubectl --context kind-guilder get crontabs -n specialstuff
+```
+``` {.bash .no-copy }
+NAME                 AGE
+my-new-cron-object   37m
 ```
 
 Examining the common workload in the guilder cluster, for example,

--- a/pkg/apiwatch/apibindings.go
+++ b/pkg/apiwatch/apibindings.go
@@ -18,12 +18,19 @@ package apiwatch
 
 import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 
 	apisv1alpha1 "github.com/kcp-dev/kcp/pkg/apis/apis/v1alpha1"
 )
 
 type APIBindingAnalyzer struct {
 	ObjectNotifier
+}
+
+var _ ResourceDefinitionSupplier = APIBindingAnalyzer{}
+
+func (aba APIBindingAnalyzer) GetGVK(obj any) schema.GroupVersionKind {
+	return apisv1alpha1.SchemeGroupVersion.WithKind("APIBinding")
 }
 
 func (aba APIBindingAnalyzer) EnumerateDefinedResources(obj any) ResourceDefinitionEnumerator {

--- a/pkg/apiwatch/crds.go
+++ b/pkg/apiwatch/crds.go
@@ -19,10 +19,17 @@ package apiwatch
 import (
 	apiext "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
 type CRDAnalyzer struct {
 	ObjectNotifier
+}
+
+var _ ResourceDefinitionSupplier = CRDAnalyzer{}
+
+func (crda CRDAnalyzer) GetGVK(obj any) schema.GroupVersionKind {
+	return apiext.SchemeGroupVersion.WithKind("CustomResourceDefinition")
 }
 
 func (crda CRDAnalyzer) EnumerateDefinedResources(obj any) ResourceDefinitionEnumerator {

--- a/pkg/apiwatch/resources.go
+++ b/pkg/apiwatch/resources.go
@@ -52,6 +52,7 @@ type ObjectNotifier interface {
 
 type ResourceDefinitionSupplier interface {
 	ObjectNotifier
+	GetGVK(obj any) schema.GroupVersionKind
 	EnumerateDefinedResources(definer any) ResourceDefinitionEnumerator
 }
 
@@ -198,8 +199,8 @@ func (rlw *resourcesListWatcher) invalidateWithDefinerLocked(obj any, supplier R
 		return
 	}
 	objM := obj.(metav1.Object)
-	objR := obj.(k8sruntime.Object)
-	gvk := objR.GetObjectKind().GroupVersionKind()
+	gvk := supplier.GetGVK(obj)
+	rlw.logger.V(4).Info("Examining resource definer", "obj", obj, "supplierType", fmt.Sprintf("%T", supplier), "gvk", gvk)
 	apiVersion, kind := gvk.ToAPIVersionAndKind()
 	oid := objectID{apiVersion, kind, objM.GetName()}
 	if oid.apiVersion == "" {

--- a/pkg/placement/apiwatch-map-provider.go
+++ b/pkg/placement/apiwatch-map-provider.go
@@ -83,6 +83,8 @@ func (awp *apiWatchProvider) AddReceivers(clusterName logicalcluster.Name,
 	defer awp.Unlock()
 	wpc := MapGetAdd(awp.perCluster, clusterName, true, func(clusterName logicalcluster.Name) *apiWatchProviderPerCluster {
 		ctx := context.Background()
+		logger := klog.FromContext(ctx).WithValues("part", "apiwatch-map-provider")
+		ctx = klog.NewContext(ctx, logger)
 		wpc := &apiWatchProviderPerCluster{
 			awp:     awp,
 			cluster: clusterName,

--- a/pkg/placement/doc.go
+++ b/pkg/placement/doc.go
@@ -80,6 +80,7 @@ package placement
 //   that enumerates and formats members.
 // - type Slice adds Visitable behavior to a slice,
 //   and adds a functional Append method.
+// - Slice is a slice with added methods that make it a Visible and almost a Set.
 
 // Set types:
 // - Interface Set declares methods to read aspects of a set.
@@ -101,6 +102,7 @@ package placement
 // - SetRemoveAll(MutableSet, Visitable) (someNew, allNew bool).
 // - MutableSetUnion1Elt(MutableSet, Elt).
 // - MutableSetUnion1Set(MutableSet, Set).
+// - SliceSet is a Set implemented by a slice with no duplicates
 
 // - MapSet implements MutableSet in the same way as the generic Set of Kubernetes
 //   (which is not in Kubernetes release 1.24).

--- a/pkg/placement/slices.go
+++ b/pkg/placement/slices.go
@@ -162,6 +162,7 @@ type Slice[Elt any] []Elt
 
 var _ Visitable[float64] = Slice[float64]{}
 
+// NewSlice makes a Visitable from a slice
 func NewSlice[Elt any](elts ...Elt) Slice[Elt] { return Slice[Elt](elts) }
 
 func (slice Slice[Elt]) IsEmpty() bool    { return len(slice) == 0 }
@@ -179,4 +180,20 @@ func (slice Slice[Elt]) Visit(visitor func(Elt) error) error {
 
 func (slice Slice[Elt]) Append(elt Elt) Slice[Elt] {
 	return append(slice, elt)
+}
+
+type SliceSet[Elt comparable] struct{ Slice[Elt] }
+
+var _ Set[int64] = SliceSet[int64]{}
+
+// NewSliceSet makes a Set from a slice that has no duplicates
+func NewSliceSet[Elt comparable](elts ...Elt) SliceSet[Elt] { return SliceSet[Elt]{NewSlice(elts...)} }
+
+func (slice SliceSet[Elt]) Has(seek Elt) bool {
+	for _, have := range slice.Slice {
+		if seek == have {
+			return true
+		}
+	}
+	return false
 }


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
This PR modifies the meaning of the downsync part of the "what predicate" in an EdgePlacement to implicitly include `CustomResourceDefinitions` and `APIBinding` objects that define the kinds of other selected objects.

This PR also makes the meaning downsync part of the "what predicate" exclude the things that match upsync part.

## Related issue(s)

I think this addresses the concerns behind #1064 and #1080.
