### PR TITLE
🐛 Make core.Dockerfile accept advance in golang version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ coverage.*
 tools
 build
 .vscode
+docs/scripts/generated_script.sh
 
 # JetBrains IDE files
 .idea/

--- a/core.Dockerfile
+++ b/core.Dockerfile
@@ -51,7 +51,7 @@ ADD test/            test/
 ADD .git/            .git/
 ADD .gitattributes Makefile Makefile.venv go.mod go.sum .
 
-RUN make innerbuild GIT_DIRTY=$GIT_DIRTY
+RUN make innerbuild GIT_DIRTY=$GIT_DIRTY IGNORE_GO_VERSION=yesplease
 
 FROM redhat/ubi9
 

--- a/docs/content/common-subs/build-syncer-image.md
+++ b/docs/content/common-subs/build-syncer-image.md
@@ -6,7 +6,7 @@ export SYNCER_IMG_REF=$(
   if (docker info | grep podman) &> /dev/null
   then export DOCKER_HOST=unix://${HOME}/.local/share/containers/podman/machine/qemu/podman.sock
   fi
-  make build-kubestellar-syncer-image-local | grep -v "make.*directory" )
+  KO_DOCKER_REPO="" make build-kubestellar-syncer-image-local | grep -v "make.*directory" )
 echo "Locally built syncer image reference is <$SYNCER_IMG_REF>; adding alias ko.local/syncer:test"
 docker tag "$SYNCER_IMG_REF" ko.local/syncer:test
 ```

--- a/docs/content/common-subs/build-syncer-image.md
+++ b/docs/content/common-subs/build-syncer-image.md
@@ -6,7 +6,7 @@ export SYNCER_IMG_REF=$(
   if (docker info | grep podman) &> /dev/null
   then export DOCKER_HOST=unix://${HOME}/.local/share/containers/podman/machine/qemu/podman.sock
   fi
-  make build-kubestellar-syncer-image-local | grep kubestellar/syncer- )
+  make build-kubestellar-syncer-image-local | grep -v "make.*directory" )
 echo "Locally built syncer image reference is <$SYNCER_IMG_REF>; adding alias ko.local/syncer:test"
 docker tag "$SYNCER_IMG_REF" ko.local/syncer:test
 ```


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
This PR changes `core.Dockerfile` to suppress the golang version check in the `make innerbuild`. This is needed because RedHat recently updated what `dnf` in the `redhat/ubi9` image finds when asked to install `golang`, from release 1.19.something to 1.20.10, causing the aforementioned version check to fail.

This PR also makes a few improvements in building and testing: add the temp script generated by docs-ecutable to .gitignore; adjust the way the syncer image is recursively built to work more broadly.

## Related issue(s)

Fixes #
