### PR TITLE
🐛 fixed make codegen to work correctly in case of deleteion from pkg/apis

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -248,6 +248,7 @@ crds: $(CONTROLLER_GEN) $(API_GEN) $(YAML_PATCH)
 .PHONY: crds
 
 codegen: crds $(CODE_GENERATOR)
+	rm -rf pkg/client/*
 	go mod download
 	./hack/update-codegen-clients.sh
 	$(MAKE) imports


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

if one of the apis defined under `pkg/apis/` is deleted, current command `make codegen` leaves garbage generated code. 
This can be easily solved by removing generated code under `pkg/client` before the code generation.

in order to test this fix I tried the following:
1. deleted syncer config api file.
2. ran `make codegen`.

BEFORE this fix, the following screenshot is the result:
![Screenshot 2023-11-28 at 15 24 54](https://github.com/kubestellar/kubestellar/assets/19717747/e43dbc49-970a-414c-b0cf-a7c4f18abf0b)


AFTER this fix, I ran the same and the following screenshot is the result:
![Screenshot 2023-11-28 at 15 27 26](https://github.com/kubestellar/kubestellar/assets/19717747/36740094-5363-4117-8f21-1506b0a7ea87)

as it can be seen in the screenshots, if this fix is not introduced, a lot of unnecessary generated code is still there even if we delete a file from the api.

## Related issue(s)

Fixes #
