### PR TITLE
✨ Test the local helm chart rather than a released one

### DIFF
--- a/docs/content/common-subs/install-helm-test.md
+++ b/docs/content/common-subs/install-helm-test.md
@@ -5,7 +5,7 @@ KUBECONFIG=~/.kube/config kubectl create namespace kubestellar
 
 helm repo add kubestellar https://helm.kubestellar.io
 helm repo update
-KUBECONFIG=~/.kube/config helm install kubestellar/kubestellar-core \
+KUBECONFIG=~/.kube/config helm install ./core-helm-chart \
   --set EXTERNAL_HOSTNAME="kubestellar.core" \
   --set EXTERNAL_PORT={{ config.ks_kind_port_num }} \
   --set image.tag=$EXTRA_CORE_TAG \


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
This PR makes the user-quickstart-test use the local copy of the helm chart rather than fetch one from the repo.

## Related issue(s)

Fixes #
