### PR TITLE
:sparkles: comment typo fix

### DIFF
--- a/config/crds/edge.kubestellar.io_singleplacementslices.yaml
+++ b/config/crds/edge.kubestellar.io_singleplacementslices.yaml
@@ -39,7 +39,7 @@ spec:
                 relevant EdgePlacement.
               properties:
                 cluster:
-                  description: Cluster is the logicacluster.Name of the logical cluster
+                  description: Cluster is the logicalcluster.Name of the logical cluster
                     that contains both the Location and the SyncTarget.
                   type: string
                 locationName:

--- a/config/exports/apiexport-edge.kubestellar.io.yaml
+++ b/config/exports/apiexport-edge.kubestellar.io.yaml
@@ -8,8 +8,8 @@ spec:
   - v231005-c6f7728ef.customizers.edge.kubestellar.io
   - v231005-c6f7728ef.edgesyncconfigs.edge.kubestellar.io
   - v231005-c6f7728ef.locations.edge.kubestellar.io
-  - v231005-c6f7728ef.singleplacementslices.edge.kubestellar.io
   - v231005-c6f7728ef.syncerconfigs.edge.kubestellar.io
   - v231020-4e62eaf7.synctargets.edge.kubestellar.io
   - v231026-b37310b41.edgeplacements.edge.kubestellar.io
+  - v231113-f0837626.singleplacementslices.edge.kubestellar.io
 status: {}

--- a/config/exports/apiresourceschema-singleplacementslices.edge.kubestellar.io.yaml
+++ b/config/exports/apiresourceschema-singleplacementslices.edge.kubestellar.io.yaml
@@ -2,7 +2,7 @@ apiVersion: apis.kcp.io/v1alpha1
 kind: APIResourceSchema
 metadata:
   creationTimestamp: null
-  name: v231005-c6f7728ef.singleplacementslices.edge.kubestellar.io
+  name: v231113-f0837626.singleplacementslices.edge.kubestellar.io
 spec:
   group: edge.kubestellar.io
   names:
@@ -34,7 +34,7 @@ spec:
               EdgePlacement.
             properties:
               cluster:
-                description: Cluster is the logicacluster.Name of the logical cluster
+                description: Cluster is the logicalcluster.Name of the logical cluster
                   that contains both the Location and the SyncTarget.
                 type: string
               locationName:

--- a/pkg/apis/edge/v2alpha1/single-placement.go
+++ b/pkg/apis/edge/v2alpha1/single-placement.go
@@ -52,7 +52,7 @@ type SinglePlacementSlice struct {
 
 // SinglePlacement describes one Location that matches the relevant EdgePlacement.
 type SinglePlacement struct {
-	// Cluster is the logicacluster.Name of the logical cluster that contains
+	// Cluster is the logicalcluster.Name of the logical cluster that contains
 	// both the Location and the SyncTarget.
 	Cluster string `json:"cluster"`
 


### PR DESCRIPTION
## Summary
Typo fix in a comment. 
This API is imported as `logicalcluster`, and that was the intention of Mike.
