### PR TITLE
:seedling: Remove kcp modules from syncer-gen codes

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "go.sum|docs/package-lock.json|cmd/kube-watchall/go.sum|docs/config.toml|docs/resources/_gen|docs/static|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2023-11-03T15:34:50Z",
+  "generated_at": "2023-11-22T10:50:45Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -98,14 +98,14 @@
       {
         "hashed_secret": "4f151c44a6783667af6cedaa3d12560f8af2f38a",
         "is_verified": false,
-        "line_number": 514,
+        "line_number": 506,
         "type": "Secret Keyword",
         "verified_result": null
       },
       {
         "hashed_secret": "eba2ae817b95fdb713f3af658a6ae1821e452264",
         "is_verified": false,
-        "line_number": 620,
+        "line_number": 658,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/pkg/cliplugins/kubestellar/base/option.go
+++ b/pkg/cliplugins/kubestellar/base/option.go
@@ -1,0 +1,96 @@
+/*
+Copyright 2022 The KubeStellar Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+/*
+Portions of this code are based on or inspired by the KCP Author's work
+Copyright Copyright 2022 The KCP Authors
+Original code: https://github.com/kcp-dev/kcp/blob/release-0.11/pkg/cliplugins/base/options.go
+*/
+
+package base
+
+import (
+	"github.com/spf13/cobra"
+
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/client-go/tools/clientcmd"
+)
+
+// Options contains options common to most CLI plugins, including settings for connecting to kcp (kubeconfig, etc).
+type Options struct {
+	// OptOutOfDefaultKubectlFlags indicates that the standard kubectl/kubeconfig-related flags should not be bound
+	// by default.
+	OptOutOfDefaultKubectlFlags bool
+	// Kubeconfig specifies kubeconfig file(s).
+	Kubeconfig string
+	// KubectlOverrides stores the extra client connection fields, such as context, user, etc.
+	KubectlOverrides *clientcmd.ConfigOverrides
+
+	genericclioptions.IOStreams
+
+	// ClientConfig is the resolved cliendcmd.ClientConfig based on the client connection flags. This is only valid
+	// after calling Complete.
+	ClientConfig clientcmd.ClientConfig
+}
+
+// NewOptions provides an instance of Options with default values.
+func NewOptions(streams genericclioptions.IOStreams) *Options {
+	return &Options{
+		KubectlOverrides: &clientcmd.ConfigOverrides{},
+		IOStreams:        streams,
+	}
+}
+
+// BindFlags binds options fields to cmd's flagset.
+func (o *Options) BindFlags(cmd *cobra.Command) {
+	if o.OptOutOfDefaultKubectlFlags {
+		return
+	}
+
+	cmd.Flags().StringVar(&o.Kubeconfig, "kubeconfig", o.Kubeconfig, "path to the kubeconfig file")
+
+	// We add only a subset of kubeconfig-related flags to the plugin.
+	// All those with LongName == "" will be ignored.
+	kubectlConfigOverrideFlags := clientcmd.RecommendedConfigOverrideFlags("")
+	kubectlConfigOverrideFlags.AuthOverrideFlags.ClientCertificate.LongName = ""
+	kubectlConfigOverrideFlags.AuthOverrideFlags.ClientKey.LongName = ""
+	kubectlConfigOverrideFlags.AuthOverrideFlags.Impersonate.LongName = ""
+	kubectlConfigOverrideFlags.AuthOverrideFlags.ImpersonateGroups.LongName = ""
+	kubectlConfigOverrideFlags.ContextOverrideFlags.ClusterName.LongName = ""
+	kubectlConfigOverrideFlags.Timeout.LongName = ""
+
+	clientcmd.BindOverrideFlags(o.KubectlOverrides, cmd.PersistentFlags(), kubectlConfigOverrideFlags)
+}
+
+// Complete initializes ClientConfig based on Kubeconfig and KubectlOverrides.
+func (o *Options) Complete() error {
+	loadingRules := clientcmd.NewDefaultClientConfigLoadingRules()
+	loadingRules.ExplicitPath = o.Kubeconfig
+
+	startingConfig, err := loadingRules.GetStartingConfig()
+	if err != nil {
+		return err
+	}
+
+	o.ClientConfig = clientcmd.NewDefaultClientConfig(*startingConfig, o.KubectlOverrides)
+
+	return nil
+}
+
+// Validate validates the configured options.
+func (o *Options) Validate() error {
+	return nil
+}


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

This is the PR for https://github.com/kubestellar/kubestellar/issues/1314.

#### What's changes

- pick up the minimum codes from utility codes in kcp cliplugin to remove the dependency on kcp repo

#### Verification

Summary: No regressions

UT passed.
```
$ go test ./pkg/cliplugins/...
?       github.com/kubestellar/kubestellar/pkg/cliplugins/kubestellar/base      [no test files]
ok      github.com/kubestellar/kubestellar/pkg/cliplugins/kubestellar/syncer-gen        0.587s
```

Case1: the target space is kcp workspace
1. Run syncer-gen
<details><summary>Details</summary>

```
$ go run ./cmd/kubectl-kubestellar-syncer_gen/main.go cluster1 --syncer-image syncer-image:latest -o /tmp/syncer-kcp.yaml
Creating service account "kubestellar-syncer-cluster1-nmoarlfc"
Creating cluster role "kubestellar-syncer-cluster1-nmoarlfc" to give service account "kubestellar-syncer-cluster1-nmoarlfc"

1. write and sync access to the synctarget "kubestellar-syncer-cluster1-nmoarlfc"
2. write access to apiresourceimports.

Creating or updating cluster role binding "kubestellar-syncer-cluster1-nmoarlfc" to bind service account "kubestellar-syncer-cluster1-nmoarlfc" to cluster role "kubestellar-syncer-cluster1-nmoarlfc".

Wrote workload execution cluster manifest to /tmp/syncer-kcp.yaml for namespace "kubestellar-syncer-cluster1-nmoarlfc". Use

  KUBECONFIG=<wec-config> kubectl apply -f "/tmp/syncer-kcp.yaml"

to apply it. Use

  KUBECONFIG=<wec-config> kubectl get deployment -n "kubestellar-syncer-cluster1-nmoarlfc" kubestellar-syncer-cluster1-nmoarlfc

to verify the syncer pod is running.
```

</details>

2. Make sure that the KCP workspace is accessible by Kubeconfig secret placed in generated manifests 
<details><summary>Details</summary>

```
$ yq 'select (.kind == "Secret" and .stringData != null) | .stringData[]' /tmp/syncer-kcp.yaml > /tmp/syncer-kcp-kubeconfig.yaml
$ KUBECONFIG=/tmp/syncer-kcp-kubeconfig.yaml k get ns 
NAME         STATUS   AGE
default      Active   92s
kcp-system   Active   96s
```

</details>

Case2: the target space is KinD cluster 
1. Run syncer-gen
<details><summary>Details</summary>

```
$ go run ./cmd/kubectl-kubestellar-syncer_gen/main.go cluster1 --syncer-image syncer-image:latest -o /tmp/syncer.yaml

Creating service account "kubestellar-syncer-cluster1-2btb0y7l"
Creating cluster role "kubestellar-syncer-cluster1-2btb0y7l" to give service account "kubestellar-syncer-cluster1-2btb0y7l"

1. write and sync access to the synctarget "kubestellar-syncer-cluster1-2btb0y7l"
2. write access to apiresourceimports.

Creating or updating cluster role binding "kubestellar-syncer-cluster1-2btb0y7l" to bind service account "kubestellar-syncer-cluster1-2btb0y7l" to cluster role "kubestellar-syncer-cluster1-2btb0y7l".

Wrote workload execution cluster manifest to /tmp/syncer.yaml for namespace "kubestellar-syncer-cluster1-2btb0y7l". Use

  KUBECONFIG=<wec-config> kubectl apply -f "/tmp/syncer.yaml"

to apply it. Use

  KUBECONFIG=<wec-config> kubectl get deployment -n "kubestellar-syncer-cluster1-2btb0y7l" kubestellar-syncer-cluster1-2btb0y7l

to verify the syncer pod is running.
```

</details>

2. Make sure that KinD is accessible by Kubeconfig secret placed in generated manifests 
<details><summary>Details</summary>

```
$ yq 'select (.kind == "Secret" and .stringData != null) | .stringData[]' /tmp/syncer.yaml > /tmp/syncer-kubeconfig.yaml
$ KUBECONFIG=/tmp/syncer-kubeconfig.yaml k get node,ns
NAME                      STATUS   ROLES           AGE   VERSION
node/kind-control-plane   Ready    control-plane   21m   v1.27.1

NAME                           STATUS   AGE
namespace/default              Active   21m
namespace/kube-node-lease      Active   21m
namespace/kube-public          Active   21m
namespace/kube-system          Active   21m
namespace/local-path-storage   Active   21m
```

</details>

## Related issue(s)

Issue: #1314
