### PR TITLE
🐛 Add missing specification of namespace holding Space

### DIFF
--- a/docs/content/Coding Milestones/PoC2023q1/commands.md
+++ b/docs/content/Coding Milestones/PoC2023q1/commands.md
@@ -998,7 +998,7 @@ Deleting a WMW can be done by simply deleting its `space` object from
 the parent.
 
 ```shell
-KUBECONFIG=$SM_CONFIG kubectl delete space example-wmw
+KUBECONFIG=$SM_CONFIG kubectl delete space -n spaceprovider-default example-wmw
 ```
 ``` { .bash .no-copy }
 workspace.tenancy.kcp.io "example-wmw" deleted

--- a/docs/content/Coding Milestones/PoC2023q1/example1-subs/example1-teardown.md
+++ b/docs/content/Coding Milestones/PoC2023q1/example1-subs/example1-teardown.md
@@ -3,9 +3,9 @@ To remove the example usage, delete the IMW and WMW and kind clusters run the fo
 
 ``` {.bash}
 rm florin-syncer.yaml guilder-syncer.yaml || true
-KUBECONFIG=$SM_CONFIG kubectl delete space imw1
-KUBECONFIG=$SM_CONFIG kubectl delete space $FLORIN_SPACE
-KUBECONFIG=$SM_CONFIG kubectl delete space $GUILDER_SPACE
+KUBECONFIG=$SM_CONFIG kubectl delete space -n spaceprovider-default imw1
+KUBECONFIG=$SM_CONFIG kubectl delete space -n spaceprovider-default $FLORIN_SPACE
+KUBECONFIG=$SM_CONFIG kubectl delete space -n spaceprovider-default $GUILDER_SPACE
 kubectl kubestellar remove wmw wmw-c
 kubectl kubestellar remove wmw wmw-s
 kind delete cluster --name florin

--- a/docs/content/common-subs/teardown-the-environment.md
+++ b/docs/content/common-subs/teardown-the-environment.md
@@ -4,8 +4,6 @@ To remove the example usage, delete the IMW and WMW and kind clusters run the fo
 ``` {.bash}
 rm florin-syncer.yaml guilder-syncer.yaml || true
 kubectl ws root
-kubectl delete workspace imw1
-kubectl kubestellar remove wmw wmw1
 kind delete cluster --name florin
 kind delete cluster --name guilder
 ```

--- a/scripts/outer/kubectl-kubestellar-remove-wmw
+++ b/scripts/outer/kubectl-kubestellar-remove-wmw
@@ -59,7 +59,7 @@ fi
 set -e
 
 kubectl ws "${kubectl_flags[@]}" root
-if kubectl "${kubectl_flags[@]}" get workspaces.tenancy.kcp.io "$wmw_name" &>/dev/null
-then kubectl "${kubectl_flags[@]}" delete workspaces.tenancy.kcp.io "$wmw_name"
+if kubectl "${kubectl_flags[@]}" get spaces -n spaceprovider-default "$wmw_name" &>/dev/null
+then kubectl "${kubectl_flags[@]}" delete spaces -n spaceprovider-default "$wmw_name"
 fi
 


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
This PR updates some scripting that deletes Space objects to supply the missing specification of the namespace holding the Space object.

This PR also removes some obsolete commands from `docs/content/common-subs/teardown-the-environment.md`.

## Related issue(s)

Fixes #1432 
