### PR TITLE
🌱 Remove 'kcp' from .wordlist

### DIFF
--- a/.github/spellcheck/.wordlist.txt
+++ b/.github/spellcheck/.wordlist.txt
@@ -108,7 +108,6 @@ IngressClass
 IPv
 ISA
 JSON
-KCP
 KCS
 Karve
 Keypair
@@ -401,8 +400,6 @@ joinus
 jq
 json
 jsonpath
-kcp
-kcp's
 ko
 ksmeta
 kube


### PR DESCRIPTION
## Summary
This PR removes 'kcp' from `.github/spellcheck/.wordlist.txt`.

@clubanderson Does this PR do what you suggsted? I'm asking because I'm not 100% sure how it is going do change the behavior of our CI. If I can get some more explanations that will be great. Thank you.