### PR TITLE
✨ Shift left the labeling of edge CRDs for kube-bind to export

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,7 @@ else
 INSTALL_GOBIN=$(shell go env GOBIN)
 endif
 
-CONTROLLER_GEN_VER := v0.10.0
+CONTROLLER_GEN_VER := v0.13.0
 CONTROLLER_GEN_BIN := controller-gen
 CONTROLLER_GEN := $(TOOLS_DIR)/$(CONTROLLER_GEN_BIN)-$(CONTROLLER_GEN_VER)
 export CONTROLLER_GEN # so hack scripts can use it

--- a/config/crds/edge.kubestellar.io_customizers.yaml
+++ b/config/crds/edge.kubestellar.io_customizers.yaml
@@ -3,8 +3,9 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.10.0
-  creationTimestamp: null
+    controller-gen.kubebuilder.io/version: v0.13.0
+  labels:
+    kube-bind.io/exported: "true"
   name: customizers.edge.kubestellar.io
 spec:
   group: edge.kubestellar.io

--- a/config/crds/edge.kubestellar.io_edgeplacements.yaml
+++ b/config/crds/edge.kubestellar.io_edgeplacements.yaml
@@ -3,8 +3,9 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.10.0
-  creationTimestamp: null
+    controller-gen.kubebuilder.io/version: v0.13.0
+  labels:
+    kube-bind.io/exported: "true"
   name: edgeplacements.edge.kubestellar.io
 spec:
   group: edge.kubestellar.io

--- a/config/crds/edge.kubestellar.io_edgesyncconfigs.yaml
+++ b/config/crds/edge.kubestellar.io_edgesyncconfigs.yaml
@@ -3,8 +3,9 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.10.0
-  creationTimestamp: null
+    controller-gen.kubebuilder.io/version: v0.13.0
+  labels:
+    kube-bind.io/exported: "true"
   name: edgesyncconfigs.edge.kubestellar.io
 spec:
   group: edge.kubestellar.io

--- a/config/crds/edge.kubestellar.io_locations.yaml
+++ b/config/crds/edge.kubestellar.io_locations.yaml
@@ -3,8 +3,9 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.10.0
-  creationTimestamp: null
+    controller-gen.kubebuilder.io/version: v0.13.0
+  labels:
+    kube-bind.io/exported: "true"
   name: locations.edge.kubestellar.io
 spec:
   group: edge.kubestellar.io

--- a/config/crds/edge.kubestellar.io_singleplacementslices.yaml
+++ b/config/crds/edge.kubestellar.io_singleplacementslices.yaml
@@ -3,8 +3,9 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.10.0
-  creationTimestamp: null
+    controller-gen.kubebuilder.io/version: v0.13.0
+  labels:
+    kube-bind.io/exported: "true"
   name: singleplacementslices.edge.kubestellar.io
 spec:
   group: edge.kubestellar.io

--- a/config/crds/edge.kubestellar.io_syncerconfigs.yaml
+++ b/config/crds/edge.kubestellar.io_syncerconfigs.yaml
@@ -3,8 +3,9 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.10.0
-  creationTimestamp: null
+    controller-gen.kubebuilder.io/version: v0.13.0
+  labels:
+    kube-bind.io/exported: "true"
   name: syncerconfigs.edge.kubestellar.io
 spec:
   group: edge.kubestellar.io

--- a/config/crds/edge.kubestellar.io_synctargets.yaml
+++ b/config/crds/edge.kubestellar.io_synctargets.yaml
@@ -3,8 +3,9 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.10.0
-  creationTimestamp: null
+    controller-gen.kubebuilder.io/version: v0.13.0
+  labels:
+    kube-bind.io/exported: "true"
   name: synctargets.edge.kubestellar.io
 spec:
   group: edge.kubestellar.io

--- a/pkg/apis/edge/v2alpha1/customize.go
+++ b/pkg/apis/edge/v2alpha1/customize.go
@@ -47,6 +47,7 @@ const CustomizerAnnotationKey string = "edge.kubestellar.io/customizer"
 
 // +crd
 // +genclient
+// +kubebuilder:metadata:labels="kube-bind.io/exported=true"
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // Customizer defines modifications to make to the relevant objects as they propagate

