### PR TITLE
🌱 Switch to the script that labels objects after their creation

### DIFF
--- a/docs/content/Coding Milestones/PoC2023q1/example1-subs/example1-post-kcp.md
+++ b/docs/content/Coding Milestones/PoC2023q1/example1-subs/example1-post-kcp.md
@@ -148,8 +148,8 @@ also label guilder with `extended=yes`.
 
 ```shell
 kubectl ws root:imw1
-kubectl kubestellar ensure location ex1 florin  loc-name=florin  env=prod
-kubectl kubestellar ensure location ex1 guilder loc-name=guilder env=prod extended=yes
+kubectl kubestellar ensure location florin  loc-name=florin  env=prod
+kubectl kubestellar ensure location guilder loc-name=guilder env=prod extended=yes
 echo "decribe the florin location object"
 kubectl describe location.edge.kubestellar.io florin
 ```


### PR DESCRIPTION
As the title.

@ezrasilvera I think we should keep `scripts/outer/kubectl-kubestellar-ensure-location-ex1` for now, until we see that #1265 passes example1 after this PR merges to `kube-bind` branch.

/cc @ezrasilvera 