### PR TITLE
✨ Reproduce kube-bind example for wmw1 and imw1 in the init container

### DIFF
--- a/inner-scripts/kubestellar
+++ b/inner-scripts/kubestellar
@@ -323,8 +323,31 @@ function ensure_espw() {
     else
         kubectl ws create "$espw_name" --enter
     fi
+    run_dex
+    run_kb_backend
     eval kubectl apply -f "$bindir/../config/exports" $verbdir
     echo "Finished populating the espw with kubestellar apiexports"
+}
+
+function run_dex() {
+    echo "--< starting dex in background >--"
+    dex serve /home/kubestellar/dex/dex-config-dev.yaml &
+    if ! pgrep dex &> /dev/null; then
+        echo "dex not started"
+        exit 1
+    fi
+}
+
+function run_kb_backend() {
+    echo "--< starting kube-bind example-backend in background >--"
+    kubectl ws root:espw
+    kubectl apply -f /home/kubestellar/kube-bind/deploy/crd
+    kubectl apply -f /home/kubestellar/kube-bind/deploy/examples/crd-mangodb.yaml
+    example-backend --oidc-issuer-client-id=kube-bind --oidc-issuer-client-secret=ZXhhbXBsZS1hcHAtc2VjcmV0 --oidc-issuer-url=http://127.0.0.1:5556/dex --oidc-callback-url=http://127.0.0.1:8080/callback --pretty-name="BigCorp.com" --namespace-prefix="kube-bind-" --cookie-signing-key=bGMHz7SR9XcI9JdDB68VmjQErrjbrAR9JdVqjAOKHzE= --cookie-encryption-key=wadqi4u+w0bqnSrVFtM38Pz2ykYVIeeadhzT34XlC1Y= --consumer-scope="Cluster" &
+    if ! pgrep example-backend &> /dev/null; then
+        echo "kube-bind example-backend not started"
+        exit 1
+    fi
 }
 
 if [ "$subcommand" != init ]; then

--- a/inner-scripts/kubestellar
+++ b/inner-scripts/kubestellar
@@ -47,6 +47,26 @@ function echoerr() {
 }
 
 
+function run_kb_konnector_for_imw() {
+    echo "starting kube-bind konnector for imw in background"
+    kubectl create namespace kube-system
+    konnector &
+    if ! pgrep konnector &> /dev/null; then
+        echo "kube-bind konnector not started"
+        exit 1
+    fi
+}
+
+
+function bind_mangodbs_for_imw() {
+    echo "bind mangodb for imw"
+    if ! kubectl bind http://127.0.0.1:8080/export --skip-konnector --unattended --resource mangodbs ; then
+        echoerr "unable to bind mangodbs for imw"
+        exit 1
+    fi
+}
+
+
 function ensure_imws() {
     initial_ws=$(kubectl ws . --short)
     while IFS=',' read -ra items; do
@@ -63,6 +83,8 @@ function ensure_imws() {
                     break
                 fi
             fi
+            run_kb_konnector_for_imw
+            bind_mangodbs_for_imw
             if ! kubectl get apibinding "edge.kubestellar.io" &> /dev/null; then
                 kubectl kcp bind apiexport root:espw:edge.kubestellar.io
             fi

--- a/overlap-scripts/kubectl-kubestellar-ensure-wmw
+++ b/overlap-scripts/kubectl-kubestellar-ensure-wmw
@@ -91,6 +91,27 @@ spec:
 EOF
 fi
 
+function run_kb_konnector_for_wmw() {
+    echo "starting kube-bind konnector for wmw in background"
+    kubectl create namespace kube-system
+    konnector &
+    if ! pgrep konnector &> /dev/null; then
+        echo "kube-bind konnector not started"
+        exit 1
+    fi
+}
+
+function bind_mangodbs_for_wmw() {
+    echo "bind mangodb for wmw"
+    if ! kubectl bind http://127.0.0.1:8080/export --skip-konnector --unattended --resource mangodbs ; then
+        echoerr "unable to bind mangodbs for wmw"
+        exit 1
+    fi
+}
+
+run_kb_konnector_for_wmw
+bind_mangodbs_for_wmw
+
 function bind_iff_wanted() { # usage: export_name
     export_name=$1
     binding_name=bind-$export_name


### PR DESCRIPTION
This PR reproduces the kube-bind README.md scenario, but inside our kubestellar deployment's init container, via some initial scripting.

After `helm install`, I checked the syncing of a mangodb object between `wmw1` and `espw` to make sure it behaves as expected, including all CRUD operations.

/cc @ezrasilvera 
