### PR TITLE
:sparkles: Switch to use the Space Framework

### DIFF
--- a/.github/workflows/docs-ecutable-syncer.yml
+++ b/.github/workflows/docs-ecutable-syncer.yml
@@ -21,7 +21,7 @@ on:
   push:
     branches:
       - main
-      
+      - space-mgt
       - "release-*"
     paths:
       - "docs/content/Coding Milestones/PoC2023q1/kubestellar-syncer.md"

--- a/cmd/kubestellar-where-resolver/cmd/where-resolver-cmd.go
+++ b/cmd/kubestellar-where-resolver/cmd/where-resolver-cmd.go
@@ -25,6 +25,8 @@ import (
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/cache"
+	"k8s.io/component-base/featuregate"
+	"k8s.io/component-base/logs"
 	"k8s.io/component-base/version"
 	"k8s.io/klog/v2"
 
@@ -43,7 +45,14 @@ func NewResolverCommand() *cobra.Command {
 		Use:   "where-resolver",
 		Short: "Maintains SinglePlacementSlice API objects for EdgePlacements",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if err := options.Logs.ValidateAndApply(utilfeature.DefaultFeatureGate); err != nil {
+			featureGate := utilfeature.DefaultMutableFeatureGate
+			if err := featureGate.Add(map[featuregate.Feature]featuregate.FeatureSpec{
+				logs.ContextualLogging: {Default: true, PreRelease: featuregate.Alpha},
+			}); err != nil {
+				return err
+			}
+
+			if err := options.Logs.ValidateAndApply(featureGate); err != nil {
 				return err
 			}
 			if err := options.Complete(); err != nil {

--- a/cmd/kubestellar-where-resolver/options/options.go
+++ b/cmd/kubestellar-where-resolver/options/options.go
@@ -31,10 +31,10 @@ const (
 )
 
 type Options struct {
-	SpaceMgtOpts  clientoptions.ClientOpts
-	Logs          *logs.Options
-	SpaceProvider string
-	KcsName       string
+	SpaceMgtClientOpts clientoptions.ClientOpts
+	Logs               *logs.Options
+	SpaceProvider      string
+	KcsName            string
 }
 
 func NewOptions() *Options {
@@ -43,15 +43,15 @@ func NewOptions() *Options {
 	logs.Config.Verbosity = config.VerbosityLevel(2)
 
 	return &Options{
-		SpaceMgtOpts:  *clientoptions.NewClientOpts("space-mgt", "access to space management"),
-		Logs:          logs,
-		SpaceProvider: defaultSpaceProviderName,
-		KcsName:       defaultKcsName,
+		SpaceMgtClientOpts: *clientoptions.NewClientOpts("space-mgt", "access to the space reference space"),
+		Logs:               logs,
+		SpaceProvider:      defaultSpaceProviderName,
+		KcsName:            defaultKcsName,
 	}
 }
 
 func (options *Options) AddFlags(fs *pflag.FlagSet) {
-	options.SpaceMgtOpts.AddFlags(fs)
+	options.SpaceMgtClientOpts.AddFlags(fs)
 	options.Logs.AddFlags(fs)
 	fs.StringVar(&options.SpaceProvider, "space-provider", options.SpaceProvider, "the name of the KubeStellar space provider")
 	fs.StringVar(&options.KcsName, "core-space", options.KcsName, "the name of the KubeStellar Core space")

--- a/cmd/kubestellar-where-resolver/options/options.go
+++ b/cmd/kubestellar-where-resolver/options/options.go
@@ -25,10 +25,16 @@ import (
 	clientoptions "github.com/kubestellar/kubestellar/pkg/client-options"
 )
 
+const (
+	defaultSpaceProviderName string = "default"
+	defaultKcsName           string = "espw"
+)
+
 type Options struct {
-	EspwClientOpts clientoptions.ClientOpts
-	BaseClientOpts clientoptions.ClientOpts
-	Logs           *logs.Options
+	SpaceMgtOpts  clientoptions.ClientOpts
+	Logs          *logs.Options
+	SpaceProvider string
+	KcsName       string
 }
 
 func NewOptions() *Options {
@@ -37,17 +43,18 @@ func NewOptions() *Options {
 	logs.Config.Verbosity = config.VerbosityLevel(2)
 
 	return &Options{
-		EspwClientOpts: *clientoptions.NewClientOpts("espw", "access to the edge service provider workspace"),
-		BaseClientOpts: *clientoptions.NewClientOpts("base", "access to all logical clusters as kcp-admin"),
-		Logs:           logs,
+		SpaceMgtOpts:  *clientoptions.NewClientOpts("space-mgt", "access to space management"),
+		Logs:          logs,
+		SpaceProvider: defaultSpaceProviderName,
+		KcsName:       defaultKcsName,
 	}
 }
 
 func (options *Options) AddFlags(fs *pflag.FlagSet) {
-	options.EspwClientOpts.AddFlags(fs)
-	options.BaseClientOpts.SetDefaultUserAndCluster("kcp-admin", "base")
-	options.BaseClientOpts.AddFlags(fs)
+	options.SpaceMgtOpts.AddFlags(fs)
 	options.Logs.AddFlags(fs)
+	fs.StringVar(&options.SpaceProvider, "space-provider", options.SpaceProvider, "the name of the KubeStellar space provider")
+	fs.StringVar(&options.KcsName, "core-space", options.KcsName, "the name of the KubeStellar Core space")
 }
 
 func (options *Options) Complete() error {

--- a/cmd/mailbox-controller/controller.go
+++ b/cmd/mailbox-controller/controller.go
@@ -68,7 +68,6 @@ type mbCtl struct {
 
 type refSyncTarget string
 
-var suffix uint64 = 142857
 var errNoSpaceId = errors.New("failed to retrive spaceID")
 
 // newMailboxController constructs a new mailbox controller.

--- a/cmd/mailbox-controller/controller.go
+++ b/cmd/mailbox-controller/controller.go
@@ -309,9 +309,9 @@ func (ctl *mbCtl) ensureBinding(ctx context.Context, spacename string) bool {
 	for _, resource := range resourcesToBind {
 		logger.V(2).Info("Ensuring binding", "script", shellScriptName, "resource", resource)
 
-		// We assume that SPACE_MANAGER_KUBECONFIG was set on the script that created the MB controller
+		// We assume that SM_CONFIG was set on the script that created the MB controller
 		invokeScript := strings.Join([]string{
-			"KUBECONFIG=$SPACE_MANAGER_KUBECONFIG",
+			"KUBECONFIG=$SM_CONFIG",
 			shellScriptName,
 			spacename,
 			resource,

--- a/cmd/mailbox-controller/controller.go
+++ b/cmd/mailbox-controller/controller.go
@@ -191,6 +191,7 @@ func (ctl *mbCtl) sync1(ctx context.Context, ref any) {
 	}
 }
 
+// sync returns true to retry, false on success or unrecoverable error
 func (ctl *mbCtl) sync(ctx context.Context, refany any) bool {
 	logger := klog.FromContext(ctx)
 	mbsName := ""
@@ -247,7 +248,7 @@ func (ctl *mbCtl) sync(ctx context.Context, refany any) bool {
 			logger.V(3).Info("Both SyncTarget and Mailbox space are absent or deleting, nothing to do", "mbsName", mbsName)
 			return false
 		}
-		err := ctl.spaceManagementClient.SpaceV1alpha1().Spaces(ctl.spaceProviderNs).Delete(ctx, mbsName, metav1.DeleteOptions{})
+		err := ctl.spaceManagementClient.SpaceV1alpha1().Spaces(ctl.spaceProviderNs).Delete(ctx, mbsName, metav1.DeleteOptions{Preconditions: &metav1.Preconditions{UID: &space.UID}})
 		if err == nil || k8sapierrors.IsNotFound(err) {
 			logger.V(2).Info("Deleted unwanted space", "mbsName", mbsName)
 			return false

--- a/cmd/mailbox-controller/controller.go
+++ b/cmd/mailbox-controller/controller.go
@@ -34,38 +34,37 @@ import (
 	_ "k8s.io/component-base/metrics/prometheus/clientgo"
 	"k8s.io/klog/v2"
 
-	tenancyv1alpha1 "github.com/kcp-dev/kcp/pkg/apis/tenancy/v1alpha1"
-	tenancyclient "github.com/kcp-dev/kcp/pkg/client/clientset/versioned/typed/tenancy/v1alpha1"
-	kcptenancyinformers "github.com/kcp-dev/kcp/pkg/client/informers/externalversions/tenancy/v1alpha1"
-	tenancylisters "github.com/kcp-dev/kcp/pkg/client/listers/tenancy/v1alpha1"
-	"github.com/kcp-dev/logicalcluster/v3"
-
 	edgev2alpha1 "github.com/kubestellar/kubestellar/pkg/apis/edge/v2alpha1"
 	edgev2alpha1informers "github.com/kubestellar/kubestellar/pkg/client/informers/externalversions/edge/v2alpha1"
 	edgev2alpha1listers "github.com/kubestellar/kubestellar/pkg/client/listers/edge/v2alpha1"
 	"github.com/kubestellar/kubestellar/pkg/kbuser"
+	spacev1alpha1 "github.com/kubestellar/kubestellar/space-framework/pkg/apis/space/v1alpha1"
+	spaceclientset "github.com/kubestellar/kubestellar/space-framework/pkg/client/clientset/versioned"
+	spacev1alpha1informers "github.com/kubestellar/kubestellar/space-framework/pkg/client/informers/externalversions/space/v1alpha1"
+	spacev1a1listers "github.com/kubestellar/kubestellar/space-framework/pkg/client/listers/space/v1alpha1"
 )
 
-const wsNameSep = "-mb-"
+const mbsNameSep = "-mb-"
 
 // This identifies an index in the SyncTarget informer
-const mbwsNameIndexKey = "mbwsName"
+const mbsNameIndexKey = "mbsName"
 
-// SyncTargetNameAnnotationKey identifies the annotation on a mailbox Workspace
+// SyncTargetNameAnnotationKey identifies the annotation on a mailbox space
 // that points to the corresponding SyncTarget.
 const SyncTargetNameAnnotationKey = "edge.kubestellar.io/sync-target-name"
 
 type mbCtl struct {
-	context                 context.Context
-	espwPath                string
-	syncTargetInformer      cache.SharedIndexInformer
-	synctargetLister        edgev2alpha1listers.SyncTargetLister
-	syncTargetIndexer       cache.Indexer
-	workspaceScopedInformer cache.SharedIndexInformer
-	workspaceScopedLister   tenancylisters.WorkspaceLister
-	workspaceScopedClient   tenancyclient.WorkspaceInterface
-	kbSpaceRelation         kbuser.KubeBindSpaceRelation
-	queue                   workqueue.RateLimitingInterface // of mailbox workspace Name
+	context               context.Context
+	syncTargetInformer    cache.SharedIndexInformer
+	synctargetLister      edgev2alpha1listers.SyncTargetLister
+	syncTargetIndexer     cache.Indexer
+	spaceInformer         cache.SharedIndexInformer
+	spaceLister           spacev1a1listers.SpaceNamespaceLister
+	spaceManagementClient spaceclientset.Clientset
+	spaceProvider         string
+	spaceProviderNs       string
+	kbSpaceRelation       kbuser.KubeBindSpaceRelation
+	queue                 workqueue.RateLimitingInterface
 }
 
 type refSyncTarget string
@@ -77,31 +76,33 @@ var errNoSpaceId = errors.New("failed to retrive spaceID")
 // syncTargetClusterPreInformer is a pre-informer for all the relevant
 // SyncTarget objects (not limited to one cluster).
 func newMailboxController(ctx context.Context,
-	espwPath string,
 	syncTargetPreInformer edgev2alpha1informers.SyncTargetInformer,
-	workspaceScopedPreInformer kcptenancyinformers.WorkspaceInformer,
-	workspaceScopedClient tenancyclient.WorkspaceInterface,
+	spacePreInformer spacev1alpha1informers.SpaceInformer,
+	spaceManagementClient *spaceclientset.Clientset,
+	spaceProvider string,
+	spaceProviderNs string,
 	kbSpaceRelation kbuser.KubeBindSpaceRelation,
 ) *mbCtl {
 	syncTargetInformer := syncTargetPreInformer.Informer()
-	workspacesInformer := workspaceScopedPreInformer.Informer()
+	spacesInformer := spacePreInformer.Informer()
 
 	ctl := &mbCtl{
-		context:                 ctx,
-		espwPath:                espwPath,
-		syncTargetInformer:      syncTargetInformer,
-		synctargetLister:        syncTargetPreInformer.Lister(),
-		syncTargetIndexer:       syncTargetInformer.GetIndexer(),
-		workspaceScopedInformer: workspacesInformer,
-		workspaceScopedLister:   workspaceScopedPreInformer.Lister(),
-		workspaceScopedClient:   workspaceScopedClient,
-		kbSpaceRelation:         kbSpaceRelation,
-		queue:                   workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "mailbox-controller"),
+		context:               ctx,
+		syncTargetInformer:    syncTargetInformer,
+		synctargetLister:      syncTargetPreInformer.Lister(),
+		syncTargetIndexer:     syncTargetInformer.GetIndexer(),
+		spaceInformer:         spacesInformer,
+		spaceLister:           spacePreInformer.Lister().Spaces(spaceProviderNs),
+		spaceManagementClient: *spaceManagementClient,
+		spaceProvider:         spaceProvider,
+		spaceProviderNs:       spaceProviderNs,
+		kbSpaceRelation:       kbSpaceRelation,
+		queue:                 workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "mailbox-controller"),
 	}
-	syncTargetInformer.AddIndexers(cache.Indexers{mbwsNameIndexKey: ctl.mbwsNameOfObj})
+	syncTargetInformer.AddIndexers(cache.Indexers{mbsNameIndexKey: ctl.mbsNameOfObj})
 
 	syncTargetInformer.AddEventHandler(ctl)
-	workspacesInformer.AddEventHandler(ctl)
+	spacesInformer.AddEventHandler(ctl)
 	return ctl
 }
 
@@ -112,7 +113,7 @@ func (ctl *mbCtl) Run(concurrency int) {
 	ctx := ctl.context
 	logger := klog.FromContext(ctx)
 	doneCh := ctx.Done()
-	if !cache.WaitForNamedCacheSync("mailbox-controller", doneCh, ctl.syncTargetInformer.HasSynced, ctl.workspaceScopedInformer.HasSynced) {
+	if !cache.WaitForNamedCacheSync("mailbox-controller", doneCh, ctl.syncTargetInformer.HasSynced, ctl.spaceInformer.HasSynced) {
 		logger.Error(nil, "Informer syncs not achieved")
 		return
 	}
@@ -147,22 +148,12 @@ func (ctl *mbCtl) OnDelete(obj any) {
 func (ctl *mbCtl) enqueue(obj any) {
 	logger := klog.FromContext(ctl.context)
 	switch typed := obj.(type) {
-	case *tenancyv1alpha1.Workspace:
-		logger.V(4).Info("Enqueuing reference due to workspace", "wsName", typed.Name)
+	case *spacev1alpha1.Space:
+		logger.V(4).Info("Enqueuing reference due to space", "spaceName", typed.Name)
 		ctl.queue.Add(typed.Name)
 	case *edgev2alpha1.SyncTarget:
-		mbwsName, err := ctl.mbwsNameOfSynctarget(typed)
-		if err != nil {
-			if err.Error() == errNoSpaceId.Error() {
-				logger.V(4).Info("Enqueuing SyncTarget reference for later retry", "syncTargetName", typed.Name)
-				ctl.queue.Add(refSyncTarget(typed.Name))
-			} else {
-				logger.Error(nil, "Failed to construct mailbox workspace name from SyncTarget", "syncTargetName", typed.Name)
-			}
-		} else {
-			logger.V(4).Info("Enqueuing reference due to SyncTarget", "wsName", mbwsName, "syncTargetName", typed.Name)
-			ctl.queue.Add(mbwsName)
-		}
+		logger.V(4).Info("Enqueuing SyncTarget reference", "syncTargetName", typed.Name)
+		ctl.queue.Add(refSyncTarget(typed.Name))
 	default:
 		logger.Error(nil, "Notified of object of unexpected type", "object", obj, "type", fmt.Sprintf("%T", obj))
 	}
@@ -204,6 +195,7 @@ func (ctl *mbCtl) sync1(ctx context.Context, ref any) {
 
 func (ctl *mbCtl) sync(ctx context.Context, refany any) bool {
 	logger := klog.FromContext(ctx)
+	mbsName := ""
 	stName, ok := refany.(refSyncTarget)
 	if ok {
 		st, err := ctl.synctargetLister.Get(string(stName))
@@ -211,26 +203,32 @@ func (ctl *mbCtl) sync(ctx context.Context, refany any) bool {
 			logger.Error(err, "Failed to fetch SyncTarget from local cache", "stName", stName)
 			return false
 		}
-		mbwsName, err := ctl.mbwsNameOfSynctarget(st)
+		mbsName, err = ctl.mbsNameOfSynctarget(st)
 		if err != nil {
-			return true
+			if err.Error() == errNoSpaceId.Error() {
+				logger.V(4).Info("Failed to retrieve Space ID. Retrying", "syncTargetName", st.Name)
+				return true
+			} else {
+				logger.Error(err, "Failed to construct mailbox space name from SyncTarget", "syncTargetName", st.Name)
+				return false
+			}
 		}
-		ctl.queue.Add(mbwsName)
-		return false
 	}
-	mbwsName, ok := refany.(string)
-	if !ok {
-		logger.Error(nil, "Sync expected a string", "ref", refany, "type", fmt.Sprintf("%T", refany))
-		return false
+	if mbsName == "" {
+		mbsName, ok = refany.(string)
+		if !ok {
+			logger.Error(nil, "Sync expected a string", "ref", refany, "type", fmt.Sprintf("%T", refany))
+			return false
+		}
 	}
-	parts := strings.Split(mbwsName, wsNameSep)
+	parts := strings.Split(mbsName, mbsNameSep)
 	if len(parts) != 2 {
-		logger.V(3).Info("Ignoring non-mailbox workspace name", "wsName", mbwsName)
+		logger.V(3).Info("Ignoring non-mailbox space name", "spaceName", mbsName)
 		return false
 	}
-	byIndex, err := ctl.syncTargetIndexer.ByIndex(mbwsNameIndexKey, mbwsName)
+	byIndex, err := ctl.syncTargetIndexer.ByIndex(mbsNameIndexKey, mbsName)
 	if err != nil {
-		logger.Error(err, "Failed to lookup SyncTargets by mailbox workspace name", "mbwsName", mbwsName)
+		logger.Error(err, "Failed to lookup SyncTargets by mailbox space name", "mbsName", mbsName)
 		return false
 	}
 	var syncTarget *edgev2alpha1.SyncTarget
@@ -238,69 +236,72 @@ func (ctl *mbCtl) sync(ctx context.Context, refany any) bool {
 	} else {
 		syncTarget = byIndex[0].(*edgev2alpha1.SyncTarget)
 		if len(byIndex) > 1 {
-			logger.Error(nil, "Impossible: more than one SyncTarget fetched from index; using the first", "mbwsName", mbwsName, "fetched", byIndex)
+			logger.Error(nil, "Impossible: more than one SyncTarget fetched from index; using the first", "mbsName", mbsName, "fetched", byIndex)
 		}
 	}
-	workspace, err := ctl.workspaceScopedLister.Get(mbwsName)
+	space, err := ctl.spaceLister.Get(mbsName)
 	if err != nil && !k8sapierrors.IsNotFound(err) {
-		logger.Error(err, "Unable to Get referenced Workspace", "mbwsName", mbwsName)
+		logger.Error(err, "Unable to Get referenced space", "mbsName", mbsName)
 		return true
 	}
 	if syncTarget == nil || syncTarget.DeletionTimestamp != nil {
-		if workspace == nil || workspace.DeletionTimestamp != nil {
-			logger.V(3).Info("Both SyncTarget and Workspace are absent or deleting, nothing to do", "mbwsName", mbwsName)
+		if space == nil || space.DeletionTimestamp != nil {
+			logger.V(3).Info("Both SyncTarget and Mailbox space are absent or deleting, nothing to do", "mbsName", mbsName)
 			return false
 		}
-		err := ctl.workspaceScopedClient.Delete(ctx, mbwsName, metav1.DeleteOptions{Preconditions: &metav1.Preconditions{UID: &workspace.UID}})
+		err := ctl.spaceManagementClient.SpaceV1alpha1().Spaces(ctl.spaceProviderNs).Delete(ctx, mbsName, metav1.DeleteOptions{})
 		if err == nil || k8sapierrors.IsNotFound(err) {
-			logger.V(2).Info("Deleted unwanted workspace", "mbwsName", mbwsName)
+			logger.V(2).Info("Deleted unwanted space", "mbsName", mbsName)
 			return false
 		}
-		logger.Error(err, "Failed to delete unwanted workspace", "mbwsName", mbwsName)
+		logger.Error(err, "Failed to delete unwanted space", "mbsName", mbsName)
 		return true
 	}
 	// Now we have established that the SyncTarget exists and is not being deleted
-	if workspace == nil {
+	if space == nil {
 		_, stOriginalName, _, err := kbuser.AnalyzeObjectID(syncTarget)
 		if err != nil {
-			logger.Error(err, "object does not appear to be a provider's copy of a consumer's object", "syncTarget", syncTarget.Name)
+			logger.Error(err, "Object does not appear to be a provider's copy of a consumer's object", "syncTarget", syncTarget.Name)
 			return false
 		}
-		ws := &tenancyv1alpha1.Workspace{
+		// create the mailbox space
+		mbspace := &spacev1alpha1.Space{
 			ObjectMeta: metav1.ObjectMeta{
 				Annotations: map[string]string{SyncTargetNameAnnotationKey: stOriginalName},
-				Name:        mbwsName,
+				Name:        mbsName,
 			},
-			Spec: tenancyv1alpha1.WorkspaceSpec{},
+			Spec: spacev1alpha1.SpaceSpec{
+				SpaceProviderDescName: ctl.spaceProvider,
+				Type:                  spacev1alpha1.SpaceTypeManaged,
+			},
 		}
-		_, err = ctl.workspaceScopedClient.Create(ctx, ws, metav1.CreateOptions{FieldManager: "mailbox-controller"})
+		_, err = ctl.spaceManagementClient.SpaceV1alpha1().Spaces(ctl.spaceProviderNs).Create(ctx, mbspace, metav1.CreateOptions{FieldManager: "mailbox-controller"})
 		if err == nil {
-			logger.V(2).Info("Created missing workspace", "mbwsName", mbwsName)
+			logger.V(2).Info("Created missing space", "mbsName", mbsName)
 			return false
 		}
 		if k8sapierrors.IsAlreadyExists(err) {
-			logger.V(3).Info("Missing workspace was created concurrently", "mbwsName", mbwsName)
+			logger.V(3).Info("Missing space was created concurrently", "mbsName", mbsName)
 			return false
 		}
-		logger.Error(err, "Failed to create workspace", "mbwsName", mbwsName)
+		logger.Error(err, "Failed to create space", "mbsName", mbsName)
 		return true
 	}
-	if workspace.DeletionTimestamp != nil {
-		logger.V(3).Info("Wanted workspace is being deleted, will retry later", "mbwsName", mbwsName)
+	if space.DeletionTimestamp != nil {
+		logger.V(3).Info("Wanted space is being deleted, will retry later", "mbsName", mbsName)
 		return true
 	}
-	logger.V(3).Info("Both SyncTarget and Workspace exist and are not being deleted, now check on the binding to edge", "mbwsName", mbwsName)
-	return ctl.ensureBinding(ctx, workspace)
+	if space.Status.Phase != spacev1alpha1.SpacePhaseReady {
+		logger.V(3).Info("Wanted space is not ready, will retry later", "mbsName", mbsName)
+		return true
+	}
+	logger.V(3).Info("Both SyncTarget and Mailbox space exist and are not being deleted, now check on the binding to edge", "mbsName", mbsName)
+	return ctl.ensureBinding(ctx, space.Name)
 
 }
 
-func (ctl *mbCtl) ensureBinding(ctx context.Context, workspace *tenancyv1alpha1.Workspace) bool {
-	logger := klog.FromContext(ctx).WithValues("mbsName", workspace.Name)
-	mbwsCluster := logicalcluster.Name(workspace.Spec.Cluster)
-	if mbwsCluster == "" {
-		logger.V(2).Info("Mailbox workspace does not have a Spec.Cluster yet")
-		return true
-	}
+func (ctl *mbCtl) ensureBinding(ctx context.Context, spacename string) bool {
+	logger := klog.FromContext(ctx).WithValues("mbsName", spacename)
 
 	// The script must be idempotent.
 	shellScriptName := "kubestellar-kube-bind"
@@ -318,7 +319,7 @@ func (ctl *mbCtl) ensureBinding(ctx context.Context, workspace *tenancyv1alpha1.
 		invokeScript := strings.Join([]string{
 			fmt.Sprintf("KUBECONFIG=$KUBECONFIG.copy%d", freshSuffix),
 			shellScriptName,
-			workspace.Name,
+			spacename,
 			resource,
 		}, " ")
 		cmdLine := strings.Join([]string{
@@ -372,14 +373,14 @@ func (ctl *mbCtl) ensureBinding(ctx context.Context, workspace *tenancyv1alpha1.
 			logger.V(2).Info("Stderr from exec", "resource", resource, "line", line)
 		}
 		if err = cmd.Wait(); err != nil {
-			logger.Error(err, "Unable to bind", "workspace", workspace.Name, "resrouce", resource)
+			logger.Error(err, "Unable to bind", "space", spacename, "resrouce", resource)
 			return true
 		}
 	}
 	return false
 }
 
-func (ctl *mbCtl) mbwsNameOfSynctarget(st *edgev2alpha1.SyncTarget) (string, error) {
+func (ctl *mbCtl) mbsNameOfSynctarget(st *edgev2alpha1.SyncTarget) (string, error) {
 	logger := klog.FromContext(ctl.context)
 	_, _, kbSpaceID, err := kbuser.AnalyzeObjectID(st)
 	if err != nil {
@@ -392,17 +393,17 @@ func (ctl *mbCtl) mbwsNameOfSynctarget(st *edgev2alpha1.SyncTarget) (string, err
 		return "", errNoSpaceId
 	}
 	// Use consumer spaceID and provider st.UID
-	return spaceID + wsNameSep + string(st.UID), nil
+	return spaceID + mbsNameSep + string(st.UID), nil
 }
 
-func (ctl *mbCtl) mbwsNameOfObj(obj any) ([]string, error) {
+func (ctl *mbCtl) mbsNameOfObj(obj any) ([]string, error) {
 	st, ok := obj.(*edgev2alpha1.SyncTarget)
 	if !ok {
 		return nil, fmt.Errorf("expected a SyncTarget but got %#+v, a %T", obj, obj)
 	}
-	mbwsName, err := ctl.mbwsNameOfSynctarget(st)
+	mbsName, err := ctl.mbsNameOfSynctarget(st)
 	if err != nil {
 		return nil, err
 	}
-	return []string{mbwsName}, nil
+	return []string{mbsName}, nil
 }

--- a/cmd/mailbox-controller/main.go
+++ b/cmd/mailbox-controller/main.go
@@ -56,7 +56,7 @@ func main() {
 	resyncPeriod := time.Duration(0)
 	var concurrency int = 4
 	serverBindAddress := ":10203"
-	coreSpace := "espw"
+	kcsName := "espw"
 	spaceProvider := "default"
 	fs := pflag.NewFlagSet("mailbox-controller", pflag.ExitOnError)
 	klog.InitFlags(flag.CommandLine)
@@ -64,10 +64,10 @@ func main() {
 	fs.Var(&utilflag.IPPortVar{Val: &serverBindAddress}, "server-bind-address", "The IP address with port at which to serve /metrics and /debug/pprof/")
 
 	fs.IntVar(&concurrency, "concurrency", concurrency, "number of syncs to run in parallel")
-	fs.StringVar(&coreSpace, "core-space", coreSpace, "the name of the KubeStellar core space")
+	fs.StringVar(&kcsName, "core-space", kcsName, "the name of the KubeStellar core space")
 	fs.StringVar(&spaceProvider, "space-provider", spaceProvider, "the name of the KubeStellar space provider")
 
-	spaceMgtOpts := clientopts.NewClientOpts("space-mgt", "access to space management")
+	spaceMgtOpts := clientopts.NewClientOpts("space-mgt", "access to the space reference space")
 	spaceMgtOpts.AddFlags(fs)
 
 	fs.Parse(os.Args[1:])
@@ -94,26 +94,26 @@ func main() {
 	// create space-aware client
 	spaceManagementConfig, err := spaceMgtOpts.ToRESTConfig()
 	if err != nil {
-		logger.Error(err, "Failed to create space management config from flags")
+		logger.Error(err, "Failed to create space management API client config from flags")
 		os.Exit(3)
 	}
 	spaceclient, err := spaceclient.NewMultiSpace(ctx, spaceManagementConfig)
 	if err != nil {
 		logger.Error(err, "Failed to create space-aware client")
-		os.Exit(4)
+		os.Exit(10)
 	}
 	spaceProviderNs := spacemanager.ProviderNS(spaceProvider)
 
-	coreRestConfig, err := spaceclient.ConfigForSpace(coreSpace, spaceProviderNs)
+	kcsRestConfig, err := spaceclient.ConfigForSpace(kcsName, spaceProviderNs)
 	if err != nil {
-		logger.Error(err, "Failed to fetch space config", "spacename", coreSpace)
-		os.Exit(5)
+		logger.Error(err, "Failed to construct space config", "spacename", kcsName)
+		os.Exit(15)
 	}
 
-	edgeClientset, err := edgeclientset.NewForConfig(coreRestConfig)
+	edgeClientset, err := edgeclientset.NewForConfig(kcsRestConfig)
 	if err != nil {
 		logger.Error(err, "Failed to create edge clientset for KubeStellar Core Space")
-		os.Exit(6)
+		os.Exit(20)
 	}
 	edgeSharedInformerFactory := edgeinformers.NewSharedScopedInformerFactoryWithOptions(edgeClientset, resyncPeriod)
 	syncTargetPreInformer := edgeSharedInformerFactory.Edge().V2alpha1().SyncTargets()
@@ -126,10 +126,10 @@ func main() {
 	spaceInformerFactory := spaceinformers.NewSharedInformerFactory(managementClientset, resyncPeriod)
 	spacePreInformer := spaceInformerFactory.Space().V1alpha1().Spaces()
 
-	kubeClient, err := kubernetes.NewForConfig(coreRestConfig)
+	kubeClient, err := kubernetes.NewForConfig(kcsRestConfig)
 	if err != nil {
 		logger.Error(err, "Failed to create k8s clientset for KubeStellar Core Space")
-		os.Exit(6)
+		os.Exit(25)
 	}
 	kbSpaceRelation := kbuser.NewKubeBindSpaceRelation(ctx, kubeClient)
 

--- a/cmd/mailbox-controller/main.go
+++ b/cmd/mailbox-controller/main.go
@@ -115,6 +115,7 @@ func main() {
 		logger.Error(err, "Failed to create edge clientset for KubeStellar Core Space")
 		os.Exit(20)
 	}
+	kcsRestConfig.UserAgent = "mailbox-controller"
 	edgeSharedInformerFactory := edgeinformers.NewSharedScopedInformerFactoryWithOptions(edgeClientset, resyncPeriod)
 	syncTargetPreInformer := edgeSharedInformerFactory.Edge().V2alpha1().SyncTargets()
 

--- a/core-container/entry.sh
+++ b/core-container/entry.sh
@@ -229,10 +229,8 @@ function run_init() {
 function run_mailbox_controller() {
     echo "--< Starting mailbox-controller >--"
     wait-kubestellar-ready
-    # TODO: remove the kcp dependency in PR3
     get_kcp_kubeconfig
-    KUBECONFIG=$kcp_kubeconfig
-    kubectl ws root:espw
+    KUBECONFIG=$SM_CONFIG
     if ! mailbox-controller -v=${VERBOSITY} ; then
         echoerr "unable to start mailbox-controller!"
         exit 1
@@ -242,10 +240,8 @@ function run_mailbox_controller() {
 function run_where_resolver() {
     echo "--< Starting where-resolver >--"
     wait-kubestellar-ready
-    # TODO: remove the kcp dependency in PR3
     get_kcp_kubeconfig
-    KUBECONFIG=$kcp_kubeconfig
-    kubectl ws root:espw
+    KUBECONFIG=$SM_CONFIG
     if ! kubestellar-where-resolver -v ${VERBOSITY} ; then
         echoerr "unable to start kubestellar-where-resolver!"
         exit 1
@@ -255,10 +251,8 @@ function run_where_resolver() {
 function run_placement_translator() {
     echo "--< Starting placement-translator >--"
     wait-kubestellar-ready
-    # TODO: remove the kcp dependency in PR3
     get_kcp_kubeconfig
-    KUBECONFIG=$kcp_kubeconfig
-    kubectl ws root:espw
+    KUBECONFIG=$SM_CONFIG
     if ! placement-translator --allclusters-context  "system:admin" -v=${VERBOSITY} ; then
         echoerr "unable to start mailbox-controller!"
         exit 1

--- a/core-container/entry.sh
+++ b/core-container/entry.sh
@@ -309,6 +309,10 @@ if [ "$SM_CONFIG" == "" ]; then
     SM_CONFIG=$host_kubeconfig
     export SM_CONFIG
 fi
+if [ "$SM_CONTEXT" == "" ]; then
+    export SM_CONTEXT=sm-mgt
+fi
+
 echo "ESPW_NAME=${ESPW_NAME}"
 echo "VERBOSITY=${VERBOSITY}"
 echo "ENSURE_IMW=${ENSURE_IMW}"
@@ -317,6 +321,7 @@ echo "NAMESPACE=${NAMESPACE}"
 echo "SPACE_PROVIDER_TYPE=${SPACE_PROVIDER_TYPE}"
 echo "KUBECONFIG_DIR=${KUBECONFIG_DIR}"
 echo "SM_CONFIG=${SM_CONFIG}"
+echo "SM_CONTEXT=${SM_CONTEXT}"
 echo "PROVIDER_NAME=${PROVIDER_NAME}"
 echo "PROVIDER_NAMESPACE=${PROVIDER_NAMESPACE}"
 

--- a/core-container/entry.sh
+++ b/core-container/entry.sh
@@ -253,7 +253,7 @@ function run_placement_translator() {
     wait-kubestellar-ready
     get_kcp_kubeconfig
     KUBECONFIG=$SM_CONFIG
-    if ! placement-translator --allclusters-context  "system:admin" -v=${VERBOSITY} ; then
+    if ! placement-translator -v=${VERBOSITY} ; then
         echoerr "unable to start mailbox-controller!"
         exit 1
     fi

--- a/core-container/entry.sh
+++ b/core-container/entry.sh
@@ -48,9 +48,9 @@ function get_kcp_kubeconfig() {
 
 function create_kcp_provider_object() {
     get_kcp_kubeconfig     # kcp is created in a seperate container 
-    kubectl --kubeconfig $SPACE_MANAGER_KUBECONFIG delete secret -n ${NAMESPACE} kcpsec > /dev/null 2>&1 || true
-    kubectl --kubeconfig $SPACE_MANAGER_KUBECONFIG create secret generic -n ${NAMESPACE} kcpsec --from-file=kubeconfig=$kcp_kubeconfig --from-file=external=$external_kcp_kubeconfig
-    kubectl --kubeconfig $SPACE_MANAGER_KUBECONFIG apply -f - <<EOF
+    kubectl --kubeconfig $SM_CONFIG delete secret -n ${NAMESPACE} kcpsec > /dev/null 2>&1 || true
+    kubectl --kubeconfig $SM_CONFIG create secret generic -n ${NAMESPACE} kcpsec --from-file=kubeconfig=$kcp_kubeconfig --from-file=external=$external_kcp_kubeconfig
+    kubectl --kubeconfig $SM_CONFIG apply -f - <<EOF
 apiVersion: space.kubestellar.io/v1alpha1
 kind: SpaceProviderDesc
 metadata:
@@ -63,7 +63,7 @@ spec:
     name: kcpsec
 EOF
     echo "Waiting for spaceproviderdesc to reach the Ready phase."
-    kubectl --kubeconfig ${SPACE_MANAGER_KUBECONFIG} wait --for=jsonpath='{.status.Phase}'=Ready spaceproviderdesc $PROVIDER_NAME
+    kubectl --kubeconfig ${SM_CONFIG} wait --for=jsonpath='{.status.Phase}'=Ready spaceproviderdesc $PROVIDER_NAME
 }
  
 function create_kubeflex_provider_object() {
@@ -74,7 +74,7 @@ function create_kubeflex_provider_object() {
         done
     )
 
-    kubectl --kubeconfig $SPACE_MANAGER_KUBECONFIG apply -f - <<EOF
+    kubectl --kubeconfig $SM_CONFIG apply -f - <<EOF
 apiVersion: space.kubestellar.io/v1alpha1
 kind: SpaceProviderDesc
 metadata:
@@ -87,7 +87,7 @@ spec:
     name: corecluster
 EOF
     echo "Waiting for spaceproviderdesc to reach the Ready phase."
-    kubectl --kubeconfig ${SPACE_MANAGER_KUBECONFIG} wait --for=jsonpath='{.status.Phase}'=Ready spaceproviderdesc $PROVIDER_NAME
+    kubectl --kubeconfig ${SM_CONFIG} wait --for=jsonpath='{.status.Phase}'=Ready spaceproviderdesc $PROVIDER_NAME
 }
 
 
@@ -309,11 +309,11 @@ fi
 if [ "$PROVIDER_SECRET_NAMESPACE" == "" ]; then
     PROVIDER_SECRET_NAMESPACE=psecret_namespace
 fi
-if [ "$SPACE_MANAGER_KUBECONFIG" == "" ]; then
+if [ "$SM_CONFIG" == "" ]; then
     # if the space_manager_kubeconfig is not set, then we assume the 
     # hosting (aka core) cluster is the space manager cluster.
-    SPACE_MANAGER_KUBECONFIG=$host_kubeconfig
-    export SPACE_MANAGER_KUBECONFIG
+    SM_CONFIG=$host_kubeconfig
+    export SM_CONFIG
 fi
 echo "ESPW_NAME=${ESPW_NAME}"
 echo "VERBOSITY=${VERBOSITY}"
@@ -322,7 +322,7 @@ echo "ENSURE_WMW=${ENSURE_WMW}"
 echo "NAMESPACE=${NAMESPACE}"
 echo "SPACE_PROVIDER_TYPE=${SPACE_PROVIDER_TYPE}"
 echo "KUBECONFIG_DIR=${KUBECONFIG_DIR}"
-echo "SPACE_MANAGER_KUBECONFIG=${SPACE_MANAGER_KUBECONFIG}"
+echo "SM_CONFIG=${SM_CONFIG}"
 echo "PROVIDER_NAME=${PROVIDER_NAME}"
 echo "PROVIDER_NAMESPACE=${PROVIDER_NAMESPACE}"
 

--- a/docs/content/Coding Milestones/PoC2023q1/commands.md
+++ b/docs/content/Coding Milestones/PoC2023q1/commands.md
@@ -257,8 +257,8 @@ that import the namespaced Kubernetes resources (kinds of objects) for managemen
 containerized workloads. At the completion of `kubestellar init` the current workspace will be
 "root".
 
-5. Creates the space provider objects to be used by the space manager. Need to pass
-in two environment variables - SPACE_MANAGER_KUBECONFIG and IN_CLUSTER. SPACE_MANAGER_KUBECONFIG
+6. Creates the space provider objects to be used by the space manager. Need to pass
+in two environment variables - SM_CONFIG and IN_CLUSTER. SM_CONFIG
 is the path to the kubeconfig for the space manager. IN_CLUSTER specify whether spaces
 are accessed from within the hosting cluster or externally by kubestellar init.
 

--- a/docs/content/Coding Milestones/PoC2023q1/example1-subs/example1-post-provider.md
+++ b/docs/content/Coding Milestones/PoC2023q1/example1-subs/example1-post-provider.md
@@ -1,4 +1,4 @@
-<!--example1-post-kcp-start-->
+<!--example1-post-provider-start-->
 #### Get KubeStellar
 
 You will need a local copy of KubeStellar.  You can either use the
@@ -138,12 +138,12 @@ KubeStellar. They label both florin and guilder with `env=prod`, and
 also label guilder with `extended=yes`.
 
 ```shell
-imw1_space_config="${PWD}/temp-space-config/spaceprovider-default-imw1"
-kubectl-kubestellar-get-config-for-space --space-name imw1 --provider-name default --sm-core-config $SM_CONFIG --space-config-file $imw1_space_config
-KUBECONFIG=$imw1_space_config kubectl kubestellar ensure location florin  loc-name=florin  env=prod --imw imw1
-KUBECONFIG=$imw1_space_config kubectl kubestellar ensure location guilder loc-name=guilder env=prod extended=yes --imw imw1
+IMW1_SPACE_CONFIG="${PWD}/temp-space-config/spaceprovider-default-imw1"
+kubectl-kubestellar-get-config-for-space --space-name imw1 --provider-name default --sm-core-config $SM_CONFIG --output $IMW1_SPACE_CONFIG
+KUBECONFIG=$IMW1_SPACE_CONFIG kubectl kubestellar ensure location florin  loc-name=florin  env=prod --imw imw1
+KUBECONFIG=$IMW1_SPACE_CONFIG kubectl kubestellar ensure location guilder loc-name=guilder env=prod extended=yes --imw imw1
 echo "describe the florin location object"
-KUBECONFIG=$imw1_space_config kubectl describe location.edge.kubestellar.io florin
+KUBECONFIG=$IMW1_SPACE_CONFIG kubectl describe location.edge.kubestellar.io florin
 ```
 
 Those two script invocations are equivalent to creating the following
@@ -199,4 +199,4 @@ spec:
 That script also deletes the Location named `default`, which is not
 used in this PoC, if it shows up.
 
-<!--example1-post-kcp-end-->
+<!--example1-post-provider-end-->

--- a/docs/content/Coding Milestones/PoC2023q1/example1-subs/example1-post-provider.md
+++ b/docs/content/Coding Milestones/PoC2023q1/example1-subs/example1-post-provider.md
@@ -75,7 +75,7 @@ In this step KubeStellar creates and populates the Edge Service
 Provider Workspace (ESPW), which exports the KubeStellar API.
 
 ```shell
-IN_CLUSTER=false SPACE_MANAGER_KUBECONFIG=$SM_CONFIG kubestellar init
+IN_CLUSTER=false kubestellar init
 ```
 
 ### Deploy kcp and KubeStellar as a workload in a Kubernetes cluster

--- a/docs/content/Coding Milestones/PoC2023q1/example1-subs/example1-post-provider.md
+++ b/docs/content/Coding Milestones/PoC2023q1/example1-subs/example1-post-provider.md
@@ -139,7 +139,7 @@ also label guilder with `extended=yes`.
 
 ```shell
 IMW1_SPACE_CONFIG="${PWD}/temp-space-config/spaceprovider-default-imw1"
-kubectl-kubestellar-get-config-for-space --space-name imw1 --provider-name default --sm-core-config $SM_CONFIG --output $IMW1_SPACE_CONFIG
+kubectl-kubestellar-get-config-for-space --space-name imw1 --provider-name default --sm-core-config $SM_CONFIG --sm-context $SM_CONTEXT --output $IMW1_SPACE_CONFIG
 KUBECONFIG=$IMW1_SPACE_CONFIG kubectl kubestellar ensure location florin  loc-name=florin  env=prod --imw imw1
 KUBECONFIG=$IMW1_SPACE_CONFIG kubectl kubestellar ensure location guilder loc-name=guilder env=prod extended=yes --imw imw1
 echo "describe the florin location object"

--- a/docs/content/Coding Milestones/PoC2023q1/example1-subs/example1-post-provider.md
+++ b/docs/content/Coding Milestones/PoC2023q1/example1-subs/example1-post-provider.md
@@ -139,7 +139,7 @@ also label guilder with `extended=yes`.
 
 ```shell
 IMW1_SPACE_CONFIG="${PWD}/temp-space-config/spaceprovider-default-imw1"
-kubectl-kubestellar-get-config-for-space --space-name imw1 --provider-name default --sm-core-config $SM_CONFIG --sm-context $SM_CONTEXT --output $IMW1_SPACE_CONFIG
+kubectl-kubestellar-get-config-for-space --space-name imw1 --sm-core-config $SM_CONFIG --sm-context $SM_CONTEXT --output $IMW1_SPACE_CONFIG
 KUBECONFIG=$IMW1_SPACE_CONFIG kubectl kubestellar ensure location florin  loc-name=florin  env=prod --imw imw1
 KUBECONFIG=$IMW1_SPACE_CONFIG kubectl kubestellar ensure location guilder loc-name=guilder env=prod extended=yes --imw imw1
 echo "describe the florin location object"

--- a/docs/content/Coding Milestones/PoC2023q1/example1-subs/example1-pre-provider.md
+++ b/docs/content/Coding Milestones/PoC2023q1/example1-subs/example1-pre-provider.md
@@ -1,4 +1,4 @@
-<!--example1-pre-kcp-start-->
+<!--example1-pre-provider-start-->
 ![Boxes and arrows. Two kind clusters exist, named florin and guilder. The Inventory Management workspace contains two pairs of SyncTarget and Location objects. The Edge Service Provider workspace contains the PoC controllers; the mailbox controller reads the SyncTarget objects and creates two mailbox workspaces.](../Edge-PoC-2023q1-Scenario-1-stage-1.svg "Stage 1 Summary")
 
 Stage 1 creates the infrastructure and the edge service provider
@@ -62,4 +62,4 @@ paying attention to `$KUBECONFIG` and, if that's empty,
 kind create cluster --name florin --config florin-config.yaml
 kind create cluster --name guilder --config guilder-config.yaml
 ```
-<!--example1-pre-kcp-end-->
+<!--example1-pre-provider-end-->

--- a/docs/content/Coding Milestones/PoC2023q1/example1-subs/example1-stage-1a.md
+++ b/docs/content/Coding Milestones/PoC2023q1/example1-subs/example1-stage-1a.md
@@ -8,22 +8,22 @@ hosting cluster. If instead you are running these controllers as bare
 processes then launch this controller as follows.
 
 ```shell
-# TODO: mailbox controller has kcp dependencies. Will remove when controllers support spaces.
-kubectl ws root:espw
-mailbox-controller -v=4 &> /tmp/mailbox-controller.log &
-sleep 20
+ESPW_SPACE_CONFIG="${PWD}/temp-space-config/spaceprovider-default-espw"
+kubectl-kubestellar-get-config-for-space --space-name espw --provider-name default --sm-core-config $SM_CONFIG --output $ESPW_SPACE_CONFIG
+(
+  KUBECONFIG=$SM_CONFIG mailbox-controller -v=4 &> /tmp/mailbox-controller.log &
+  sleep 20
+)
 ```
 
 This controller is in charge of maintaining the collection of mailbox
-workspaces, which are an implementation detail not intended for user
+spaces, which are an implementation detail not intended for user
 consumption. You can use the following command to wait for the
-appearance of the mailbox workspaces implied by the florin and guilder
+appearance of the mailbox spaces implied by the florin and guilder
 `SyncTarget` objects that you made earlier.
 
 ```shell
-# TODO: leaving this here so we get a list of all the workspaces.  Once all the workspaces, including the ones created by the mailbox are converted to spaces, we'll remove this ws."
-kubectl ws root
-while [ $(kubectl ws tree | grep "\-mb\-" | wc -l) -ne 2 ]; do
+while [ KUBECONFIG=$SM_CONFIG $(kubectl get spaces -A | grep "\-mb\-" | wc -l) -ne 2 ]; do
   sleep 10
 done
 ```
@@ -48,15 +48,13 @@ mbwsName="1d55jhazpo3d3va6-mb-732cf72a-1ca9-4def-a5e7-78fd0e36e61c" mbwsCluster
 ```
 
 You need a `-v` setting of 2 or numerically higher to get log messages
-about individual mailbox workspaces.
+about individual mailbox spaces.
 
-A mailbox workspace name is distinguished by `-mb-` separator.
-You can get a listing of those mailbox workspaces as follows.
+A mailbox space name is distinguished by `-mb-` separator.
+You can get a listing of those mailbox spaces as follows.
 
 ```shell
-# TODO: currently some workspaces are not created as spaces, specifically the mailbox workspaces, so leaving this code.
-kubectl ws root
-kubectl get Workspaces
+KUBECONFIG=$SM_CONFIG kubectl get spaces -A
 ```
 ``` { .bash .no-copy }
 NAME                                                       TYPE          REGION   PHASE   URL                                                     AGE
@@ -71,8 +69,7 @@ More usefully, using custom columns you can get a listing that shows
 the _name_ of the associated SyncTarget.
 
 ```shell
-# TODO: currently some workspaces are not created as spaces, specifically the mailbox workspaces, so leaving this code
-kubectl get Workspace -o "custom-columns=NAME:.metadata.name,SYNCTARGET:.metadata.annotations['edge\.kubestellar\.io/sync-target-name'],CLUSTER:.spec.cluster"
+KUBECONFIG=$SM_CONFIG kubectl get spaces -n spaceprovider-default -o "custom-columns=NAME:.metadata.name,SYNCTARGET:.metadata.annotations['edge\.kubestellar\.io/sync-target-name'],CLUSTER:.spec.cluster"
 ```
 ``` { .bash .no-copy }
 NAME                                                       SYNCTARGET   CLUSTER
@@ -82,25 +79,23 @@ compute                                                    <none>       mqnl7r5f
 espw                                                       <none>       2n88ugkhysjbxqp5
 imw1                                                       <none>       4d2r9stcyy2qq5c1
 ```
-
-Also: if you ever need to look up just one mailbox workspace by
+  
+Also: if you ever need to look up just one mailbox space by
 SyncTarget name, you could do it as follows.
 
 ```shell
-# TODO: currently some workspaces are not created as spaces, specifically the mailbox workspaces, so leaving this code
-GUILDER_WS=$(kubectl get Workspace -o json | jq -r '.items | .[] | .metadata | select(.annotations ["edge.kubestellar.io/sync-target-name"] == "guilder") | .name')
-echo The guilder mailbox workspace name is $GUILDER_WS
+GUILDER_SPACE=$(KUBECONFIG=$SM_CONFIG kubectl get space -n spaceprovider-default -o json | jq -r '.items | .[] | .metadata | select(.annotations ["edge.kubestellar.io/sync-target-name"] == "guilder") | .name')
+echo The guilder mailbox space name is $GUILDER_SPACE
 ```
 ``` { .bash .no-copy }
-The guilder mailbox workspace name is 1t82bk54r6gjnzsp-mb-f0a82ab1-63f4-49ea-954d-3a41a35a9f1c
+The guilder mailbox space name is 1t82bk54r6gjnzsp-mb-f0a82ab1-63f4-49ea-954d-3a41a35a9f1c
 ```
 
 ```shell
-# TODO: currently some workspaces are not created as spaces, specifically the mailbox workspaces, so leaving this code
-FLORIN_WS=$(kubectl get Workspace -o json | jq -r '.items | .[] | .metadata | select(.annotations ["edge.kubestellar.io/sync-target-name"] == "florin") | .name')
-echo The florin mailbox workspace name is $FLORIN_WS
+FLORIN_SPACE=$(KUBECONFIG=$SM_CONFIG kubectl get space -n spaceprovider-default -o json | jq -r '.items | .[] | .metadata | select(.annotations ["edge.kubestellar.io/sync-target-name"] == "florin") | .name')
+echo The florin mailbox space name is $FLORIN_SPACE
 ```
 ``` { .bash .no-copy }
-The florin mailbox workspace name is 1t82bk54r6gjnzsp-mb-1a045336-8178-4026-8a56-5cd5609c0ec1
+The florin mailbox space name is 1t82bk54r6gjnzsp-mb-1a045336-8178-4026-8a56-5cd5609c0ec1
 ```
 <!--example1-stage-1a-end-->

--- a/docs/content/Coding Milestones/PoC2023q1/example1-subs/example1-stage-1a.md
+++ b/docs/content/Coding Milestones/PoC2023q1/example1-subs/example1-stage-1a.md
@@ -9,7 +9,7 @@ processes then launch this controller as follows.
 
 ```shell
 ESPW_SPACE_CONFIG="${PWD}/temp-space-config/spaceprovider-default-espw"
-kubectl-kubestellar-get-config-for-space --space-name espw --provider-name default --sm-core-config $SM_CONFIG --output $ESPW_SPACE_CONFIG
+kubectl-kubestellar-get-config-for-space --space-name espw --provider-name default --sm-core-config $SM_CONFIG --sm-context $SM_CONTEXT --output $ESPW_SPACE_CONFIG
 (
   KUBECONFIG=$SM_CONFIG mailbox-controller -v=4 &> /tmp/mailbox-controller.log &
   sleep 20

--- a/docs/content/Coding Milestones/PoC2023q1/example1-subs/example1-stage-1a.md
+++ b/docs/content/Coding Milestones/PoC2023q1/example1-subs/example1-stage-1a.md
@@ -79,7 +79,7 @@ compute                                                    <none>       mqnl7r5f
 espw                                                       <none>       2n88ugkhysjbxqp5
 imw1                                                       <none>       4d2r9stcyy2qq5c1
 ```
-  
+
 Also: if you ever need to look up just one mailbox space by
 SyncTarget name, you could do it as follows.
 

--- a/docs/content/Coding Milestones/PoC2023q1/example1-subs/example1-stage-1a.md
+++ b/docs/content/Coding Milestones/PoC2023q1/example1-subs/example1-stage-1a.md
@@ -9,7 +9,7 @@ processes then launch this controller as follows.
 
 ```shell
 ESPW_SPACE_CONFIG="${PWD}/temp-space-config/spaceprovider-default-espw"
-kubectl-kubestellar-get-config-for-space --space-name espw --provider-name default --sm-core-config $SM_CONFIG --sm-context $SM_CONTEXT --output $ESPW_SPACE_CONFIG
+kubectl-kubestellar-get-config-for-space --space-name espw --sm-core-config $SM_CONFIG --sm-context $SM_CONTEXT --output $ESPW_SPACE_CONFIG
 (
   KUBECONFIG=$SM_CONFIG mailbox-controller -v=4 &> /tmp/mailbox-controller.log &
   sleep 20

--- a/docs/content/Coding Milestones/PoC2023q1/example1-subs/example1-stage-2.md
+++ b/docs/content/Coding Milestones/PoC2023q1/example1-subs/example1-stage-2.md
@@ -18,7 +18,7 @@ workload, with the following commands.
 
 ```shell
 IN_CLUSTER=false SPACE_MANAGER_KUBECONFIG=$SM_CONFIG kubectl kubestellar ensure wmw wmw-c
-wmw_c_space_config=$PWD/temp-space-config/spaceprovider-default-wmw-c
+WMW_C_SPACE_CONFIG=$PWD/temp-space-config/spaceprovider-default-wmw-c
 ```
 
 ``` {.bash .hide-me}
@@ -31,7 +31,7 @@ that serves up a very simple web page, conveyed via a Kubernetes
 ConfigMap that is mounted as a volume for the httpd pod.
 
 ```shell
-kubectl --kubeconfig $wmw_c_space_config apply -f - <<EOF
+kubectl --kubeconfig $WMW_C_SPACE_CONFIG apply -f - <<EOF
 apiVersion: v1
 kind: Namespace
 metadata:
@@ -107,7 +107,7 @@ selector that matches both Location objects created earlier, thus
 directing the common workload to both edge clusters.
 
 ```shell
-kubectl --kubeconfig $wmw_c_space_config apply -f - <<EOF
+kubectl --kubeconfig $WMW_C_SPACE_CONFIG apply -f - <<EOF
 apiVersion: edge.kubestellar.io/v2alpha1
 kind: EdgePlacement
 metadata:
@@ -145,7 +145,7 @@ workload.
 
 ```shell
 IN_CLUSTER=false SPACE_MANAGER_KUBECONFIG=$SM_CONFIG kubectl kubestellar ensure wmw wmw-s
-wmw_s_space_config=$PWD/temp-space-config/spaceprovider-default-wmw-s
+WMW_S_SPACE_CONFIG=$PWD/temp-space-config/spaceprovider-default-wmw-s
 ```
 
 In this workload we will also demonstrate how to downsync objects
@@ -156,7 +156,7 @@ modified so that the resource it defines is in the category
 `all`. First, create the definition object with the following command.
 
 ```shell
-kubectl --kubeconfig $wmw_s_space_config apply -f - <<EOF
+kubectl --kubeconfig $WMW_S_SPACE_CONFIG apply -f - <<EOF
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
@@ -206,7 +206,7 @@ Next, use the following command to wait for the apiserver to process
 that definition.
 
 ```shell
-kubectl --kubeconfig $wmw_s_space_config wait --for condition=Established crd crontabs.stable.example.com
+kubectl --kubeconfig $WMW_S_SPACE_CONFIG wait --for condition=Established crd crontabs.stable.example.com
 ```
 
 Next, use `kubectl` to create the following workload objects in that
@@ -215,7 +215,7 @@ to the httpd workload but is here to demonstrate that `APIService`
 objects can be downsynced.
 
 ```shell
-kubectl --kubeconfig $wmw_s_space_config apply -f - <<EOF
+kubectl --kubeconfig $WMW_S_SPACE_CONFIG apply -f - <<EOF
 apiVersion: v1
 kind: Namespace
 metadata:
@@ -322,7 +322,7 @@ common EdgePlacement, which does not explicitly mention the
 namespaces as needed in the WECs.
    
 ```shell
-kubectl --kubeconfig $wmw_s_space_config apply -f - <<EOF
+kubectl --kubeconfig $WMW_S_SPACE_CONFIG apply -f - <<EOF
 apiVersion: edge.kubestellar.io/v2alpha1
 kind: EdgePlacement
 metadata:
@@ -383,22 +383,20 @@ following commands to launch the where-resolver; it requires the ESPW
 to be the current kcp workspace at start time.
 
 ```shell
-espw_space_config="${PWD}/temp-space-config/spaceprovider-default-espw"
-kubectl-kubestellar-get-config-for-space --space-name espw --provider-name default --sm-core-config $SM_CONFIG --space-config-file $espw_space_config
-# TODO: where-resolver needs access to multiple configs. Will remove when controllers support spaces.
-kubectl ws root:espw 
-kubestellar-where-resolver -v=4 &> /tmp/where-resolver.log &
-sleep 10
+(
+  KUBECONFIG=$SM_CONFIG kubestellar-where-resolver -v=4 &> /tmp/where-resolver.log &
+  sleep 10
+)
 ```
 
 The following commands wait until the where-resolver has done its job
 for the common and special `EdgePlacement` objects.
 
 ```shell
-while ! kubectl --kubeconfig $wmw_c_space_config get SinglePlacementSlice &> /dev/null; do
+while ! kubectl --kubeconfig $WMW_C_SPACE_CONFIG get SinglePlacementSlice &> /dev/null; do
   sleep 10
 done
-while ! kubectl --kubeconfig $wmw_s_space_config get SinglePlacementSlice &> /dev/null; do
+while ! kubectl --kubeconfig $WMW_S_SPACE_CONFIG get SinglePlacementSlice &> /dev/null; do
   sleep 10
 done
 ```
@@ -417,7 +415,7 @@ I0423 01:33:37.391772   11305 reconcile_on_location.go:192] "updated SinglePlace
 Check out a SinglePlacementSlice object as follows.
 
 ```shell
-kubectl --kubeconfig $wmw_c_space_config get SinglePlacementSlice -o yaml
+kubectl --kubeconfig $WMW_C_SPACE_CONFIG get SinglePlacementSlice -o yaml
 ```
 ``` { .bash .no-copy }
 apiVersion: v1

--- a/docs/content/Coding Milestones/PoC2023q1/example1-subs/example1-stage-2.md
+++ b/docs/content/Coding Milestones/PoC2023q1/example1-subs/example1-stage-2.md
@@ -17,7 +17,7 @@ management workspace (WMW).  Start by creating a WMW for the common
 workload, with the following commands.
 
 ```shell
-IN_CLUSTER=false SPACE_MANAGER_KUBECONFIG=$SM_CONFIG kubectl kubestellar ensure wmw wmw-c
+IN_CLUSTER=false kubectl kubestellar ensure wmw wmw-c
 WMW_C_SPACE_CONFIG=$PWD/temp-space-config/spaceprovider-default-wmw-c
 ```
 
@@ -144,7 +144,7 @@ Use the following `kubectl` commands to create the WMW for the special
 workload.
 
 ```shell
-IN_CLUSTER=false SPACE_MANAGER_KUBECONFIG=$SM_CONFIG kubectl kubestellar ensure wmw wmw-s
+IN_CLUSTER=false kubectl kubestellar ensure wmw wmw-s
 WMW_S_SPACE_CONFIG=$PWD/temp-space-config/spaceprovider-default-wmw-s
 ```
 

--- a/docs/content/Coding Milestones/PoC2023q1/example1-subs/example1-stage-3.md
+++ b/docs/content/Coding Milestones/PoC2023q1/example1-subs/example1-stage-3.md
@@ -25,8 +25,8 @@ The following commands wait for the placement translator to get its
 job done for this example.
 
 ```shell
-$FLORIN_MB_CONFIG="${PWD}/temp-space-config/${FLORIN_SPACE}"
-$GUILDER_MB_CONFIG="${PWD}/temp-space-config/${GUILDER_SPACE}"
+FLORIN_MB_CONFIG="${PWD}/temp-space-config/${FLORIN_SPACE}"
+GUILDER_MB_CONFIG="${PWD}/temp-space-config/${GUILDER_SPACE}"
 kubectl-kubestellar-get-config-for-space --space-name $FLOWIN_SPACE --provider-name default --sm-core-config $SM_CONFIG --output $FLORIN_MB_CONFIG
 kubectl-kubestellar-get-config-for-space --space-name $GUILDER_SPACE --provider-name default --sm-core-config $SM_CONFIG --output $GUILDER_MB_CONFIG
 

--- a/docs/content/Coding Milestones/PoC2023q1/example1-subs/example1-stage-3.md
+++ b/docs/content/Coding Milestones/PoC2023q1/example1-subs/example1-stage-3.md
@@ -27,8 +27,8 @@ job done for this example.
 ```shell
 FLORIN_MB_CONFIG="${PWD}/temp-space-config/${FLORIN_SPACE}"
 GUILDER_MB_CONFIG="${PWD}/temp-space-config/${GUILDER_SPACE}"
-kubectl-kubestellar-get-config-for-space --space-name $FLORIN_SPACE --provider-name default --sm-core-config $SM_CONFIG --sm-context $SM_CONTEXT --output $FLORIN_MB_CONFIG
-kubectl-kubestellar-get-config-for-space --space-name $GUILDER_SPACE --provider-name default --sm-core-config $SM_CONFIG --sm-context $SM_CONTEXT --output $GUILDER_MB_CONFIG
+kubectl-kubestellar-get-config-for-space --space-name $FLORIN_SPACE --sm-core-config $SM_CONFIG --sm-context $SM_CONTEXT --output $FLORIN_MB_CONFIG
+kubectl-kubestellar-get-config-for-space --space-name $GUILDER_SPACE --sm-core-config $SM_CONFIG --sm-context $SM_CONTEXT --output $GUILDER_MB_CONFIG
 
 # wait until SyncerConfig, ReplicaSets and Deployments are ready
 mbxws=($FLORIN_SPACE $GUILDER_SPACE)

--- a/docs/content/Coding Milestones/PoC2023q1/example1-subs/example1-stage-3.md
+++ b/docs/content/Coding Milestones/PoC2023q1/example1-subs/example1-stage-3.md
@@ -27,8 +27,8 @@ job done for this example.
 ```shell
 FLORIN_MB_CONFIG="${PWD}/temp-space-config/${FLORIN_SPACE}"
 GUILDER_MB_CONFIG="${PWD}/temp-space-config/${GUILDER_SPACE}"
-kubectl-kubestellar-get-config-for-space --space-name $FLORIN_SPACE --provider-name default --sm-core-config $SM_CONFIG --output $FLORIN_MB_CONFIG
-kubectl-kubestellar-get-config-for-space --space-name $GUILDER_SPACE --provider-name default --sm-core-config $SM_CONFIG --output $GUILDER_MB_CONFIG
+kubectl-kubestellar-get-config-for-space --space-name $FLORIN_SPACE --provider-name default --sm-core-config $SM_CONFIG --sm-context $SM_CONTEXT --output $FLORIN_MB_CONFIG
+kubectl-kubestellar-get-config-for-space --space-name $GUILDER_SPACE --provider-name default --sm-core-config $SM_CONFIG --sm-context $SM_CONTEXT --output $GUILDER_MB_CONFIG
 
 # wait until SyncerConfig, ReplicaSets and Deployments are ready
 mbxws=($FLORIN_SPACE $GUILDER_SPACE)

--- a/docs/content/Coding Milestones/PoC2023q1/example1-subs/example1-stage-3.md
+++ b/docs/content/Coding Milestones/PoC2023q1/example1-subs/example1-stage-3.md
@@ -15,53 +15,62 @@ use the following commands to launch the placement translator; it
 requires the ESPW to be current at start time.
 
 ```shell
-# TODO: placement-translator needs access to multiple configs. Will remove when controllers support spaces.
-kubectl ws root:espw
-placement-translator -v=4 &> /tmp/placement-translator.log &
-sleep 10
+(
+  KUBECONFIG=$SM_CONFIG placement-translator -v=4  &> /tmp/placement-translator.log &
+  sleep 10
+)
 ```
 
 The following commands wait for the placement translator to get its
 job done for this example.
 
 ```shell
-# TODO: unfortunately, the $FLORIN_WS and $GUILDER_WS are mailbox ws names that we are not supporting in the space framework yet
+$FLORIN_MB_CONFIG="${PWD}/temp-space-config/${FLORIN_SPACE}"
+$GUILDER_MB_CONFIG="${PWD}/temp-space-config/${GUILDER_SPACE}"
+kubectl-kubestellar-get-config-for-space --space-name $FLOWIN_SPACE --provider-name default --sm-core-config $SM_CONFIG --output $FLORIN_MB_CONFIG
+kubectl-kubestellar-get-config-for-space --space-name $GUILDER_SPACE --provider-name default --sm-core-config $SM_CONFIG --output $GUILDER_MB_CONFIG
+
 # wait until SyncerConfig, ReplicaSets and Deployments are ready
-mbxws=($FLORIN_WS $GUILDER_WS)
+mbxws=($FLORIN_SPACE $GUILDER_SPACE)
 for ii in "${mbxws[@]}"; do
-  kubectl ws root:$ii
-  # wait for SyncerConfig resource
-  while ! kubectl get SyncerConfig the-one &> /dev/null; do
+  (
+    export KUBECONFIG="${PWD}/temp-space-config/$ii"
+    # wait for SyncerConfig resource
+    while ! kubectl get SyncerConfig the-one &> /dev/null; do
+      sleep 10
+    done
+    echo "* SyncerConfig resource exists in mailbox $ii"
+    # wait for ReplicaSet resource
+    while ! kubectl get rs &> /dev/null; do
+      sleep 10
+    done
+    echo "* ReplicaSet resource exists in mailbox $ii"
+    # wait until ReplicaSet in mailbox
+    while ! kubectl get rs -n commonstuff commond; do
+      sleep 10
+    done
+    echo "* commonstuff ReplicaSet in mailbox $ii"
+  )
+done
+(
+  export KUBECONFIG=$GUILDER_MB_CONFIG
+  # check for deployment in guilder
+  while ! kubectl get deploy -A &> /dev/null; do
     sleep 10
   done
-  echo "* SyncerConfig resource exists in mailbox $ii"
-  # wait for ReplicaSet resource
-  while ! kubectl get rs &> /dev/null; do
+  echo "* Deployment resource exists"
+  while ! kubectl get deploy -n specialstuff speciald; do
     sleep 10
   done
-  echo "* ReplicaSet resource exists in mailbox $ii"
-  # wait until ReplicaSet in mailbox
-  while ! kubectl get rs -n commonstuff commond; do
-    sleep 10
-  done
-  echo "* commonstuff ReplicaSet in mailbox $ii"
-done
-# check for deployment in guilder
-while ! kubectl get deploy -A &> /dev/null; do
-  sleep 10
-done
-echo "* Deployment resource exists"
-while ! kubectl get deploy -n specialstuff speciald; do
-  sleep 10
-done
-echo "* specialstuff Deployment in its mailbox"
-# wait for crontab CRD to be established
-while ! kubectl get crd crontabs.stable.example.com; do sleep 10; done
-kubectl wait --for condition=Established crd crontabs.stable.example.com
-echo "* CronTab CRD is established in its mailbox"
-# wait for my-new-cron-object to be in its mailbox
-while ! kubectl get ct -n specialstuff my-new-cron-object; do sleep 10; done
-echo "* CronTab my-new-cron-object is in its mailbox"
+  echo "* specialstuff Deployment in its mailbox"
+  # wait for crontab CRD to be established
+  while ! kubectl get crd crontabs.stable.example.com; do sleep 10; done
+  kubectl wait --for condition=Established crd crontabs.stable.example.com
+  echo "* CronTab CRD is established in its mailbox"
+  # wait for my-new-cron-object to be in its mailbox
+  while ! kubectl get ct -n specialstuff my-new-cron-object; do sleep 10; done
+  echo "* CronTab my-new-cron-object is in its mailbox"
+)
 ```
 
 You can check that the common workload's ReplicaSet objects got to
@@ -141,16 +150,7 @@ The florin cluster gets only the common workload.  Examine florin's
 for florin (which you stored in Stage 1) here.
 
 ```shell
-# TODO: $FLORIN_WS is a mailbox workspace 
-kubectl ws root:$FLORIN_WS
-```
-
-``` { .bash .no-copy }
-Current workspace is "root:1t82bk54r6gjnzsp-mb-1a045336-8178-4026-8a56-5cd5609c0ec1" (type root:universal).
-```
-
-```shell
-kubectl get SyncerConfig the-one -o yaml
+KUBECONFIG=$FLORIN_MB_CONFIG kubectl get SyncerConfig the-one -o yaml
 ```
 
 ``` { .bash .no-copy }
@@ -204,15 +204,7 @@ Examine guilder's `SyncerConfig` object and workloads as follows,
 using the mailbox workspace name that you stored in Stage 1.
 
 ```shell
-# TODO: $GUILDER_WS is a mailbox workspace 
-kubectl ws root:$GUILDER_WS
-```
-``` { .bash .no-copy }
-Current workspace is "root:1t82bk54r6gjnzsp-mb-f0a82ab1-63f4-49ea-954d-3a41a35a9f1c" (type root:universal).
-```
-
-```shell
-kubectl get SyncerConfig the-one -o yaml
+KUBECONFIG=$GUILDER_MB_CONFIG kubectl get SyncerConfig the-one -o yaml
 ```
 ``` { .bash .no-copy }
 apiVersion: edge.kubestellar.io/v2alpha1
@@ -302,7 +294,7 @@ You can check for specific workload objects here with the following
 command.
 
 ```shell
-kubectl get deployments,replicasets -A
+KUBECONFIG=$GUILDER_MB_CONFIG kubectl get deployments,replicasets -A
 ```
 ``` { .bash .no-copy }
 NAMESPACE      NAME                       READY   UP-TO-DATE   AVAILABLE   AGE

--- a/docs/content/Coding Milestones/PoC2023q1/example1-subs/example1-stage-3.md
+++ b/docs/content/Coding Milestones/PoC2023q1/example1-subs/example1-stage-3.md
@@ -27,7 +27,7 @@ job done for this example.
 ```shell
 FLORIN_MB_CONFIG="${PWD}/temp-space-config/${FLORIN_SPACE}"
 GUILDER_MB_CONFIG="${PWD}/temp-space-config/${GUILDER_SPACE}"
-kubectl-kubestellar-get-config-for-space --space-name $FLOWIN_SPACE --provider-name default --sm-core-config $SM_CONFIG --output $FLORIN_MB_CONFIG
+kubectl-kubestellar-get-config-for-space --space-name $FLORIN_SPACE --provider-name default --sm-core-config $SM_CONFIG --output $FLORIN_MB_CONFIG
 kubectl-kubestellar-get-config-for-space --space-name $GUILDER_SPACE --provider-name default --sm-core-config $SM_CONFIG --output $GUILDER_MB_CONFIG
 
 # wait until SyncerConfig, ReplicaSets and Deployments are ready

--- a/docs/content/Coding Milestones/PoC2023q1/example1-subs/example1-teardown.md
+++ b/docs/content/Coding Milestones/PoC2023q1/example1-subs/example1-teardown.md
@@ -3,10 +3,9 @@ To remove the example usage, delete the IMW and WMW and kind clusters run the fo
 
 ``` {.bash}
 rm florin-syncer.yaml guilder-syncer.yaml || true
-kubectl ws root
-kubectl delete workspace imw1
-kubectl delete workspace $FLORIN_WS
-kubectl delete workspace $GUILDER_WS
+KUBECONFIG=$SM_CONFIG kubectl delete space imw1
+KUBECONFIG=$SM_CONFIG kubectl delete space $FLORIN_SPACE
+KUBECONFIG=$SM_CONFIG kubectl delete space $GUILDER_SPACE
 kubectl kubestellar remove wmw wmw-c
 kubectl kubestellar remove wmw wmw-s
 kind delete cluster --name florin

--- a/docs/content/Coding Milestones/PoC2023q1/example1.md
+++ b/docs/content/Coding Milestones/PoC2023q1/example1.md
@@ -78,21 +78,21 @@ of executing copies to be reported.  Check that the reported number is
 2.
 
 ```shell
-kubectl --kubeconfig $wmw_c_space_config get rs -n commonstuff commond -o yaml | grep 'kubestellar.io/executing-count: "2"' || { kubectl --kubeconfig $wmw_c_space_config get rs -n commonstuff commond -o yaml; false; }
+kubectl --kubeconfig $WMW_C_SPACE_CONFIG get rs -n commonstuff commond -o yaml | grep 'kubestellar.io/executing-count: "2"' || { kubectl --kubeconfig $WMW_C_SPACE_CONFIG get rs -n commonstuff commond -o yaml; false; }
 ```
 
 For the special workload, the number of executing copies should be 1.
 Check that the reported number agrees.
 
 ```shell
-kubectl --kubeconfig $wmw_s_space_config get deploy -n specialstuff speciald -o yaml | grep 'kubestellar.io/executing-count: "1"' || { kubectl --kubeconfig $wmw_s_space_config get deploy -n specialstuff speciald -o yaml; false; }
+kubectl --kubeconfig $WMW_S_SPACE_CONFIG get deploy -n specialstuff speciald -o yaml | grep 'kubestellar.io/executing-count: "1"' || { kubectl --kubeconfig $WMW_S_SPACE_CONFIG get deploy -n specialstuff speciald -o yaml; false; }
 ```
 
 Look at the status section of the "speciald" `Deployment` and see that
 it has been filled in with the information from the guilder cluster.
 
 ```shell
-kubectl --kubeconfig $wmw_s_space_config get deploy -n specialstuff speciald -o yaml
+kubectl --kubeconfig $WMW_S_SPACE_CONFIG get deploy -n specialstuff speciald -o yaml
 ```
 
 Current status might not be there yet. The following command waits for
@@ -101,7 +101,7 @@ status that reports that there is a special workload pod "ready".
 ```shell
 let count=1
 while true; do
-    rsyaml=$(kubectl --kubeconfig $wmw_s_space_config get deploy -n specialstuff speciald -o yaml)
+    rsyaml=$(kubectl --kubeconfig $WMW_S_SPACE_CONFIG get deploy -n specialstuff speciald -o yaml)
     if grep 'readyReplicas: 1' <<<"$rsyaml"
     then break
     fi

--- a/docs/content/Coding Milestones/PoC2023q1/example1.md
+++ b/docs/content/Coding Milestones/PoC2023q1/example1.md
@@ -28,9 +28,9 @@ they appear in this example.
 ## Stage 1
 
 {%
-   include-markdown "example1-subs/example1-pre-kcp.md"
-   start="<!--example1-pre-kcp-start-->"
-   end="<!--example1-pre-kcp-end-->"
+   include-markdown "example1-subs/example1-pre-provider.md"
+   start="<!--example1-pre-provider-start-->"
+   end="<!--example1-pre-provider-end-->"
 %}
 
 {%
@@ -52,9 +52,9 @@ they appear in this example.
 %}
 
 {%
-   include-markdown "example1-subs/example1-post-kcp.md"
-   start="<!--example1-post-kcp-start-->"
-   end="<!--example1-post-kcp-end-->"
+   include-markdown "example1-subs/example1-post-provider.md"
+   start="<!--example1-post-provider-start-->"
+   end="<!--example1-post-provider-end-->"
 %}
 
 {%

--- a/docs/content/Coding Milestones/PoC2023q1/kubestellar-syncer-subs/kubestellar-syncer-0-deploy-florin.md
+++ b/docs/content/Coding Milestones/PoC2023q1/kubestellar-syncer-subs/kubestellar-syncer-0-deploy-florin.md
@@ -1,12 +1,12 @@
 <!--kubestellar-syncer-0-deploy-florin-start-->
 Go to inventory management workspace and find the mailbox workspace name.
 ```shell
-kubectl ws root:espw
-pvname=`kubectl get synctargets.edge.kubestellar.io | grep florin | awk '{print $1}'`
-stuid=`kubectl get synctargets.edge.kubestellar.io $pvname -o jsonpath="{.metadata.uid}"`
-kubectl ws root:imw1
-stcid=`kubectl get synctargets.edge.kubestellar.io florin -o jsonpath="{.metadata.annotations['kcp\.io/cluster']}"`
-mbws="$stcid-mb-$stuid"
+espw_space_config="${PWD}/temp-space-config/espw.config"
+kubectl-kubestellar-get-config-for-space --space-name espw --provider-name default --sm-core-config $SM_CONFIG --sm-context $SM_CONTEXT --output $espw_space_config
+
+pvname=`kubectl --kubeconfig $espw_space_config get synctargets.edge.kubestellar.io | grep florin | awk '{print $1}'`
+stuid=`kubectl --kubeconfig $espw_space_config get synctargets.edge.kubestellar.io $pvname -o jsonpath="{.metadata.uid}"`
+mbws="imw1-mb-$stuid"
 echo "mailbox workspace name = $mbws"
 ```
 ``` { .bash .no-copy }
@@ -16,8 +16,10 @@ mailbox workspace name = vosh9816n2xmpdwm-mb-bb47149d-52d3-4f14-84dd-7b64ac01c97
 
 Go to the mailbox workspace and run the following command to obtain yaml manifests to bootstrap KubeStellar-Syncer.
 ```shell
-kubectl ws root:$mbws
-./bin/kubectl-kubestellar-syncer_gen florin --syncer-image quay.io/kubestellar/syncer:v0.2.2 -o florin-syncer.yaml
+mbwsname_space_config="${PWD}/temp-space-config/${mbws}.config"
+kubectl-kubestellar-get-config-for-space --space-name ${mbws} --provider-name default --sm-core-config $SM_CONFIG --sm-context $SM_CONTEXT --output $mbwsname_space_config
+
+./bin/kubectl-kubestellar-syncer_gen --kubeconfig $mbwsname_space_config florin --syncer-image quay.io/kubestellar/syncer:v0.2.2 -o florin-syncer.yaml
 ```
 ``` { .bash .no-copy }
 Current workspace is "root:vosh9816n2xmpdwm-mb-bb47149d-52d3-4f14-84dd-7b64ac01c97f".

--- a/docs/content/Coding Milestones/PoC2023q1/kubestellar-syncer-subs/kubestellar-syncer-0-deploy-guilder.md
+++ b/docs/content/Coding Milestones/PoC2023q1/kubestellar-syncer-subs/kubestellar-syncer-0-deploy-guilder.md
@@ -1,12 +1,12 @@
 <!--kubestellar-syncer-0-deploy-guilder-start-->
 Go to inventory management workspace and find the mailbox workspace name.
 ```shell
-kubectl ws root:espw
-pvname=`kubectl get synctargets.edge.kubestellar.io | grep guilder | awk '{print $1}'`
-stuid=`kubectl get synctargets.edge.kubestellar.io $pvname -o jsonpath="{.metadata.uid}"`
-kubectl ws root:imw1
-stcid=`kubectl get synctargets.edge.kubestellar.io guilder -o jsonpath="{.metadata.annotations['kcp\.io/cluster']}"`
-mbws="$stcid-mb-$stuid"
+espw_space_config="${PWD}/temp-space-config/espw.config"
+kubectl-kubestellar-get-config-for-space --space-name espw --provider-name default --sm-core-config $SM_CONFIG --sm-context $SM_CONTEXT --output $espw_space_config
+
+pvname=`kubectl --kubeconfig $espw_space_config get synctargets.edge.kubestellar.io | grep guilder | awk '{print $1}'`
+stuid=`kubectl --kubeconfig $espw_space_config get synctargets.edge.kubestellar.io $pvname -o jsonpath="{.metadata.uid}"`
+mbws="imw1-mb-$stuid"
 echo "mailbox workspace name = $mbws"
 ```
 
@@ -17,8 +17,10 @@ mailbox workspace name = vosh9816n2xmpdwm-mb-bf1277df-0da9-4a26-b0fc-3318862b1a5
 
 Go to the mailbox workspace and run the following command to obtain yaml manifests to bootstrap KubeStellar-Syncer.
 ```shell
-kubectl ws root:$mbws
-./bin/kubectl-kubestellar-syncer_gen guilder --syncer-image quay.io/kubestellar/syncer:v0.2.2 -o guilder-syncer.yaml
+mbwsname_space_config="${PWD}/temp-space-config/${mbws}.config"
+kubectl-kubestellar-get-config-for-space --space-name ${mbws} --provider-name default --sm-core-config $SM_CONFIG --sm-context $SM_CONTEXT --output $mbwsname_space_config
+
+./bin/kubectl-kubestellar-syncer_gen --kubeconfig $mbwsname_space_config guilder --syncer-image quay.io/kubestellar/syncer:v0.2.2 -o guilder-syncer.yaml
 ```
 ``` { .bash .no-copy }
 Current workspace is "root:vosh9816n2xmpdwm-mb-bf1277df-0da9-4a26-b0fc-3318862b1a5e".

--- a/docs/content/Coding Milestones/PoC2023q1/kubestellar-syncer.md
+++ b/docs/content/Coding Milestones/PoC2023q1/kubestellar-syncer.md
@@ -24,9 +24,9 @@ KubeStellar-Syncer runs in the target cluster and sync kubernetes resource objec
 The KubeStellar-Syncer can be exercised after setting up KubeStellar mailbox workspaces. Firstly we'll follow to similar steps in [example1](../example1) until `The mailbox controller` in stage 2. 
 
 {%
-   include-markdown "example1-subs/example1-pre-kcp.md"
-   start="<!--example1-pre-kcp-start-->"
-   end="<!--example1-pre-kcp-end-->"
+   include-markdown "example1-subs/example1-pre-provider.md"
+   start="<!--example1-pre-provider-start-->"
+   end="<!--example1-pre-provider-end-->"
 %}
 
 {%
@@ -48,9 +48,9 @@ The KubeStellar-Syncer can be exercised after setting up KubeStellar mailbox wor
 %}
 
 {%
-   include-markdown "example1-subs/example1-post-kcp.md"
-   start="<!--example1-post-kcp-start-->"
-   end="<!--example1-post-kcp-end-->"
+   include-markdown "example1-subs/example1-post-provider.md"
+   start="<!--example1-post-provider-start-->"
+   end="<!--example1-post-provider-end-->"
 %}
 
 {%

--- a/docs/content/Coding Milestones/PoC2023q1/placement-translator.md
+++ b/docs/content/Coding Milestones/PoC2023q1/placement-translator.md
@@ -136,9 +136,9 @@ where resolver and mailbox controller long enough for them to create what
 this scenario calls for, but they can be terminated after that.
 
 {%
-   include-markdown "example1-subs/example1-pre-kcp.md"
-   start="<!--example1-pre-kcp-start-->"
-   end="<!--example1-pre-kcp-end-->"
+   include-markdown "example1-subs/example1-pre-provider.md"
+   start="<!--example1-pre-provider-start-->"
+   end="<!--example1-pre-provider-end-->"
 %}
 
 {%
@@ -148,9 +148,9 @@ this scenario calls for, but they can be terminated after that.
 %}
 
 {%
-   include-markdown "example1-subs/example1-post-kcp.md"
-   start="<!--example1-post-kcp-start-->"
-   end="<!--example1-post-kcp-end-->"
+   include-markdown "example1-subs/example1-post-provider.md"
+   start="<!--example1-post-provider-start-->"
+   end="<!--example1-post-provider-end-->"
 %}
 
 Continue to follow the steps until the start of Stage 3 of the

--- a/docs/content/Getting-Started/quickstart-subs/quickstart-1-install-and-run-kubestellar.md
+++ b/docs/content/Getting-Started/quickstart-subs/quickstart-1-install-and-run-kubestellar.md
@@ -1,9 +1,5 @@
 <!--quickstart-1-install-and-run-kubestellar-start-->
 
-KubeStellar works in the context of [kcp](https://www.kcp.io/), so to use KubeStellar you also need kcp.
-
-KubeStellar works with release `v0.11.0` of kcp.
-
 We support two ways to deploy kcp and KubeStellar. The older way is to run them as bare processes. The newer way is to deploy them as workload in a Kubernetes (possibly OpenShift) cluster.
 
 ### Deploy kcp and KubeStellar as bare processes
@@ -14,6 +10,8 @@ The following commands will download the kcp and **KubeStellar** executables int
 bash <(curl -s {{ config.repo_raw_url }}/{{ config.ks_branch }}/bootstrap/bootstrap-kubestellar.sh) --kubestellar-version {{ config.ks_current_tag }}
 export PATH="$PATH:$(pwd)/kcp/bin:$(pwd)/kubestellar/bin"
 export KUBECONFIG="$(pwd)/.kcp/admin.kubeconfig"
+export SM_CONFIG=~/.kube/config
+mkdir ${PWD}/temp-space-config
 ```
 
 Check that `KubeStellar` is running.
@@ -32,10 +30,10 @@ user     1902  0.3  0.3 743652 27504 pts/1    Sl   10:51   0:02 kubestellar-wher
 user     1912  0.3  0.5 760428 41660 pts/1    Sl   10:51   0:02 placement-translator -v=2
 ``` 
 
-Second, check that TMC compute service provider workspace and the KubeStellar Edge Service Provider Workspace (`espw`) have been created with the following command:
+Second, check that TMC compute service provider space and the KubeStellar Edge Service Provider space (`espw`) have been created with the following command:
 
 ```shell
-kubectl ws tree
+KUBECONFIG=$SM_CONFIG kubectl get spaces -A
 ```
 
 which should yield:
@@ -80,6 +78,8 @@ The following commands will (a) download the kcp and **KubeStellar** executables
 ``` {.bash}
 bash <(curl -s {{ config.repo_raw_url }}/{{ config.ks_branch }}/bootstrap/bootstrap-kubestellar.sh) --kubestellar-version {{ config.ks_current_tag }} --external-endpoint hostname.favorite.my:{{ config.ks_kind_port_num }}
 export PATH="$PATH:$(pwd)/kcp/bin:$(pwd)/kubestellar/bin"
+export SM_CONFIG=~/.kube/config
+mkdir ${PWD}/temp-space-config
 ```
 
 Using your original `kubectl` configuration that manipulates the hosting cluster, check that the KubeStellar Deployment has its intended one running Pod.
@@ -103,10 +103,10 @@ The bootstrap command above will print out instructions to set your KUBECONFIG e
 export KUBECONFIG="$(pwd)/kubestellar.kubeconfig"
 ```
 
-Check that the TMC compute service provider workspace and the KubeStellar Edge Service Provider Workspace (`espw`) have been created with the following command:
+Check that the TMC compute service provider spaces and the KubeStellar Edge Service Provider space (`espw`) have been created with the following command:
 
 ``` {.bash}
-kubectl ws tree
+KUBECONFIG=$SM_CONFIG kubectl get spaces -A
 ```
 
 which should yield:

--- a/docs/content/Getting-Started/quickstart-subs/quickstart-1-install-and-run-kubestellar.md
+++ b/docs/content/Getting-Started/quickstart-subs/quickstart-1-install-and-run-kubestellar.md
@@ -11,7 +11,7 @@ bash <(curl -s {{ config.repo_raw_url }}/{{ config.ks_branch }}/bootstrap/bootst
 export PATH="$PATH:$(pwd)/kcp/bin:$(pwd)/kubestellar/bin"
 export KUBECONFIG="$(pwd)/.kcp/admin.kubeconfig"
 export SM_CONFIG=~/.kube/config
-mkdir ${PWD}/temp-space-config
+mkdir -p ${PWD}/temp-space-config
 ```
 
 Check that `KubeStellar` is running.
@@ -79,7 +79,7 @@ The following commands will (a) download the kcp and **KubeStellar** executables
 bash <(curl -s {{ config.repo_raw_url }}/{{ config.ks_branch }}/bootstrap/bootstrap-kubestellar.sh) --kubestellar-version {{ config.ks_current_tag }} --external-endpoint hostname.favorite.my:{{ config.ks_kind_port_num }}
 export PATH="$PATH:$(pwd)/kcp/bin:$(pwd)/kubestellar/bin"
 export SM_CONFIG=~/.kube/config
-mkdir ${PWD}/temp-space-config
+mkdir -p ${PWD}/temp-space-config
 ```
 
 Using your original `kubectl` configuration that manipulates the hosting cluster, check that the KubeStellar Deployment has its intended one running Pod.

--- a/docs/content/Getting-Started/quickstart-subs/quickstart-2-apache-example-deployment-c-onboarding-clusters.md
+++ b/docs/content/Getting-Started/quickstart-subs/quickstart-2-apache-example-deployment-c-onboarding-clusters.md
@@ -1,33 +1,22 @@
 <!--quickstart-2-apache-example-deployment-c-onboarding-clusters-start-->
-The above use of `kind` has knocked kcp's `kubectl ws` plugin off kilter, as the latter uses the local kubeconfig to store its state about the "current" and "previous" workspaces.  Get it back on track with the following command.
-
-```shell
-kubectl config use-context root
-```
-
-KubeStellar will have created an Inventory Management Workspace (IMW)
+KubeStellar will have created an Inventory Management space (IMW)
 for the user to put inventory objects in, describing the user's
 clusters. The IMW that is automatically created for the user is at
-`root:imw1`.
+`imw1`.
 
 Let's begin by onboarding the `florin` cluster:
 
 ```shell
-kubectl ws root
-kubectl kubestellar prep-for-cluster --imw root:imw1 florin env=prod
+KUBECONFIG=$SM_CONFIG kubectl kubestellar prep-for-cluster --imw root:imw1 florin env=prod
 ```
 
 which should yield something like:
 
 ``` { .sh .no-copy }
-Current workspace is "root:imw1".
 synctarget.edge.kubestellar.io/florin created
 location.edge.kubestellar.io/florin created
 synctarget.edge.kubestellar.io/florin labeled
 location.edge.kubestellar.io/florin labeled
-Current workspace is "root:imw1".
-Current workspace is "root:espw".
-Current workspace is "root".
 Creating service account "kubestellar-syncer-florin-1yi5q9c4"
 Creating cluster role "kubestellar-syncer-florin-1yi5q9c4" to give service account "kubestellar-syncer-florin-1yi5q9c4"
 
@@ -45,8 +34,6 @@ to apply it. Use
   KUBECONFIG=<workload-execution-cluster-config> kubectl get deployment -n "kubestellar-syncer-florin-1yi5q9c4" kubestellar-syncer-florin-1yi5q9c4
 
 to verify the syncer pod is running.
-Current workspace is "root:imw1".
-Current workspace is "root".
 ```
 
 An edge syncer manifest yaml file was created in your current directory: `florin-syncer.yaml`. The default for the output file is the name of the SyncTarget object with “-syncer.yaml” appended.
@@ -96,8 +83,7 @@ local-path-storage                   local-path-provisioner-684f458cdd-kw2xz    
 Now, let's onboard the `guilder` cluster:
 
 ```shell
-kubectl ws root
-kubectl kubestellar prep-for-cluster --imw root:imw1 guilder env=prod extended=yes
+KUBECONFIG=$SM_CONFIG kubectl kubestellar prep-for-cluster --imw root:imw1 guilder env=prod extended=yes
 ```
 
 Apply the created edge syncer manifest:

--- a/docs/content/Getting-Started/quickstart-subs/quickstart-2-apache-example-deployment-d-create-and-deploy-apache-into-clusters.md
+++ b/docs/content/Getting-Started/quickstart-subs/quickstart-2-apache-example-deployment-d-create-and-deploy-apache-into-clusters.md
@@ -1,16 +1,14 @@
 <!--quickstart-2-apache-example-deployment-d-create-and-deploy-apache-into-clusters-start-->
 KubeStellar will have automatically created a Workload Management
-Workspace (WMW) for the user to store workload descriptions and KubeStellar Core
-control objects in. The automatically created WMW is at `root:wmw1`.
+space (WMW) for the user to store workload descriptions and KubeStellar Core
+control objects in. The automatically created WMW is at `wmw1`.
 
 Create the `EdgePlacement` object for your workload. Its “where predicate” (the locationSelectors array) has one label selector that matches the Location objects (`florin` and `guilder`) created earlier, thus directing the workload to both edge clusters. The `upsync` field is only a demonstration of the syntax, it plays no functional role in this scenario.
 
-In the `root:wmw1` workspace create the following `EdgePlacement` object: 
+In the `wmw1` space create the following `EdgePlacement` object: 
   
 ```shell
-kubectl ws root:wmw1
-
-kubectl apply -f - <<EOF
+KUBECONFIG=$WMW1_SPACE_CONFIG kubectl apply -f - <<EOF
 apiVersion: edge.kubestellar.io/v2alpha1
 kind: EdgePlacement
 metadata:

--- a/docs/content/Getting-Started/user-quickstart-test.md
+++ b/docs/content/Getting-Started/user-quickstart-test.md
@@ -174,11 +174,11 @@ MB2=$(KUBECONFIG=$SM_CONFIG kubectl get spaces -n spaceprovider-default -o json 
 echo The mailbox for ks-edge-cluster2 is $MB2
 
 MB1_SPACE="${PWD}/temp-space-config/${MB1}"
-kubectl-kubestellar-get-config-for-space --space-name $MB1 --provider-name default --sm-core-config $SM_CONFIG --sm-context $SM_CONTEXT --output $MB1_SPACE
+kubectl-kubestellar-get-config-for-space --space-name $MB1 --sm-core-config $SM_CONFIG --sm-context $SM_CONTEXT --output $MB1_SPACE
 MB2_SPACE="${PWD}/temp-space-config/${MB2}"
-kubectl-kubestellar-get-config-for-space --space-name $MB2 --provider-name default --sm-core-config $SM_CONFIG --sm-context $SM_CONTEXT --output $MB2_SPACE
+kubectl-kubestellar-get-config-for-space --space-name $MB2 --sm-core-config $SM_CONFIG --sm-context $SM_CONTEXT --output $MB2_SPACE
 WMW1_SPACE_CONFIG="${PWD}/temp-space-config/spaceprovider-default-wmw1"
-kubectl-kubestellar-get-config-for-space --space-name wmw1 --provider-name default --sm-core-config $SM_CONFIG --sm-context $SM_CONTEXT --output $WMW1_SPACE_CONFIG
+kubectl-kubestellar-get-config-for-space --space-name wmw1 --sm-core-config $SM_CONFIG --sm-context $SM_CONTEXT --output $WMW1_SPACE_CONFIG
 ```
 
 #### 5. Deploy an Apache Web Server to ks-edge-cluster1 and ks-edge-cluster2

--- a/docs/content/Getting-Started/user-quickstart-test.md
+++ b/docs/content/Getting-Started/user-quickstart-test.md
@@ -119,8 +119,7 @@ export PATH=$PWD/bin:$PATH
 bash -c "$(cat bootstrap/install-kcp-with-plugins.sh)" -V -V --version v0.11.0
 export PATH=$PWD/kcp/bin:$PATH
 export SM_CONFIG=~/.kube/config
-export SM_CONTEXT=ks-core
-mkdir -p ${PWD}/temp-space-config
+mkdir ${PWD}/temp-space-config
 ```
 
 #### 3. View your <span class="Space-Bd-BT">KUBESTELLAR</span> Core Space environment
@@ -164,16 +163,21 @@ mkdir -p ${PWD}/temp-space-config
            end="<!--kubestellar-apply-syncer-end-->"
          %}
 
-Wait for the mailbox controller to create the corresponding mailbox workspaces and remember them.
+Wait for the mailbox controller to create the corresponding mailbox spaces and remember them.
 
 ```shell
-# TODO: the mailbox workspaces have not been converted into spaces yet.
-KUBECONFIG=ks-core.kubeconfig kubectl ws root
-while [ $(KUBECONFIG=ks-core.kubeconfig kubectl get workspaces | grep -c -e -mb-) -lt 2 ]; do sleep 10; done
-MB1=$(KUBECONFIG=ks-core.kubeconfig kubectl get workspaces -o json | jq -r '.items | .[] | .metadata | select(.annotations ["edge.kubestellar.io/sync-target-name"] == "ks-edge-cluster1") | .name')
+while [ $(KUBECONFIG=$SM_CONFIG kubectl get spaces -A | grep -c -e -mb-) -lt 2 ]; do sleep 10; done
+MB1=$(KUBECONFIG=$SM_CONFIG kubectl get spaces -n spaceprovider-default -o json | jq -r '.items | .[] | .metadata | select(.annotations ["edge.kubestellar.io/sync-target-name"] == "ks-edge-cluster1") | .name')
 echo The mailbox for ks-edge-cluster1 is $MB1
-MB2=$(KUBECONFIG=ks-core.kubeconfig kubectl get workspaces -o json | jq -r '.items | .[] | .metadata | select(.annotations ["edge.kubestellar.io/sync-target-name"] == "ks-edge-cluster2") | .name')
+MB2=$(KUBECONFIG=$SM_CONFIG kubectl get spaces -n spaceprovider-default -o json | jq -r '.items | .[] | .metadata | select(.annotations ["edge.kubestellar.io/sync-target-name"] == "ks-edge-cluster2") | .name')
 echo The mailbox for ks-edge-cluster2 is $MB2
+
+MB1_SPACE="${PWD}/temp-space-config/${MB1}"
+kubectl-kubestellar-get-config-for-space --space-name $MB1 --provider-name default --sm-core-config $SM_CONFIG --output $MB1_SPACE
+MB2_SPACE="${PWD}/temp-space-config/${MB2}"
+kubectl-kubestellar-get-config-for-space --space-name $MB2 --provider-name default --sm-core-config $SM_CONFIG --output $MB2_SPACE
+WMW1_SPACE_CONFIG="${PWD}/temp-space-config/spaceprovider-default-wmw1"
+kubectl-kubestellar-get-config-for-space --space-name wmw1 --provider-name default --sm-core-config $SM_CONFIG --sm-context ks-core --output $WMW1_SPACE_CONFIG
 ```
 
 #### 5. Deploy an Apache Web Server to ks-edge-cluster1 and ks-edge-cluster2
@@ -188,10 +192,7 @@ echo The mailbox for ks-edge-cluster2 is $MB2
 Add a ServiceAccount that will be downsynced.
 
 ```shell
-wmw1_space_config="${PWD}/temp-space-config/spaceprovider-default-wmw1"
-kubectl-kubestellar-get-config-for-space --space-name wmw1 --provider-name default --sm-core-config $SM_CONFIG --sm-context $SM_CONTEXT --space-config-file $wmw1_space_config
-
-KUBECONFIG=$wmw1_space_config kubectl apply -f - <<EOF
+KUBECONFIG=$WMW1_SPACE_CONFIG kubectl apply -f - <<EOF
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -205,7 +206,7 @@ EOF
 Add an EdgePlacement that calls for that ServiceAccount to be downsynced.
 
 ```shell
-KUBECONFIG=$wmw1_space_config kubectl apply -f - <<EOF
+KUBECONFIG=$WMW1_SPACE_CONFIG kubectl apply -f - <<EOF
 apiVersion: edge.kubestellar.io/v2alpha1
 kind: EdgePlacement
 metadata:
@@ -221,27 +222,13 @@ spec:
 EOF
 ```
 
-Wait for the ServiceAccount to get to the mailbox workspaces.
+Wait for the ServiceAccount to get to the mailbox spaces.
 
 ```shell
-# TODO: the mailbox workspaces have not been converted into spaces yet.
-# Once the mailbox is converted to spaces, this is the code we want to use:
-# MB1_space_config="${PWD}/temp-space-config/spaceprovider-default-${MB1}"
-# kubectl-kubestellar-get-config-for-space --space-name ${MB1} --provider-name default --sm-core-config $SM_CONFIG --sm-context $SM_CONTEXT --space-config-file $MB1_space_config
-# while ! KUBECONFIG=$MB1_space_config kubectl get ServiceAccount -n my-namespace test-sa ; do
-#     sleep 10
-# done
-# MB2_space_config="${PWD}/temp-space-config/spaceprovider-default-${MB2}"
-# kubectl-kubestellar-get-config-for-space --space-name ${MB2} --provider-name default --sm-core-config $SM_CONFIG --sm-context $SM_CONTEXT --space-config-file $MB2_space_config
-# while ! KUBECONFIG=MB2_space_config kubectl get ServiceAccount -n my-namespace test-sa ; do
-#    sleep 10
-# done
-KUBECONFIG=ks-core.kubeconfig kubectl ws root:$MB1
-while ! KUBECONFIG=ks-core.kubeconfig kubectl get ServiceAccount -n my-namespace test-sa ; do
+while ! KUBECONFIG=$MB1_SPACE kubectl get ServiceAccount -n my-namespace test-sa ; do
     sleep 10
 done
-KUBECONFIG=ks-core.kubeconfig kubectl ws root:$MB2
-while ! KUBECONFIG=ks-core.kubeconfig kubectl get ServiceAccount -n my-namespace test-sa ; do
+while ! KUBECONFIG=$MB2_SPACE kubectl get ServiceAccount -n my-namespace test-sa ; do
     sleep 10
 done
 ```
@@ -251,7 +238,7 @@ Thrash the ServiceAccount some in its WDS.
 ```shell
 for key in k1 k2 k3 k4; do
     sleep 15
-    KUBECONFIG=$wmw1_space_config kubectl annotate sa -n my-namespace test-sa ${key}=${key}
+    KUBECONFIG=$WMW1_SPACE_CONFIG kubectl annotate sa -n my-namespace test-sa ${key}=${key}
 done
 ```
 
@@ -265,8 +252,8 @@ Look for excess secrets in the WDS. Expect 2 token Secrets: one for
 the default ServiceAccount and one for `test-sa`.
 
 ```shell
-KUBECONFIG=$wmw1_space_config kubectl get secrets -n my-namespace
-[ $(KUBECONFIG=$wmw1_space_config kubectl get Secret -n my-namespace -o jsonpath='{.items[?(@.type=="kubernetes.io/service-account-token")]}' | jq length | wc -l) -lt 3 ]
+KUBECONFIG=$WMW1_SPACE_CONFIG kubectl get secrets -n my-namespace
+[ $(KUBECONFIG=$WMW1_SPACE_CONFIG kubectl get Secret -n my-namespace -o jsonpath='{.items[?(@.type=="kubernetes.io/service-account-token")]}' | jq length | wc -l) -lt 3 ]
 ```
 
 Look for excess secrets in the two mailbox spaces. Allow up to three:
@@ -275,12 +262,10 @@ for the `test-sa` ServiceAccount, and one generated locally for the
 `test-sa` ServiceAccount.
 
 ```shell
-# TODO: the mailbox workspaces have not been converted into spaces yet.
-for mb in $MB1 $MB2; do
-    KUBECONFIG=ks-core.kubeconfig kubectl ws root:$mb
-    KUBECONFIG=ks-core.kubeconfig kubectl get sa -n my-namespace test-sa --show-managed-fields -o yaml
-    KUBECONFIG=ks-core.kubeconfig kubectl get secrets -n my-namespace
-    [ $(KUBECONFIG=ks-core.kubeconfig kubectl get Secret -n my-namespace -o jsonpath='{.items[?(@.type=="kubernetes.io/service-account-token")]}' | jq length | wc -l) -lt 4 ]
+for mb in $MB1_SPACE $MB2_SPACE; do
+    KUBECONFIG=$mb kubectl get sa -n my-namespace test-sa --show-managed-fields -o yaml
+    KUBECONFIG=$mb kubectl get secrets -n my-namespace
+    [ $(KUBECONFIG=$mb kubectl get Secret -n my-namespace -o jsonpath='{.items[?(@.type=="kubernetes.io/service-account-token")]}' | jq length | wc -l) -lt 4 ]
 done
 ```
 
@@ -357,7 +342,7 @@ how to create, but not overwrite/update a synchronized resource
            -o jsonpath='{.data.external\.kubeconfig}' \
            -n kubestellar | base64 -d > ks-core.kubeconfig
 
-         KUBECONFIG=ks-core.kubeconfig kubectl ws tree
+         KUBECONFIG=$SM_CONFIG kubectl get spaces -A 
          ```
     === "uh oh, error?"
          {%

--- a/docs/content/Getting-Started/user-quickstart-test.md
+++ b/docs/content/Getting-Started/user-quickstart-test.md
@@ -174,9 +174,9 @@ MB2=$(KUBECONFIG=$SM_CONFIG kubectl get spaces -n spaceprovider-default -o json 
 echo The mailbox for ks-edge-cluster2 is $MB2
 
 MB1_SPACE="${PWD}/temp-space-config/${MB1}"
-kubectl-kubestellar-get-config-for-space --space-name $MB1 --provider-name default --sm-core-config $SM_CONFIG --output $MB1_SPACE
+kubectl-kubestellar-get-config-for-space --space-name $MB1 --provider-name default --sm-core-config $SM_CONFIG --sm-context $SM_CONTEXT --output $MB1_SPACE
 MB2_SPACE="${PWD}/temp-space-config/${MB2}"
-kubectl-kubestellar-get-config-for-space --space-name $MB2 --provider-name default --sm-core-config $SM_CONFIG --output $MB2_SPACE
+kubectl-kubestellar-get-config-for-space --space-name $MB2 --provider-name default --sm-core-config $SM_CONFIG --sm-context $SM_CONTEXT --output $MB2_SPACE
 WMW1_SPACE_CONFIG="${PWD}/temp-space-config/spaceprovider-default-wmw1"
 kubectl-kubestellar-get-config-for-space --space-name wmw1 --provider-name default --sm-core-config $SM_CONFIG --sm-context $SM_CONTEXT --output $WMW1_SPACE_CONFIG
 ```

--- a/docs/content/Getting-Started/user-quickstart-test.md
+++ b/docs/content/Getting-Started/user-quickstart-test.md
@@ -119,7 +119,8 @@ export PATH=$PWD/bin:$PATH
 bash -c "$(cat bootstrap/install-kcp-with-plugins.sh)" -V -V --version v0.11.0
 export PATH=$PWD/kcp/bin:$PATH
 export SM_CONFIG=~/.kube/config
-mkdir ${PWD}/temp-space-config
+export SM_CONTEXT=ks-core
+mkdir -p ${PWD}/temp-space-config
 ```
 
 #### 3. View your <span class="Space-Bd-BT">KUBESTELLAR</span> Core Space environment
@@ -177,7 +178,7 @@ kubectl-kubestellar-get-config-for-space --space-name $MB1 --provider-name defau
 MB2_SPACE="${PWD}/temp-space-config/${MB2}"
 kubectl-kubestellar-get-config-for-space --space-name $MB2 --provider-name default --sm-core-config $SM_CONFIG --output $MB2_SPACE
 WMW1_SPACE_CONFIG="${PWD}/temp-space-config/spaceprovider-default-wmw1"
-kubectl-kubestellar-get-config-for-space --space-name wmw1 --provider-name default --sm-core-config $SM_CONFIG --sm-context ks-core --output $WMW1_SPACE_CONFIG
+kubectl-kubestellar-get-config-for-space --space-name wmw1 --provider-name default --sm-core-config $SM_CONFIG --sm-context $SM_CONTEXT --output $WMW1_SPACE_CONFIG
 ```
 
 #### 5. Deploy an Apache Web Server to ks-edge-cluster1 and ks-edge-cluster2

--- a/docs/content/common-subs/kubestellar-apply-apache-kind.md
+++ b/docs/content/common-subs/kubestellar-apply-apache-kind.md
@@ -37,7 +37,7 @@ KUBECONFIG=$WMW1_SPACE_CONFIG kubectl get edgeplacements -n kubestellar -o yaml
 
 Now, apply the HTTP server workload definition into the WMW on **ks-core**. Note the namespace label matches the label in the namespaceSelector for the EdgePlacement (`my-first-edge-placement`) object created above. 
 ```shell hl_lines="5 10 24 25"
-KUBECONFIG=ks-core.kubeconfig kubectl apply -f - <<EOF
+KUBECONFIG=$WMW1_SPACE_CONFIG kubectl apply -f - <<EOF
 apiVersion: v1
 kind: Namespace
 metadata:

--- a/docs/content/common-subs/kubestellar-apply-apache-kind.md
+++ b/docs/content/common-subs/kubestellar-apply-apache-kind.md
@@ -4,11 +4,9 @@ Workspace (WMW) for you to store kubernetes workload descriptions and KubeStella
 
 Create an EdgePlacement control object to direct where your workload runs using the 'location-group=edge' label selector. This label selector's value ensures your workload is directed to both clusters, as they were labeled with 'location-group=edge' when you issued the 'kubestellar prep-for-cluster' command above.
 
-In the `root:wmw1` workspace create the following `EdgePlacement` object: 
+In the `wmw1` space create the following `EdgePlacement` object: 
 ```shell hl_lines="9 10 14 18 19"
-KUBECONFIG=ks-core.kubeconfig kubectl ws root:wmw1
-
-KUBECONFIG=ks-core.kubeconfig kubectl apply -f - <<EOF
+KUBECONFIG=$WMW1_SPACE_CONFIG kubectl apply -f - <<EOF
 apiVersion: edge.kubestellar.io/v2alpha1
 kind: EdgePlacement
 metadata:
@@ -34,8 +32,7 @@ EOF
 
 check if your edgeplacement was applied to the **ks-core** `kubestellar` namespace correctly
 ```shell
-KUBECONFIG=ks-core.kubeconfig kubectl ws root:wmw1
-KUBECONFIG=ks-core.kubeconfig kubectl get edgeplacements -n kubestellar -o yaml
+KUBECONFIG=$WMW1_SPACE_CONFIG kubectl get edgeplacements -n kubestellar -o yaml
 ```
 
 Now, apply the HTTP server workload definition into the WMW on **ks-core**. Note the namespace label matches the label in the namespaceSelector for the EdgePlacement (`my-first-edge-placement`) object created above. 
@@ -94,9 +91,8 @@ EOF
 check if your configmap and deployment was applied to the **ks-core** `my-namespace` namespace correctly
 ```shell
 
-KUBECONFIG=ks-core.kubeconfig kubectl ws root:wmw1
-KUBECONFIG=ks-core.kubeconfig kubectl get deployments/my-first-kubestellar-deployment -n my-namespace -o yaml
-KUBECONFIG=ks-core.kubeconfig kubectl get deployments,cm -n my-namespace
+KUBECONFIG=$WMW1_SPACE_CONFIG kubectl get deployments/my-first-kubestellar-deployment -n my-namespace -o yaml
+KUBECONFIG=$WMW1_SPACE_CONFIG kubectl get deployments,cm -n my-namespace
 ```
 
 <!--kubestellar-apply-apache-kind-end-->

--- a/pkg/mailboxwatch/impl.go
+++ b/pkg/mailboxwatch/impl.go
@@ -96,7 +96,7 @@ func (clw *crossClusterListerWatcher[Scoped, ListType]) OnDelete(obj any) {
 func (clw *crossClusterListerWatcher[Scoped, ListType]) setInclusion(obj any, include bool) {
 	ws := obj.(*tenancyv1a1.Workspace)
 	mbwsName := ws.Name
-	mbwsNameParts := strings.Split(mbwsName, placement.WSNameSep)
+	mbwsNameParts := strings.Split(mbwsName, placement.MBspaceNameSep)
 	if len(mbwsNameParts) != 2 {
 		// Only accept the workspace if its name looks like a mailbox workspace name
 		include = false

--- a/pkg/mailboxwatch/impl_test.go
+++ b/pkg/mailboxwatch/impl_test.go
@@ -246,7 +246,7 @@ func TestMailboxInformer(t *testing.T) {
 				invWSClusterS := fmt.Sprintf("ic%d", invWSNum)
 				syncTargetNum := rand.Intn(int(math.Sqrt(float64(iteration))))
 				syncTargetUID := fmt.Sprintf("beef-%d", syncTargetNum)
-				mbwsName := invWSClusterS + placement.WSNameSep + syncTargetUID
+				mbwsName := invWSClusterS + placement.MBspaceNameSep + syncTargetUID
 				mbwsNum := invWSNum*100 + syncTargetNum
 				mbwsClusterS := fmt.Sprintf("mc%d", mbwsNum)
 				mbwsClusterN := logicalcluster.Name(mbwsClusterS)

--- a/pkg/placement/apiwatch-map-provider.go
+++ b/pkg/placement/apiwatch-map-provider.go
@@ -115,6 +115,10 @@ func (awp *apiWatchProvider) AddReceivers(clusterName string,
 		kcpInformerFactory := kcpinformers.NewSharedScopedInformerFactoryWithOptions(kcpClientset, 0)
 		bindingInformer := kcpInformerFactory.Apis().V1alpha1().APIBindings().Informer()
 
+		doneCh := ctx.Done()
+		apiextFactory.Start(doneCh)
+		kcpInformerFactory.Start(doneCh)
+
 		wpc.informer, wpc.lister, _ = apiwatch.NewAPIResourceInformer(ctx, clusterName, discoveryScopedClient, false, crdInformer, bindingInformer)
 		wpc.informer.AddEventHandler(wpc)
 		go wpc.informer.Run(ctx.Done())

--- a/pkg/placement/declarations.go
+++ b/pkg/placement/declarations.go
@@ -26,8 +26,6 @@ import (
 	k8ssets "k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/klog/v2"
 
-	"github.com/kcp-dev/logicalcluster/v3"
-
 	edgeapi "github.com/kubestellar/kubestellar/pkg/apis/edge/v2alpha1"
 )
 
@@ -101,7 +99,7 @@ type WorkloadProjectionSections struct {
 
 type SinglePlacement = edgeapi.SinglePlacement
 
-type ExternalNamespacedName = Triple[logicalcluster.Name, NamespaceName, ObjectName]
+type ExternalNamespacedName = Triple[string, NamespaceName, ObjectName]
 
 type NamespacedDistributionTuple = Pair[ProjectionModeKey, ExternalNamespacedName /*of downsynced object*/]
 
@@ -314,13 +312,13 @@ type APIMapProvider interface {
 	//AddClient(cluster logicalcluster.Name, client Client[ScopedAPIProvider])
 
 	// Neither receiver is invoked synchronously.
-	AddReceivers(cluster logicalcluster.Name,
+	AddReceivers(cluster string,
 		groupReceiver *MappingReceiverHolder[string /*group name*/, APIGroupInfo],
 		resourceReceiver *MappingReceiverHolder[metav1.GroupResource, ResourceDetails])
 
 	// The receiver values have to be comparable.
 	// Neither receiver is invoked synchronously.
-	RemoveReceivers(cluster logicalcluster.Name,
+	RemoveReceivers(cluster string,
 		groupReceiver *MappingReceiverHolder[string /*group name*/, APIGroupInfo],
 		resourceReceiver *MappingReceiverHolder[metav1.GroupResource, ResourceDetails])
 
@@ -422,10 +420,10 @@ func (rscMode ResourceMode) GoesToEdge() bool {
 }
 
 func SPMailboxWorkspaceName(sp SinglePlacement) string {
-	return sp.Cluster + WSNameSep + string(sp.SyncTargetUID)
+	return sp.Cluster + MBspaceNameSep + string(sp.SyncTargetUID)
 }
 
-const WSNameSep = "-mb-"
+const MBspaceNameSep = "-mb-"
 
 // EventHandler can be given Event objects.
 type EventHandler interface {
@@ -449,6 +447,6 @@ type NamespaceName string
 
 type NamespaceAndDestination = Pair[NamespaceName, SinglePlacement]
 
-type SourceAndDestination = Pair[logicalcluster.Name, SinglePlacement]
+type SourceAndDestination = Pair[string, SinglePlacement]
 
-type NamespacedJoinKeyLessnS = Triple[logicalcluster.Name, metav1.GroupResource, SinglePlacement]
+type NamespacedJoinKeyLessnS = Triple[string, metav1.GroupResource, SinglePlacement]

--- a/pkg/placement/external-name.go
+++ b/pkg/placement/external-name.go
@@ -16,31 +16,10 @@ limitations under the License.
 
 package placement
 
-import (
-	"github.com/kcp-dev/logicalcluster/v3"
-)
-
 // ExternalName identifies a cluster-scoped object of some implicit kind
 type ExternalName struct {
-	// Cluster identifies the cluster.  It is the one-part ID, not a path.
-	Cluster logicalcluster.Name
+	// Cluster identifies the cluster.  It is the space ID.
+	Cluster string
 
 	Name ObjectName
-}
-
-// NewExternalName assumes the given cluster identifier is proper
-func NewExternalName(cluster, name string) ExternalName {
-	return ExternalName{Cluster: logicalcluster.Name(cluster), Name: ObjectName(name)}
-}
-
-func (ExternalName) OfSPLocation(sp SinglePlacement) ExternalName {
-	return ExternalName{Cluster: logicalcluster.Name(sp.Cluster), Name: ObjectName(sp.LocationName)}
-}
-
-func (ExternalName) OfSPTarget(sp SinglePlacement) ExternalName {
-	return ExternalName{Cluster: logicalcluster.Name(sp.Cluster), Name: ObjectName(sp.SyncTargetName)}
-}
-
-func (en ExternalName) String() string {
-	return en.Cluster.String() + ":" + en.Name.String()
 }

--- a/pkg/placement/hash-domain.go
+++ b/pkg/placement/hash-domain.go
@@ -19,8 +19,6 @@ package placement
 import (
 	"hash/crc64"
 
-	"github.com/kcp-dev/logicalcluster/v3"
-
 	edgeapi "github.com/kubestellar/kubestellar/pkg/apis/edge/v2alpha1"
 )
 
@@ -123,19 +121,19 @@ func StringHash(arg string) HashValue { return crc64.Checksum([]byte(arg), ecmaT
 
 var SliceOfStringDomain = NewSliceHashDomain[string](HashDomainString{})
 
-var HashLogicalClusterName = NewTransformHashDomain[logicalcluster.Name, string](func(name logicalcluster.Name) string { return string(name) }, HashDomainString{})
+var HashLogicalClusterName = NewTransformHashDomain[string, string](func(name string) string { return string(name) }, HashDomainString{})
 
 var HashObjectName = NewTransformHashDomain[ObjectName, string](func(name ObjectName) string { return string(name) }, HashDomainString{})
 
-var HashClusterString = PairHashDomain[logicalcluster.Name, string](HashLogicalClusterName, HashDomainString{})
+var HashClusterString = PairHashDomain[string, string](HashLogicalClusterName, HashDomainString{})
 
-var HashClusterObjectName = PairHashDomain[logicalcluster.Name, ObjectName](HashLogicalClusterName, HashObjectName)
+var HashClusterObjectName = PairHashDomain[string, ObjectName](HashLogicalClusterName, HashObjectName)
 
 var factorExternalName = NewFactorer(
-	func(whole ExternalName) Pair[logicalcluster.Name, ObjectName] {
+	func(whole ExternalName) Pair[string, ObjectName] {
 		return NewPair(whole.Cluster, whole.Name)
 	},
-	func(parts Pair[logicalcluster.Name, ObjectName]) ExternalName {
+	func(parts Pair[string, ObjectName]) ExternalName {
 		return ExternalName{parts.First, parts.Second}
 	})
 

--- a/pkg/placement/rotations_test.go
+++ b/pkg/placement/rotations_test.go
@@ -25,8 +25,6 @@ import (
 	machtypes "k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/uuid"
 
-	"github.com/kcp-dev/logicalcluster/v3"
-
 	edgeapi "github.com/kubestellar/kubestellar/pkg/apis/edge/v2alpha1"
 )
 
@@ -182,8 +180,8 @@ func (generator) String() string {
 	return builder.String()
 }
 
-func (gen generator) ClusterName() logicalcluster.Name {
-	return logicalcluster.Name(gen.String())
+func (gen generator) ClusterName() string {
+	return gen.String()
 }
 
 func (gen generator) NamespaceName() NamespaceName {

--- a/pkg/placement/set-binder-assembly.go
+++ b/pkg/placement/set-binder-assembly.go
@@ -21,8 +21,6 @@ import (
 
 	"k8s.io/klog/v2"
 
-	"github.com/kcp-dev/logicalcluster/v3"
-
 	edgeapi "github.com/kubestellar/kubestellar/pkg/apis/edge/v2alpha1"
 )
 
@@ -40,7 +38,7 @@ type setBinder struct {
 	downsyncPartsDifferencerConstructor DownsyncsDifferencerConstructor
 	upsyncsDifferenceConstructor        UpsyncsDifferenceConstructor
 	resolvedWhereDifferencerConstructor ResolvedWhereDifferencerConstructor
-	perCluster                          map[logicalcluster.Name]*setBindingForCluster
+	perCluster                          map[string]*setBindingForCluster
 	singleBinder                        SingleBinder
 	downsyncJoinLeftInput               MappingReceiver[Pair[ExternalName, WorkloadPartID], WorkloadPartDetails]
 	bothJoinRightInput                  SetWriter[Pair[ExternalName, SinglePlacement]]
@@ -51,7 +49,7 @@ type setBinder struct {
 
 type setBindingForCluster struct {
 	*setBinder
-	cluster      logicalcluster.Name
+	cluster      string
 	perPlacement map[ObjectName]*setBindingForPlacement
 }
 
@@ -84,7 +82,7 @@ func NewSetBinder(
 			downsyncPartsDifferencerConstructor: downsyncPartsDifferencerConstructor,
 			upsyncsDifferenceConstructor:        upsyncsDifferenceConstructor,
 			resolvedWhereDifferencerConstructor: resolvedWhereDifferencerConstructor,
-			perCluster:                          map[logicalcluster.Name]*setBindingForCluster{},
+			perCluster:                          map[string]*setBindingForCluster{},
 			singleBinder:                        singleBinder,
 		}
 
@@ -193,7 +191,7 @@ func (sb sbAsResolvedWhereReceiver) Delete(epName ExternalName) {
 	})
 }
 
-func (sb *setBinder) getCluster(cluster logicalcluster.Name, want bool) *setBindingForCluster {
+func (sb *setBinder) getCluster(cluster string, want bool) *setBindingForCluster {
 	sbc := sb.perCluster[cluster]
 	if sbc == nil && want {
 		sbc = &setBindingForCluster{

--- a/pkg/placement/set-binder-test.go
+++ b/pkg/placement/set-binder-test.go
@@ -23,8 +23,6 @@ import (
 	apimachtypes "k8s.io/apimachinery/pkg/types"
 	"k8s.io/klog/v2"
 
-	"github.com/kcp-dev/logicalcluster/v3"
-
 	edgeapi "github.com/kubestellar/kubestellar/pkg/apis/edge/v2alpha1"
 )
 
@@ -33,7 +31,7 @@ import (
 // invoke this from TestFoo (or whatever).
 // At the current state of development, the test is utterly simple.
 // TODO: make this test harder.
-func exerciseSetBinder(t *testing.T, logger klog.Logger, resourceDiscoveryReceiver MappingReceiver[Pair[logicalcluster.Name, metav1.GroupResource], ResourceDetails], binder SetBinder) {
+func exerciseSetBinder(t *testing.T, logger klog.Logger, resourceDiscoveryReceiver MappingReceiver[Pair[string, metav1.GroupResource], ResourceDetails], binder SetBinder) {
 	gr1 := metav1.GroupResource{
 		Group:    "apiextensions.k8s.io",
 		Resource: "customresourcedefinitions"}
@@ -60,7 +58,7 @@ func exerciseSetBinder(t *testing.T, logger klog.Logger, resourceDiscoveryReceiv
 	ups2 := []edgeapi.UpsyncSet{
 		ups1[0],
 		{APIGroup: "group3.test", Resources: []string{"widgets"}, Names: []string{"*"}}}
-	sc1 := logicalcluster.Name("wm1")
+	sc1 := "wm1"
 	ep1Ref := ExternalName{Cluster: sc1, Name: "ep1"}
 	spA := SinglePlacement{
 		Cluster:        "inv1",

--- a/pkg/placement/what-resolver.go
+++ b/pkg/placement/what-resolver.go
@@ -23,7 +23,8 @@ import (
 	"time"
 
 	apiext "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
-	apiextkcpinformers "k8s.io/apiextensions-apiserver/pkg/client/kcp/informers/externalversions/apiextensions/v1"
+	apiextclient "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
+	apiextinfactory "k8s.io/apiextensions-apiserver/pkg/client/informers/externalversions"
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	k8sapierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -32,17 +33,16 @@ import (
 	schema "k8s.io/apimachinery/pkg/runtime/schema"
 	k8ssets "k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/discovery"
+	"k8s.io/client-go/dynamic"
 	kubedynamicinformer "k8s.io/client-go/dynamic/dynamicinformer"
 	upstreamcache "k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/util/workqueue"
 	"k8s.io/klog/v2"
 
-	kcpcache "github.com/kcp-dev/apimachinery/v2/pkg/cache"
-	clusterdiscovery "github.com/kcp-dev/client-go/discovery"
-	clusterdynamic "github.com/kcp-dev/client-go/dynamic"
 	apisv1alpha1 "github.com/kcp-dev/kcp/pkg/apis/apis/v1alpha1"
-	bindinginformers "github.com/kcp-dev/kcp/pkg/client/informers/externalversions/apis/v1alpha1"
-	"github.com/kcp-dev/logicalcluster/v3"
+	kcpclientset "github.com/kcp-dev/kcp/pkg/client/clientset/versioned"
+	kcpinformers "github.com/kcp-dev/kcp/pkg/client/informers/externalversions"
 
 	edgeapi "github.com/kubestellar/kubestellar/pkg/apis/edge/v2alpha1"
 	ksmetav1a1 "github.com/kubestellar/kubestellar/pkg/apis/meta/v1alpha1"
@@ -50,6 +50,7 @@ import (
 	edgev2alpha1informers "github.com/kubestellar/kubestellar/pkg/client/informers/externalversions/edge/v2alpha1"
 	edgev2alpha1listers "github.com/kubestellar/kubestellar/pkg/client/listers/edge/v2alpha1"
 	"github.com/kubestellar/kubestellar/pkg/kbuser"
+	msclient "github.com/kubestellar/kubestellar/space-framework/pkg/msclientlib"
 )
 
 type whatResolver struct {
@@ -62,17 +63,15 @@ type whatResolver struct {
 	edgePlacementInformer upstreamcache.SharedIndexInformer
 	edgePlacementLister   edgev2alpha1listers.EdgePlacementLister
 
-	discoveryClusterClient    clusterdiscovery.DiscoveryClusterInterface
-	crdClusterPreInformer     apiextkcpinformers.CustomResourceDefinitionClusterInformer
-	bindingClusterPreInformer bindinginformers.APIBindingClusterInformer
-	dynamicClusterClient      clusterdynamic.ClusterInterface
-	kbSpaceRelation           kbuser.KubeBindSpaceRelation
+	spaceclient     msclient.KubestellarSpaceInterface
+	spaceProviderNs string
+	kbSpaceRelation kbuser.KubeBindSpaceRelation
 
 	// Hold this while accessing data listed below
 	sync.Mutex
 
 	// workspaceDetails maps lc.Name of a workload LC (WDS) to all the relevant information for that LC.
-	workspaceDetails map[logicalcluster.Name]*workspaceDetails
+	workspaceDetails map[string]*workspaceDetails
 }
 
 // workspaceDetails holds the data for a given WDS
@@ -119,10 +118,8 @@ type objectDetails struct {
 func NewWhatResolver(
 	ctx context.Context,
 	edgePlacementPreInformer edgev2alpha1informers.EdgePlacementInformer,
-	discoveryClusterClient clusterdiscovery.DiscoveryClusterInterface,
-	crdClusterPreInformer apiextkcpinformers.CustomResourceDefinitionClusterInformer,
-	bindingClusterPreInformer bindinginformers.APIBindingClusterInformer,
-	dynamicClusterClient clusterdynamic.ClusterInterface,
+	spaceclient msclient.KubestellarSpaceInterface,
+	spaceProviderNs string,
 	kbSpaceRelation kbuser.KubeBindSpaceRelation,
 	numThreads int,
 ) WhatResolver {
@@ -130,18 +127,16 @@ func NewWhatResolver(
 	logger := klog.FromContext(ctx).WithValues("part", controllerName)
 	ctx = klog.NewContext(ctx, logger)
 	wr := &whatResolver{
-		ctx:                       ctx,
-		logger:                    logger,
-		numThreads:                numThreads,
-		queue:                     workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), controllerName),
-		edgePlacementInformer:     edgePlacementPreInformer.Informer(),
-		edgePlacementLister:       edgePlacementPreInformer.Lister(),
-		discoveryClusterClient:    discoveryClusterClient,
-		crdClusterPreInformer:     crdClusterPreInformer,
-		bindingClusterPreInformer: bindingClusterPreInformer,
-		dynamicClusterClient:      dynamicClusterClient,
-		kbSpaceRelation:           kbSpaceRelation,
-		workspaceDetails:          map[logicalcluster.Name]*workspaceDetails{},
+		ctx:                   ctx,
+		logger:                logger,
+		numThreads:            numThreads,
+		queue:                 workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), controllerName),
+		edgePlacementInformer: edgePlacementPreInformer.Informer(),
+		edgePlacementLister:   edgePlacementPreInformer.Lister(),
+		spaceclient:           spaceclient,
+		spaceProviderNs:       spaceProviderNs,
+		kbSpaceRelation:       kbSpaceRelation,
+		workspaceDetails:      map[string]*workspaceDetails{},
 	}
 	return func(receiver MappingReceiver[ExternalName, ResolvedWhat]) Runnable {
 		wr.receiver = receiver
@@ -167,7 +162,7 @@ func (wr *whatResolver) Run(ctx context.Context) {
 
 type namespacedQueueItem struct {
 	GK      schema.GroupKind
-	Cluster logicalcluster.Name
+	Cluster string
 	NN      NamespacedName
 }
 
@@ -189,19 +184,20 @@ func (wrh WhatResolverClusterHandler) OnDelete(obj any) {
 }
 
 func (wr *whatResolver) enqueue(gk schema.GroupKind, objAny any) {
-	key, err := kcpcache.DeletionHandlingMetaClusterNamespaceKeyFunc(objAny)
+	key, err := upstreamcache.DeletionHandlingMetaNamespaceKeyFunc(objAny)
 	if err != nil {
 		wr.logger.Error(err, "Failed to extract object reference", "object", objAny)
 		return
 	}
-	cluster, namespace, name, err := kcpcache.SplitMetaClusterNamespaceKey(key)
+	namespace, name, err := upstreamcache.SplitMetaNamespaceKey(key)
 	if err != nil {
 		wr.logger.Error(err, "Impossible! SplitMetaClusterNamespaceKey failed", "key", key)
 	}
 	if namespace != "" {
 		panic("Namespace must be empty here")
 	}
-	item := namespacedQueueItem{GK: gk, Cluster: cluster, NN: NewPair(NamespaceName(metav1.NamespaceNone), ObjectName(name))}
+	// Enqueuewith empty cluster. Set it later
+	item := namespacedQueueItem{GK: gk, Cluster: "", NN: NewPair(NamespaceName(metav1.NamespaceNone), ObjectName(name))}
 	wr.logger.V(4).Info("Enqueuing", "item", item)
 	wr.queue.Add(item)
 }
@@ -209,7 +205,7 @@ func (wr *whatResolver) enqueue(gk schema.GroupKind, objAny any) {
 type WhatResolverScopedHandler struct {
 	*whatResolver
 	gk      schema.GroupKind
-	cluster logicalcluster.Name
+	cluster string
 }
 
 func (wrh WhatResolverScopedHandler) OnAdd(obj any) {
@@ -224,7 +220,7 @@ func (wrh WhatResolverScopedHandler) OnDelete(obj any) {
 	wrh.enqueueScoped(wrh.gk, wrh.cluster, obj)
 }
 
-func (wr *whatResolver) enqueueScoped(gk schema.GroupKind, cluster logicalcluster.Name, objAny any) {
+func (wr *whatResolver) enqueueScoped(gk schema.GroupKind, cluster string, objAny any) {
 	key, err := upstreamcache.DeletionHandlingMetaNamespaceKeyFunc(objAny)
 	if err != nil {
 		wr.logger.Error(err, "Failed to extract object reference", "object", objAny)
@@ -240,7 +236,7 @@ func (wr *whatResolver) enqueueScoped(gk schema.GroupKind, cluster logicalcluste
 	wr.queue.Add(item)
 }
 
-func (wr *whatResolver) getPartsLocked(wldCluster logicalcluster.Name, epName ObjectName) ResolvedWhat {
+func (wr *whatResolver) getPartsLocked(wldCluster string, epName ObjectName) ResolvedWhat {
 	parts := WorkloadParts{}
 	var upsyncs []edgeapi.UpsyncSet
 	wsDetails, found := wr.workspaceDetails[wldCluster]
@@ -295,14 +291,14 @@ var definerKindToPieces = map[string]Pair[metav1.GroupResource, WorkloadPartDeta
 	"APIBinding":               NewPair(metav1.GroupResource{Group: apisv1alpha1.SchemeGroupVersion.Group, Resource: "apibindings"}, WorkloadPartDetails{APIVersion: apisv1alpha1.SchemeGroupVersion.Version}),
 }
 
-func (wr *whatResolver) notifyReceiversOfPlacements(cluster logicalcluster.Name, placements Set[ObjectName]) {
+func (wr *whatResolver) notifyReceiversOfPlacements(cluster string, placements Set[ObjectName]) {
 	placements.Visit(func(epName ObjectName) error {
 		wr.notifyReceivers(cluster, epName)
 		return nil
 	})
 }
 
-func (wr *whatResolver) notifyReceivers(wldCluster logicalcluster.Name, epName ObjectName) {
+func (wr *whatResolver) notifyReceivers(wldCluster string, epName ObjectName) {
 	resolvedWhat := wr.getPartsLocked(wldCluster, epName)
 	epRef := ExternalName{Cluster: wldCluster, Name: epName}
 	wr.receiver.Put(epRef, resolvedWhat)
@@ -348,7 +344,7 @@ func (wr *whatResolver) process(ctx context.Context, item namespacedQueueItem) b
 }
 
 // process returns true on success or unrecoverable error, false to retry
-func (wr *whatResolver) processCenterObject(ctx context.Context, cluster logicalcluster.Name, gk schema.GroupKind, objName NamespacedName) bool {
+func (wr *whatResolver) processCenterObject(ctx context.Context, cluster string, gk schema.GroupKind, objName NamespacedName) bool {
 	logger := klog.FromContext(ctx)
 	wr.Lock()
 	defer wr.Unlock()
@@ -414,7 +410,7 @@ func newObjectDetails() *objectDetails {
 }
 
 // process returns true on success or unrecoverable error, false to retry
-func (wr *whatResolver) processResource(ctx context.Context, cluster logicalcluster.Name, arName string) bool {
+func (wr *whatResolver) processResource(ctx context.Context, cluster string, arName string) bool {
 	logger := klog.FromContext(ctx)
 	wr.Lock()
 	defer wr.Unlock()
@@ -517,32 +513,56 @@ func (wr *whatResolver) processEdgePlacement(ctx context.Context, epName ObjectN
 	//change to consumer SpaceID
 	_, epOriginalName, kbSpaceID, err := kbuser.AnalyzeObjectID(ep)
 	if err != nil {
-		logger.Error(err, "object does not appear to be a provider's copy of a consumer's object")
+		logger.Error(err, "Object does not appear to be a provider's copy of a consumer's object")
 		return true
 	}
 	spaceID := wr.kbSpaceRelation.SpaceIDFromKubeBind(kbSpaceID)
 	if spaceID == "" {
-		logger.Error(nil, "failed to get consumer space ID from a provider's copy")
+		logger.Error(nil, "Failed to get consumer space ID from a provider's copy")
 		return false
 	}
-	cluster := logicalcluster.Name(spaceID)
 	epName = ObjectName(epOriginalName)
 
 	wr.Lock()
 	defer wr.Unlock()
-	wsDetails, wsDetailsFound := wr.workspaceDetails[cluster]
+	wsDetails, wsDetailsFound := wr.workspaceDetails[spaceID]
 	if !wsDetailsFound {
 		if !epFound {
 			logger.V(4).Info(`Both workspaceDetails and EdgePlacement were not found`)
 			return true
 		}
+		config, err := wr.spaceclient.ConfigForSpace(spaceID, wr.spaceProviderNs)
+		if err != nil {
+			logger.Error(err, "Failed to get space config", "space", spaceID)
+			return true
+		}
+		discoveryScopedClient, err := discovery.NewDiscoveryClientForConfig(config)
+		if err != nil {
+			logger.Error(err, "Failed to create discovery client", "space", spaceID)
+			return true
+		}
+		scopedDynamic, err := dynamic.NewForConfig(config)
+		if err != nil {
+			logger.Error(err, "Failed to create dynamic client", "space", spaceID)
+			return true
+		}
+		apiextClient, err := apiextclient.NewForConfig(config)
+		if err != nil {
+			logger.Error(err, "Failed to create clientset for CustomResourceDefinitions")
+		}
+		apiextFactory := apiextinfactory.NewSharedInformerFactory(apiextClient, 0)
+		crdInformer := apiextFactory.Apiextensions().V1().CustomResourceDefinitions().Informer()
+		kcpClientset, err := kcpclientset.NewForConfig(config)
+		if err != nil {
+			logger.Error(err, "Failed to create clientset for kcp APIs")
+		}
+		kcpInformerFactory := kcpinformers.NewSharedScopedInformerFactoryWithOptions(kcpClientset, 0)
+		bindingInformer := kcpInformerFactory.Apis().V1alpha1().APIBindings().Informer()
+
 		wsCtx, stopWS := context.WithCancel(wr.ctx)
-		discoveryScopedClient := wr.discoveryClusterClient.Cluster(cluster.Path())
-		crdInformer := wr.crdClusterPreInformer.Cluster(cluster).Informer()
-		bindingInformer := wr.bindingClusterPreInformer.Cluster(cluster).Informer()
-		apiInformer, apiLister, _ := apiwatch.NewAPIResourceInformer(wsCtx, cluster.String(), discoveryScopedClient, false,
+
+		apiInformer, apiLister, _ := apiwatch.NewAPIResourceInformer(wsCtx, spaceID, discoveryScopedClient, false,
 			apiwatch.CRDAnalyzer{ObjectNotifier: crdInformer}, apiwatch.APIBindingAnalyzer{ObjectNotifier: bindingInformer})
-		scopedDynamic := wr.dynamicClusterClient.Cluster(cluster.Path())
 		dynamicInformerFactory := kubedynamicinformer.NewDynamicSharedInformerFactory(scopedDynamic, 0)
 		wsDetails = &workspaceDetails{
 			ctx:                    wsCtx,
@@ -554,9 +574,9 @@ func (wr *whatResolver) processEdgePlacement(ctx context.Context, epName ObjectN
 			resources:              map[string]*resourceResolver{},
 			gkToARName:             map[schema.GroupKind]string{},
 		}
-		wr.workspaceDetails[cluster] = wsDetails
-		apiInformer.AddEventHandler(WhatResolverScopedHandler{wr, mkgk(ksmetav1a1.SchemeGroupVersion.Group, "APIResource"), cluster})
-		logger.V(2).Info("Started watching logical cluster")
+		wr.workspaceDetails[spaceID] = wsDetails
+		apiInformer.AddEventHandler(WhatResolverScopedHandler{wr, mkgk(ksmetav1a1.SchemeGroupVersion.Group, "APIResource"), spaceID})
+		logger.V(2).Info("Started watching space")
 		go apiInformer.Run(wsCtx.Done())
 		dynamicInformerFactory.Start(wsCtx.Done())
 		if !upstreamcache.WaitForCacheSync(wsCtx.Done(), apiInformer.HasSynced) {
@@ -582,12 +602,12 @@ func (wr *whatResolver) processEdgePlacement(ctx context.Context, epName ObjectN
 		logger.V(3).Info("Stopped watching EdgePlacement")
 		if len(wsDetails.placements) == 0 {
 			wsDetails.stop()
-			logger.V(2).Info("Stopped watching logical cluster")
-			delete(wr.workspaceDetails, cluster)
+			logger.V(2).Info("Stopped watching space")
+			delete(wr.workspaceDetails, spaceID)
 		} else {
-			wr.notifyReceivers(cluster, epName)
+			wr.notifyReceivers(spaceID, epName)
 		}
-		wr.notifyReceivers(cluster, epName)
+		wr.notifyReceivers(spaceID, epName)
 		return true
 	}
 	// Now we know that ep != nil
@@ -633,7 +653,7 @@ func (wr *whatResolver) processEdgePlacement(ctx context.Context, epName ObjectN
 	}
 	logger.V(5).Info("Finished looping over resources", "numResources", len(wsDetails.resources))
 	if anyChange {
-		wr.notifyReceivers(cluster, epName)
+		wr.notifyReceivers(spaceID, epName)
 	}
 	return completeSuccess
 }

--- a/pkg/placement/where-resolver_test.go
+++ b/pkg/placement/where-resolver_test.go
@@ -26,8 +26,6 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 	fakeupkube "k8s.io/client-go/kubernetes/fake"
 
-	"github.com/kcp-dev/logicalcluster/v3"
-
 	edgeapi "github.com/kubestellar/kubestellar/pkg/apis/edge/v2alpha1"
 	fakeedge "github.com/kubestellar/kubestellar/pkg/client/clientset/versioned/fake"
 	edgeinformers "github.com/kubestellar/kubestellar/pkg/client/informers/externalversions"
@@ -41,15 +39,14 @@ func TestWhereResolver(t *testing.T) {
 		ctx, cancel = context.WithDeadline(ctx, deadline)
 		t.Cleanup(cancel)
 	}
-	is1N := logicalcluster.Name("is1clusterid")
-	wds1N := logicalcluster.Name("wds1clusterid")
+	is1N := "is1clusterid"
+	wds1N := "wds1clusterid"
 	// wantedLabels := map[string]string{"foo":"bar"}
-	sp1 := SinglePlacement{Cluster: is1N.String(), LocationName: "l1", SyncTargetName: "s1", SyncTargetUID: "s1uid"}
+	sp1 := SinglePlacement{Cluster: is1N, LocationName: "l1", SyncTargetName: "s1", SyncTargetUID: "s1uid"}
 	sps1 := &edgeapi.SinglePlacementSlice{
 		TypeMeta: metav1.TypeMeta{Kind: "SinglePlacementSlice", APIVersion: edgeapi.SchemeGroupVersion.String()},
 		ObjectMeta: metav1.ObjectMeta{
-			Annotations: map[string]string{logicalcluster.AnnotationKey: wds1N.String()},
-			Name:        "ep1",
+			Name: "ep1",
 		},
 		Destinations: []edgeapi.SinglePlacement{sp1},
 	}

--- a/pkg/where-resolver/reconcile_on_edgeplacement.go
+++ b/pkg/where-resolver/reconcile_on_edgeplacement.go
@@ -86,12 +86,12 @@ func (c *controller) reconcileOnEdgePlacement(ctx context.Context, epKey string)
 	singles := []edgev2alpha1.SinglePlacement{}
 	for _, loc := range locsFilteredByEp {
 		// 2)
-		stsInLws, err := c.synctargetLister.List(labels.Everything())
+		allSts, err := c.synctargetLister.List(labels.Everything())
 		if err != nil {
 			logger.Error(err, "Failed to list SyncTargets in local cache")
 			return err
 		}
-		stsSelecting, err := filterStsByLoc(stsInLws, loc)
+		stsSelecting, err := filterStsByLoc(allSts, loc)
 		if err != nil {
 			logger.Error(err, "failed to find SyncTargets for Location", "location", loc.Name)
 			return err

--- a/pkg/where-resolver/reconcile_on_edgeplacement.go
+++ b/pkg/where-resolver/reconcile_on_edgeplacement.go
@@ -23,23 +23,22 @@ import (
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/client-go/tools/cache"
 	"k8s.io/klog/v2"
 
-	kcpcache "github.com/kcp-dev/apimachinery/v2/pkg/cache"
-	"github.com/kcp-dev/logicalcluster/v3"
-
 	edgev2alpha1 "github.com/kubestellar/kubestellar/pkg/apis/edge/v2alpha1"
+	edgeclientset "github.com/kubestellar/kubestellar/pkg/client/clientset/versioned"
 	"github.com/kubestellar/kubestellar/pkg/kbuser"
 )
 
 func (c *controller) reconcileOnEdgePlacement(ctx context.Context, epKey string) error {
 	logger := klog.FromContext(ctx)
-	epws, _, epName, err := kcpcache.SplitMetaClusterNamespaceKey(epKey)
+	_, epName, err := cache.SplitMetaNamespaceKey(epKey)
 	if err != nil {
 		logger.Error(err, "invalid EdgePlacement key")
 		return err
 	}
-	logger = logger.WithValues("workspace", epws, "edgePlacement", epName)
+	logger = logger.WithValues("edgePlacement", epName)
 	ctx = klog.NewContext(ctx, logger)
 	logger.V(2).Info("reconciling")
 
@@ -87,15 +86,14 @@ func (c *controller) reconcileOnEdgePlacement(ctx context.Context, epKey string)
 	singles := []edgev2alpha1.SinglePlacement{}
 	for _, loc := range locsFilteredByEp {
 		// 2)
-		lws := logicalcluster.From(loc)
 		stsInLws, err := c.synctargetLister.List(labels.Everything())
 		if err != nil {
-			logger.Error(err, "failed to list SyncTargets in Location workspace", "locationWorkspace", lws.String())
+			logger.Error(err, "Failed to list SyncTargets in local cache")
 			return err
 		}
 		stsSelecting, err := filterStsByLoc(stsInLws, loc)
 		if err != nil {
-			logger.Error(err, "failed to find SyncTargets for Location", "locationWorkspace", lws.String(), "location", loc.Name)
+			logger.Error(err, "failed to find SyncTargets for Location", "location", loc.Name)
 			return err
 		}
 		singles = append(singles, c.makeSinglePlacementsForLoc(loc, stsSelecting)...)
@@ -118,16 +116,25 @@ func (c *controller) reconcileOnEdgePlacement(ctx context.Context, epKey string)
 	// 4)
 	_, originalName, kbSpaceID, err := kbuser.AnalyzeObjectID(ep)
 	if err != nil {
-		logger.Error(err, "object does not appear to be a provider's copy of a consumer's object", "edgePlacement", ep.Name)
+		logger.Error(err, "Object does not appear to be a provider's copy of a consumer's object", "edgePlacement", ep.Name)
 		return err
 	}
 	spaceID := c.kbSpaceRelation.SpaceIDFromKubeBind(kbSpaceID)
 	if spaceID == "" {
 		relErr := errors.New("failed to obtain space ID from kube-bind reference")
-		logger.Error(relErr, "failed to get consumer space ID from a provider's copy", "edgePlacement", originalName)
+		logger.Error(relErr, "Failed to get consumer space ID from a provider's copy", "edgePlacement", originalName)
 		return relErr
 	}
-	originalEP, err := c.edgeClusterClient.Cluster(logicalcluster.NewPath(spaceID)).EdgeV2alpha1().EdgePlacements().Get(ctx, originalName, metav1.GetOptions{})
+
+	spaceConfig, err := c.spaceClient.ConfigForSpace(spaceID, c.spaceProviderNs)
+	if err != nil {
+		return err
+	}
+	edgeClientset, err := edgeclientset.NewForConfig(spaceConfig)
+	if err != nil {
+		return err
+	}
+	originalEP, err := edgeClientset.EdgeV2alpha1().EdgePlacements().Get(ctx, originalName, metav1.GetOptions{})
 	if err != nil {
 		logger.Error(err, "failed to get consumer's object", "edgePlacement", originalName)
 		return err
@@ -150,7 +157,7 @@ func (c *controller) reconcileOnEdgePlacement(ctx context.Context, epKey string)
 				},
 				Destinations: singles,
 			}
-			_, err = c.edgeClusterClient.Cluster(logicalcluster.NewPath(spaceID)).EdgeV2alpha1().SinglePlacementSlices().Create(ctx, sps, metav1.CreateOptions{})
+			_, err = edgeClientset.EdgeV2alpha1().SinglePlacementSlices().Create(ctx, sps, metav1.CreateOptions{})
 			if err != nil {
 				if !k8serrors.IsAlreadyExists(err) {
 					logger.Error(err, "failed creating SinglePlacementSlice")

--- a/pkg/where-resolver/reconcile_on_location.go
+++ b/pkg/where-resolver/reconcile_on_location.go
@@ -26,23 +26,22 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/cache"
 	"k8s.io/klog/v2"
 
-	kcpcache "github.com/kcp-dev/apimachinery/v2/pkg/cache"
-	"github.com/kcp-dev/logicalcluster/v3"
-
 	edgev2alpha1 "github.com/kubestellar/kubestellar/pkg/apis/edge/v2alpha1"
+	edgeclientset "github.com/kubestellar/kubestellar/pkg/client/clientset/versioned"
 	"github.com/kubestellar/kubestellar/pkg/kbuser"
 )
 
 func (c *controller) reconcileOnLocation(ctx context.Context, locKey string) error {
 	logger := klog.FromContext(ctx)
-	lws, _, lName, err := kcpcache.SplitMetaClusterNamespaceKey(locKey)
+	_, lName, err := cache.SplitMetaNamespaceKey(locKey)
 	if err != nil {
 		logger.Error(err, "invalid Location key")
 		return err
 	}
-	logger = logger.WithValues("locationWorkspace", lws, "location", lName)
+	logger = logger.WithValues("location", lName)
 	logger.V(2).Info("reconciling")
 
 	/*
@@ -156,14 +155,14 @@ func (c *controller) reconcileOnLocation(ctx context.Context, locKey string) err
 			// an (obsolete) ep doesn't select loc anymore
 			// we need to remove all relevant sp(s) from the corresponding sps where 'relevant' means an sp has loc
 			logger.V(1).Info("stop selecting Location", "edgePlacement", ep)
-			ws, _, name, err := kcpcache.SplitMetaClusterNamespaceKey(ep)
+			_, name, err := cache.SplitMetaNamespaceKey(ep)
 			if err != nil {
 				logger.Error(err, "invalid EdgePlacement key")
 				return err
 			}
 			currentSPS, err := c.singlePlacementSliceLister.Get(name)
 			if err != nil {
-				logger.Error(err, "failed to get SinglePlacementSlice", "workloadWorkspace", ws, "singlePlacementSlice", name)
+				logger.Error(err, "failed to get SinglePlacementSlice", "singlePlacementSlice", name)
 				return err
 			}
 			// get consumer's space ID by currentSPS
@@ -176,10 +175,10 @@ func (c *controller) reconcileOnLocation(ctx context.Context, locKey string) err
 			nextSPS := cleanSPSByLoc(currentSPS, locSpaceID, locOriginalName)
 			err = c.patchSpsDestinations(nextSPS.Destinations, spaceID, originalName)
 			if err != nil {
-				logger.Error(err, "failed to update SinglePlacementSlice", "workloadWorkspace", ws, "singlePlacementSlice", nextSPS.Name)
+				logger.Error(err, "failed to update SinglePlacementSlice", "singlePlacementSlice", nextSPS.Name)
 				return err
 			} else {
-				logger.V(1).Info("updated SinglePlacementSlice", "workloadWorkspace", ws, "singlePlacementSlice", nextSPS.Name)
+				logger.V(1).Info("updated SinglePlacementSlice", "singlePlacementSlice", nextSPS.Name)
 			}
 		} else {
 			// 4b)
@@ -188,14 +187,14 @@ func (c *controller) reconcileOnLocation(ctx context.Context, locKey string) err
 			// the two sets of synctargets may or may not overlap
 			// thus, we need to clean then extend the corresponding sps
 			logger.V(1).Info("continue to select Location", "edgePlacement", ep)
-			ws, _, name, err := kcpcache.SplitMetaClusterNamespaceKey(ep)
+			_, name, err := cache.SplitMetaNamespaceKey(ep)
 			if err != nil {
 				logger.Error(err, "invalid EdgePlacement key")
 				return err
 			}
 			currentSPS, err := c.singlePlacementSliceLister.Get(name)
 			if err != nil {
-				logger.Error(err, "failed to get SinglePlacementSlice", "workloadWorkspace", ws, "singlePlacementSlice", name)
+				logger.Error(err, "failed to get SinglePlacementSlice", "singlePlacementSlice", name)
 				return err
 			}
 			// get consumer's space ID by currentSPS
@@ -208,10 +207,10 @@ func (c *controller) reconcileOnLocation(ctx context.Context, locKey string) err
 			nextSPS = extendSPS(nextSPS, singles)
 			err = c.patchSpsDestinations(nextSPS.Destinations, spaceID, originalName)
 			if err != nil {
-				logger.Error(err, "failed to update SinglePlacementSlice", "workloadWorkspace", ws, "singlePlacementSlice", nextSPS.Name)
+				logger.Error(err, "failed to update SinglePlacementSlice", "singlePlacementSlice", nextSPS.Name)
 				return err
 			} else {
-				logger.V(1).Info("updated SinglePlacementSlice", "workloadWorkspace", ws, "singlePlacementSlice", nextSPS.Name)
+				logger.V(1).Info("updated SinglePlacementSlice", "singlePlacementSlice", nextSPS.Name)
 			}
 		}
 	}
@@ -222,14 +221,14 @@ func (c *controller) reconcileOnLocation(ctx context.Context, locKey string) err
 			// a (new) ep begins to select loc
 			// we need to ensure the existence of sp(s) in the corresponding sps
 			logger.V(1).Info("begin to select Location", "edgePlacement", ep)
-			ws, _, name, err := kcpcache.SplitMetaClusterNamespaceKey(ep)
+			_, name, err := cache.SplitMetaNamespaceKey(ep)
 			if err != nil {
 				logger.Error(err, "invalid EdgePlacement key")
 				return err
 			}
 			currentSPS, err := c.singlePlacementSliceLister.Get(name)
 			if err != nil {
-				logger.Error(err, "failed to get SinglePlacementSlice", "workloadWorkspace", ws, "singlePlacementSlice", name)
+				logger.Error(err, "failed to get SinglePlacementSlice", "singlePlacementSlice", name)
 				return err
 			}
 			// get consumer's space ID by currentSPS
@@ -243,10 +242,10 @@ func (c *controller) reconcileOnLocation(ctx context.Context, locKey string) err
 			nextSPS = extendSPS(nextSPS, singles)
 			err = c.patchSpsDestinations(nextSPS.Destinations, spaceID, originalName)
 			if err != nil {
-				logger.Error(err, "failed to update SinglePlacementSlice", "workloadWorkspace", ws, "singlePlacementSlice", nextSPS.Name)
+				logger.Error(err, "failed to update SinglePlacementSlice", "singlePlacementSlice", nextSPS.Name)
 				return err
 			} else {
-				logger.V(1).Info("updated SinglePlacementSlice", "workloadWorkspace", ws, "singlePlacementSlice", nextSPS.Name)
+				logger.V(1).Info("updated SinglePlacementSlice", "singlePlacementSlice", nextSPS.Name)
 			}
 		}
 	}
@@ -292,7 +291,7 @@ func filterEpsByLoc(eps []*edgev2alpha1.EdgePlacement, loc *edgev2alpha1.Locatio
 func packEpKeys(eps []*edgev2alpha1.EdgePlacement) map[string]empty {
 	keys := map[string]empty{}
 	for _, ep := range eps {
-		key, _ := kcpcache.MetaClusterNamespaceKeyFunc(ep)
+		key, _ := cache.MetaNamespaceKeyFunc(ep)
 		keys[key] = empty{}
 	}
 	return keys
@@ -302,17 +301,17 @@ func packEpKeys(eps []*edgev2alpha1.EdgePlacement) map[string]empty {
 func packStKeys(sts []*edgev2alpha1.SyncTarget) map[string]empty {
 	keys := map[string]empty{}
 	for _, st := range sts {
-		key, _ := kcpcache.MetaClusterNamespaceKeyFunc(st)
+		key, _ := cache.MetaNamespaceKeyFunc(st)
 		keys[key] = empty{}
 	}
 	return keys
 }
 
 // cleanSPSByLoc removes all singleplacements that has the specified location, from a singleplacementslice
-func cleanSPSByLoc(sps *edgev2alpha1.SinglePlacementSlice, lws, lName string) *edgev2alpha1.SinglePlacementSlice {
+func cleanSPSByLoc(sps *edgev2alpha1.SinglePlacementSlice, locSpaceID, lName string) *edgev2alpha1.SinglePlacementSlice {
 	nextDests := []edgev2alpha1.SinglePlacement{}
 	for _, sp := range sps.Destinations {
-		if sp.Cluster != lws || sp.LocationName != lName {
+		if sp.Cluster != locSpaceID || sp.LocationName != lName {
 			nextDests = append(nextDests, sp)
 		}
 	}
@@ -367,7 +366,16 @@ func (c *controller) patchSpsDestinations(destinations []edgev2alpha1.SinglePlac
 		return err
 	}
 	patch := []byte(fmt.Sprintf(`{"destinations": %s}`, destBytes))
-	_, err = c.edgeClusterClient.Cluster(logicalcluster.NewPath(spaceID)).EdgeV2alpha1().SinglePlacementSlices().Patch(c.context, spsName, types.MergePatchType, patch, metav1.PatchOptions{})
+
+	spaceConfig, err := c.spaceClient.ConfigForSpace(spaceID, c.spaceProviderNs)
+	if err != nil {
+		return err
+	}
+	edgeClientset, err := edgeclientset.NewForConfig(spaceConfig)
+	if err != nil {
+		return err
+	}
+	_, err = edgeClientset.EdgeV2alpha1().SinglePlacementSlices().Patch(c.context, spsName, types.MergePatchType, patch, metav1.PatchOptions{})
 	if err != nil {
 		return err
 	}

--- a/pkg/where-resolver/reconcile_on_location.go
+++ b/pkg/where-resolver/reconcile_on_location.go
@@ -256,7 +256,21 @@ func (c *controller) reconcileOnLocation(ctx context.Context, locKey string) err
 // filterStsByLoc returns those SyncTargets that selected by the Location
 func filterStsByLoc(sts []*edgev2alpha1.SyncTarget, loc *edgev2alpha1.Location) ([]*edgev2alpha1.SyncTarget, error) {
 	filtered := []*edgev2alpha1.SyncTarget{}
+
+	_, _, locKBSpaceID, err := kbuser.AnalyzeObjectID(loc)
+	if err != nil {
+		return filtered, err
+	}
+
 	for _, st := range sts {
+		_, _, stKBSpaceID, err := kbuser.AnalyzeObjectID(st)
+		if err != nil {
+			return filtered, err
+		}
+
+		if stKBSpaceID != locKBSpaceID {
+			continue
+		}
 		s := loc.Spec.InstanceSelector
 		selector, err := metav1.LabelSelectorAsSelector(s)
 		if err != nil {

--- a/pkg/where-resolver/reconcile_on_location.go
+++ b/pkg/where-resolver/reconcile_on_location.go
@@ -95,12 +95,12 @@ func (c *controller) reconcileOnLocation(ctx context.Context, locKey string) err
 	// 2a)
 	stsFilteredByLoc := []*edgev2alpha1.SyncTarget{}
 	if !locDeleted {
-		stsInLws, err := c.synctargetLister.List(labels.Everything())
+		allSts, err := c.synctargetLister.List(labels.Everything())
 		if err != nil {
 			logger.Error(err, "failed to list SyncTargets")
 			return err
 		}
-		stsFilteredByLoc, err = filterStsByLoc(stsInLws, loc)
+		stsFilteredByLoc, err = filterStsByLoc(allSts, loc)
 		if err != nil {
 			logger.Error(err, "failed to find SyncTargets for Location")
 			return err

--- a/scripts/inner/kubestellar
+++ b/scripts/inner/kubestellar
@@ -95,7 +95,7 @@ function ensure_imws() {
             echo "Ensuring IMW: $imw"
             space_config="${KUBECONFIG_DIR}/${PROVIDER_NAMESPACE}-${imw}"
             kubectl-kubestellar-create-space --space-name $imw --provider-name $PROVIDER_NAME --sm-core-config $SM_CONFIG
-            kubectl-kubestellar-get-config-for-space --space-name $imw --provider-name $PROVIDER_NAME --sm-core-config $SM_CONFIG ${in_cluster} --sm-context $SM_CONTEXT --output $space_config
+            kubectl-kubestellar-get-config-for-space --space-name $imw --sm-core-config $SM_CONFIG ${in_cluster} --sm-context $SM_CONTEXT --output $space_config
             KUBECONFIG=$SM_CONFIG kubestellar-kube-bind "$imw" "synctargets"
             KUBECONFIG=$SM_CONFIG kubestellar-kube-bind "$imw" "locations"
         done
@@ -197,7 +197,7 @@ function ensure_espw() {
     fi 
     space_config="${KUBECONFIG_DIR}/${PROVIDER_NAMESPACE}-${espw_name}"
     kubectl-kubestellar-create-space --space-name $espw_name --provider-name $PROVIDER_NAME --sm-core-config $SM_CONFIG 
-    kubectl-kubestellar-get-config-for-space --space-name $espw_name --provider-name $PROVIDER_NAME --sm-core-config $SM_CONFIG ${in_cluster} --sm-context $SM_CONTEXT --output $space_config
+    kubectl-kubestellar-get-config-for-space --space-name $espw_name --sm-core-config $SM_CONFIG ${in_cluster} --sm-context $SM_CONTEXT --output $space_config
     run_dex
     sleep 2
     run_kb_backend
@@ -236,7 +236,7 @@ function run_kb_backend() {
 
     echo "starting kube-bind example-backend in background"
 
-    kubectl-kubestellar-get-config-for-space --space-name "espw" --provider-name $PROVIDER_NAME --sm-core-config $SM_CONFIG ${in_cluster} --sm-context $SM_CONTEXT --output "/tmp/espw-conf"
+    kubectl-kubestellar-get-config-for-space --space-name "espw" --sm-core-config $SM_CONFIG ${in_cluster} --sm-context $SM_CONTEXT --output "/tmp/espw-conf"
     
     ( 
         KUBECONFIG="/tmp/espw-conf"

--- a/scripts/inner/kubestellar
+++ b/scripts/inner/kubestellar
@@ -95,7 +95,7 @@ function ensure_imws() {
             echo "Ensuring IMW: $imw"
             space_config="${KUBECONFIG_DIR}/${PROVIDER_NAMESPACE}-${imw}"
             kubectl-kubestellar-create-space --space-name $imw --provider-name $PROVIDER_NAME --sm-core-config $SM_CONFIG
-            kubectl-kubestellar-get-config-for-space --space-name $imw --provider-name $PROVIDER_NAME --sm-core-config $SM_CONFIG ${in_cluster} --output $space_config
+            kubectl-kubestellar-get-config-for-space --space-name $imw --provider-name $PROVIDER_NAME --sm-core-config $SM_CONFIG ${in_cluster} --sm-context $SM_CONTEXT --output $space_config
             KUBECONFIG=$SM_CONFIG kubestellar-kube-bind "$imw" "synctargets"
             KUBECONFIG=$SM_CONFIG kubestellar-kube-bind "$imw" "locations"
         done
@@ -171,12 +171,16 @@ if [ "$SM_CONFIG" == "" ]; then
     SM_CONFIG="${KUBECONFIG_DIR}/config"
     export SM_CONFIG
 fi
+if [ "$SM_CONTEXT" == "" ]; then
+    export SM_CONTEXT=sm-mgt
+fi
 if [ "$IN_CLUSTER" == "" ]; then
     IN_CLUSTER=true
     export IN_CLUSTER
 fi
 echo "KUBECONFIG_DIR=${KUBECONFIG_DIR}"
 echo "SM_CONFIG=${SM_CONFIG}"
+echo "SM_CONTEXT=${SM_CONTEXT}"
 echo "PROVIDER_NAME=${PROVIDER_NAME}"
 echo "PROVIDER_NAMESPACE=${PROVIDER_NAMESPACE}"
 echo "IN_CLUSTER=${IN_CLUSTER}"
@@ -193,7 +197,7 @@ function ensure_espw() {
     fi 
     space_config="${KUBECONFIG_DIR}/${PROVIDER_NAMESPACE}-${espw_name}"
     kubectl-kubestellar-create-space --space-name $espw_name --provider-name $PROVIDER_NAME --sm-core-config $SM_CONFIG 
-    kubectl-kubestellar-get-config-for-space --space-name $espw_name --provider-name $PROVIDER_NAME --sm-core-config $SM_CONFIG ${in_cluster} --output $space_config
+    kubectl-kubestellar-get-config-for-space --space-name $espw_name --provider-name $PROVIDER_NAME --sm-core-config $SM_CONFIG ${in_cluster} --sm-context $SM_CONTEXT --output $space_config
     run_dex
     sleep 2
     run_kb_backend
@@ -232,7 +236,7 @@ function run_kb_backend() {
 
     echo "starting kube-bind example-backend in background"
 
-    kubectl-kubestellar-get-config-for-space --space-name "espw" --provider-name $PROVIDER_NAME --sm-core-config $SM_CONFIG ${in_cluster} --output "/tmp/espw-conf"
+    kubectl-kubestellar-get-config-for-space --space-name "espw" --provider-name $PROVIDER_NAME --sm-core-config $SM_CONFIG ${in_cluster} --sm-context $SM_CONTEXT --output "/tmp/espw-conf"
     
     ( 
         KUBECONFIG="/tmp/espw-conf"

--- a/scripts/inner/kubestellar
+++ b/scripts/inner/kubestellar
@@ -95,7 +95,7 @@ function ensure_imws() {
             echo "Ensuring IMW: $imw"
             space_config="${KUBECONFIG_DIR}/${PROVIDER_NAMESPACE}-${imw}"
             kubectl-kubestellar-create-space --space-name $imw --provider-name $PROVIDER_NAME --sm-core-config $SPACE_MANAGER_KUBECONFIG
-            kubectl-kubestellar-get-config-for-space --space-name $imw --provider-name $PROVIDER_NAME --sm-core-config $SPACE_MANAGER_KUBECONFIG ${in_cluster} --space-config-file $space_config
+            kubectl-kubestellar-get-config-for-space --space-name $imw --provider-name $PROVIDER_NAME --sm-core-config $SPACE_MANAGER_KUBECONFIG ${in_cluster} --output $space_config
             KUBECONFIG=$space_config kubestellar-kube-bind "$imw" "synctargets"
             KUBECONFIG=$space_config kubestellar-kube-bind "$imw" "locations"
         done
@@ -193,7 +193,7 @@ function ensure_espw() {
     fi 
     space_config="${KUBECONFIG_DIR}/${PROVIDER_NAMESPACE}-${espw_name}"
     kubectl-kubestellar-create-space --space-name $espw_name --provider-name $PROVIDER_NAME --sm-core-config $SPACE_MANAGER_KUBECONFIG 
-    kubectl-kubestellar-get-config-for-space --space-name $espw_name --provider-name $PROVIDER_NAME --sm-core-config $SPACE_MANAGER_KUBECONFIG ${in_cluster} --space-config-file $space_config
+    kubectl-kubestellar-get-config-for-space --space-name $espw_name --provider-name $PROVIDER_NAME --sm-core-config $SPACE_MANAGER_KUBECONFIG ${in_cluster} --output $space_config
     run_dex
     sleep 2
     run_kb_backend

--- a/scripts/inner/kubestellar
+++ b/scripts/inner/kubestellar
@@ -349,7 +349,7 @@ fi
 
 # Start the Placement Translator
 sleep 3
-placement-translator --allclusters-context  "system:admin" -v=2 >> $log_folder/placement-translator-log.txt 2>&1 &
+placement-translator -v=2 >> $log_folder/placement-translator-log.txt 2>&1 &
 
 run_status=$(wait_for_process placement-translator)
 if [ $run_status -eq 0 ]; then

--- a/scripts/inner/kubestellar
+++ b/scripts/inner/kubestellar
@@ -94,10 +94,10 @@ function ensure_imws() {
             imw=${i#"root:"}
             echo "Ensuring IMW: $imw"
             space_config="${KUBECONFIG_DIR}/${PROVIDER_NAMESPACE}-${imw}"
-            kubectl-kubestellar-create-space --space-name $imw --provider-name $PROVIDER_NAME --sm-core-config $SPACE_MANAGER_KUBECONFIG
-            kubectl-kubestellar-get-config-for-space --space-name $imw --provider-name $PROVIDER_NAME --sm-core-config $SPACE_MANAGER_KUBECONFIG ${in_cluster} --output $space_config
-            KUBECONFIG=$SPACE_MANAGER_KUBECONFIG kubestellar-kube-bind "$imw" "synctargets"
-            KUBECONFIG=$SPACE_MANAGER_KUBECONFIG kubestellar-kube-bind "$imw" "locations"
+            kubectl-kubestellar-create-space --space-name $imw --provider-name $PROVIDER_NAME --sm-core-config $SM_CONFIG
+            kubectl-kubestellar-get-config-for-space --space-name $imw --provider-name $PROVIDER_NAME --sm-core-config $SM_CONFIG ${in_cluster} --output $space_config
+            KUBECONFIG=$SM_CONFIG kubestellar-kube-bind "$imw" "synctargets"
+            KUBECONFIG=$SM_CONFIG kubestellar-kube-bind "$imw" "locations"
         done
     done <<< "$1"
 }
@@ -167,16 +167,16 @@ if [ "$KUBECONFIG_DIR" == "" ]; then
     mkdir -p $KUBECONFIG_DIR
     export KUBECONFIG_DIR
 fi
-if [ "$SPACE_MANAGER_KUBECONFIG" == "" ]; then
-    SPACE_MANAGER_KUBECONFIG="${KUBECONFIG_DIR}/config"
-    export SPACE_MANAGER_KUBECONFIG
+if [ "$SM_CONFIG" == "" ]; then
+    SM_CONFIG="${KUBECONFIG_DIR}/config"
+    export SM_CONFIG
 fi
 if [ "$IN_CLUSTER" == "" ]; then
     IN_CLUSTER=true
     export IN_CLUSTER
 fi
 echo "KUBECONFIG_DIR=${KUBECONFIG_DIR}"
-echo "SPACE_MANAGER_KUBECONFIG=${SPACE_MANAGER_KUBECONFIG}"
+echo "SM_CONFIG=${SM_CONFIG}"
 echo "PROVIDER_NAME=${PROVIDER_NAME}"
 echo "PROVIDER_NAMESPACE=${PROVIDER_NAMESPACE}"
 echo "IN_CLUSTER=${IN_CLUSTER}"
@@ -192,8 +192,8 @@ function ensure_espw() {
         in_cluster="--in-cluster"
     fi 
     space_config="${KUBECONFIG_DIR}/${PROVIDER_NAMESPACE}-${espw_name}"
-    kubectl-kubestellar-create-space --space-name $espw_name --provider-name $PROVIDER_NAME --sm-core-config $SPACE_MANAGER_KUBECONFIG 
-    kubectl-kubestellar-get-config-for-space --space-name $espw_name --provider-name $PROVIDER_NAME --sm-core-config $SPACE_MANAGER_KUBECONFIG ${in_cluster} --output $space_config
+    kubectl-kubestellar-create-space --space-name $espw_name --provider-name $PROVIDER_NAME --sm-core-config $SM_CONFIG 
+    kubectl-kubestellar-get-config-for-space --space-name $espw_name --provider-name $PROVIDER_NAME --sm-core-config $SM_CONFIG ${in_cluster} --output $space_config
     run_dex
     sleep 2
     run_kb_backend
@@ -232,7 +232,7 @@ function run_kb_backend() {
 
     echo "starting kube-bind example-backend in background"
 
-    kubectl-kubestellar-get-config-for-space --space-name "espw" --provider-name $PROVIDER_NAME --sm-core-config $SPACE_MANAGER_KUBECONFIG ${in_cluster} --output "/tmp/espw-conf"
+    kubectl-kubestellar-get-config-for-space --space-name "espw" --provider-name $PROVIDER_NAME --sm-core-config $SM_CONFIG ${in_cluster} --output "/tmp/espw-conf"
     
     ( 
         KUBECONFIG="/tmp/espw-conf"

--- a/scripts/inner/kubestellar
+++ b/scripts/inner/kubestellar
@@ -96,8 +96,8 @@ function ensure_imws() {
             space_config="${KUBECONFIG_DIR}/${PROVIDER_NAMESPACE}-${imw}"
             kubectl-kubestellar-create-space --space-name $imw --provider-name $PROVIDER_NAME --sm-core-config $SPACE_MANAGER_KUBECONFIG
             kubectl-kubestellar-get-config-for-space --space-name $imw --provider-name $PROVIDER_NAME --sm-core-config $SPACE_MANAGER_KUBECONFIG ${in_cluster} --output $space_config
-            KUBECONFIG=$space_config kubestellar-kube-bind "$imw" "synctargets"
-            KUBECONFIG=$space_config kubestellar-kube-bind "$imw" "locations"
+            KUBECONFIG=$SPACE_MANAGER_KUBECONFIG kubestellar-kube-bind "$imw" "synctargets"
+            KUBECONFIG=$SPACE_MANAGER_KUBECONFIG kubestellar-kube-bind "$imw" "locations"
         done
     done <<< "$1"
 }
@@ -231,9 +231,14 @@ function run_kb_backend() {
     fi
 
     echo "starting kube-bind example-backend in background"
-    kubectl ws root:espw
-    kubectl apply -f "$bindir/../kube-bind/deploy/crd"
-    example-backend --oidc-issuer-client-id=kube-bind --oidc-issuer-client-secret=ZXhhbXBsZS1hcHAtc2VjcmV0 --oidc-issuer-url=http://127.0.0.1:5556/dex --oidc-callback-url=http://127.0.0.1:8080/callback --pretty-name="BigCorp.com" --namespace-prefix="kube-bind-" --cookie-signing-key=bGMHz7SR9XcI9JdDB68VmjQErrjbrAR9JdVqjAOKHzE= --cookie-encryption-key=wadqi4u+w0bqnSrVFtM38Pz2ykYVIeeadhzT34XlC1Y= --consumer-scope="Cluster" &> /dev/null &
+
+    kubectl-kubestellar-get-config-for-space --space-name "espw" --provider-name $PROVIDER_NAME --sm-core-config $SPACE_MANAGER_KUBECONFIG ${in_cluster} --output "/tmp/espw-conf"
+    
+    ( 
+        KUBECONFIG="/tmp/espw-conf"
+        kubectl apply -f "$bindir/../kube-bind/deploy/crd"
+        example-backend --oidc-issuer-client-id=kube-bind --oidc-issuer-client-secret=ZXhhbXBsZS1hcHAtc2VjcmV0 --oidc-issuer-url=http://127.0.0.1:5556/dex --oidc-callback-url=http://127.0.0.1:8080/callback --pretty-name="BigCorp.com" --namespace-prefix="kube-bind-" --cookie-signing-key=bGMHz7SR9XcI9JdDB68VmjQErrjbrAR9JdVqjAOKHzE= --cookie-encryption-key=wadqi4u+w0bqnSrVFtM38Pz2ykYVIeeadhzT34XlC1Y= --consumer-scope="Cluster" &> /dev/null &
+    )
 
     run_status=$(wait_for_process example-backend)
     if [ $run_status -eq 0 ]; then

--- a/scripts/inner/kubestellar-kube-bind
+++ b/scripts/inner/kubestellar-kube-bind
@@ -57,7 +57,7 @@ then
 fi
 
 conf_file="/tmp/$space_name.conf"
-kubectl-kubestellar-get-config-for-space --space-name $space_name --sm-core-config $SM_CONFIG --in_cluster --output $conf_file
+kubectl-kubestellar-get-config-for-space --space-name $space_name --sm-core-config $SM_CONFIG --in-cluster --output $conf_file
 KUBECONFIG=$conf_file
 
 if kubectl get crd $resource_to_bind.edge.kubestellar.io &> /dev/null; then
@@ -75,8 +75,9 @@ else
     log_file=$log_dir/kube-bind-konnector-$space_name.log
     echo "starting kube-bind konnector for space $space_name in background, logs writing to $log_file"
     KB_CONSUMER=$space_name konnector &> $log_file &
-    sleep 2
+    sleep 10
     if ! pgrep konnector &> /dev/null; then
+        cat $log_file
         echo "Error: kube-bind konnector process not found" >&2
         exit 1
     fi
@@ -95,7 +96,7 @@ else
     echo "cluster namespace is $cluster_ns"
 fi
 
-kubectl-kubestellar-get-config-for-space --space-name "espw" --provider-name $PROVIDER_NAME --sm-core-config $SM_CONFIG ${in_cluster} --output "/tmp/espw-conf"
+kubectl-kubestellar-get-config-for-space --space-name "espw" --provider-name $PROVIDER_NAME --sm-core-config $SM_CONFIG --in-cluster --output "/tmp/espw-conf"
 KUBECONFIG="/tmp/espw-conf"
 
 if ! kubectl get namespace "$cm_namespace" &> /dev/null

--- a/scripts/inner/kubestellar-kube-bind
+++ b/scripts/inner/kubestellar-kube-bind
@@ -96,7 +96,7 @@ else
     echo "cluster namespace is $cluster_ns"
 fi
 
-kubectl-kubestellar-get-config-for-space --space-name "espw" --provider-name $PROVIDER_NAME --sm-core-config $SM_CONFIG --sm-context $SM_CONTEXT --in-cluster --output "/tmp/espw-conf"
+kubectl-kubestellar-get-config-for-space --space-name "espw" --sm-core-config $SM_CONFIG --sm-context $SM_CONTEXT --in-cluster --output "/tmp/espw-conf"
 KUBECONFIG="/tmp/espw-conf"
 
 if ! kubectl get namespace "$cm_namespace" &> /dev/null

--- a/scripts/inner/kubestellar-kube-bind
+++ b/scripts/inner/kubestellar-kube-bind
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# SPACE_MANAGER_KUBECONFIG should be set before calling this script
+# SM_CONFIG should be set before calling this script
 
 space_name=""
 resource_to_bind=""
@@ -57,7 +57,7 @@ then
 fi
 
 conf_file="/tmp/$space_name.conf"
-kubectl-kubestellar-get-config-for-space --space-name $space_name --sm-core-config $SPACE_MANAGER_KUBECONFIG --in_cluster --output $conf_file
+kubectl-kubestellar-get-config-for-space --space-name $space_name --sm-core-config $SM_CONFIG --in_cluster --output $conf_file
 KUBECONFIG=$conf_file
 
 if kubectl get crd $resource_to_bind.edge.kubestellar.io &> /dev/null; then
@@ -95,7 +95,7 @@ else
     echo "cluster namespace is $cluster_ns"
 fi
 
-kubectl-kubestellar-get-config-for-space --space-name "espw" --provider-name $PROVIDER_NAME --sm-core-config $SPACE_MANAGER_KUBECONFIG ${in_cluster} --output "/tmp/espw-conf"
+kubectl-kubestellar-get-config-for-space --space-name "espw" --provider-name $PROVIDER_NAME --sm-core-config $SM_CONFIG ${in_cluster} --output "/tmp/espw-conf"
 KUBECONFIG="/tmp/espw-conf"
 
 if ! kubectl get namespace "$cm_namespace" &> /dev/null

--- a/scripts/inner/kubestellar-kube-bind
+++ b/scripts/inner/kubestellar-kube-bind
@@ -14,6 +14,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# SPACE_MANAGER_KUBECONFIG should be set before calling this script
+
 space_name=""
 resource_to_bind=""
 cm_namespace=kubestellar # the namespace where the configmaps live in on the provider side
@@ -54,20 +56,9 @@ then
     exit 1
 fi
 
-initial_ws=$(kubectl ws . --short)
-trap "kubectl ws use $initial_ws &> /dev/null # go back to the initial state" EXIT
-
-kubectl ws root
-kcp_id="$(kubectl get ws $space_name -ojsonpath='{.spec.cluster}')"
-if [ -z "$kcp_id" ]
-then
-    echo "Failed to find the kcp workspace ID for $space_name" >&2
-    exit 1
-else
-    echo "kcp workspace $space_name's ID is $kcp_id"
-fi
-
-kubectl ws "root:$space_name"
+conf_file="/tmp/$space_name.conf"
+kubectl-kubestellar-get-config-for-space --space-name $space_name --sm-core-config $SPACE_MANAGER_KUBECONFIG ${in_cluster} --output $conf_file
+KUBECONFIG=$conf_file
 
 if kubectl get crd $resource_to_bind.edge.kubestellar.io &> /dev/null; then
     echo "CRD for $resource_to_bind already in place"
@@ -104,7 +95,9 @@ else
     echo "cluster namespace is $cluster_ns"
 fi
 
-kubectl ws root:espw
+kubectl-kubestellar-get-config-for-space --space-name "espw" --provider-name $PROVIDER_NAME --sm-core-config $SPACE_MANAGER_KUBECONFIG ${in_cluster} --output "/tmp/espw-conf"
+KUBECONFIG="/tmp/espw-conf"
+
 if ! kubectl get namespace "$cm_namespace" &> /dev/null
 then kubectl create namespace "$cm_namespace"
 else echo "namespace $cm_namespace already exists"
@@ -114,7 +107,7 @@ kubectl apply -f - <<EOF
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: kbmap-$kcp_id
+  name: kbmap-$space_name
   namespace: $cm_namespace
   labels:
     kubestellar.io/kube-bind-id: $cluster_ns

--- a/scripts/inner/kubestellar-kube-bind
+++ b/scripts/inner/kubestellar-kube-bind
@@ -57,7 +57,7 @@ then
 fi
 
 conf_file="/tmp/$space_name.conf"
-kubectl-kubestellar-get-config-for-space --space-name $space_name --sm-core-config $SM_CONFIG --in-cluster --output $conf_file
+kubectl-kubestellar-get-config-for-space --space-name $space_name --sm-core-config $SM_CONFIG --sm-context $SM_CONTEXT --in-cluster --output $conf_file
 KUBECONFIG=$conf_file
 
 if kubectl get crd $resource_to_bind.edge.kubestellar.io &> /dev/null; then
@@ -96,7 +96,7 @@ else
     echo "cluster namespace is $cluster_ns"
 fi
 
-kubectl-kubestellar-get-config-for-space --space-name "espw" --provider-name $PROVIDER_NAME --sm-core-config $SM_CONFIG --in-cluster --output "/tmp/espw-conf"
+kubectl-kubestellar-get-config-for-space --space-name "espw" --provider-name $PROVIDER_NAME --sm-core-config $SM_CONFIG --sm-context $SM_CONTEXT --in-cluster --output "/tmp/espw-conf"
 KUBECONFIG="/tmp/espw-conf"
 
 if ! kubectl get namespace "$cm_namespace" &> /dev/null

--- a/scripts/inner/kubestellar-kube-bind
+++ b/scripts/inner/kubestellar-kube-bind
@@ -57,7 +57,7 @@ then
 fi
 
 conf_file="/tmp/$space_name.conf"
-kubectl-kubestellar-get-config-for-space --space-name $space_name --sm-core-config $SPACE_MANAGER_KUBECONFIG ${in_cluster} --output $conf_file
+kubectl-kubestellar-get-config-for-space --space-name $space_name --sm-core-config $SPACE_MANAGER_KUBECONFIG --in_cluster --output $conf_file
 KUBECONFIG=$conf_file
 
 if kubectl get crd $resource_to_bind.edge.kubestellar.io &> /dev/null; then

--- a/scripts/outer/kubectl-kubestellar-ensure-location
+++ b/scripts/outer/kubectl-kubestellar-ensure-location
@@ -115,7 +115,7 @@ set -e
 echo "--- current directory is $PWD"
 
 imw_space_config="${PWD}/temp-space-config/spaceprovider-default-${imw}"
-kubectl-kubestellar-get-config-for-space --space-name ${imw} --provider-name default --sm-core-config $SM_CONFIG --sm-context $SM_CONTEXT --space-config-file $imw_space_config
+kubectl-kubestellar-get-config-for-space --space-name ${imw} --provider-name default --sm-core-config $SM_CONFIG --sm-context $SM_CONTEXT --output $imw_space_config
 
 if ! kubectl "${kubectl_flags[@]}" --kubeconfig $imw_space_config get synctargets.edge.kubestellar.io "$objname" &> /dev/null; then
 (cat <<EOF

--- a/scripts/outer/kubectl-kubestellar-ensure-location
+++ b/scripts/outer/kubectl-kubestellar-ensure-location
@@ -115,7 +115,7 @@ set -e
 echo "--- current directory is $PWD"
 
 imw_space_config="${PWD}/temp-space-config/spaceprovider-default-${imw}"
-kubectl-kubestellar-get-config-for-space --space-name ${imw} --provider-name default --sm-core-config $SM_CONFIG --sm-context $SM_CONTEXT --output $imw_space_config
+kubectl-kubestellar-get-config-for-space --space-name ${imw} --sm-core-config $SM_CONFIG --sm-context $SM_CONTEXT --output $imw_space_config
 
 if ! kubectl "${kubectl_flags[@]}" --kubeconfig $imw_space_config get synctargets.edge.kubestellar.io "$objname" &> /dev/null; then
 (cat <<EOF

--- a/scripts/outer/kubectl-kubestellar-prep_for_syncer
+++ b/scripts/outer/kubectl-kubestellar-prep_for_syncer
@@ -22,7 +22,7 @@
 
 # This script requires the `kubestellar syncer-gen` kubectl plugin to
 # already exist at ../bin/kubectl-kubestellar-syncer_gen.
-
+ 
 bindir="$(dirname "$0")"
 
 if ! [ -x "$bindir/kubectl-kubestellar-syncer_gen" ]; then

--- a/scripts/outer/kubectl-kubestellar-prep_for_syncer
+++ b/scripts/outer/kubectl-kubestellar-prep_for_syncer
@@ -162,10 +162,10 @@ sleep 5
 TESTMB_CMD="KUBECONFIG=$SM_CONFIG kubectl get space -n spaceprovider-default "$mbwsname" -o=jsonpath='{.status.Phase}'"
 
 
-if  phase=$(TESTMB_CMD); [ "$phase" != "READY" ]; then
+if  phase=($TESTMB_CMD); [ "$phase" != "READY" ]; then
     echo "tried once to switch to $mbwsname"
     sleep 15
-    if phase=$(TESTMB_CMD); [ "$phase" != "READY" ]; then
+    if phase=($TESTMB_CMD); [ "$phase" != "READY" ]; then
         echo "tried twice to switch to $mbwsname"
         sleep 15
     fi

--- a/scripts/outer/kubectl-kubestellar-prep_for_syncer
+++ b/scripts/outer/kubectl-kubestellar-prep_for_syncer
@@ -114,69 +114,44 @@ imw_space_config="${PWD}/temp-space-config/spaceprovider-default-${imw}"
 kubectl-kubestellar-get-config-for-space --space-name ${imw} --provider-name default --sm-core-config $SM_CONFIG --sm-context $SM_CONTEXT --output $imw_space_config
 mbwsname=$(KUBECONFIG=$imw_space_config kubectl "${kubectl_flags[@]}" get synctargets.edge.kubestellar.io "$stname" -o jsonpath="{.metadata.annotations['kcp\.io/cluster']}-mb-{.metadata.uid}")
 
-original_ws=$(kubectl ws "${kubectl_flags[@]}" . --short)
-
-if [ "$imw" == "." ]
-then imw="$original_ws"
-elif ! [[ "$imw" =~ [a-z0-9].* ]]; then
+if ! [[ "$imw" =~ [a-z0-9].* ]]; then
     echo "$0: imw ${espw@Q} is not valid" >&2
     exit 1
 fi
 
-if [ "$espw" == "." ]
-then espw="$original_ws"
-elif ! [[ "$espw" =~ [a-z0-9].* ]]; then
+lif ! [[ "$espw" =~ [a-z0-9].* ]]; then
     echo "$0: espw ${espw@Q} is not valid" >&2
     exit 1
 fi
 
-if [ "$silent" == "true" ]; then
-    trap 'kubectl ws "${kubectl_flags[@]}" "$original_ws" > /dev/null' EXIT
-else
-    trap 'kubectl ws "${kubectl_flags[@]}" "$original_ws"' EXIT
-fi
+espw_space_config="${PWD}/temp-space-config/spaceprovider-default-${espw}"
+kubectl-kubestellar-get-config-for-space --space-name ${espw} --provider-name default --sm-core-config $SM_CONFIG --sm-context $SM_CONTEXT --output $espw_space_config
 
-if [ "$silent" == "true" ]; then
-    kubectl ws "${kubectl_flags[@]}" "${rootws}:${imw}" > /dev/null
-else
-    kubectl ws "${kubectl_flags[@]}" "${rootws}:${imw}"
-fi
-kubectl ws "${kubectl_flags[@]}" "${rootws}:${imw}"
-
-kubectl ws "${kubectl_flags[@]}" "${rootws}:${espw}"
-if ! cluster_ns_name="$(kubectl "${kubectl_flags[@]}" -n kubestellar get configmap kbmap-"$imw" -ojsonpath="{.metadata.labels['kubestellar\.io\/kube-bind-id']}")"; then
+if ! cluster_ns_name="$(KUBECONFIG=$espw_space_config kubectl "${kubectl_flags[@]}" -n kubestellar get configmap kbmap-"$imw" -ojsonpath="{.metadata.labels['kubestellar\.io\/kube-bind-id']}")"; then
 	echo "error reading kube-bind cluster namespace from ConfigMap kbmap-$imw" >&2
 	exit 1
 fi
+
 prefixed_stname="$cluster_ns_name"-"$stname"
-stUID=$(kubectl "${kubectl_flags[@]}" get synctargets.edge.kubestellar.io $prefixed_stname -o jsonpath="{.metadata.uid}")
+stUID=$(KUBECONFIG=$espw_space_config kubectl "${kubectl_flags[@]}" get synctargets.edge.kubestellar.io $prefixed_stname -o jsonpath="{.metadata.uid}")
 mbwsname="$imw"-mb-"$stUID"
 
-espw_space_config="${PWD}/temp-space-config/spaceprovider-default-${espw}"
-kubectl-kubestellar-get-config-for-space --space-name ${espw} --provider-name default --sm-core-config $SM_CONFIG --sm-context $SM_CONTEXT --output $espw_space_config
 if ! KUBECONFIG=$espw_space_config kubectl "${kubectl_flags[@]}" get APIExport edge.kubestellar.io &> /dev/null ; then
     echo "$0: it looks like ${espw@Q} is not the edge service provider workspace" >&2
     exit 2
 fi
 
-# TODO: mailbox does not support spaces yet
-if [ "$silent" == "true" ]; then
-    kubectl ws "${kubectl_flags[@]}" "$rootws" > /dev/null
-else
-    kubectl ws "${kubectl_flags[@]}" "$rootws"
-fi
-
-if ! kubectl "${kubectl_flags[@]}" get Workspace "$mbwsname" &> /dev/null; then
+if ! KUBECONFIG=$SM_CONFIG kubectl get space -n spaceprovider-default "$mbwsname" &> /dev/null; then
 	echo "maybe the mailbox controller is slow, give it a chance"
     sleep 15
 fi
 
-if ! kubectl "${kubectl_flags[@]}" get Workspace "$mbwsname" &> /dev/null; then
+if ! KUBECONFIG=$SM_CONFIG kubectl get space -n spaceprovider-default "$mbwsname" &> /dev/null; then
 	echo "maybe the mailbox controller is slow, give it another chance"
     sleep 15
 fi
 
-if ! kubectl "${kubectl_flags[@]}" get Workspace "$mbwsname" &> /dev/null; then
+if ! KUBECONFIG=$SM_CONFIG kubectl get space -n spaceprovider-default "$mbwsname" &> /dev/null; then
     echo "$0: did not find the mailbox workspace $mbwsname; is the mailbox controller running?" >&2
     exit 5
 fi
@@ -184,15 +159,19 @@ fi
 echo "now that workspace _exists_, but is it _ready_?"
 sleep 5
 
-if ! kubectl ws "${kubectl_flags[@]}" "$mbwsname" &> /dev/null; then
+TESTMB_CMD="KUBECONFIG=$SM_CONFIG kubectl get space -n spaceprovider-default "$mbwsname" -o=jsonpath='{.status.Phase}'"
+
+
+if  phase=$(TESTMB_CMD); [ "$phase" != "READY" ]; then
     echo "tried once to switch to $mbwsname"
     sleep 15
-    if ! kubectl ws "${kubectl_flags[@]}" "$mbwsname" &> /dev/null; then
+    if phase=$(TESTMB_CMD); [ "$phase" != "READY" ]; then
         echo "tried twice to switch to $mbwsname"
         sleep 15
-        kubectl ws "${kubectl_flags[@]}" "$mbwsname"
     fi
 fi
 
-echo "current workspace is now $(kubectl ws "${kubectl_flags[@]}" . --short)"
-"$bindir/kubectl-kubestellar-syncer_gen" "$prefixed_stname" --syncer-image "$syncer_image" -o "$output"
+mbwsname_space_config="${PWD}/temp-space-config/spaceprovider-default-${mbwsname}"
+kubectl-kubestellar-get-config-for-space --space-name ${mbwsname} --provider-name default --sm-core-config $SM_CONFIG --sm-context $SM_CONTEXT --output $mbwsname_space_config
+
+#"KUBECONFIG=$mbwsname_space_config $bindir/kubectl-kubestellar-syncer_gen" "$prefixed_stname" --syncer-image "$syncer_image" -o "$output"

--- a/scripts/outer/kubectl-kubestellar-prep_for_syncer
+++ b/scripts/outer/kubectl-kubestellar-prep_for_syncer
@@ -174,4 +174,4 @@ fi
 mbwsname_space_config="${PWD}/temp-space-config/spaceprovider-default-${mbwsname}"
 kubectl-kubestellar-get-config-for-space --space-name ${mbwsname} --provider-name default --sm-core-config $SM_CONFIG --sm-context $SM_CONTEXT --output $mbwsname_space_config
 
-"KUBECONFIG=$mbwsname_space_config $bindir/kubectl-kubestellar-syncer_gen" "$prefixed_stname" --syncer-image "$syncer_image" -o "$output"
+KUBECONFIG=$mbwsname_space_config $bindir/kubectl-kubestellar-syncer_gen "$prefixed_stname" --syncer-image "$syncer_image" -o "$output"

--- a/scripts/outer/kubectl-kubestellar-prep_for_syncer
+++ b/scripts/outer/kubectl-kubestellar-prep_for_syncer
@@ -142,16 +142,15 @@ else
     kubectl ws "${kubectl_flags[@]}" "${rootws}:${imw}"
 fi
 kubectl ws "${kubectl_flags[@]}" "${rootws}:${imw}"
-spaceID=$(kubectl "${kubectl_flags[@]}" get synctargets.edge.kubestellar.io "$stname" -o jsonpath="{.metadata.annotations['kcp\.io/cluster']}")
 
 kubectl ws "${kubectl_flags[@]}" "${rootws}:${espw}"
-if ! cluster_ns_name="$(kubectl "${kubectl_flags[@]}" -n kubestellar get configmap kbmap-"$spaceID" -ojsonpath="{.metadata.labels['kubestellar\.io\/kube-bind-id']}")"; then
-	echo "error reading kube-bind cluster namespace from ConfigMap kbmap-$spaceID" >&2
+if ! cluster_ns_name="$(kubectl "${kubectl_flags[@]}" -n kubestellar get configmap kbmap-"$imw" -ojsonpath="{.metadata.labels['kubestellar\.io\/kube-bind-id']}")"; then
+	echo "error reading kube-bind cluster namespace from ConfigMap kbmap-$imw" >&2
 	exit 1
 fi
 prefixed_stname="$cluster_ns_name"-"$stname"
 stUID=$(kubectl "${kubectl_flags[@]}" get synctargets.edge.kubestellar.io $prefixed_stname -o jsonpath="{.metadata.uid}")
-mbwsname="$spaceID"-mb-"$stUID"
+mbwsname="$imw"-mb-"$stUID"
 
 espw_space_config="${PWD}/temp-space-config/spaceprovider-default-${espw}"
 kubectl-kubestellar-get-config-for-space --space-name ${espw} --provider-name default --sm-core-config $SM_CONFIG --sm-context $SM_CONTEXT --output $espw_space_config

--- a/scripts/outer/kubectl-kubestellar-prep_for_syncer
+++ b/scripts/outer/kubectl-kubestellar-prep_for_syncer
@@ -22,7 +22,7 @@
 
 # This script requires the `kubestellar syncer-gen` kubectl plugin to
 # already exist at ../bin/kubectl-kubestellar-syncer_gen.
- 
+
 bindir="$(dirname "$0")"
 
 if ! [ -x "$bindir/kubectl-kubestellar-syncer_gen" ]; then

--- a/scripts/outer/kubectl-kubestellar-prep_for_syncer
+++ b/scripts/outer/kubectl-kubestellar-prep_for_syncer
@@ -111,7 +111,7 @@ fi
 set -e
 
 imw_space_config="${PWD}/temp-space-config/spaceprovider-default-${imw}"
-kubectl-kubestellar-get-config-for-space --space-name ${imw} --provider-name default --sm-core-config $SM_CONFIG --sm-context $SM_CONTEXT --output $imw_space_config
+kubectl-kubestellar-get-config-for-space --space-name ${imw} --sm-core-config $SM_CONFIG --sm-context $SM_CONTEXT --output $imw_space_config
 mbwsname=$(KUBECONFIG=$imw_space_config kubectl "${kubectl_flags[@]}" get synctargets.edge.kubestellar.io "$stname" -o jsonpath="{.metadata.annotations['kcp\.io/cluster']}-mb-{.metadata.uid}")
 
 if ! [[ "$imw" =~ [a-z0-9].* ]]; then
@@ -125,7 +125,7 @@ if ! [[ "$espw" =~ [a-z0-9].* ]]; then
 fi
 
 espw_space_config="${PWD}/temp-space-config/spaceprovider-default-${espw}"
-kubectl-kubestellar-get-config-for-space --space-name ${espw} --provider-name default --sm-core-config $SM_CONFIG --sm-context $SM_CONTEXT --output $espw_space_config
+kubectl-kubestellar-get-config-for-space --space-name ${espw} --sm-core-config $SM_CONFIG --sm-context $SM_CONTEXT --output $espw_space_config
 
 if ! cluster_ns_name="$(KUBECONFIG=$espw_space_config kubectl "${kubectl_flags[@]}" -n kubestellar get configmap kbmap-"$imw" -ojsonpath="{.metadata.labels['kubestellar\.io\/kube-bind-id']}")"; then
 	echo "error reading kube-bind cluster namespace from ConfigMap kbmap-$imw" >&2
@@ -172,6 +172,6 @@ if  phase=($TESTMB_CMD); [ "$phase" != "READY" ]; then
 fi
 
 mbwsname_space_config="${PWD}/temp-space-config/spaceprovider-default-${mbwsname}"
-kubectl-kubestellar-get-config-for-space --space-name ${mbwsname} --provider-name default --sm-core-config $SM_CONFIG --sm-context $SM_CONTEXT --output $mbwsname_space_config
+kubectl-kubestellar-get-config-for-space --space-name ${mbwsname} --sm-core-config $SM_CONFIG --sm-context $SM_CONTEXT --output $mbwsname_space_config
 
 KUBECONFIG=$mbwsname_space_config $bindir/kubectl-kubestellar-syncer_gen "$prefixed_stname" --syncer-image "$syncer_image" -o "$output"

--- a/scripts/outer/kubectl-kubestellar-prep_for_syncer
+++ b/scripts/outer/kubectl-kubestellar-prep_for_syncer
@@ -136,7 +136,7 @@ prefixed_stname="$cluster_ns_name"-"$stname"
 stUID=$(KUBECONFIG=$espw_space_config kubectl "${kubectl_flags[@]}" get synctargets.edge.kubestellar.io $prefixed_stname -o jsonpath="{.metadata.uid}")
 mbwsname="$imw"-mb-"$stUID"
 
-if ! KUBECONFIG=$espw_space_config kubectl "${kubectl_flags[@]}" get APIExport edge.kubestellar.io &> /dev/null ; then
+if [ $(KUBECONFIG=$espw_space_config kubectl get crd -l kube-bind.io/exported=true -oname 2>/dev/null | wc -l) -eq 0 ]; then
     echo "$0: it looks like ${espw@Q} is not the edge service provider workspace" >&2
     exit 2
 fi

--- a/scripts/outer/kubectl-kubestellar-prep_for_syncer
+++ b/scripts/outer/kubectl-kubestellar-prep_for_syncer
@@ -111,7 +111,7 @@ fi
 set -e
 
 imw_space_config="${PWD}/temp-space-config/spaceprovider-default-${imw}"
-kubectl-kubestellar-get-config-for-space --space-name ${imw} --provider-name default --sm-core-config $SM_CONFIG --sm-context $SM_CONTEXT --space-config-file $imw_space_config
+kubectl-kubestellar-get-config-for-space --space-name ${imw} --provider-name default --sm-core-config $SM_CONFIG --sm-context $SM_CONTEXT --output $imw_space_config
 mbwsname=$(KUBECONFIG=$imw_space_config kubectl "${kubectl_flags[@]}" get synctargets.edge.kubestellar.io "$stname" -o jsonpath="{.metadata.annotations['kcp\.io/cluster']}-mb-{.metadata.uid}")
 
 original_ws=$(kubectl ws "${kubectl_flags[@]}" . --short)
@@ -154,7 +154,7 @@ stUID=$(kubectl "${kubectl_flags[@]}" get synctargets.edge.kubestellar.io $prefi
 mbwsname="$spaceID"-mb-"$stUID"
 
 espw_space_config="${PWD}/temp-space-config/spaceprovider-default-${espw}"
-kubectl-kubestellar-get-config-for-space --space-name ${espw} --provider-name default --sm-core-config $SM_CONFIG --sm-context $SM_CONTEXT --space-config-file $espw_space_config
+kubectl-kubestellar-get-config-for-space --space-name ${espw} --provider-name default --sm-core-config $SM_CONFIG --sm-context $SM_CONTEXT --output $espw_space_config
 if ! KUBECONFIG=$espw_space_config kubectl "${kubectl_flags[@]}" get APIExport edge.kubestellar.io &> /dev/null ; then
     echo "$0: it looks like ${espw@Q} is not the edge service provider workspace" >&2
     exit 2

--- a/scripts/outer/kubectl-kubestellar-prep_for_syncer
+++ b/scripts/outer/kubectl-kubestellar-prep_for_syncer
@@ -119,7 +119,7 @@ if ! [[ "$imw" =~ [a-z0-9].* ]]; then
     exit 1
 fi
 
-lif ! [[ "$espw" =~ [a-z0-9].* ]]; then
+if ! [[ "$espw" =~ [a-z0-9].* ]]; then
     echo "$0: espw ${espw@Q} is not valid" >&2
     exit 1
 fi
@@ -174,4 +174,4 @@ fi
 mbwsname_space_config="${PWD}/temp-space-config/spaceprovider-default-${mbwsname}"
 kubectl-kubestellar-get-config-for-space --space-name ${mbwsname} --provider-name default --sm-core-config $SM_CONFIG --sm-context $SM_CONTEXT --output $mbwsname_space_config
 
-#"KUBECONFIG=$mbwsname_space_config $bindir/kubectl-kubestellar-syncer_gen" "$prefixed_stname" --syncer-image "$syncer_image" -o "$output"
+"KUBECONFIG=$mbwsname_space_config $bindir/kubectl-kubestellar-syncer_gen" "$prefixed_stname" --syncer-image "$syncer_image" -o "$output"

--- a/scripts/overlap/kubectl-kubestellar-create-space
+++ b/scripts/overlap/kubectl-kubestellar-create-space
@@ -26,7 +26,7 @@ provider_name="default"
 while (( $# > 0 )); do
     case "$1" in
 	(-h|--help)
-	    echo "Usage: kubectl kubestellar get-config-for-space (--space-name name | --sm-core-config filepath "
+	    echo "Usage: kubectl kubestellar create space (--space-name name | --sm-core-config filepath | --provider-name provider)"
 	    exit 0;;
 	(-X) set -o xtrace;;
 	(--space-name)
@@ -56,11 +56,6 @@ done
 
 if [ -z "$space_name" ]; then
     echo "$0: must be given a non-empty space name" >&2
-    exit 1
-fi
-
-if [ -z "$provider_name" ]; then
-    echo "$0: must be given a non-empty space provider name" >&2
     exit 1
 fi
 

--- a/scripts/overlap/kubectl-kubestellar-ensure-wmw
+++ b/scripts/overlap/kubectl-kubestellar-ensure-wmw
@@ -71,16 +71,16 @@ if [ "$KUBECONFIG_DIR" == "" ]; then
     mkdir -p $KUBECONFIG_DIR
     export KUBECONFIG_DIR
 fi
-if [ "$SPACE_MANAGER_KUBECONFIG" == "" ]; then
-    SPACE_MANAGER_KUBECONFIG="${KUBECONFIG_DIR}/config"
-    export SPACE_MANAGER_KUBECONFIG
+if [ "$SM_CONFIG" == "" ]; then
+    SM_CONFIG="${KUBECONFIG_DIR}/config"
+    export SM_CONFIG
 fi
 if [ "$IN_CLUSTER" == "" ]; then
     IN_CLUSTER=true
     export IN_CLUSTER
 fi
 
-echo "SPACE_MANAGER_KUBECONFIG=${SPACE_MANAGER_KUBECONFIG}"
+echo "SM_CONFIG=${SM_CONFIG}"
 echo "PROVIDER_NAME=${PROVIDER_NAME}"
 echo "PROVIDER_NAMESPACE=${PROVIDER_NAMESPACE}"
 echo "IN_CLUSTER=${IN_CLUSTER}"
@@ -104,12 +104,12 @@ if $IN_CLUSTER; then
 fi
 
 space_config="${KUBECONFIG_DIR}/${PROVIDER_NAMESPACE}-${wmw_name}"
-kubectl-kubestellar-create-space --space-name $wmw_name --provider-name $PROVIDER_NAME --sm-core-config $SPACE_MANAGER_KUBECONFIG
-kubectl-kubestellar-get-config-for-space --space-name $wmw_name --provider-name $PROVIDER_NAME --sm-core-config $SPACE_MANAGER_KUBECONFIG ${in_cluster} --output $space_config
+kubectl-kubestellar-create-space --space-name $wmw_name --provider-name $PROVIDER_NAME --sm-core-config $SM_CONFIG
+kubectl-kubestellar-get-config-for-space --space-name $wmw_name --provider-name $PROVIDER_NAME --sm-core-config $SM_CONFIG ${in_cluster} --output $space_config
 
-KUBECONFIG=$SPACE_MANAGER_KUBECONFIG kubestellar-kube-bind "$wmw_name" "edgeplacements"
-KUBECONFIG=$SPACE_MANAGER_KUBECONFIG kubestellar-kube-bind "$wmw_name" "customizers"
-KUBECONFIG=$SPACE_MANAGER_KUBECONFIG kubestellar-kube-bind "$wmw_name" "singleplacementslices"
+KUBECONFIG=$SM_CONFIG kubestellar-kube-bind "$wmw_name" "edgeplacements"
+KUBECONFIG=$SM_CONFIG kubestellar-kube-bind "$wmw_name" "customizers"
+KUBECONFIG=$SM_CONFIG kubestellar-kube-bind "$wmw_name" "singleplacementslices"
 
 function reconcile_kube_CRDs() {
 	if [ "$want_kube" == true ]; then

--- a/scripts/overlap/kubectl-kubestellar-ensure-wmw
+++ b/scripts/overlap/kubectl-kubestellar-ensure-wmw
@@ -105,7 +105,7 @@ fi
 
 space_config="${KUBECONFIG_DIR}/${PROVIDER_NAMESPACE}-${wmw_name}"
 kubectl-kubestellar-create-space --space-name $wmw_name --provider-name $PROVIDER_NAME --sm-core-config $SPACE_MANAGER_KUBECONFIG
-kubectl-kubestellar-get-config-for-space --space-name $wmw_name --provider-name $PROVIDER_NAME --sm-core-config $SPACE_MANAGER_KUBECONFIG ${in_cluster} --space-config-file $space_config
+kubectl-kubestellar-get-config-for-space --space-name $wmw_name --provider-name $PROVIDER_NAME --sm-core-config $SPACE_MANAGER_KUBECONFIG ${in_cluster} --output $space_config
 
 KUBECONFIG=$space_config kubestellar-kube-bind "$wmw_name" "edgeplacements"
 KUBECONFIG=$space_config kubestellar-kube-bind "$wmw_name" "customizers"

--- a/scripts/overlap/kubectl-kubestellar-ensure-wmw
+++ b/scripts/overlap/kubectl-kubestellar-ensure-wmw
@@ -105,7 +105,7 @@ fi
 
 space_config="${KUBECONFIG_DIR}/${PROVIDER_NAMESPACE}-${wmw_name}"
 kubectl-kubestellar-create-space --space-name $wmw_name --provider-name $PROVIDER_NAME --sm-core-config $SM_CONFIG
-kubectl-kubestellar-get-config-for-space --space-name $wmw_name --provider-name $PROVIDER_NAME --sm-core-config $SM_CONFIG ${in_cluster} --output $space_config
+kubectl-kubestellar-get-config-for-space --space-name $wmw_name --sm-core-config $SM_CONFIG --sm-context $SM_CONTEXT ${in_cluster} --output $space_config
 
 KUBECONFIG=$SM_CONFIG kubestellar-kube-bind "$wmw_name" "edgeplacements"
 KUBECONFIG=$SM_CONFIG kubestellar-kube-bind "$wmw_name" "customizers"

--- a/scripts/overlap/kubectl-kubestellar-ensure-wmw
+++ b/scripts/overlap/kubectl-kubestellar-ensure-wmw
@@ -107,9 +107,9 @@ space_config="${KUBECONFIG_DIR}/${PROVIDER_NAMESPACE}-${wmw_name}"
 kubectl-kubestellar-create-space --space-name $wmw_name --provider-name $PROVIDER_NAME --sm-core-config $SPACE_MANAGER_KUBECONFIG
 kubectl-kubestellar-get-config-for-space --space-name $wmw_name --provider-name $PROVIDER_NAME --sm-core-config $SPACE_MANAGER_KUBECONFIG ${in_cluster} --output $space_config
 
-KUBECONFIG=$space_config kubestellar-kube-bind "$wmw_name" "edgeplacements"
-KUBECONFIG=$space_config kubestellar-kube-bind "$wmw_name" "customizers"
-KUBECONFIG=$space_config kubestellar-kube-bind "$wmw_name" "singleplacementslices"
+KUBECONFIG=$SPACE_MANAGER_KUBECONFIG kubestellar-kube-bind "$wmw_name" "edgeplacements"
+KUBECONFIG=$SPACE_MANAGER_KUBECONFIG kubestellar-kube-bind "$wmw_name" "customizers"
+KUBECONFIG=$SPACE_MANAGER_KUBECONFIG kubestellar-kube-bind "$wmw_name" "singleplacementslices"
 
 function reconcile_kube_CRDs() {
 	if [ "$want_kube" == true ]; then

--- a/scripts/overlap/kubectl-kubestellar-get-config-for-space
+++ b/scripts/overlap/kubectl-kubestellar-get-config-for-space
@@ -23,12 +23,11 @@ bindir="$(dirname "$0")"
 
 in_cluster="false"
 provider_name="default"
-sm_context="sm-mgt"
 
 while (( $# > 0 )); do
     case "$1" in
 	(-h|--help)
-	    echo "Usage: kubectl kubestellar get-config-for-space (--space-name name | --sm-core-config filepath | --sm-context sm context | -- provider-name provider name | --in-cluster | --output output config file )"
+	    echo "Usage: kubectl kubestellar get-config-for-space (--space-name name | --sm-core-config filepath | --sm-context sm context | --provider-name provider name | --in-cluster | --output output config file )"
 	    exit 0;;
 	(-X) set -o xtrace;;
 	(--space-name)

--- a/scripts/overlap/kubectl-kubestellar-get-config-for-space
+++ b/scripts/overlap/kubectl-kubestellar-get-config-for-space
@@ -97,5 +97,6 @@ echo "SECRET_NAME=${SECRET_NAME}"
 SECRET_NAMESPACE=$($sm_kubectl get space ${space_name} -n ${space_ns} -o jsonpath="{$.status.${secret_ctx}.namespace}")
 echo "SECRET_NAMESPACE=${SECRET_NAMESPACE}"
 
+echo "$sm_kubectl get secret ${SECRET_NAME} -n ${SECRET_NAMESPACE} -o jsonpath='{$.data.kubeconfig}' "
 $sm_kubectl get secret ${SECRET_NAME} -n ${SECRET_NAMESPACE} -o jsonpath='{$.data.kubeconfig}' | base64 -d | base64 -d > $space_config_file_name
 

--- a/scripts/overlap/kubectl-kubestellar-get-config-for-space
+++ b/scripts/overlap/kubectl-kubestellar-get-config-for-space
@@ -78,6 +78,11 @@ if [ -z "$sm_core_config" ]; then
     exit 1
 fi
 
+if [ -z "$sm_context" ]; then
+    echo "$0: must be given a non-empty SM context" >&2
+    exit 1
+fi
+
 if [ -z "$space_config_file_name" ]; then
     echo "$0: must be given a non-empty space config file name" >&2
     exit 1

--- a/scripts/overlap/kubectl-kubestellar-get-config-for-space
+++ b/scripts/overlap/kubectl-kubestellar-get-config-for-space
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Usage: $0 (--space-name space-name | --space-config-file space-kubeconfig | --sm-context space-context | --provider-name provider-name | --core-config core-kubeconfig | --in-cluster | -X)* synctarget_name
+# Usage: $0 (--space-name space-name | --output space-kubeconfig | --sm-context space-context | --provider-name provider-name | --core-config core-kubeconfig | --in-cluster | -X)* synctarget_name
 
 # Purpose: Retrieve the kubeconfig information for a specific space and generate a kubeconfig for it
 
@@ -28,7 +28,7 @@ sm_context="sm-mgt"
 while (( $# > 0 )); do
     case "$1" in
 	(-h|--help)
-	    echo "Usage: kubectl kubestellar get-config-for-space (--space-name name | --sm-core-config filepath "
+	    echo "Usage: kubectl kubestellar get-config-for-space (--space-name name | --sm-core-config filepath | --sm-context sm context | -- provider-name provider name | --in-cluster | --output output config file )"
 	    exit 0;;
 	(-X) set -o xtrace;;
 	(--space-name)
@@ -36,7 +36,7 @@ while (( $# > 0 )); do
 	    then space_name="$2"; shift
 	    else echo "$0: missing space name" >&2; exit 1
 	    fi;;
-	(--space-config-file)
+	(--output)
 	    if (( $# >1 ))
 	    then space_config_file_name="$2"; shift
 	    else echo "$0: missing output filename" >&2; exit 1
@@ -78,18 +78,17 @@ if [ -z "$sm_core_config" ]; then
     exit 1
 fi
 
+if [ -z "$space_config_file_name" ]; then
+    echo "$0: must be given a non-empty space config file name" >&2
+    exit 1
+fi
+
 space_ns="spaceprovider-${provider_name}"
 
 secret_ctx="externalSecretRef"
 if [ "$in_cluster" == "true" ]; then
     secret_ctx="inClusterSecretRef"
 fi
-
-if [ -z "$space_config_file_name" ]; then
-	space_config_file_name="${provider_name}_${space_name}.config"
-    echo "$0: output config file name was not supplied. Using $space_config_file_name" >&2
-fi
-
 
 sm_kubectl="kubectl --kubeconfig $sm_core_config  --context $sm_context"
 


### PR DESCRIPTION
This PR replaces #1286.   It is still WIP until all changes are pushed into the space-mgt branch

It includes changing all the scripts, tests, and KS code to use the SF instead of KCP workspaces.
It also switch from using a "cluster ID" to using "space name"

<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

## Related issue(s)

Fixes #
