### PR TITLE
:sparkles:Add bind for singleplacementslices in WMW

### DIFF
--- a/scripts/overlap/kubectl-kubestellar-ensure-wmw
+++ b/scripts/overlap/kubectl-kubestellar-ensure-wmw
@@ -79,6 +79,7 @@ fi
 
 kube-bind "$wmw_name" "edgeplacements" --start-konnector true
 kube-bind "$wmw_name" "customizers"
+kube-bind "$wmw_name" "singleplacementslices"
 
 function bind_iff_wanted() { # usage: export_name
     export_name=$1


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
This PR will add binding for singleplacementslices in kubectl-kubestellar-ensure-wmw script.

## Related issue(s)

Fixes #
