### PR TITLE
🐛 Fix bugs wrt name of projected SyncerConfig

### DIFF
--- a/pkg/placement/main.go
+++ b/pkg/placement/main.go
@@ -81,7 +81,7 @@ func NewPlacementTranslator(
 	}
 	pt.workloadProjector = NewWorkloadProjector(ctx, numThreads, DefaultResourceModes,
 		pt.spaceInformer, pt.spaceLister, pt.syncfgInformer,
-		spaceclient, spaceProviderNs)
+		spaceclient, spaceProviderNs, kbSpaceRelation)
 
 	return pt
 }


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
This PR fixes bugs in how the name of a SyncerConfig object in the KCS is handled.

## Related issue(s)

Fixes #1431 
