### PR TITLE
✨ Kube-bind KubeStellar resources for IMWs, WMWs, and MBWs

### DIFF
--- a/core.Dockerfile
+++ b/core.Dockerfile
@@ -86,7 +86,6 @@ COPY --from=builder /home/kubestellar/bin                                bin/
 COPY --from=builder /home/kubestellar/config                             config/
 COPY --from=builder /home/kubestellar/kube-bind/bin                      kube-bind/bin/
 COPY --from=builder /home/kubestellar/kube-bind/deploy/crd               kube-bind/deploy/crd
-COPY --from=builder /home/kubestellar/kube-bind/deploy/examples          kube-bind/deploy/examples
 COPY --from=builder /home/kubestellar/dex/bin                            dex/bin/
 COPY --from=builder /home/kubestellar/kube-bind/hack/dex-config-dev.yaml dex/dex-config-dev.yaml
 

--- a/inner-scripts/kubestellar
+++ b/inner-scripts/kubestellar
@@ -92,9 +92,6 @@ function ensure_imws() {
             run_kb_konnector_for_imw
             bind_resource_for_imw "synctargets"
             bind_resource_for_imw "locations"
-            if ! kubectl get apibinding "edge.kubestellar.io" &> /dev/null; then
-                kubectl kcp bind apiexport root:espw:edge.kubestellar.io
-            fi
         done
     done <<< "$1"
     kubectl ws use $initial_ws &> /dev/null # go back to the initial state

--- a/inner-scripts/kubestellar
+++ b/inner-scripts/kubestellar
@@ -65,9 +65,9 @@ function run_kb_konnector_for_imw() {
 
 function bind_resource_for_imw() {
     RESOURCE="$1"
-    echo "bind $RESOURCE for imw"
+    echo "binding $RESOURCE for imw"
     if ! kubectl bind http://127.0.0.1:8080/export --skip-konnector --unattended --resource "$RESOURCE" ; then
-        echoerr "unable to bind $RESOURCE for imw"
+        echo "unable to bind $RESOURCE for imw"
         exit 1
     fi
 }
@@ -373,8 +373,6 @@ function run_kb_backend() {
     echo "--< starting kube-bind example-backend in background >--"
     kubectl ws root:espw
     kubectl apply -f /home/kubestellar/kube-bind/deploy/crd
-    # TODO: remove mangodb crd
-    kubectl apply -f /home/kubestellar/kube-bind/deploy/examples/crd-mangodb.yaml
     example-backend --oidc-issuer-client-id=kube-bind --oidc-issuer-client-secret=ZXhhbXBsZS1hcHAtc2VjcmV0 --oidc-issuer-url=http://127.0.0.1:5556/dex --oidc-callback-url=http://127.0.0.1:8080/callback --pretty-name="BigCorp.com" --namespace-prefix="kube-bind-" --cookie-signing-key=bGMHz7SR9XcI9JdDB68VmjQErrjbrAR9JdVqjAOKHzE= --cookie-encryption-key=wadqi4u+w0bqnSrVFtM38Pz2ykYVIeeadhzT34XlC1Y= --consumer-scope="Cluster" &
     if ! pgrep example-backend &> /dev/null; then
         echo "kube-bind example-backend not started"

--- a/inner-scripts/kubestellar
+++ b/inner-scripts/kubestellar
@@ -48,8 +48,13 @@ function echoerr() {
 
 
 function run_kb_konnector_for_imw() {
+    if kubectl get ns kube-system &> /dev/null; then
+        echo "namespace kube-system already exists, skipping"
+    else
+        echo "creating namespace kube-system"
+        kubectl create ns kube-system
+    fi
     echo "starting kube-bind konnector for imw in background"
-    kubectl create namespace kube-system
     konnector &
     if ! pgrep konnector &> /dev/null; then
         echo "kube-bind konnector not started"
@@ -58,10 +63,11 @@ function run_kb_konnector_for_imw() {
 }
 
 
-function bind_mangodbs_for_imw() {
-    echo "bind mangodb for imw"
-    if ! kubectl bind http://127.0.0.1:8080/export --skip-konnector --unattended --resource mangodbs ; then
-        echoerr "unable to bind mangodbs for imw"
+function bind_resource_for_imw() {
+    RESOURCE="$1"
+    echo "bind $RESOURCE for imw"
+    if ! kubectl bind http://127.0.0.1:8080/export --skip-konnector --unattended --resource "$RESOURCE" ; then
+        echoerr "unable to bind $RESOURCE for imw"
         exit 1
     fi
 }
@@ -84,7 +90,8 @@ function ensure_imws() {
                 fi
             fi
             run_kb_konnector_for_imw
-            bind_mangodbs_for_imw
+            bind_resource_for_imw "synctargets"
+            bind_resource_for_imw "locations"
             if ! kubectl get apibinding "edge.kubestellar.io" &> /dev/null; then
                 kubectl kcp bind apiexport root:espw:edge.kubestellar.io
             fi
@@ -347,6 +354,8 @@ function ensure_espw() {
     fi
     run_dex
     run_kb_backend
+    kubectl apply -f /home/kubestellar/config/crds/
+    kubectl get crd -oname | grep kubestellar.io | xargs -i kubectl label {} kube-bind.io/exported=true
     eval kubectl apply -f "$bindir/../config/exports" $verbdir
     echo "Finished populating the espw with kubestellar apiexports"
 }
@@ -364,6 +373,7 @@ function run_kb_backend() {
     echo "--< starting kube-bind example-backend in background >--"
     kubectl ws root:espw
     kubectl apply -f /home/kubestellar/kube-bind/deploy/crd
+    # TODO: remove mangodb crd
     kubectl apply -f /home/kubestellar/kube-bind/deploy/examples/crd-mangodb.yaml
     example-backend --oidc-issuer-client-id=kube-bind --oidc-issuer-client-secret=ZXhhbXBsZS1hcHAtc2VjcmV0 --oidc-issuer-url=http://127.0.0.1:5556/dex --oidc-callback-url=http://127.0.0.1:8080/callback --pretty-name="BigCorp.com" --namespace-prefix="kube-bind-" --cookie-signing-key=bGMHz7SR9XcI9JdDB68VmjQErrjbrAR9JdVqjAOKHzE= --cookie-encryption-key=wadqi4u+w0bqnSrVFtM38Pz2ykYVIeeadhzT34XlC1Y= --consumer-scope="Cluster" &
     if ! pgrep example-backend &> /dev/null; then

--- a/overlap-scripts/kubectl-kubestellar-ensure-mbw
+++ b/overlap-scripts/kubectl-kubestellar-ensure-mbw
@@ -1,0 +1,141 @@
+#!/usr/bin/env bash
+
+# Copyright 2023 The KubeStellar Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Purpose: ensure that a mailbox workspace has the needed KubeStellar CRDs.
+
+# Usage: $0 ($kubectl_flag | --with-kube boolean | -X)* mbw_name
+
+want_kube=true
+mbw_name=""
+
+while (( $# > 0 )); do
+    case "$1" in
+	(-h|--help)
+	    echo "Usage: kubectl kubestellar ensure mbw (\$kubectl_flag | --with-kube boolean | -X)* wm_workspace_name"
+	    exit 0;;
+	(-X) set -o xtrace;;
+	(--with-kube)
+	    if (( $# >1 ))
+	    then want_kube="$2"; shift
+	    else echo "$0: missing with-kube value" >&2; exit 1
+	    fi;;
+	(--context*)
+	    # TODO: support --context
+	    echo "$0: --context flag not supported" >&2; exit 1;;
+	(--*=*|-?=*)
+	    kubectl_flags[${#kubectl_flags[*]}]="$1";;
+	(--*|-?)
+	    kubectl_flags[${#kubectl_flags[*]}]="$1";
+	    if (( $# > 1 )); then 
+		 kubectl_flags[${#kubectl_flags[*]}]="$2"
+		 shift
+	    fi;;
+	(-*)
+	    echo "$0: flag syntax error" >&2
+	    exit 1;;
+	(*)
+	    if [ -z "$mbw_name" ]
+	    then mbw_name="$1"
+	    else echo "$0: too many positional arguments" >&2
+		 exit 1
+	    fi
+    esac
+    shift
+done
+
+if [ "$mbw_name" == "" ]; then
+    echo "$0: workload management workspace name not specified" >&2
+    exit 1
+fi
+
+case "$want_kube" in
+    (true|false) ;;
+    (*) echo "$0: with-kube should be true or false" >&2
+	exit 1;;
+esac
+
+set -e
+
+kubectl ws "${kubectl_flags[@]}" root
+
+if kubectl "${kubectl_flags[@]}" get workspaces.tenancy.kcp.io "$mbw_name" &> /dev/null
+then kubectl ws "${kubectl_flags[@]}" "$mbw_name"
+else
+    echo "mailbox workspace $mbw_name doesn't exist"
+    exit 1
+fi
+
+function run_kb_konnector_for_mbw() {
+    if kubectl get ns kube-system &> /dev/null; then
+        echo "namespace kube-system already exists, skipping"
+    else
+        echo "creating namespace kube-system"
+        kubectl create ns kube-system
+    fi
+    echo "starting kube-bind konnector for mbw in background"
+    konnector &
+    if ! pgrep konnector &> /dev/null; then
+        echo "kube-bind konnector not started"
+        exit 1
+    fi
+}
+
+function bind_resource_for_mbw() {
+    RESOURCE="$1"
+    echo "binding $RESOURCE for mbw"
+    if ! kubectl bind http://127.0.0.1:8080/export --skip-konnector --unattended --resource "$RESOURCE" ; then
+        echo "unable to bind $RESOURCE for mbw"
+        exit 1
+    fi
+}
+
+run_kb_konnector_for_mbw
+bind_resource_for_mbw "syncerconfigs"
+bind_resource_for_mbw "edgesyncconfigs"
+
+function bind_iff_wanted() { # usage: export_name
+    export_name=$1
+    binding_name=bind-$export_name
+    if [ "$want_kube" == true ] && ! kubectl "${kubectl_flags[@]}" get APIBinding ${binding_name} &> /dev/null; then
+kubectl "${kubectl_flags[@]}" apply -f - <<EOF
+apiVersion: apis.kcp.io/v1alpha1
+kind: APIBinding
+metadata:
+  name: ${binding_name}
+spec:
+  reference:
+    export:
+      path: root:compute
+      name: ${export_name}
+EOF
+elif [ "$want_kube" == false ] && kubectl "${kubectl_flags[@]}" get APIBinding ${binding_name} &> /dev/null; then
+     kubectl "${kubectl_flags[@]}" delete APIBinding ${binding_name}
+fi
+}
+
+bind_iff_wanted kubernetes
+bind_iff_wanted apiregistration.k8s.io
+bind_iff_wanted apps
+bind_iff_wanted autoscaling
+bind_iff_wanted batch
+bind_iff_wanted core.k8s.io
+bind_iff_wanted discovery.k8s.io
+bind_iff_wanted flowcontrol.apiserver.k8s.io
+bind_iff_wanted networking.k8s.io
+bind_iff_wanted node.k8s.io
+bind_iff_wanted policy
+bind_iff_wanted scheduling.k8s.io
+bind_iff_wanted storage.k8s.io

--- a/overlap-scripts/kubectl-kubestellar-ensure-wmw
+++ b/overlap-scripts/kubectl-kubestellar-ensure-wmw
@@ -77,20 +77,6 @@ then kubectl ws "${kubectl_flags[@]}" "$wmw_name"
 else kubectl ws "${kubectl_flags[@]}" create "$wmw_name" --enter
 fi
 
-if ! kubectl "${kubectl_flags[@]}" get APIBinding bind-espw &> /dev/null; then
-kubectl "${kubectl_flags[@]}" apply -f - <<EOF
-apiVersion: apis.kcp.io/v1alpha1
-kind: APIBinding
-metadata:
-  name: bind-espw
-spec:
-  reference:
-    export:
-      path: root:espw
-      name: edge.kubestellar.io
-EOF
-fi
-
 function run_kb_konnector_for_wmw() {
     if kubectl get ns kube-system &> /dev/null; then
         echo "namespace kube-system already exists, skipping"
@@ -118,6 +104,7 @@ function bind_resource_for_wmw() {
 run_kb_konnector_for_wmw
 bind_resource_for_wmw "edgeplacements"
 bind_resource_for_wmw "customizers"
+bind_resource_for_wmw "singleplacementslices"
 
 function bind_iff_wanted() { # usage: export_name
     export_name=$1

--- a/overlap-scripts/kubectl-kubestellar-ensure-wmw
+++ b/overlap-scripts/kubectl-kubestellar-ensure-wmw
@@ -106,16 +106,18 @@ function run_kb_konnector_for_wmw() {
     fi
 }
 
-function bind_mangodbs_for_wmw() {
-    echo "bind mangodb for wmw"
-    if ! kubectl bind http://127.0.0.1:8080/export --skip-konnector --unattended --resource mangodbs ; then
-        echoerr "unable to bind mangodbs for wmw"
+function bind_resource_for_wmw() {
+    RESOURCE="$1"
+    echo "binding $RESOURCE for wmw"
+    if ! kubectl bind http://127.0.0.1:8080/export --skip-konnector --unattended --resource "$RESOURCE" ; then
+        echo "unable to bind $RESOURCE for wmw"
         exit 1
     fi
 }
 
 run_kb_konnector_for_wmw
-bind_mangodbs_for_wmw
+bind_resource_for_wmw "edgeplacements"
+bind_resource_for_wmw "customizers"
 
 function bind_iff_wanted() { # usage: export_name
     export_name=$1

--- a/overlap-scripts/kubectl-kubestellar-ensure-wmw
+++ b/overlap-scripts/kubectl-kubestellar-ensure-wmw
@@ -92,8 +92,13 @@ EOF
 fi
 
 function run_kb_konnector_for_wmw() {
+    if kubectl get ns kube-system &> /dev/null; then
+        echo "namespace kube-system already exists, skipping"
+    else
+        echo "creating namespace kube-system"
+        kubectl create ns kube-system
+    fi
     echo "starting kube-bind konnector for wmw in background"
-    kubectl create namespace kube-system
     konnector &
     if ! pgrep konnector &> /dev/null; then
         echo "kube-bind konnector not started"


### PR DESCRIPTION
## Summary
This PR, along with previous PRs, finishes step 2 of the 'Use kube-bind' section listed in #1208.

Just a partial copy of that list:
1. the KS container image (used by all KS containers) should include the KB needed executables
2. Setup scripts that build the ESPW, WDS, and IS should be changed to:
- Run dex,
- ESPW: Run backend engine + import all KS CRDs + add KB export label + import the KB CRDs
- IS, WDS: Run konnector, bind all KS resources
