### PR TITLE
🐛 Stop executing outdated part of syncer doc

### DIFF
--- a/docs/content/Coding Milestones/PoC2023q1/kubestellar-syncer-subs/kubestellar-syncer-1-syncer-gen-plugin.md
+++ b/docs/content/Coding Milestones/PoC2023q1/kubestellar-syncer-subs/kubestellar-syncer-1-syncer-gen-plugin.md
@@ -1,4 +1,8 @@
 <!--kubestellar-syncer-1-syncer-gen-plugin-start-->
+``` {.bash .hide-me}
+exit 0
+```
+
 Generate UUID for Syncer identification.
 ```shell
 syncer_id="syncer-"`uuidgen | tr '[:upper:]' '[:lower:]'`
@@ -65,7 +69,7 @@ subjects:
 EOL
 ```
 
-Get the serviceaccount token that will be set in the upstream kubeconfig manifest.
+Get the serviceaccount token that will be set in the upstream kubeconfig manifest.  **NOTE** This part is outdated due to the recent denaturing of ServiceAccounts in kcp workspaces; the syncer-gen plugin will actually wait a little while and then create the Secret if nothing else has.
 ```shell
 secret_name=`kubectl get secret -o custom-columns=":.metadata.name"| grep $syncer_id`
 token=`kubectl get secret $secret_name -o jsonpath='{.data.token}' | base64 -d`


### PR DESCRIPTION
Also explain in the text how it is outdated.

<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
This PR updates the syncer doc so that (a) the text briefly outlines how part is outdated and (b) the outdated part is no longer docs-ecuted.

## Related issue(s)

Fixes #
