### PR TITLE
:bug: fix syncer integration test to create SA token in downstream workspace

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "go.sum|docs/package-lock.json|cmd/kube-watchall/go.sum|docs/config.toml|docs/resources/_gen|docs/static|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2023-11-03T15:34:50Z",
+  "generated_at": "2023-11-08T22:15:00Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -106,16 +106,6 @@
         "hashed_secret": "eba2ae817b95fdb713f3af658a6ae1821e452264",
         "is_verified": false,
         "line_number": 620,
-        "type": "Secret Keyword",
-        "verified_result": null
-      }
-    ],
-    "test/e2e/framework/kubestellar_syncer.go": [
-      {
-        "hashed_secret": "4d55af37dbbb6a42088d917caa1ca25428ec42c9",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 360,
         "type": "Secret Keyword",
         "verified_result": null
       }


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

This is a followup fix of https://github.com/kubestellar/kubestellar/pull/1256#issuecomment-1797812534.
Now kcp used in KS does not create SA token automatically. Syncer integration test code relies on this feature. The fix is to create SA token in tests. 

## Related issue(s)

Fixes #1256#issuecomment-1797812534
