### PR TITLE
:bug: introduce timeout in syncer-gen cmd

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "go.sum|docs/package-lock.json|cmd/kube-watchall/go.sum|docs/config.toml|docs/resources/_gen|docs/static|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2023-11-03T15:34:50Z",
+  "generated_at": "2023-11-21T21:05:34Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -91,21 +91,21 @@
       {
         "hashed_secret": "9fbd4024ebb2c7e2779a80aa127d560c62234e4f",
         "is_verified": false,
-        "line_number": 495,
+        "line_number": 505,
         "type": "Secret Keyword",
         "verified_result": null
       },
       {
         "hashed_secret": "4f151c44a6783667af6cedaa3d12560f8af2f38a",
         "is_verified": false,
-        "line_number": 514,
+        "line_number": 516,
         "type": "Secret Keyword",
         "verified_result": null
       },
       {
         "hashed_secret": "eba2ae817b95fdb713f3af658a6ae1821e452264",
         "is_verified": false,
-        "line_number": 620,
+        "line_number": 668,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/cmd/kubectl-kubestellar-syncer_gen/main.go
+++ b/cmd/kubectl-kubestellar-syncer_gen/main.go
@@ -87,7 +87,6 @@ func syncerGenCommand() *cobra.Command {
 func main() {
 	cmd := syncerGenCommand()
 	if err := cmd.Execute(); err != nil {
-		fmt.Fprintf(os.Stderr, "error: %v\n", err)
 		os.Exit(1)
 	}
 }


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

If the target workspace is not a mailbox workspace, Syncer will fall into infinite loop until calling EdgeSyncConfig API succeeds. This PR introduces timeout and enhances messages to be output to stderr.  The timeout is specified by `--timeout` argument (20s as default).

```
$ KUBECONFIG=/tmp/.kcp/admin.kubeconfig go run ./cmd/kubectl-kubestellar-syncer_gen/main.go cluster1 --syncer-image syncer-image:latest -o "-"         
failed to create EdgeSyncConfig. Retrying...
 Reason: failed to get resource mapping :no matches for kind "EdgeSyncConfig" in version "edge.kubestellar.io/v2alpha1"
failed to create EdgeSyncConfig. Retrying...
 Reason: failed to get resource mapping :no matches for kind "EdgeSyncConfig" in version "edge.kubestellar.io/v2alpha1"
failed to create EdgeSyncConfig. Retrying...
...
Error: failed to get or create EdgeSyncConfig resource.
 Reason: timed out waiting for the condition
```

## Related issue(s)

Fixes #
