### PR TITLE
✨ Use a hot fix of kube-bind to sync labels

### DIFF
--- a/core.Dockerfile
+++ b/core.Dockerfile
@@ -38,13 +38,16 @@ RUN mkdir -p .kcp && \
     mkdir -p bin && \
     mkdir -p scripts
 
-RUN git clone https://github.com/kube-bind/kube-bind.git && \
+RUN git clone https://github.com/waltforme/kube-bind.git && \
     pushd kube-bind && \
-    IGNORE_GO_VERSION=1 make build && \
-    popd && \
-    git clone -b autobind https://github.com/waltforme/kube-bind.git kube-bind-autobind && \
-    pushd kube-bind-autobind && \
-    IGNORE_GO_VERSION=1 go build -o ../kube-bind/bin/kubectl-bind cmd/kubectl-bind/main.go && \
+    mkdir bin && \
+    IGNORE_GO_VERSION=1 go build -o ./bin/example-backend ./cmd/example-backend/main.go && \
+    git checkout origin/syncmore && \
+    IGNORE_GO_VERSION=1 go build -o ./bin/konnector ./cmd/konnector/main.go && \
+    git checkout origin/autobind && \
+    IGNORE_GO_VERSION=1 go build -o ./bin/kubectl-bind ./cmd/kubectl-bind/main.go && \
+    export PATH=$(pwd)/bin:$PATH && \
+    git checkout main && \
     popd && \
     git clone https://github.com/dexidp/dex.git && \
     pushd dex && \

--- a/docs/content/Coding Milestones/PoC2023q1/example1-subs/example1-post-kcp.md
+++ b/docs/content/Coding Milestones/PoC2023q1/example1-subs/example1-post-kcp.md
@@ -52,15 +52,16 @@ The command below makes kube-bind binaries and dex binary available in `$PATH`.
 
 ```shell
 rm -rf kube-bind
-rm -rf kube-bind-autobind
-git clone https://github.com/kube-bind/kube-bind.git && \
+git clone https://github.com/waltforme/kube-bind.git && \
 pushd kube-bind && \
-IGNORE_GO_VERSION=1 make build && \
+mkdir bin && \
+IGNORE_GO_VERSION=1 go build -o ./bin/example-backend ./cmd/example-backend/main.go && \
+git checkout origin/syncmore && \
+IGNORE_GO_VERSION=1 go build -o ./bin/konnector ./cmd/konnector/main.go && \
+git checkout origin/autobind && \
+IGNORE_GO_VERSION=1 go build -o ./bin/kubectl-bind ./cmd/kubectl-bind/main.go && \
 export PATH=$(pwd)/bin:$PATH && \
-popd && \
-git clone -b autobind https://github.com/waltforme/kube-bind.git kube-bind-autobind && \
-pushd kube-bind-autobind && \
-IGNORE_GO_VERSION=1 go build -o ../kube-bind/bin/kubectl-bind cmd/kubectl-bind/main.go && \
+git checkout main && \
 popd && \
 git clone https://github.com/dexidp/dex.git && \
 pushd dex && \


### PR DESCRIPTION
## Summary
This PR uses a hot fix of kube-bind to sync labels.

The fix lives in the `syncmore` branch of my fork of kube-bind.

Tested it using example 1 locally:
```
ubuntu@ip-172-31-67-225:~$ kc ws tree
.
└── root
    ├── compute
    ├── espw
    ├── imw1
    ├── rzfwtmtzwqwwpog8-mb-52542adf-e1e9-4501-8b28-8a7612d9644d
    ├── rzfwtmtzwqwwpog8-mb-e4318a18-e02b-4b5b-af88-67e47c610a7d
    ├── wmw-c
    ├── wmw-s
    └── wmw1

ubuntu@ip-172-31-67-225:~$ kc ws root:imw1
Current workspace is "root:imw1".
ubuntu@ip-172-31-67-225:~$ kc get synctarget.edge
NAME      AGE
florin    3m48s
guilder   3m46s
ubuntu@ip-172-31-67-225:~$ kc label synctarget.edge florin time="0248"
synctarget.edge.kubestellar.io/florin labeled
ubuntu@ip-172-31-67-225:~$ kc ws root:espw
Current workspace is "root:espw".
ubuntu@ip-172-31-67-225:~$ kc get synctarget.edge
NAME                      AGE
kube-bind-9dj7r-florin    4m16s
kube-bind-9dj7r-guilder   4m14s
ubuntu@ip-172-31-67-225:~$ kc get synctarget.edge kube-bind-9dj7r-florin -oyaml | yq .metadata.labels
env: prod
id: florin
loc-name: florin
time: "0248"
ubuntu@ip-172-31-67-225:~$ kc ws root:imw1
Current workspace is "root:imw1".
ubuntu@ip-172-31-67-225:~$ kc label synctarget.edge florin time-
synctarget.edge.kubestellar.io/florin unlabeled
ubuntu@ip-172-31-67-225:~$ kc ws root:espw
Current workspace is "root:espw".
ubuntu@ip-172-31-67-225:~$ kc get synctarget.edge kube-bind-9dj7r-florin -oyaml | yq .metadata.labels
env: prod
id: florin
loc-name: florin
ubuntu@ip-172-31-67-225:
```