--- a/pkg/apis/edge/v2alpha1/edge-placement.go
+++ b/pkg/apis/edge/v2alpha1/edge-placement.go
@@ -51,6 +51,7 @@ import (
 // +genclient
 // +genclient:nonNamespaced
 // +kubebuilder:resource:scope=Cluster,shortName=epl
+// +kubebuilder:metadata:labels="kube-bind.io/exported=true"
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 type EdgePlacement struct {
 	metav1.TypeMeta `json:",inline"`

--- a/pkg/apis/edge/v2alpha1/edge-syncconfig.go
+++ b/pkg/apis/edge/v2alpha1/edge-syncconfig.go
@@ -24,6 +24,7 @@ import (
 // +genclient
 // +genclient:nonNamespaced
 // +kubebuilder:resource:scope=Cluster,shortName=esc
+// +kubebuilder:metadata:labels="kube-bind.io/exported=true"
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 type EdgeSyncConfig struct {
 	/*

--- a/pkg/apis/edge/v2alpha1/single-placement.go
+++ b/pkg/apis/edge/v2alpha1/single-placement.go
@@ -38,6 +38,7 @@ const SourcePlacementLabelKey string = "edge.kubestellar.io/source-placement"
 // +genclient
 // +genclient:nonNamespaced
 // +kubebuilder:resource:scope=Cluster,shortName=sps,path=singleplacementslices
+// +kubebuilder:metadata:labels="kube-bind.io/exported=true"
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 type SinglePlacementSlice struct {
 	metav1.TypeMeta `json:",inline"`

--- a/pkg/apis/edge/v2alpha1/syncer-config.go
+++ b/pkg/apis/edge/v2alpha1/syncer-config.go
@@ -31,6 +31,7 @@ import (
 // +genclient
 // +genclient:nonNamespaced
 // +kubebuilder:resource:scope=Cluster,shortName=escfg
+// +kubebuilder:metadata:labels="kube-bind.io/exported=true"
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 type SyncerConfig struct {
 	metav1.TypeMeta `json:",inline"`

--- a/pkg/apis/edge/v2alpha1/synctarget_types.go
+++ b/pkg/apis/edge/v2alpha1/synctarget_types.go
@@ -34,6 +34,7 @@ import (
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // +kubebuilder:subresource:status
 // +kubebuilder:resource:scope=Cluster
+// +kubebuilder:metadata:labels="kube-bind.io/exported=true"
 // +kubebuilder:printcolumn:name="Location",type="string",JSONPath=`.metadata.name`,priority=1
 // +kubebuilder:printcolumn:name="Ready",type="string",JSONPath=`.status.conditions[?(@.type=="Ready")].status`,priority=2
 // +kubebuilder:printcolumn:name="Synced API resources",type="string",JSONPath=`.status.syncedResources`,priority=3

--- a/pkg/apis/edge/v2alpha1/types_location.go
+++ b/pkg/apis/edge/v2alpha1/types_location.go
@@ -42,6 +42,7 @@ const (
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // +kubebuilder:subresource:status
 // +kubebuilder:resource:scope=Cluster
+// +kubebuilder:metadata:labels="kube-bind.io/exported=true"
 // +kubebuilder:printcolumn:name="Resource",type=string,JSONPath=`.spec.resource.resource`,description="Type of the workspace"
 // +kubebuilder:printcolumn:name="Available",type=string,JSONPath=`.status.availableInstances`,description="Available instances in this location"
 // +kubebuilder:printcolumn:name="Instances",type=string,JSONPath=`.status.instances`,description="Instances in this location"

--- a/scripts/inner/kubestellar
+++ b/scripts/inner/kubestellar
@@ -359,7 +359,6 @@ function ensure_espw() {
     sleep 2
     run_kb_backend
     KUBECONFIG=$space_config kubectl apply -f "$bindir/../config/crds/"
-    KUBECONFIG=$space_config kubectl get crd -oname | grep kubestellar.io | KUBECONFIG=$space_config xargs -i kubectl label {} kube-bind.io/exported=true
     KUBECONFIG=$space_config kubectl apply -f "$bindir/../config/exports" 
     echo "Finished populating the espw with kubestellar apiexports"
 }


### PR DESCRIPTION
## Summary
This PR uses some more kubebuilder markers to label the edge CRDs earlier for them to be later exported via kube-bind.
