### PR TITLE
🐛 Also don't count kubestellar-kube-bind-logs/ and build/

### DIFF
--- a/hack/count-commit.sh
+++ b/hack/count-commit.sh
@@ -46,5 +46,5 @@ else descr="c $commit"
 fi
 cp -R . forcount
 cd forcount
-rm -rf counts bin .git .vscode docs/venv docs/__pycache__ docs/scripts/generated_script.sh
+rm -rf counts bin build kubestellar-kube-bind-logs .git .vscode docs/venv docs/__pycache__ docs/scripts/generated_script.sh
 ${bindir}/count-tree.sh ../counts "$ts_pretty" "$commit" "$descr"


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
This PR updates the hack/count-commit.sh script to add `kubestellar-kube-bind-logs/` and `build/` to the directories not counted.

## Related issue(s)

Fixes #
