### PR TITLE
✨ Make test user quickstart exercise ServiceAccount

### DIFF
--- a/docs/content/Getting-Started/user-quickstart-test.md
+++ b/docs/content/Getting-Started/user-quickstart-test.md
@@ -110,25 +110,15 @@ qs_sort: test
 %}
 
 #### 2. Install <span class="Space-Bd-BT">KUBESTELLAR</span>'s user commands and kubectl plugins
-!!! tip ""
-    === "install"
-         {%
-           include-markdown "../common-subs/brew-install.md"
-           start="<!--brew-install-start-->"
-           end="<!--brew-install-end-->"
-         %}
-    === "remove"
-         {%
-           include-markdown "../common-subs/brew-remove.md"
-           start="<!--brew-remove-start-->"
-           end="<!--brew-remove-end-->"
-         %}
-    === "uh oh, no brew?"
-         {%
-           include-markdown "../common-subs/brew-no.md"
-           start="<!--brew-no-start-->"
-           end="<!--brew-no-end-->"
-         %}
+
+```shell
+pwd
+rm -f bin/*
+make userbuild
+export PATH=$PWD/bin:$PATH
+bash -c "$(cat bootstrap/install-kcp-with-plugins.sh)" -V -V --version v0.11.0
+export PATH=$PWD/kcp/bin:$PATH
+```
 
 #### 3. View your <span class="Space-Bd-BT">KUBESTELLAR</span> Core Space environment
 !!! tip ""

--- a/docs/content/common-subs/install-helm-test.md
+++ b/docs/content/common-subs/install-helm-test.md
@@ -8,6 +8,7 @@ helm repo update
 KUBECONFIG=~/.kube/config helm install ./core-helm-chart \
   --set EXTERNAL_HOSTNAME="kubestellar.core" \
   --set EXTERNAL_PORT={{ config.ks_kind_port_num }} \
+  --set CONTROLLER_VERBOSITY=4 \
   --set image.tag=$EXTRA_CORE_TAG \
   --namespace kubestellar \
   --generate-name

