### PR TITLE
🌱 Revert to plain kcp

### DIFF
--- a/bootstrap/bootstrap-kubestellar.sh
+++ b/bootstrap/bootstrap-kubestellar.sh
@@ -47,10 +47,10 @@ kcp_installed() {
 
 kcp_download() {
     if [ $verbose == "true" ]; then
-        curl -SL -o kcp.tar.gz "https://github.com/kubestellar/kubestellar/releases/download/v0.12.0/kcp_0.11.0_${os_type}_${arch_type}.tar.gz"
+        curl -SL -o kcp.tar.gz "https://github.com/kcp-dev/kcp/releases/download/${kcp_version}/kcp_${kcp_version//v}_${os_type}_${arch_type}.tar.gz"
         curl -SL -o kcp-plugins.tar.gz "https://github.com/kcp-dev/kcp/releases/download/${kcp_version}/kubectl-kcp-plugin_${kcp_version//v}_${os_type}_${arch_type}.tar.gz"
     else
-        curl -sSL -o kcp.tar.gz "https://github.com/kubestellar/kubestellar/releases/download/v0.12.0/kcp_0.11.0_${os_type}_${arch_type}.tar.gz"
+        curl -sSL -o kcp.tar.gz "https://github.com/kcp-dev/kcp/releases/download/${kcp_version}/kcp_${kcp_version//v}_${os_type}_${arch_type}.tar.gz"
         curl -sSL -o kcp-plugins.tar.gz "https://github.com/kcp-dev/kcp/releases/download/${kcp_version}/kubectl-kcp-plugin_${kcp_version//v}_${os_type}_${arch_type}.tar.gz"
     fi
 }

--- a/bootstrap/install-kcp-with-plugins.sh
+++ b/bootstrap/install-kcp-with-plugins.sh
@@ -128,11 +128,11 @@ fi
 
 if [ $verbose == "true" ]; then
     echo "Downloading KCP $kcp_version $kcp_os/$kcp_arch..."
-    curl -SL -o kcp.tar.gz "https://github.com/kubestellar/kubestellar/releases/download/v0.12.0/kcp_0.11.0_${kcp_os}_${kcp_arch}.tar.gz"
+    curl -SL -o kcp.tar.gz "https://github.com/kcp-dev/kcp/releases/download/${kcp_version}/kcp_${kcp_version//v}_${kcp_os}_${kcp_arch}.tar.gz"
     echo "Downloading KCP plugins $kcp_version $kcp_os/$kcp_arch..."
     curl -SL -o kcp-plugins.tar.gz "https://github.com/kcp-dev/kcp/releases/download/${kcp_version}/kubectl-kcp-plugin_${kcp_version//v}_${kcp_os}_${kcp_arch}.tar.gz"
 else
-    curl -sSL -o kcp.tar.gz "https://github.com/kubestellar/kubestellar/releases/download/v0.12.0/kcp_0.11.0_${kcp_os}_${kcp_arch}.tar.gz"
+    curl -sSL -o kcp.tar.gz "https://github.com/kcp-dev/kcp/releases/download/${kcp_version}/kcp_${kcp_version//v}_${kcp_os}_${kcp_arch}.tar.gz"
     curl -sSL -o kcp-plugins.tar.gz "https://github.com/kcp-dev/kcp/releases/download/${kcp_version}/kubectl-kcp-plugin_${kcp_version//v}_${kcp_os}_${kcp_arch}.tar.gz"
 fi
 

--- a/core.Dockerfile
+++ b/core.Dockerfile
@@ -26,7 +26,7 @@ RUN mkdir -p .kcp && \
     mkdir easy-rsa && \
     tar -C easy-rsa -zxf easy-rsa.tar.gz --wildcards --strip-components=1 EasyRSA*/* && \
     rm easy-rsa.tar.gz && \
-    curl -SL -o kcp.tar.gz "https://github.com/kubestellar/kubestellar/releases/download/v0.12.0/kcp_0.11.0_${TARGETOS}_${TARGETARCH}.tar.gz" && \
+    curl -SL -o kcp.tar.gz "https://github.com/kcp-dev/kcp/releases/download/v0.11.0/kcp_0.11.0_${TARGETOS}_${TARGETARCH}.tar.gz" && \
     mkdir kcp && \
     tar -C kcp -zxf kcp.tar.gz && \
     rm kcp.tar.gz && \

--- a/docs/content/Coding Milestones/PoC2023q1/example1-subs/example1-start-kcp.md
+++ b/docs/content/Coding Milestones/PoC2023q1/example1-subs/example1-start-kcp.md
@@ -6,40 +6,23 @@ ways: as bare processes on whatever host you are using to run this
 example, or as workload in a Kubernetes cluster (an OpenShift cluster
 qualifies).  Do one or the other, not both.
 
-KubeStellar only works with release `v0.11.0` of kcp. To downsync ServiceAccount objects you will need a patched version of that in order to get the denaturing of them as discussed [in the design outline](../../outline/#needs-to-be-denatured-in-center-natured-in-edge).
+KubeStellar only works with release `v0.11.0` of kcp.
 
 ### Deploy kcp and KubeStellar as bare processes
 
 #### Start kcp
 
-The following commands fetch the appropriate kcp server and plugins for your OS and ISA and download them and put them on your `$PATH`.
+Download and build or install [kcp](https://github.com/kcp-dev/kcp/releases/tag/v0.11.0),
+according to your preference.  See the start of [the kcp quickstart](https://docs.kcp.io/kcp/v0.11/#quickstart) for instructions on that, but get [release v0.11.0](https://github.com/kcp-dev/kcp/releases/tag/v0.11.0) rather than the latest (the downloadable assets appear after the long list of changes/features/etc).
 
+Clone the v0.11.0 branch of the kcp source:
 ```shell
-rm -rf kcp
-mkdir kcp
+git clone -b v0.11.0 https://github.com/kcp-dev/kcp kcp
+```
+and build the kubectl-ws binary and include it in `$PATH`
+```shell
 pushd kcp
-(
-  set -x
-  case "$OSTYPE" in
-      linux*)   os_type="linux" ;;
-      darwin*)  os_type="darwin" ;;
-      *)        echo "Unsupported operating system type: $OSTYPE" >&2
-                false ;;
-  esac
-  case "$HOSTTYPE" in
-      x86_64*)  arch_type="amd64" ;;
-      aarch64*) arch_type="arm64" ;;
-      arm64*)   arch_type="arm64" ;;
-      *)        echo "Unsupported architecture type: $HOSTTYPE" >&2
-                false ;;
-  esac
-  kcp_version=v0.11.0
-  trap "rm kcp.tar.gz kcp-plugins.tar.gz" EXIT
-  curl -SL -o kcp.tar.gz "https://github.com/kubestellar/kubestellar/releases/download/v0.12.0/kcp_0.11.0_${os_type}_${arch_type}.tar.gz"
-  curl -SL -o kcp-plugins.tar.gz "https://github.com/kcp-dev/kcp/releases/download/${kcp_version}/kubectl-kcp-plugin_${kcp_version//v}_${os_type}_${arch_type}.tar.gz"
-  tar -xzf kcp-plugins.tar.gz
-  tar -xzf kcp.tar.gz
-)
+make build
 export PATH=$(pwd)/bin:$PATH
 ```
 

--- a/docs/content/Coding Milestones/PoC2023q1/outline.md
+++ b/docs/content/Coding Milestones/PoC2023q1/outline.md
@@ -249,7 +249,7 @@ the normal kcp behavior.
 
 **NOTE**: The denaturing described here is not implemented yet.  The
 kinds of objects listed above can be put into a workload management
-workspace and it will give them its usual interpretation. For ones
+workspace and it will give them its usual interpretation. For objects
 that add authorizations, this will indeed _add_ authorizations but not
 otherwise break something. The kcp server does not implement
 `FlowSchema` nor `PriorityLevelConfiguration`; those will indeed be
@@ -257,13 +257,18 @@ uninterpreted. For objects that configure calls to other servers,
 these will fail unless the user arranges for them to work when made in
 the center as well in the edge clusters.
 
-**NOTE on NOTE**: Paolo Dettori denatured ServiceAccount objects in kcp workspaces by creating a fork of kcp v0.11.0 with [the activation of the relevant controller](https://github.com/kcp-dev/kcp/blob/v0.11.0/pkg/server/server.go#L345-L347) (the [ServiceAccount Token Controller](https://v1-24.docs.kubernetes.io/docs/reference/access-authn-authz/service-accounts-admin/#token-controller)) disabled. Builds of this variant of kcp are in the following archives.
-
-- <https://github.com/kubestellar/kubestellar/releases/download/v0.12.0/kcp_0.11.0_linux_amd64.tar.gz>
-- <https://github.com/kubestellar/kubestellar/releases/download/v0.12.0/kcp_0.11.0_linux_arm64.tar.gz>
-- <https://github.com/kubestellar/kubestellar/releases/download/v0.12.0/kcp_0.11.0_linux_ppc64le.tar.gz>
-- <https://github.com/kubestellar/kubestellar/releases/download/v0.12.0/kcp_0.11.0_darwin_amd64.tar.gz>
-- <https://github.com/kubestellar/kubestellar/releases/download/v0.12.0/kcp_0.11.0_darwin_arm64.tar.gz>
+In kcp v0.11.0 the Token controller (for ServiceAccounts) creates a
+token Secret for each ServiceAccount that does not currently reference
+one created by that controller and updates the ServiceAccount to
+reference the Secret just created. Should another controller undo that
+change to that ServiceAccount, the two controllers will fight
+continually --- leading to an ever growning collection of Secret
+objects. To prevent the placement translator from fighting with a
+mailbox space, users must mark a downsynced ServiceAccount as
+"create-only". To prevent some non-KubeStellar controller from
+fighting with a WDS, users must use feature(s) of that non-KubeStellar
+controller. In later versions of kcp and Kubernetes there is not such
+automatic Secret creation.
 
 #### Needs to be natured in center and edge
 

--- a/docs/content/Getting-Started/user-quickstart-test.md
+++ b/docs/content/Getting-Started/user-quickstart-test.md
@@ -190,7 +190,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   annotations:
-    edge.kubestellar.io/downsync-overwrite: "true"
+    edge.kubestellar.io/downsync-overwrite: "false"
   namespace: my-namespace
   name: test-sa
 EOF
@@ -225,6 +225,16 @@ done
 KUBECONFIG=ks-core.kubeconfig kubectl ws root:$MB2
 while ! KUBECONFIG=ks-core.kubeconfig kubectl get ServiceAccount -n my-namespace test-sa ; do
     sleep 10
+done
+```
+
+Thrash the ServiceAccount some in its WDS.
+
+```shell
+KUBECONFIG=ks-core.kubeconfig kubectl ws root:wmw1
+for key in k1 k2 k3 k4; do
+    sleep 15
+    KUBECONFIG=ks-core.kubeconfig kubectl annotate sa -n my-namespace test-sa ${key}=${key}
 done
 ```
 

--- a/docs/content/Getting-Started/user-quickstart-test.md
+++ b/docs/content/Getting-Started/user-quickstart-test.md
@@ -234,12 +234,13 @@ Give the controllers some time to fight over ServiceAccount secrets.
 sleep 120
 ```
 
-Look for excess secrets in the WDS.
+Look for excess secrets in the WDS. Expect 2 token Secrets: one for
+the default ServiceAccount and one for `test-sa`.
 
 ```shell
 KUBECONFIG=ks-core.kubeconfig kubectl ws root:wmw1
 KUBECONFIG=ks-core.kubeconfig kubectl get secrets -n my-namespace
-[ $(KUBECONFIG=ks-core.kubeconfig kubectl get Secret -n my-namespace -o jsonpath='{.items[?(@.type=="kubernetes.io/service-account-token")]}' | jq length | wc -l) -lt 2 ]
+[ $(KUBECONFIG=ks-core.kubeconfig kubectl get Secret -n my-namespace -o jsonpath='{.items[?(@.type=="kubernetes.io/service-account-token")]}' | jq length | wc -l) -lt 3 ]
 ```
 
 Look for excess secrets in the two mailbox spaces.
@@ -248,7 +249,7 @@ Look for excess secrets in the two mailbox spaces.
 for mb in $MB1 $MB2; do
     KUBECONFIG=ks-core.kubeconfig kubectl ws root:$mb
     KUBECONFIG=ks-core.kubeconfig kubectl get secrets -n my-namespace
-    [ $(KUBECONFIG=ks-core.kubeconfig kubectl get Secret -n my-namespace -o jsonpath='{.items[?(@.type=="kubernetes.io/service-account-token")]}' | jq length | wc -l) -lt 2 ]
+    [ $(KUBECONFIG=ks-core.kubeconfig kubectl get Secret -n my-namespace -o jsonpath='{.items[?(@.type=="kubernetes.io/service-account-token")]}' | jq length | wc -l) -lt 3 ]
 done
 ```
 


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
This PR undoes most of #1256, to revert to using plain kcp v0.11.0 instead of the patched variant that disables the Token controller for ServiceAccounts.

## Related issue(s)

This is part of the campaign #1274 
