### PR TITLE
:sparkles: Kube-bind provider-consumer object relationship

### DIFF
--- a/cmd/mailbox-controller/controller.go
+++ b/cmd/mailbox-controller/controller.go
@@ -40,7 +40,9 @@ import (
 	"github.com/kcp-dev/logicalcluster/v3"
 
 	edgev2alpha1 "github.com/kubestellar/kubestellar/pkg/apis/edge/v2alpha1"
+	edgeclusterclient "github.com/kubestellar/kubestellar/pkg/client/clientset/versioned/cluster/typed/edge/v2alpha1"
 	edgev2alpha1informers "github.com/kubestellar/kubestellar/pkg/client/informers/externalversions/edge/v2alpha1"
+	"github.com/kubestellar/kubestellar/pkg/kbuser"
 )
 
 const wsNameSep = "-mb-"
@@ -60,6 +62,8 @@ type mbCtl struct {
 	workspaceScopedInformer cache.SharedIndexInformer
 	workspaceScopedLister   tenancylisters.WorkspaceLister
 	workspaceScopedClient   tenancyclient.WorkspaceInterface
+	stClusterInterface      edgeclusterclient.SyncTargetClusterInterface
+	kbSpaceRelation         kbuser.KubeBindSpaceRelation
 	queue                   workqueue.RateLimitingInterface // of mailbox workspace Name
 }
 
@@ -73,21 +77,25 @@ func newMailboxController(ctx context.Context,
 	syncTargetPreInformer edgev2alpha1informers.SyncTargetInformer,
 	workspaceScopedPreInformer kcptenancyinformers.WorkspaceInformer,
 	workspaceScopedClient tenancyclient.WorkspaceInterface,
+	stClusterInterface edgeclusterclient.SyncTargetClusterInterface,
+	kbSpaceRelation kbuser.KubeBindSpaceRelation,
 ) *mbCtl {
 	syncTargetInformer := syncTargetPreInformer.Informer()
-	syncTargetInformer.AddIndexers(cache.Indexers{mbwsNameIndexKey: mbwsNameOfObj})
 	workspacesInformer := workspaceScopedPreInformer.Informer()
 
 	ctl := &mbCtl{
 		context:                 ctx,
 		espwPath:                espwPath,
-		syncTargetInformer:      syncTargetInformer,
-		syncTargetIndexer:       syncTargetInformer.GetIndexer(),
 		workspaceScopedInformer: workspacesInformer,
 		workspaceScopedLister:   workspaceScopedPreInformer.Lister(),
 		workspaceScopedClient:   workspaceScopedClient,
+		stClusterInterface:      stClusterInterface,
+		kbSpaceRelation:         kbSpaceRelation,
 		queue:                   workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "mailbox-controller"),
 	}
+	syncTargetInformer.AddIndexers(cache.Indexers{mbwsNameIndexKey: ctl.mbwsNameOfObj})
+	ctl.syncTargetInformer = syncTargetInformer
+	ctl.syncTargetIndexer = syncTargetInformer.GetIndexer()
 
 	syncTargetInformer.AddEventHandler(ctl)
 	workspacesInformer.AddEventHandler(ctl)
