### PR TITLE
:sparkles: add external secret ref to provider

### DIFF
--- a/space-framework/pkg/space-manager/provider.go
+++ b/space-framework/pkg/space-manager/provider.go
@@ -41,8 +41,7 @@ import (
 
 // Each provider gets its own namespace named prefixNamespace+providerName
 const (
-	prefixNamespace     = "spaceprovider-"
-	PROVIDER_CONFIG_KEY = "kubeconfig"
+	prefixNamespace = "spaceprovider-"
 )
 
 func ProviderNS(name string) string {
@@ -66,16 +65,16 @@ type provider struct {
 }
 
 // TODO: this is termporary for stage 1. For stage 2 we expect to have a uniform interface for all informers.
-func newProviderClient(pType spacev1alpha1apis.SpaceProviderType, config string) spaceprovider.ProviderClient {
+func newProviderClient(pType spacev1alpha1apis.SpaceProviderType, configStrs map[string]string) spaceprovider.ProviderClient {
 	var pClient spaceprovider.ProviderClient = nil
 	var err error
 	switch pType {
 	case spacev1alpha1apis.KindProviderType:
-		pClient, err = kindprovider.New(config)
+		pClient, err = kindprovider.New(configStrs)
 	case spacev1alpha1apis.KubeflexProviderType:
-		pClient, err = kflexprovider.New(config)
+		pClient, err = kflexprovider.New(configStrs)
 	case spacev1alpha1apis.KcpProviderType:
-		pClient, err = providerkcp.New(config)
+		pClient, err = providerkcp.New(configStrs)
 	default:
 		return nil
 	}
@@ -89,7 +88,7 @@ func newProviderClient(pType spacev1alpha1apis.SpaceProviderType, config string)
 
 // CreateProvider returns new provider client
 func CreateProvider(c *controller, providerDesc *spacev1alpha1apis.SpaceProviderDesc) (*provider, error) {
-	var configStr string
+	var configStrs map[string]string
 	var err error
 	providerName := providerDesc.Name
 	c.lock.Lock()
@@ -102,15 +101,15 @@ func CreateProvider(c *controller, providerDesc *spacev1alpha1apis.SpaceProvider
 
 	if providerDesc.Spec.ProviderType != spacev1alpha1apis.KindProviderType {
 		if providerDesc.Spec.SecretRef == nil {
-			return nil, fmt.Errorf("Provider description for %s is missing secret reference", string(providerDesc.Name))
+			return nil, fmt.Errorf("provider description for %s is missing internal secret reference", string(providerDesc.Name))
 		}
 
-		configStr, err = getConfigFromSecret(*c.k8sClientset, providerDesc.Spec.SecretRef)
+		configStrs, err = getConfigFromSecret(*c.k8sClientset, providerDesc.Spec.SecretRef)
 		if err != nil {
 			return nil, err
 		}
 	}
-	newProviderClient := newProviderClient(providerDesc.Spec.ProviderType, configStr)
+	newProviderClient := newProviderClient(providerDesc.Spec.ProviderType, configStrs)
 	if newProviderClient == nil {
 		return nil, fmt.Errorf("failed to create client for provider: %s", string(providerDesc.Spec.ProviderType))
 	}
@@ -132,31 +131,30 @@ func CreateProvider(c *controller, providerDesc *spacev1alpha1apis.SpaceProvider
 	return p, nil
 }
 
-func getConfigFromSecret(cs kubeclient.Clientset, sRef *v1.SecretReference) (string, error) {
+func getConfigFromSecret(cs kubeclient.Clientset, sRef *v1.SecretReference) (map[string]string, error) {
 
 	ctx := context.Background()
 	logger := klog.FromContext(ctx)
+	configStrs := make(map[string]string)
 
 	var kubeconfigBytes []byte
 	secret, err := cs.CoreV1().Secrets(sRef.Namespace).Get(ctx, sRef.Name, metav1.GetOptions{})
 	if err != nil {
-		return "", err
+		return configStrs, err
 	}
 
-	// Retrieve the kubeconfig data from the Secret
-	kubeconfigData, found := secret.Data[PROVIDER_CONFIG_KEY]
-	if !found {
-		return "", errors.New("secret doesn't have kubeconfig data")
+	for key, value := range secret.Data {
+		// Retrieve the kubeconfig data from the Secret
+		kubeconfigBytes, err = base64.StdEncoding.DecodeString(string(value))
+		if err != nil {
+			//We assume this happen because the data was not encoded pring message and get the string
+			kubeconfigBytes = value
+			logger.Info("Provider secret was not encoded", "Secret", sRef.Name)
+		}
+		configStrs[key] = string(kubeconfigBytes)
 	}
 
-	kubeconfigBytes, err = base64.StdEncoding.DecodeString(string(kubeconfigData))
-	if err != nil {
-		//We assume this happen because the data was not encoded pring message and get the string
-		kubeconfigBytes = kubeconfigData
-		logger.Info("Provider secret was not encoded", "Secret", sRef.Name)
-	}
-
-	return string(kubeconfigBytes), nil
+	return configStrs, nil
 }
 
 func (p *provider) filterOut(spaceName string) bool {
@@ -341,7 +339,7 @@ func (p *provider) createSpaceSecrets(space *spacev1alpha1apis.Space, spInfo spa
 	if needExternal {
 		if spInfo.Config[spaceprovider.EXTERNAL] != "" {
 			secretName = "external-" + space.Name
-			secret = buildSecret(secretName, spInfo.Config[spaceprovider.INCLUSTER])
+			secret = buildSecret(secretName, spInfo.Config[spaceprovider.EXTERNAL])
 			_, err := p.c.k8sClientset.CoreV1().Secrets(p.nameSpace).Create(p.c.ctx, secret, metav1.CreateOptions{})
 			if err != nil {
 				if !k8sapierrors.IsAlreadyExists(err) {

--- a/space-framework/pkg/space-manager/providerclient/client_interface.go
+++ b/space-framework/pkg/space-manager/providerclient/client_interface.go
@@ -17,8 +17,9 @@ limitations under the License.
 package providerclient
 
 const (
-	INCLUSTER = "incluster"
-	EXTERNAL  = "external"
+	INCLUSTER           = "incluster"
+	EXTERNAL            = "external"
+	PROVIDER_CONFIG_KEY = "kubeconfig"
 )
 
 // SpaceInfo is a minimal space information.

--- a/space-framework/space-provider/kind/kind.go
+++ b/space-framework/space-provider/kind/kind.go
@@ -36,7 +36,8 @@ type KindClusterProvider struct {
 }
 
 // New creates a new KindClusterProvider
-func New(pConfig string) (KindClusterProvider, error) {
+func New(configStrs map[string]string) (KindClusterProvider, error) {
+	pConfig := configStrs[clusterprovider.PROVIDER_CONFIG_KEY]
 	kindProvider := kind.NewProvider()
 	return KindClusterProvider{
 		kindProvider: kindProvider,

--- a/space-framework/space-provider/kubeflex/kubeflex.go
+++ b/space-framework/space-provider/kubeflex/kubeflex.go
@@ -54,7 +54,8 @@ type KflexClusterProvider struct {
 }
 
 // New creates a new KflexClusterProvider
-func New(pConfig string) (KflexClusterProvider, error) {
+func New(configStrs map[string]string) (KflexClusterProvider, error) {
+	pConfig := configStrs[clusterprovider.PROVIDER_CONFIG_KEY]
 
 	ctx := context.Background()
 	logger := klog.FromContext(ctx)


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
The provider secret for kcp now include two configs: one named kubeconfig which is the default config used by the space manager to access the provider, and one named incluster or external.  This is needed for kcp so we can generate the in-cluster and external secrets when creating spaces.  The applicable changes to the helm install and the other scripts will follow in #1268 .
## Related issue(s)

Fixes #
