### PR TITLE
🐛 Make example1 wait for readyReplicas==1

### DIFF
--- a/docs/content/Coding Milestones/PoC2023q1/example1.md
+++ b/docs/content/Coding Milestones/PoC2023q1/example1.md
@@ -83,7 +83,28 @@ it has been filled in with the information from the guilder cluster.
 
 ```shell
 kubectl get deploy -n specialstuff speciald -o yaml
-kubectl get deploy -n specialstuff speciald -o yaml | grep 'readyReplicas: 1'
+```
+
+Current status might not be there yet. The following command waits for
+status that reports that there is a special workload pod "ready".
+
+```shell
+let count=1
+while true; do
+    rsyaml=$(kubectl get deploy -n specialstuff speciald -o yaml)
+    if grep 'readyReplicas: 1' <<<"$rsyaml"
+    then break
+    fi
+    echo ""
+    echo "Got:"
+    cat <<<"$rsyaml"
+    if (( count > 5 )); then
+        echo 'Giving up!' >&2
+        false
+    fi
+    sleep 15
+    let count=count+1
+done
 ```
 
 ### Status Summarization (aspirational)


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
This PR updates the example1 script to wait for the expected ReplicaSet status rather than fail if it is not there at once.

## Related issue(s)

Fixes #1234 
