### PR TITLE
🌱 Clarify single placement

### DIFF
--- a/config/crds/edge.kubestellar.io_singleplacementslices.yaml
+++ b/config/crds/edge.kubestellar.io_singleplacementslices.yaml
@@ -39,20 +39,21 @@ spec:
                 relevant EdgePlacement.
               properties:
                 cluster:
-                  description: Cluster is the logicalcluster.Name of the logical cluster
-                    that contains both the Location and the SyncTarget.
+                  description: '`cluster` is the logicalcluster.Name of the logical
+                    cluster that contains both the Location and the SyncTarget. This
+                    identifies the Inventory Space (IS), not the KCS (formerly ESPW).'
                   type: string
                 locationName:
+                  description: '`locationName` is the name of the Location object
+                    as it appears in the IS.'
                   type: string
                 syncTargetName:
-                  description: '`syncTargetName` identifies the relevant SyncTarget
-                    at the Location'
+                  description: '`syncTargetName` is the name of the corresponding
+                    SyncTarget object, as it appears in the IS.'
                   type: string
                 syncTargetUID:
-                  description: UID is a type that holds unique ID values, including
-                    UUIDs.  Because we don't ONLY use UUIDs, this is an alias to string.  Being
-                    a type captures intent and helps make sure that UIDs and names
-                    do not get conflated.
+                  description: '`syncTargetUID` is the `metadata.UID` of the SyncTarget
+                    object **in the KCS**.'
                   type: string
               required:
               - cluster

--- a/config/exports/apiexport-edge.kubestellar.io.yaml
+++ b/config/exports/apiexport-edge.kubestellar.io.yaml
@@ -11,5 +11,5 @@ spec:
   - v231005-c6f7728ef.syncerconfigs.edge.kubestellar.io
   - v231020-4e62eaf7.synctargets.edge.kubestellar.io
   - v231026-b37310b41.edgeplacements.edge.kubestellar.io
-  - v231113-f0837626.singleplacementslices.edge.kubestellar.io
+  - v231121-62262f2a1.singleplacementslices.edge.kubestellar.io
 status: {}

--- a/config/exports/apiresourceschema-singleplacementslices.edge.kubestellar.io.yaml
+++ b/config/exports/apiresourceschema-singleplacementslices.edge.kubestellar.io.yaml
@@ -2,7 +2,7 @@ apiVersion: apis.kcp.io/v1alpha1
 kind: APIResourceSchema
 metadata:
   creationTimestamp: null
-  name: v231113-f0837626.singleplacementslices.edge.kubestellar.io
+  name: v231121-62262f2a1.singleplacementslices.edge.kubestellar.io
 spec:
   group: edge.kubestellar.io
   names:
@@ -34,20 +34,21 @@ spec:
               EdgePlacement.
             properties:
               cluster:
-                description: Cluster is the logicalcluster.Name of the logical cluster
-                  that contains both the Location and the SyncTarget.
+                description: '`cluster` is the logicalcluster.Name of the logical
+                  cluster that contains both the Location and the SyncTarget. This
+                  identifies the Inventory Space (IS), not the KCS (formerly ESPW).'
                 type: string
               locationName:
+                description: '`locationName` is the name of the Location object as
+                  it appears in the IS.'
                 type: string
               syncTargetName:
-                description: '`syncTargetName` identifies the relevant SyncTarget
-                  at the Location'
+                description: '`syncTargetName` is the name of the corresponding SyncTarget
+                  object, as it appears in the IS.'
                 type: string
               syncTargetUID:
-                description: UID is a type that holds unique ID values, including
-                  UUIDs.  Because we don't ONLY use UUIDs, this is an alias to string.  Being
-                  a type captures intent and helps make sure that UIDs and names do
-                  not get conflated.
+                description: '`syncTargetUID` is the `metadata.UID` of the SyncTarget
+                  object **in the KCS**.'
                 type: string
             required:
             - cluster

--- a/pkg/apis/edge/v2alpha1/single-placement.go
+++ b/pkg/apis/edge/v2alpha1/single-placement.go
@@ -52,15 +52,18 @@ type SinglePlacementSlice struct {
 
 // SinglePlacement describes one Location that matches the relevant EdgePlacement.
 type SinglePlacement struct {
-	// Cluster is the logicalcluster.Name of the logical cluster that contains
+	// `cluster` is the logicalcluster.Name of the logical cluster that contains
 	// both the Location and the SyncTarget.
+	// This identifies the Inventory Space (IS), not the KCS (formerly ESPW).
 	Cluster string `json:"cluster"`
 
+	// `locationName` is the name of the Location object as it appears in the IS.
 	LocationName string `json:"locationName"`
 
-	// `syncTargetName` identifies the relevant SyncTarget at the Location
+	// `syncTargetName` is the name of the corresponding SyncTarget object, as it appears in the IS.
 	SyncTargetName string `json:"syncTargetName"`
 
+	// `syncTargetUID` is the `metadata.UID` of the SyncTarget object **in the KCS**.
 	SyncTargetUID apimachtypes.UID `json:"syncTargetUID"`
 }
 


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
The PR updates the comments on the fields of SinglePlacement to specify which of the two copies of the objects involved are identified. This is documenting an agreement already reached and appearing in https://github.com/kubestellar/kubestellar/blob/5fe587ecf309234a4f23cb8c97b5171d5efac364/docs/content/Coding%20Milestones/PoC2023q1/outline.md?plain=1#L778-L781 but somehow still not widely known.

## Related issue(s)

Fixes #
