### PR TITLE
✨ More verbose logging in example1

### DIFF
--- a/docs/content/Coding Milestones/PoC2023q1/example1-subs/example1-stage-1a.md
+++ b/docs/content/Coding Milestones/PoC2023q1/example1-subs/example1-stage-1a.md
@@ -10,7 +10,7 @@ processes then launch this controller as follows.
 ```shell
 # TODO: mailbox controller has kcp dependencies. Will remove when controllers support spaces.
 kubectl ws root:espw
-mailbox-controller -v=2 &
+mailbox-controller -v=4 &
 sleep 20
 ```
 

--- a/docs/content/Coding Milestones/PoC2023q1/example1-subs/example1-stage-2.md
+++ b/docs/content/Coding Milestones/PoC2023q1/example1-subs/example1-stage-2.md
@@ -411,7 +411,7 @@ espw_space_config="${PWD}/temp-space-config/spaceprovider-default-espw"
 kubectl-kubestellar-get-config-for-space --space-name espw --provider-name default --sm-core-config $SM_CONFIG --space-config-file $espw_space_config
 # TODO: where-resolver needs access to multiple configs. Will remove when controllers support spaces.
 kubectl ws root:espw 
-kubestellar-where-resolver &
+kubestellar-where-resolver -v=4 &
 sleep 10
 ```
 

--- a/docs/content/Coding Milestones/PoC2023q1/example1-subs/example1-stage-3.md
+++ b/docs/content/Coding Milestones/PoC2023q1/example1-subs/example1-stage-3.md
@@ -17,7 +17,7 @@ requires the ESPW to be current at start time.
 ```shell
 # TODO: placement-translator needs access to multiple configs. Will remove when controllers support spaces.
 kubectl ws root:espw
-placement-translator &
+placement-translator -v=4 &
 sleep 10
 ```
 


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
This PR increases the debug logging verbosity of the core controllers from `-v=2` to `-v=4` in example1. This is good because it helps debugging and this example is intended for contributors, who can tolerate that.

## Related issue(s)

Fixes #
