### PR TITLE
:bug: support status update for both cases of subresource and non subresource

### DIFF
--- a/pkg/syncer/clientfactory/client.go
+++ b/pkg/syncer/clientfactory/client.go
@@ -28,12 +28,17 @@ import (
 )
 
 type Client struct {
-	ResourceClient dynamic.NamespaceableResourceInterface
-	scope          meta.RESTScope
+	ResourceClient          dynamic.NamespaceableResourceInterface
+	scope                   meta.RESTScope
+	hasStatusInSubresources bool
 }
 
 func (c *Client) IsNamespaced() bool {
 	return c.scope == meta.RESTScopeNamespace
+}
+
+func (c *Client) HasStatusInSubresources() bool {
+	return c.hasStatusInSubresources
 }
 
 func (c *Client) Create(resource edgev2alpha1.EdgeSyncConfigResource, unstObj *unstructured.Unstructured) (*unstructured.Unstructured, error) {

--- a/pkg/syncer/clientfactory/clientfactory.go
+++ b/pkg/syncer/clientfactory/clientfactory.go
@@ -74,6 +74,27 @@ func (cf *ClientFactory) GetResourceClient(group string, kind string) (Client, e
 	resourceClient = Client{
 		ResourceClient: client,
 		scope:          mapping.Scope,
+		hasStatusInSubresources: cf.hasStatus(groupResources, schema.GroupVersionResource{
+			Group:    mapping.Resource.Group,
+			Version:  mapping.Resource.Version,
+			Resource: mapping.Resource.Resource,
+		}),
 	}
 	return resourceClient, nil
+}
+
+func (cf *ClientFactory) hasStatus(groupResources []*restmapper.APIGroupResources, gvr schema.GroupVersionResource) bool {
+	for _, grs := range groupResources {
+		if grs.Group.Name == gvr.Group {
+			rs, found := grs.VersionedResources[gvr.Version]
+			if found {
+				for _, r := range rs {
+					if r.Name == gvr.Resource+"/status" {
+						return true
+					}
+				}
+			}
+		}
+	}
+	return false
 }

--- a/pkg/syncer/syncers/downsyncer.go
+++ b/pkg/syncer/syncers/downsyncer.go
@@ -19,7 +19,6 @@ package syncers
 import (
 	"errors"
 	"fmt"
-	"strings"
 	"sync"
 
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
@@ -394,15 +393,10 @@ func (ds *DownSyncer) BackStatusMany(resource edgev2alpha1.EdgeSyncConfigResourc
 }
 
 func updateStatusByResource(upstreamClient *Client, resourceForUp edgev2alpha1.EdgeSyncConfigResource, upstreamResource *unstructured.Unstructured) (*unstructured.Unstructured, error) {
-	// TODO: make a more informed choice
-	if isKubeResource(resourceForUp) {
+	if upstreamClient.HasStatusInSubresources() {
 		return upstreamClient.UpdateStatus(resourceForUp, upstreamResource)
 	}
 	return upstreamClient.Update(resourceForUp, upstreamResource)
-}
-
-func isKubeResource(rsc edgev2alpha1.EdgeSyncConfigResource) bool {
-	return strings.HasSuffix(rsc.Group, ".k8s.io") || !strings.Contains(rsc.Group, ".")
 }
 
 func findWithObject(target unstructured.Unstructured, resourceList *unstructured.UnstructuredList) (*unstructured.Unstructured, bool) {

--- a/test/e2e/kubestellar-syncer/testdata/update-status/non-subresource/sample-crd-cr.yaml
+++ b/test/e2e/kubestellar-syncer/testdata/update-status/non-subresource/sample-crd-cr.yaml
@@ -1,0 +1,8 @@
+apiVersion: my.domain/v1alpha1
+kind: Sample
+metadata:
+  name: sample
+  annotations:
+    edge.kubestellar.io/downsync-overwrite: "false"
+spec:
+  foo: bar downsync

--- a/test/e2e/kubestellar-syncer/testdata/update-status/non-subresource/sample-crd.yaml
+++ b/test/e2e/kubestellar-syncer/testdata/update-status/non-subresource/sample-crd.yaml
@@ -1,0 +1,51 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: samples.my.domain
+spec:
+  group: my.domain
+  names:
+    kind: Sample
+    listKind: SampleList
+    plural: samples
+    singular: sample
+  scope: Cluster
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: Widget is the Schema for the clusterscopedcrs API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: WidgetSpec defines the desired state of Widget
+            properties:
+              foo:
+                type: string
+            type: object
+          status:
+            description: WidgetStatus defines the observed state of Widget
+            properties:
+              state:
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/test/e2e/kubestellar-syncer/testdata/update-status/non-subresource/sample-subresource-crd-cr.yaml
+++ b/test/e2e/kubestellar-syncer/testdata/update-status/non-subresource/sample-subresource-crd-cr.yaml
@@ -1,0 +1,6 @@
+apiVersion: my.domain/v1alpha1
+kind: SampleSubresource
+metadata:
+  name: sample-subresource
+spec:
+  foo: bar downsync

--- a/test/e2e/kubestellar-syncer/testdata/update-status/non-subresource/sample-subresource-crd.yaml
+++ b/test/e2e/kubestellar-syncer/testdata/update-status/non-subresource/sample-subresource-crd.yaml
@@ -1,0 +1,53 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: samplesubresources.my.domain
+spec:
+  group: my.domain
+  names:
+    kind: SampleSubresource
+    listKind: SampleSubresourceList
+    plural: samplesubresources
+    singular: samplesubresource
+  scope: Cluster
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: Widget is the Schema for the clusterscopedcrs API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: WidgetSpec defines the desired state of Widget
+            properties:
+              foo:
+                type: string
+            type: object
+          status:
+            description: WidgetStatus defines the observed state of Widget
+            properties:
+              state:
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/test/e2e/kubestellar-syncer/testdata/update-status/non-subresource/status.yaml
+++ b/test/e2e/kubestellar-syncer/testdata/update-status/non-subresource/status.yaml
@@ -1,0 +1,1 @@
+state: pass

--- a/test/e2e/kubestellar-syncer/testdata/update-status/non-subresource/syncer-config.yaml
+++ b/test/e2e/kubestellar-syncer/testdata/update-status/non-subresource/syncer-config.yaml
@@ -1,0 +1,22 @@
+apiVersion: edge.kubestellar.io/v2alpha1
+kind: SyncerConfig
+metadata:
+  name: syncer-config
+spec:
+  clusterScope:
+  - apiVersion: v1
+    group: apiextensions.k8s.io
+    resource: customresourcedefinitions
+    objects:
+    - samples.my.domain
+    - samplesubresources.my.domain
+  - apiVersion: v1alpha1
+    group: my.domain
+    resource: samples
+    objects:
+    - sample
+  - apiVersion: v1alpha1
+    group: my.domain
+    resource: samplesubresources
+    objects:
+    - sample-subresource


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

MCAD has fixed to move `status` field of [appWrapper](https://github.com/cwiklik/multi-cluster-app-dispatcher/blob/mcad133/config/crd/bases/mcad.ibm.com_appwrappers.yaml) in subresource since v1.33. In the previous versions (at least before v1.31), the `status` hadn't been subresource. Such `status` can not be updated by [UpdateStatus method.](https://github.com/kubernetes/client-go/blob/v0.28.3/dynamic/interface.go#L36C4-L36C4) In order to address this issue, we made a tentative fix so that we use UpdateStatus method for built-in k8s resources while just [Update method](https://github.com/kubernetes/client-go/blob/v0.28.3/dynamic/interface.go#L35). (The corresponding git issue is   https://github.com/kubestellar/kubestellar/pull/947/files#diff-8f3c8f861fc2c427af64605adf617851b657a18cb8518cc4b46267b11014fa48R336)

To support both cases, I add a check logic if the status field of the resource to be status-upsynced is defined in subresource or not in this PR.
 
FYI: @dumb0002 

## Related issue(s)

Fixes #947, #945
