### PR TITLE
🐛 Fix `kubectl-kubestellar-ensure-location`

### DIFF
--- a/scripts/outer/kubectl-kubestellar-ensure-location
+++ b/scripts/outer/kubectl-kubestellar-ensure-location
@@ -117,6 +117,9 @@ echo "--- current directory is $PWD"
 imw_space_config="${PWD}/temp-space-config/spaceprovider-default-${imw}"
 kubectl-kubestellar-get-config-for-space --space-name ${imw} --provider-name default --sm-core-config $SM_CONFIG --sm-context $SM_CONTEXT --space-config-file $imw_space_config
 
+KUBECONFIG=$imw_space_config kubestellar-kube-bind "$imw" "synctargets"
+KUBECONFIG=$imw_space_config kubestellar-kube-bind "$imw" "locations"
+
 if ! kubectl "${kubectl_flags[@]}" --kubeconfig $imw_space_config get synctargets.edge.kubestellar.io "$objname" &> /dev/null; then
 (cat <<EOF
 apiVersion: edge.kubestellar.io/v2alpha1


### PR DESCRIPTION
## Summary
With an idempotent script for kube-bind, we can now addresses https://github.com/kubestellar/kubestellar/issues/1337#issuecomment-1832146503.

## Related issue(s)

Closes #1337
