### PR TITLE
:bug: fix syncer-gen to generate SA token for later K8Ss that no longer generate SA token automatically

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "go.sum|docs/package-lock.json|cmd/kube-watchall/go.sum|docs/config.toml|docs/resources/_gen|docs/static|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2023-10-07T07:06:02Z",
+  "generated_at": "2023-11-03T15:34:50Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -89,18 +89,23 @@
     ],
     "pkg/cliplugins/kubestellar/syncer-gen/edgesync.go": [
       {
-        "hashed_secret": "4f151c44a6783667af6cedaa3d12560f8af2f38a",
-        "is_secret": false,
+        "hashed_secret": "9fbd4024ebb2c7e2779a80aa127d560c62234e4f",
         "is_verified": false,
-        "line_number": 481,
+        "line_number": 495,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "4f151c44a6783667af6cedaa3d12560f8af2f38a",
+        "is_verified": false,
+        "line_number": 514,
         "type": "Secret Keyword",
         "verified_result": null
       },
       {
         "hashed_secret": "eba2ae817b95fdb713f3af658a6ae1821e452264",
-        "is_secret": false,
         "is_verified": false,
-        "line_number": 585,
+        "line_number": 620,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/go.mod
+++ b/go.mod
@@ -30,6 +30,7 @@ require (
 	k8s.io/component-base v0.24.3
 	k8s.io/klog/v2 v2.100.1
 	k8s.io/kubernetes v1.24.3
+	k8s.io/utils v0.0.0-20230406110748-d93618cff8a2
 	sigs.k8s.io/yaml v1.3.0
 )
 
@@ -174,7 +175,6 @@ require (
 	k8s.io/kubelet v0.0.0 // indirect
 	k8s.io/mount-utils v0.0.0 // indirect
 	k8s.io/pod-security-admission v0.0.0 // indirect
-	k8s.io/utils v0.0.0-20230406110748-d93618cff8a2 // indirect
 	sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.0.30 // indirect
 	sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd // indirect
 	sigs.k8s.io/kind v0.20.0 // indirect


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

- Fix syncer-gen (`kubectl kubestellar syncer-gen`) to generate the service account token for the service account for Syncer to connect to MBS for K8Ss environments that no longer generate SA token automatically.

(Thanks Paolo for giving the manual sequences.)

## Verification
I verified in two kcp environments (regular k8s and k8s compounded in kubestellar v0.12.0 where workspace is configured so that SA token is not generated automatically) that the generated kubeconfig can be accessible to MBS.

## Related issue(s)

Fixes #
