### PR TITLE
🐛 Consistency wrt dynamicDuo.preInformer

### DIFF
--- a/docs/content/Coding Milestones/PoC2023q1/example1-subs/example1-stage-2.md
+++ b/docs/content/Coding Milestones/PoC2023q1/example1-subs/example1-stage-2.md
@@ -251,6 +251,7 @@ kind: Namespace
 metadata:
   name: specialstuff
   labels: {special: "yes"}
+  annotations: {just-for: fun}
 ---
 apiVersion: "stable.example.com/v1"
 kind: CronTab
@@ -345,6 +346,13 @@ Finally, use `kubectl` to create the following EdgePlacement object.
 Its "where predicate" (the `locationSelectors` array) has one label
 selector that matches only one of the Location objects created
 earlier, thus directing the special workload to just one edge cluster.
+
+The "what predicate" explicitly includes the `Namespace` object named
+"specialstuff", which causes all of its desired state (including
+labels and annotations) to be downsynced. This contrasts with the
+common EdgePlacement, which does not explicitly mention the
+`commonstuff` namespace, relying on the implicit creation of
+namespaces as needed in the WECs.
    
 ```shell
 kubectl apply -f - <<EOF
@@ -379,6 +387,9 @@ spec:
     resources: [ crontabs ]
     namespaces: [ specialstuff ]
     objectNames: [ my-new-cron-object ]
+  - apiGroup: ""
+    resources: [ namespaces ]
+    objectNames: [ specialstuff ]
   wantSingletonReportedState: true
   upsync:
   - apiGroup: "group1.test"

--- a/docs/content/Coding Milestones/PoC2023q1/example1-subs/example1-stage-3.md
+++ b/docs/content/Coding Milestones/PoC2023q1/example1-subs/example1-stage-3.md
@@ -196,6 +196,11 @@ metadata:
 spec:
   clusterScope:
   - apiVersion: v1
+    group: ""
+    objects:
+    - specialstuff
+    resource: namespaces
+  - apiVersion: v1
     group: apiextensions.k8s.io
     objects:
     - crontabs.stable.example.com

--- a/docs/content/Coding Milestones/PoC2023q1/outline.md
+++ b/docs/content/Coding Milestones/PoC2023q1/outline.md
@@ -259,8 +259,13 @@ These should have their usual effect in both center and edge; they
 need no distinct treatment.
 
 Note, however, that they _do_ have some sequencing implications.  They
-have to be created before any dependent objects, deleted after all
-dependent objects.
+should be created before any dependent objects, deleted after all
+dependent objects. Ordering violations only cause log noise.
+
+These are also exceptional in their reported state. It is managed by
+the apiserver. Leaving them natured in the WDS and the mailbox
+workspace means that they can not hold their reported state from the
+WEC.
 
 | APIVERSION | KIND | NAMESPACED |
 | ---------- | ---- | ---------- |


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
This PR updates the design outline to explicitly discuss reported state of Namespace and CustomResourceDefinition objects, and fixes some bugs in the workload-projector in those areas.

This PR also expands example1 so that one of the EdgePlacement's "what predicate" explicitly matches a Namespace object.

## Related issue(s)

Fixes #1226
