### PR TITLE
✨ Parse the kube-bind cluster namespace at binding time

### DIFF
--- a/cmd/mailbox-controller/controller.go
+++ b/cmd/mailbox-controller/controller.go
@@ -261,7 +261,7 @@ func (ctl *mbCtl) ensureBinding(ctx context.Context, workspace *tenancyv1alpha1.
 
 	logger.V(2).Info("Executing shell script", "script", shellScriptName)
 	// Make a sandbox for the concurrent access of the kubeconfig from the mailbox-controller
-	cmdLine := "cp $KUBECONFIG $KUBECONFIG.copy	&& " + "KUBECONFIG=$KUBECONFIG.copy" + " " + shellScriptName + " " + workspace.Name
+	cmdLine := "cp $KUBECONFIG $KUBECONFIG.copy && KUBECONFIG=$KUBECONFIG.copy " + shellScriptName + " " + workspace.Name
 	logger.V(2).Info(cmdLine)
 	cmd := exec.Command("/bin/sh", "-c", cmdLine)
 	stdout, err := cmd.StdoutPipe()

--- a/cmd/mailbox-controller/controller.go
+++ b/cmd/mailbox-controller/controller.go
@@ -17,9 +17,11 @@ limitations under the License.
 package main
 
 import (
+	"bufio"
 	"context"
 	"fmt"
 	"os/exec"
+	"regexp"
 	"strings"
 
 	k8sapierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -254,21 +256,75 @@ func (ctl *mbCtl) ensureBinding(ctx context.Context, workspace *tenancyv1alpha1.
 	logger := klog.FromContext(ctx).WithValues("mbsName", workspace.Name)
 
 	// The script ensures that a mailbox workspace has the needed KubeStellar CRDs.
+	// The script is idempotent.
 	shellScriptName := "kubectl-kubestellar-ensure-mbw"
 
-	// The script is idempotent.
 	logger.V(2).Info("Executing shell script", "script", shellScriptName)
 	cmdLine := shellScriptName + " " + workspace.Name
+	logger.V(2).Info(cmdLine)
 	cmd := exec.Command("/bin/sh", "-c", cmdLine)
-	_, err := cmd.Output()
+	stdout, err := cmd.StdoutPipe()
 	if err != nil {
-		logger.Error(err, "Unable to execute shell script", "script", shellScriptName)
+		logger.Error(err, "Unable to return a pipe for stdout")
 		return true
 	}
+	stderr, err := cmd.StderrPipe()
+	if err != nil {
+		logger.Error(err, "Unable to return a pipe for stderr")
+		return true
+	}
+	err = cmd.Start()
+	if err != nil {
+		logger.Error(err, "Unable to start executing the script")
+		return true
+	}
+	outBuf := bufio.NewReader(stdout)
+	errBuf := bufio.NewReader(stderr)
 
-	// TODO get kube-bind NS from the output and update the Space object(label/annotation). For phase1 just log the NS
+	r, _ := regexp.Compile("🔒 (Created|Updated) secret.*namespace (.*)")
+	found, namespaceName := false, ""
+	for {
+		line, _, err := errBuf.ReadLine()
+		if err != nil {
+			logger.V(4).Info("End of stderr")
+			break
+		}
+		logger.V(2).Info(string(line))
+		// kube-bind put the information that we interesed in (the cluster namespace) in stderr
+		matches := r.FindStringSubmatch(string(line))
+		if len(matches) == r.NumSubexp()+1 {
+			found, namespaceName = true, matches[len(matches)-1]
+		}
+	}
+	if found {
+		logger.V(2).Info("Kube-bind cluster namespace", "namespaceName", namespaceName)
+	}
 
-	logger.V(2).Info("binding created")
+	// There is a contact between the script and the code here that this message is the signal for successful bindings
+	r, _ = regexp.Compile("CRDs already in place, returning")
+	established := false
+	for {
+		line, _, err := outBuf.ReadLine()
+		if err != nil {
+			logger.V(4).Info("End of stdout")
+			break
+		}
+		logger.V(2).Info(string(line))
+		if r.MatchString(string(line)) {
+			established = true
+		}
+	}
+	if established {
+		logger.V(2).Info("bindings already exist or just created")
+	}
+
+	err = cmd.Wait()
+	if !established {
+		return true
+	}
+	if err != nil {
+		logger.V(2).Info("Errors other than binding occurred during the execution", "script", shellScriptName, "error", err)
+	}
 	return false
 }
 

--- a/docs/content/Coding Milestones/PoC2023q1/example1-subs/example1-stage-2.md
+++ b/docs/content/Coding Milestones/PoC2023q1/example1-subs/example1-stage-2.md
@@ -124,15 +124,12 @@ spec:
           optional: false
 EOF
 ```
-``` {.bash .hide-me}
-sleep 10
-```
 
 Finally, use `kubectl` to create the following EdgePlacement object.
 Its "where predicate" (the `locationSelectors` array) has one label
 selector that matches both Location objects created earlier, thus
 directing the common workload to both edge clusters.
-   
+
 ```shell
 kubectl apply -f - <<EOF
 apiVersion: edge.kubestellar.io/v2alpha1
@@ -334,9 +331,6 @@ spec:
   version: v1090
   versionPriority: 42
 EOF
-```
-``` {.bash .hide-me}
-sleep 10
 ```
 
 Finally, use `kubectl` to create the following EdgePlacement object.

--- a/inner-scripts/kube-bind
+++ b/inner-scripts/kube-bind
@@ -1,0 +1,120 @@
+#!/usr/bin/env bash
+
+# Copyright 2023 The KubeStellar Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+space_name=""
+resource_to_bind=""
+start_konnector=false
+cm_namespace=kubestellar # the namespace where the configmaps live in on the provider side
+
+while (( $# > 0 )); do
+    case "$1" in
+    (-h|--help)
+        echo "Usage: $0 (--start_konnector boolean | -X)* space_name resource_to_bind"
+        echo "space_name is the name of a kube-bind consumer space, which currently must be a kcp workspace whose parent is root"
+        echo "resource_to_bind is a resource offered by the kube-bind provider, in lower case and plural form"
+        exit 0;;
+    (-X)
+        set -o xtrace;;
+    (--start-konnector)
+        if (( $# >1 ))
+        then start_konnector="$2"; shift
+        else echo "$0: missing start-konnector value" >&2; exit 1
+        fi;;
+    (-*)
+        echo "$0: flag syntax error" >&2
+        exit 1;;
+    (*)
+        if [ -z "$space_name" ]
+        then space_name="$1"
+        elif [ -z "$resource_to_bind" ]
+        then resource_to_bind="$1"
+        else echo "$0: too many positional arguments" >&2
+        exit 1
+        fi
+    esac
+    shift
+done
+
+if [ -z "$space_name" ]
+then
+    echo "space_name not specified" >&2
+    exit 1
+fi
+
+if [ -z "$resource_to_bind" ]
+then
+    echo "resource_to_bind not specified" >&2
+    exit 1
+fi
+
+case "$start_konnector" in
+    (true|false) ;;
+    (*) echo "$0: start_konnector should be true or false" >&2
+	  exit 1;;
+esac
+
+initial_ws=$(kubectl ws . --short)
+
+kubectl ws root
+kcp_id="$(kubectl get ws $space_name -ojsonpath='{.metadata.annotations.internal\.tenancy\.kcp\.io/\cluster}')"
+if [ -z "$kcp_id" ]
+then
+    echo "failed to find the kcp workspace ID for $space_name"
+    exit 1
+else
+    echo "kcp workspace $space_name's ID is $kcp_id"
+fi
+
+#TODO: move the starting of konnector here
+
+kubectl ws "root:$space_name"
+
+if kubectl get crd $resource_to_bind.edge.kubestellar.io &> /dev/null; then
+    echo "CRDs for $resource_to_bind already in place"
+    exit 0
+fi
+
+#TODO: error check for the bind commmand
+echo "binding $resource_to_bind for $space_name"
+result="$(kubectl bind http://127.0.0.1:8080/export --skip-konnector --unattended --resource $resource_to_bind 2>&1)"
+
+cluster_ns="$(echo $result | grep -e 'kube-bind-\w*' -o)"
+if [ -z "$cluster_ns" ]
+then
+    echo "failed to find the cluster namespace"
+    exit 1
+else
+    echo "cluster namespace is $cluster_ns"
+fi
+
+kubectl ws root:espw
+if ! kubectl get namespace "$cm_namespace" &> /dev/null
+then kubectl create namespace "$cm_namespace"
+else echo "namespace $cm_namespace already exists"
+fi
+
+kubectl apply -f - <<EOF
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: kbmap-$kcp_id
+  namespace: $cm_namespace
+  labels:
+    kubestellar.io/kube-bind-id: $cluster_ns
+data: {}
+EOF
+
+kubectl ws use $initial_ws &> /dev/null # go back to the initial state

--- a/inner-scripts/kubestellar
+++ b/inner-scripts/kubestellar
@@ -96,16 +96,6 @@ function run_kb_konnector_for_imw() {
 }
 
 
-function bind_resource_for_imw() {
-    RESOURCE="$1"
-    echo "binding $RESOURCE for imw"
-    if ! kubectl bind http://127.0.0.1:8080/export --skip-konnector --unattended --resource "$RESOURCE" ; then
-        echo "unable to bind $RESOURCE for imw"
-        exit 1
-    fi
-}
-
-
 function ensure_imws() {
     initial_ws=$(kubectl ws . --short)
     while IFS=',' read -ra items; do
@@ -123,8 +113,8 @@ function ensure_imws() {
                 fi
             fi
             run_kb_konnector_for_imw
-            bind_resource_for_imw "synctargets"
-            bind_resource_for_imw "locations"
+            kube-bind "$imw" "synctargets"
+            kube-bind "$imw" "locations"
         done
     done <<< "$1"
     kubectl ws use $initial_ws &> /dev/null # go back to the initial state

--- a/outer-scripts/kubectl-kubestellar-prep_for_syncer
+++ b/outer-scripts/kubectl-kubestellar-prep_for_syncer
@@ -177,11 +177,14 @@ echo "now that workspace _exists_, but is it _ready_?"
 sleep 5
 
 if ! kubectl ws "${kubectl_flags[@]}" "$mbwsname" &> /dev/null; then
+	kubectl ws .
 	echo "tried once to switch to $mbwsname"
     sleep 15
     if ! kubectl ws "${kubectl_flags[@]}" "$mbwsname" &> /dev/null; then
+	kubectl ws .
 	echo "tried twice to switch to $mbwsname"
 	sleep 15
+	kubectl ws .
 	kubectl ws "${kubectl_flags[@]}" "$mbwsname"
     fi
 fi

--- a/overlap-scripts/kubectl-kubestellar-ensure-mbw
+++ b/overlap-scripts/kubectl-kubestellar-ensure-mbw
@@ -57,7 +57,7 @@ while (( $# > 0 )); do
 done
 
 if [ "$mbw_name" == "" ]; then
-    echo "$0: workload management workspace name not specified" >&2
+    echo "$0: mailbox workspace name not specified" >&2
     exit 1
 fi
 

--- a/overlap-scripts/kubectl-kubestellar-ensure-mbw
+++ b/overlap-scripts/kubectl-kubestellar-ensure-mbw
@@ -80,7 +80,7 @@ fi
 
 function run_kb_konnector_for_mbw() {
     if kubectl get crd syncerconfigs.edge.kubestellar.io &> /dev/null && kubectl get crd edgesyncconfigs.edge.kubestellar.io &> /dev/null; then
-        echo "CRDs already in place, returning"
+        echo "CRDs already in place, returning" # This message is parsed by the mailbox controller as a signal of success
         return
     fi
     if kubectl get ns kube-system &> /dev/null; then

--- a/overlap-scripts/kubectl-kubestellar-ensure-wmw
+++ b/overlap-scripts/kubectl-kubestellar-ensure-wmw
@@ -92,18 +92,9 @@ function run_kb_konnector_for_wmw() {
     fi
 }
 
-function bind_resource_for_wmw() {
-    RESOURCE="$1"
-    echo "binding $RESOURCE for wmw"
-    if ! kubectl bind http://127.0.0.1:8080/export --skip-konnector --unattended --resource "$RESOURCE" ; then
-        echo "unable to bind $RESOURCE for wmw"
-        exit 1
-    fi
-}
-
 run_kb_konnector_for_wmw
-bind_resource_for_wmw "edgeplacements"
-bind_resource_for_wmw "customizers"
+kube-bind "$wmw_name" "edgeplacements"
+kube-bind "$wmw_name" "customizers"
 
 function bind_iff_wanted() { # usage: export_name
     export_name=$1


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
This PR makes the kube-bind cluster namespace available for the mailbox controller go code to consume. The cluster namespace will be available at the time of the 1st successful binding, of any CRD offered by the provider.