### PR TITLE
🐛 Rebased update bootstrap and container image to use the patched kcp 0.11

### DIFF
--- a/bootstrap/bootstrap-kubestellar.sh
+++ b/bootstrap/bootstrap-kubestellar.sh
@@ -47,10 +47,10 @@ kcp_installed() {
 
 kcp_download() {
     if [ $verbose == "true" ]; then
-        curl -SL -o kcp.tar.gz "https://github.com/kcp-dev/kcp/releases/download/${kcp_version}/kcp_${kcp_version//v}_${os_type}_${arch_type}.tar.gz"
+        curl -SL -o kcp.tar.gz "https://github.com/kubestellar/kubestellar/releases/download/v0.12.0/kcp_0.11.0_${os_type}_${arch_type}.tar.gz"
         curl -SL -o kcp-plugins.tar.gz "https://github.com/kcp-dev/kcp/releases/download/${kcp_version}/kubectl-kcp-plugin_${kcp_version//v}_${os_type}_${arch_type}.tar.gz"
     else
-        curl -sSL -o kcp.tar.gz "https://github.com/kcp-dev/kcp/releases/download/${kcp_version}/kcp_${kcp_version//v}_${os_type}_${arch_type}.tar.gz"
+        curl -sSL -o kcp.tar.gz "https://github.com/kubestellar/kubestellar/releases/download/v0.12.0/kcp_0.11.0_${os_type}_${arch_type}.tar.gz"
         curl -sSL -o kcp-plugins.tar.gz "https://github.com/kcp-dev/kcp/releases/download/${kcp_version}/kubectl-kcp-plugin_${kcp_version//v}_${os_type}_${arch_type}.tar.gz"
     fi
 }

--- a/bootstrap/install-kcp-with-plugins.sh
+++ b/bootstrap/install-kcp-with-plugins.sh
@@ -128,11 +128,11 @@ fi
 
 if [ $verbose == "true" ]; then
     echo "Downloading KCP $kcp_version $kcp_os/$kcp_arch..."
-    curl -SL -o kcp.tar.gz "https://github.com/kcp-dev/kcp/releases/download/${kcp_version}/kcp_${kcp_version//v}_${kcp_os}_${kcp_arch}.tar.gz"
+    curl -SL -o kcp.tar.gz "https://github.com/kubestellar/kubestellar/releases/download/v0.12.0/kcp_0.11.0_${kcp_os}_${kcp_arch}.tar.gz"
     echo "Downloading KCP plugins $kcp_version $kcp_os/$kcp_arch..."
     curl -SL -o kcp-plugins.tar.gz "https://github.com/kcp-dev/kcp/releases/download/${kcp_version}/kubectl-kcp-plugin_${kcp_version//v}_${kcp_os}_${kcp_arch}.tar.gz"
 else
-    curl -sSL -o kcp.tar.gz "https://github.com/kcp-dev/kcp/releases/download/${kcp_version}/kcp_${kcp_version//v}_${kcp_os}_${kcp_arch}.tar.gz"
+    curl -sSL -o kcp.tar.gz "https://github.com/kubestellar/kubestellar/releases/download/v0.12.0/kcp_0.11.0_${kcp_os}_${kcp_arch}.tar.gz"
     curl -sSL -o kcp-plugins.tar.gz "https://github.com/kcp-dev/kcp/releases/download/${kcp_version}/kubectl-kcp-plugin_${kcp_version//v}_${kcp_os}_${kcp_arch}.tar.gz"
 fi
 

--- a/core.Dockerfile
+++ b/core.Dockerfile
@@ -26,7 +26,7 @@ RUN mkdir -p .kcp && \
     mkdir easy-rsa && \
     tar -C easy-rsa -zxf easy-rsa.tar.gz --wildcards --strip-components=1 EasyRSA*/* && \
     rm easy-rsa.tar.gz && \
-    curl -SL -o kcp.tar.gz "https://github.com/kcp-dev/kcp/releases/download/v0.11.0/kcp_0.11.0_${TARGETOS}_${TARGETARCH}.tar.gz" && \
+    curl -SL -o kcp.tar.gz "https://github.com/kubestellar/kubestellar/releases/download/v0.12.0/kcp_0.11.0_${TARGETOS}_${TARGETARCH}.tar.gz" && \
     mkdir kcp && \
     tar -C kcp -zxf kcp.tar.gz && \
     rm kcp.tar.gz && \

--- a/docs/content/Coding Milestones/PoC2023q1/example1-subs/example1-start-kcp.md
+++ b/docs/content/Coding Milestones/PoC2023q1/example1-subs/example1-start-kcp.md
@@ -6,23 +6,40 @@ ways: as bare processes on whatever host you are using to run this
 example, or as workload in a Kubernetes cluster (an OpenShift cluster
 qualifies).  Do one or the other, not both.
 
-KubeStellar only works with release `v0.11.0` of kcp.
+KubeStellar only works with release `v0.11.0` of kcp. To downsync ServiceAccount objects you will need a patched version of that in order to get the denaturing of them as discussed [in the design outline](../../outline/#needs-to-be-denatured-in-center-natured-in-edge).
 
 ### Deploy kcp and KubeStellar as bare processes
 
 #### Start kcp
 
-Download and build or install [kcp](https://github.com/kcp-dev/kcp/releases/tag/v0.11.0),
-according to your preference.  See the start of [the kcp quickstart](https://docs.kcp.io/kcp/v0.11/#quickstart) for instructions on that, but get [release v0.11.0](https://github.com/kcp-dev/kcp/releases/tag/v0.11.0) rather than the latest (the downloadable assets appear after the long list of changes/features/etc).
+The following commands fetch the appropriate kcp server and plugins for your OS and ISA and download them and put them on your `$PATH`.
 
-Clone the v0.11.0 branch of the kcp source:
 ```shell
-git clone -b v0.11.0 https://github.com/kcp-dev/kcp kcp
-```
-and build the kubectl-ws binary and include it in `$PATH`
-```shell
+rm -rf kcp
+mkdir kcp
 pushd kcp
-make build
+(
+  set -x
+  case "$OSTYPE" in
+      linux*)   os_type="linux" ;;
+      darwin*)  os_type="darwin" ;;
+      *)        echo "Unsupported operating system type: $OSTYPE" >&2
+                false ;;
+  esac
+  case "$HOSTTYPE" in
+      x86_64*)  arch_type="amd64" ;;
+      aarch64*) arch_type="arm64" ;;
+      arm64*)   arch_type="arm64" ;;
+      *)        echo "Unsupported architecture type: $HOSTTYPE" >&2
+                false ;;
+  esac
+  kcp_version=v0.11.0
+  trap "rm kcp.tar.gz kcp-plugins.tar.gz" EXIT
+  curl -SL -o kcp.tar.gz "https://github.com/kubestellar/kubestellar/releases/download/v0.12.0/kcp_0.11.0_${os_type}_${arch_type}.tar.gz"
+  curl -SL -o kcp-plugins.tar.gz "https://github.com/kcp-dev/kcp/releases/download/${kcp_version}/kubectl-kcp-plugin_${kcp_version//v}_${os_type}_${arch_type}.tar.gz"
+  tar -xzf kcp-plugins.tar.gz
+  tar -xzf kcp.tar.gz
+)
 export PATH=$(pwd)/bin:$PATH
 ```
 

--- a/outer-scripts/kubectl-kubestellar-prep_for_syncer
+++ b/outer-scripts/kubectl-kubestellar-prep_for_syncer
@@ -35,7 +35,7 @@ rootws="root"
 espw="root:espw"
 stname=""
 output=""
-syncer_image="quay.io/kubestellar/syncer:v0.13.0"
+syncer_image="quay.io/kubestellar/syncer:release-0.14"
 kubectl_flags=()
 silent="false"
 


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
This PR is #1249 but without the problematic merge of `main` into the PR's branch. I also added a commit that updates example1 to use the patched kcp when deploying bare processes.

## Related issue(s)

Fixes #1248 
