### PR TITLE
🌱 Dump example1 verbose logs at the end of CI

### DIFF
--- a/.github/workflows/docs-ecutable-example1.yml
+++ b/.github/workflows/docs-ecutable-example1.yml
@@ -51,3 +51,21 @@ jobs:
       - run: |
           make MANIFEST="${{ env.docs-ecutable-md-filename }}" \
           docs-ecutable
+
+      - name: Dump mailbox-controller log
+        if: always()
+        run: cat /tmp/mailbox-controller.log
+
+      - name: Dump where-resolver log
+        if: always()
+        run: cat /tmp/where-resolver.log
+
+      - name: Tail placement-translator log
+        if: always()
+        run: |
+          wc /tmp/placement-translator.log
+          tail /tmp/placement-translator.log
+
+      - name: Dump placement-translator log
+        if: always()
+        run: cat /tmp/placement-translator.log

--- a/docs/content/Coding Milestones/PoC2023q1/example1-subs/example1-stage-1a.md
+++ b/docs/content/Coding Milestones/PoC2023q1/example1-subs/example1-stage-1a.md
@@ -10,7 +10,7 @@ processes then launch this controller as follows.
 ```shell
 # TODO: mailbox controller has kcp dependencies. Will remove when controllers support spaces.
 kubectl ws root:espw
-mailbox-controller -v=4 &
+mailbox-controller -v=4 &> /tmp/mailbox-controller.log &
 sleep 20
 ```
 

--- a/docs/content/Coding Milestones/PoC2023q1/example1-subs/example1-stage-2.md
+++ b/docs/content/Coding Milestones/PoC2023q1/example1-subs/example1-stage-2.md
@@ -411,7 +411,7 @@ espw_space_config="${PWD}/temp-space-config/spaceprovider-default-espw"
 kubectl-kubestellar-get-config-for-space --space-name espw --provider-name default --sm-core-config $SM_CONFIG --space-config-file $espw_space_config
 # TODO: where-resolver needs access to multiple configs. Will remove when controllers support spaces.
 kubectl ws root:espw 
-kubestellar-where-resolver -v=4 &
+kubestellar-where-resolver -v=4 &> /tmp/where-resolver.log &
 sleep 10
 ```
 

--- a/docs/content/Coding Milestones/PoC2023q1/example1-subs/example1-stage-3.md
+++ b/docs/content/Coding Milestones/PoC2023q1/example1-subs/example1-stage-3.md
@@ -17,7 +17,7 @@ requires the ESPW to be current at start time.
 ```shell
 # TODO: placement-translator needs access to multiple configs. Will remove when controllers support spaces.
 kubectl ws root:espw
-placement-translator -v=4 &
+placement-translator -v=4 &> /tmp/placement-translator.log &
 sleep 10
 ```
 


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
This PR changes example1 so that the controller logs go to /tmp files and are dumped at the end of a CI run.

## Related issue(s)

Fixes #
