### PR TITLE
🌱 Update default image refs to release-0.15 tag

### DIFF
--- a/outer-scripts/kubectl-kubestellar-deploy
+++ b/outer-scripts/kubectl-kubestellar-deploy
@@ -20,7 +20,7 @@
 
 KSDIR=$(cd -- $(dirname $(realpath ${BASH_SOURCE[0]})); cd ..; pwd)
 
-image_tag=v0.10.0-alpha.2.git2b11954-clean
+image_tag=release-0.15
 
 external_endpoint=""
 openshift=false

--- a/outer-scripts/kubectl-kubestellar-prep_for_syncer
+++ b/outer-scripts/kubectl-kubestellar-prep_for_syncer
@@ -35,7 +35,7 @@ rootws="root"
 espw="root:espw"
 stname=""
 output=""
-syncer_image="quay.io/kubestellar/syncer:release-0.14"
+syncer_image="quay.io/kubestellar/syncer:release-0.15"
 kubectl_flags=()
 silent="false"
 


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
This PR updates the default image references to use the tag `release-0.15`. I recently built syncer and core images from `main` as it is at the moment, commit c414165a9335d47a067bf22ccfcabe05c164457f, and added the `release-0.15` tag to them.

## Related issue(s)

Fixes #