--- a/pkg/placement/declarations.go
+++ b/pkg/placement/declarations.go
@@ -17,6 +17,7 @@ limitations under the License.
 package placement
 
 import (
+	"encoding/json"
 	"fmt"
 	"strings"
 
@@ -169,6 +170,12 @@ type ResolvedWhat struct {
 // match the corresponding CRD when the workload includes an object
 // of a kind that is not built into the edge cluster.
 type WorkloadParts map[WorkloadPartID]WorkloadPartDetails
+
+var _ json.Marshaler = WorkloadParts{}
+
+func (wp WorkloadParts) MarshalJSON() ([]byte, error) {
+	return MarshalMap(wp)
+}
 
 // WorkloadPartID identifies part of a workload.
 type WorkloadPartID = Triple[metav1.GroupResource, NamespaceName, ObjectName]

--- a/pkg/placement/map-types.go
+++ b/pkg/placement/map-types.go
@@ -17,6 +17,7 @@ limitations under the License.
 package placement
 
 import (
+	"fmt"
 	"sync"
 
 	"k8s.io/klog/v2"
@@ -344,7 +345,7 @@ type loggingMappingReceiver[Key, Val any] struct {
 var _ MappingReceiver[string, []any] = loggingMappingReceiver[string, []any]{}
 
 func (lmr loggingMappingReceiver[Key, Val]) Put(key Key, val Val) {
-	lmr.logger.Info("Put", "map", lmr.mapName, "key", key, "val", val)
+	lmr.logger.Info("Put", "map", lmr.mapName, "key", key, "val", fmt.Sprintf("%+v", val))
 }
 
 func (lmr loggingMappingReceiver[Key, Val]) Delete(key Key) {

--- a/pkg/placement/marshal.go
+++ b/pkg/placement/marshal.go
@@ -1,0 +1,47 @@
+/*
+Copyright 2023 The KubeStellar Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package placement
+
+import (
+	"encoding/json"
+	"strings"
+)
+
+func MarshalMap[Key comparable, Val any](it map[Key]Val) ([]byte, error) {
+	if it == nil {
+		return []byte("null"), nil
+	}
+	var builder strings.Builder
+	enc := json.NewEncoder(&builder)
+	builder.WriteRune('[')
+	first := true
+	for key, val := range it {
+		item := struct{ Key, Val any }{key, val}
+		if first {
+			first = false
+		} else {
+			builder.WriteString(", ")
+		}
+		err := enc.Encode(item)
+		if err != nil {
+			errS := err.Error()
+			enc.Encode(errS)
+		}
+	}
+	builder.WriteRune(']')
+	return []byte(builder.String()), nil
+}

--- a/pkg/placement/where-resolver.go
+++ b/pkg/placement/where-resolver.go
@@ -50,13 +50,13 @@ type whereResolver struct {
 }
 
 type queueItem struct {
-	gk      schema.GroupKind
-	cluster logicalcluster.Name
-	name    string
+	GK      schema.GroupKind
+	Cluster logicalcluster.Name
+	Name    string
 }
 
 func (qi queueItem) toExternalName() ExternalName {
-	return ExternalName{Cluster: qi.cluster, Name: ObjectName(qi.name)}
+	return ExternalName{Cluster: qi.Cluster, Name: ObjectName(qi.Name)}
 }
 
 // NewWhereResolver returns a WhereResolver.
@@ -126,7 +126,7 @@ func (wr *whereResolver) enqueue(gk schema.GroupKind, objAny any) {
 	if err != nil {
 		wr.logger.Error(err, "Impossible! SplitMetaClusterNamespaceKey failed", "key", key)
 	}
-	item := queueItem{gk: gk, cluster: cluster, name: name}
+	item := queueItem{GK: gk, Cluster: cluster, Name: name}
 	wr.logger.V(4).Info("Enqueuing", "item", item)
 	wr.queue.Add(item)
 }
@@ -153,7 +153,7 @@ func (wr *whereResolver) processNextWorkItem() bool {
 	defer wr.queue.Done(itemAny)
 	item := itemAny.(queueItem)
 
-	logger := klog.FromContext(wr.ctx).WithValues("group", item.gk.Group, "kind", item.gk.Kind, "cluster", item.cluster, "name", item.name)
+	logger := klog.FromContext(wr.ctx).WithValues("group", item.GK.Group, "kind", item.GK.Kind, "cluster", item.Cluster, "name", item.Name)
 	ctx := klog.NewContext(wr.ctx, logger)
 	logger.V(4).Info("processing queueItem")
 
@@ -168,8 +168,8 @@ func (wr *whereResolver) processNextWorkItem() bool {
 // process returns true on success or unrecoverable error, false to retry
 func (wr *whereResolver) process(ctx context.Context, item queueItem) bool {
 	logger := klog.FromContext(ctx)
-	cluster := item.cluster
-	epName := item.name
+	cluster := item.Cluster
+	epName := item.Name
 	objName := item.toExternalName()
 	sps, err := wr.spsLister.Cluster(cluster).Get(epName)
 	if err != nil && !k8sapierrors.IsNotFound(err) {


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
This PR extends the test user quickstart to exercise a downsynced ServiceAccount object.

This PR also replaces the use of brew to get user executables with building the local sources and fetching a patched kcp release archive. This is the last step in the campaign to address #1060 .

This PR also reacts to a change snuck in through an earlier update to `go.mod`, advancing the required version of `klog/v2` (from v2.70.1 to v2.100.1) through a big change (https://github.com/kubernetes/klog/pull/375) in the way it logs `any` values. Now they are logged by marshaling as JSON! Previously those values were rendered with `fmt.Sprintf("%v", .)`. This klog change means that every private field of a struct being logged is now invisible in the log. This PR changes many structs to make their fields exported (i.e., the field name is capitalized). This PR also adds the method needed to make `WorkloadParts` a `json.Marshaler`.

## Related issue(s)

Fixes #1060 