@@ -140,7 +148,7 @@ func (ctl *mbCtl) enqueue(obj any) {
 		logger.V(4).Info("Enqueuing reference due to workspace", "wsName", typed.Name)
 		ctl.queue.Add(typed.Name)
 	case *edgev2alpha1.SyncTarget:
-		mbwsName := mbwsNameOfSynctarget(typed)
+		mbwsName := ctl.mbwsNameOfSynctarget(typed)
 		logger.V(4).Info("Enqueuing reference due to SyncTarget", "wsName", mbwsName, "syncTargetName", typed.Name)
 		ctl.queue.Add(mbwsName)
 	default:
@@ -338,15 +346,33 @@ func (ctl *mbCtl) ensureBinding(ctx context.Context, workspace *tenancyv1alpha1.
 	return false
 }
 
-func mbwsNameOfSynctarget(st *edgev2alpha1.SyncTarget) string {
-	cluster := logicalcluster.From(st)
-	return cluster.String() + wsNameSep + string(st.UID)
+func (ctl *mbCtl) mbwsNameOfSynctarget(st *edgev2alpha1.SyncTarget) string {
+	logger := klog.FromContext(ctl.context)
+	_, stName, kbSpaceID, err := kbuser.AnalyzeObjectID(st)
+	if err != nil {
+		//TODO should we return an error?
+		logger.Error(err, "object does not appear to be a provider's copy of a consumer's object", "syncTarget", st.Name)
+		return ""
+	}
+	spaceID := ctl.kbSpaceRelation.SpaceIDFromKubeBind(kbSpaceID)
+	if spaceID == "" {
+		//TODO should we return an error?
+		logger.Error(nil, "failed to get consumer space ID from a provider's copy", "syncTarget", st.Name)
+		return ""
+	}
+	//get consumer SyncTarget for correct UID
+	consumerST, err := ctl.stClusterInterface.Cluster(logicalcluster.NewPath(spaceID)).Get(ctl.context, stName, metav1.GetOptions{})
+	if err != nil {
+		logger.Error(err, "failed to get consumer's object", "syncTarget", st.Name)
+		return ""
+	}
+	return spaceID + wsNameSep + string(consumerST.UID)
 }
 
-func mbwsNameOfObj(obj any) ([]string, error) {
+func (ctl *mbCtl) mbwsNameOfObj(obj any) ([]string, error) {
 	st, ok := obj.(*edgev2alpha1.SyncTarget)
 	if !ok {
 		return nil, fmt.Errorf("expected a SyncTarget but got %#+v, a %T", obj, obj)
 	}
-	return []string{mbwsNameOfSynctarget(st)}, nil
+	return []string{ctl.mbwsNameOfSynctarget(st)}, nil
 }

--- a/docs/content/Coding Milestones/PoC2023q1/example1-subs/example1-stage-1b.md
+++ b/docs/content/Coding Milestones/PoC2023q1/example1-subs/example1-stage-1b.md
@@ -7,7 +7,7 @@ write a file containing YAML for deploying the syncer in the guilder
 cluster.
 
 ```shell
-kubectl kubestellar prep-for-syncer --imw root:imw1 guilder --central -X
+kubectl kubestellar prep-for-syncer --imw root:imw1 guilder
 ```
 ``` { .bash .no-copy }
 Current workspace is "root:imw1".
@@ -68,7 +68,7 @@ local-path-storage                 local-path-provisioner             1/1     1 
 Do the analogous stuff for the florin cluster.
 
 ```shell
-kubectl kubestellar prep-for-syncer --imw root:imw1 florin --central -X
+kubectl kubestellar prep-for-syncer --imw root:imw1 florin
 ```
 ``` { .bash .no-copy }
 Current workspace is "root:imw1".

--- a/pkg/where-resolver/controller.go
+++ b/pkg/where-resolver/controller.go
@@ -34,6 +34,7 @@ import (
 	edgeclientset "github.com/kubestellar/kubestellar/pkg/client/clientset/versioned/cluster"
 	edgev2alpha1informers "github.com/kubestellar/kubestellar/pkg/client/informers/externalversions/edge/v2alpha1"
 	edgev2alpha1listers "github.com/kubestellar/kubestellar/pkg/client/listers/edge/v2alpha1"
+	"github.com/kubestellar/kubestellar/pkg/kbuser"
 )
 
 const (
@@ -54,9 +55,9 @@ type queueItem struct {
 }
 
 type controller struct {
-	context context.Context
-	queue   workqueue.RateLimitingInterface
-
+	context           context.Context
+	queue             workqueue.RateLimitingInterface
+	kbSpaceRelation   kbuser.KubeBindSpaceRelation
 	edgeClusterClient edgeclientset.ClusterInterface
 
 	singlePlacementSliceLister  edgev2alpha1listers.SinglePlacementSliceLister
@@ -79,14 +80,15 @@ func NewController(
 	singlePlacementSliceAccess edgev2alpha1informers.SinglePlacementSliceInformer,
 	locationAccess edgev2alpha1informers.LocationInformer,
 	syncTargetAccess edgev2alpha1informers.SyncTargetInformer,
+	kbSpaceRelation kbuser.KubeBindSpaceRelation,
 ) (*controller, error) {
 	context = klog.NewContext(context, klog.FromContext(context).WithValues("controller", ControllerName))
 	queue := workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), ControllerName)
 
 	c := &controller{
-		context: context,
-		queue:   queue,
-
+		context:           context,
+		queue:             queue,
+		kbSpaceRelation:   kbSpaceRelation,
 		edgeClusterClient: edgeClusterClient,
 
 		edgePlacementLister:  edgePlacementAccess.Lister(),

--- a/pkg/where-resolver/reconcile_on_edgeplacement.go
+++ b/pkg/where-resolver/reconcile_on_edgeplacement.go
@@ -18,8 +18,9 @@ package where_resolver
 
 import (
 	"context"
+	"errors"
 
-	"k8s.io/apimachinery/pkg/api/errors"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/klog/v2"
@@ -28,6 +29,7 @@ import (
 	"github.com/kcp-dev/logicalcluster/v3"
 
 	edgev2alpha1 "github.com/kubestellar/kubestellar/pkg/apis/edge/v2alpha1"
+	"github.com/kubestellar/kubestellar/pkg/kbuser"
 )
 
 func (c *controller) reconcileOnEdgePlacement(ctx context.Context, epKey string) error {
@@ -59,7 +61,7 @@ func (c *controller) reconcileOnEdgePlacement(ctx context.Context, epKey string)
 
 	ep, err := c.edgePlacementLister.Get(epName)
 	if err != nil {
-		if errors.IsNotFound(err) {
+		if k8serrors.IsNotFound(err) {
 			logger.V(1).Info("EdgePlacement not found")
 			logger.V(3).Info("dropping EdgePlacement from store")
 			store.dropEp(epKey)
@@ -114,27 +116,43 @@ func (c *controller) reconcileOnEdgePlacement(ctx context.Context, epKey string)
 	}
 
 	// 4)
+	_, originalName, kbSpaceID, err := kbuser.AnalyzeObjectID(ep)
+	if err != nil {
+		logger.Error(err, "object does not appear to be a provider's copy of a consumer's object", "edgePlacement", ep.Name)
+		return err
+	}
+	spaceID := c.kbSpaceRelation.SpaceIDFromKubeBind(kbSpaceID)
+	if spaceID == "" {
+		relErr := errors.New("failed to obtain space ID from kube-bind reference")
+		logger.Error(relErr, "failed to get consumer space ID from a provider's copy", "edgePlacement", originalName)
+		return relErr
+	}
+	originalEP, err := c.edgeClusterClient.Cluster(logicalcluster.NewPath(spaceID)).EdgeV2alpha1().EdgePlacements().Get(ctx, originalName, metav1.GetOptions{})
+	if err != nil {
+		logger.Error(err, "failed to get consumer's object", "edgePlacement", originalName)
+		return err
+	}
 	currentSPS, err := c.singlePlacementSliceLister.Get(epName)
 	if err != nil {
-		if errors.IsNotFound(err) { // create
+		if k8serrors.IsNotFound(err) { // create
 			logger.V(1).Info("creating SinglePlacementSlice")
 			sps := &edgev2alpha1.SinglePlacementSlice{
 				ObjectMeta: metav1.ObjectMeta{
-					Name: epName,
+					Name: originalName,
 					OwnerReferences: []metav1.OwnerReference{
 						{
 							APIVersion: edgev2alpha1.SchemeGroupVersion.String(),
 							Kind:       "EdgePlacement",
-							Name:       epName,
-							UID:        ep.UID,
+							Name:       originalName,
+							UID:        originalEP.UID,
 						},
 					},
 				},
 				Destinations: singles,
 			}
-			_, err = c.edgeClusterClient.Cluster(epws.Path()).EdgeV2alpha1().SinglePlacementSlices().Create(ctx, sps, metav1.CreateOptions{})
+			_, err = c.edgeClusterClient.Cluster(logicalcluster.NewPath(spaceID)).EdgeV2alpha1().SinglePlacementSlices().Create(ctx, sps, metav1.CreateOptions{})
 			if err != nil {
-				if !errors.IsAlreadyExists(err) {
+				if !k8serrors.IsAlreadyExists(err) {
 					logger.Error(err, "failed creating SinglePlacementSlice")
 					return err
 				}
@@ -147,7 +165,7 @@ func (c *controller) reconcileOnEdgePlacement(ctx context.Context, epKey string)
 		}
 	} else { // update
 		currentSPS.Destinations = singles
-		_, err = c.edgeClusterClient.Cluster(epws.Path()).EdgeV2alpha1().SinglePlacementSlices().Update(ctx, currentSPS, metav1.UpdateOptions{})
+		_, err = c.edgeClusterClient.Cluster(logicalcluster.NewPath(spaceID)).EdgeV2alpha1().SinglePlacementSlices().Update(ctx, currentSPS, metav1.UpdateOptions{})
 		if err != nil {
 			logger.Error(err, "failed updating SinglePlacementSlice")
 			return err

--- a/pkg/where-resolver/reconcile_on_synctarget.go
+++ b/pkg/where-resolver/reconcile_on_synctarget.go
@@ -132,7 +132,12 @@ func (c *controller) reconcileOnSyncTarget(ctx context.Context, stKey string) er
 				return err
 			}
 			nextSPS := cleanSPSBySt(currentSPS, stws.String(), stName)
-			_, err = c.edgeClusterClient.EdgeV2alpha1().SinglePlacementSlices().Cluster(ws.Path()).Update(ctx, nextSPS, metav1.UpdateOptions{})
+			spaceID, err := c.getConsumerSpaceForSPS(currentSPS)
+			if err != nil {
+				logger.Error(err, "failed to get consumer space ID from a provider's copy", "singlePlacementSlice", name)
+				return err
+			}
+			_, err = c.edgeClusterClient.EdgeV2alpha1().SinglePlacementSlices().Cluster(logicalcluster.NewPath(spaceID)).Update(ctx, nextSPS, metav1.UpdateOptions{})
 			if err != nil {
 				logger.Error(err, "failed to update SinglePlacementSlice", "workloadWorkspace", ws, "singlePlacementSlice", nextSPS.Name)
 				return err
@@ -172,7 +177,12 @@ func (c *controller) reconcileOnSyncTarget(ctx context.Context, stKey string) er
 			additionalSingles := makeSinglePlacementsForSt(locsFilteredByStAndEp, st)
 			nextSPS = extendSPS(nextSPS, additionalSingles)
 
-			_, err = c.edgeClusterClient.EdgeV2alpha1().SinglePlacementSlices().Cluster(ws.Path()).Update(ctx, nextSPS, metav1.UpdateOptions{})
+			spaceID, err := c.getConsumerSpaceForSPS(currentSPS)
+			if err != nil {
+				logger.Error(err, "failed to get consumer space ID from a provider's copy", "singlePlacementSlice", name)
+				return err
+			}
+			_, err = c.edgeClusterClient.EdgeV2alpha1().SinglePlacementSlices().Cluster(logicalcluster.NewPath(spaceID)).Update(ctx, nextSPS, metav1.UpdateOptions{})
 			if err != nil {
 				logger.Error(err, "failed to update SinglePlacementSlice", "workloadWorkspace", ws, "singlePlacementSlice", nextSPS.Name)
 				return err
@@ -213,7 +223,12 @@ func (c *controller) reconcileOnSyncTarget(ctx context.Context, stKey string) er
 			additionalSingles := makeSinglePlacementsForSt(locsFilteredByStAndEp, st)
 			nextSPS = extendSPS(nextSPS, additionalSingles)
 
-			_, err = c.edgeClusterClient.EdgeV2alpha1().SinglePlacementSlices().Cluster(ws.Path()).Update(ctx, nextSPS, metav1.UpdateOptions{})
+			spaceID, err := c.getConsumerSpaceForSPS(currentSPS)
+			if err != nil {
+				logger.Error(err, "failed to get consumer space ID from a provider's copy", "singlePlacementSlice", name)
+				return err
+			}
+			_, err = c.edgeClusterClient.EdgeV2alpha1().SinglePlacementSlices().Cluster(logicalcluster.NewPath(spaceID)).Update(ctx, nextSPS, metav1.UpdateOptions{})
 			if err != nil {
 				logger.Error(err, "failed to update SinglePlacementSlice", "workloadWorkspace", ws, "singlePlacementSlice", nextSPS.Name)
 				return err


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
1. In mailbox-controller construct a mailbox space name from the original SyncTarget object
2. In where-resolver controller create and update SPS in the WMW space and not in the ESPW.
3. In placement-translator TBD

## Related issue(s)

Fixes #
