### PR TITLE
:sparkles: Add cli flag for external access to space provider

### DIFF
--- a/cmd/kubestellar-where-resolver/cmd/where-resolver-cmd.go
+++ b/cmd/kubestellar-where-resolver/cmd/where-resolver-cmd.go
@@ -97,7 +97,7 @@ func Run(ctx context.Context, options *resolveroptions.Options) error {
 		logger.Error(err, "Failed to create space management API client config from flags")
 		return err
 	}
-	spaceClient, err := spaceclient.NewMultiSpace(ctx, spaceManagementConfig)
+	spaceClient, err := spaceclient.NewMultiSpace(ctx, spaceManagementConfig, options.ExternalAccess)
 	if err != nil {
 		logger.Error(err, "Failed to create space-aware client")
 		return err

--- a/cmd/kubestellar-where-resolver/options/options.go
+++ b/cmd/kubestellar-where-resolver/options/options.go
@@ -58,7 +58,7 @@ func (options *Options) AddFlags(fs *pflag.FlagSet) {
 	options.Logs.AddFlags(fs)
 	fs.StringVar(&options.SpaceProvider, "space-provider", options.SpaceProvider, "the name of the KubeStellar space provider")
 	fs.StringVar(&options.KcsName, "core-space", options.KcsName, "the name of the KubeStellar Core space")
-	fs.BoolVar(&options.ExternalAccess, "external-access", options.ExternalAccess, "the access to the spaces. True for external, default false for in cluster access")
+	fs.BoolVar(&options.ExternalAccess, "external-access", options.ExternalAccess, "the access to the spaces. True when the space-provider is hosted in a space while the controller is running outside of that space")
 
 }
 

--- a/cmd/kubestellar-where-resolver/options/options.go
+++ b/cmd/kubestellar-where-resolver/options/options.go
@@ -28,6 +28,7 @@ import (
 const (
 	defaultSpaceProviderName string = "default"
 	defaultKcsName           string = "espw"
+	externalAccess           bool   = false
 )
 
 type Options struct {
@@ -35,6 +36,7 @@ type Options struct {
 	Logs               *logs.Options
 	SpaceProvider      string
 	KcsName            string
+	ExternalAccess     bool
 }
 
 func NewOptions() *Options {
@@ -47,6 +49,7 @@ func NewOptions() *Options {
 		Logs:               logs,
 		SpaceProvider:      defaultSpaceProviderName,
 		KcsName:            defaultKcsName,
+		ExternalAccess:     externalAccess,
 	}
 }
 
@@ -55,6 +58,8 @@ func (options *Options) AddFlags(fs *pflag.FlagSet) {
 	options.Logs.AddFlags(fs)
 	fs.StringVar(&options.SpaceProvider, "space-provider", options.SpaceProvider, "the name of the KubeStellar space provider")
 	fs.StringVar(&options.KcsName, "core-space", options.KcsName, "the name of the KubeStellar Core space")
+	fs.BoolVar(&options.ExternalAccess, "external-access", options.ExternalAccess, "the access to the spaces. True for external, default false for in cluster access")
+
 }
 
 func (options *Options) Complete() error {

--- a/cmd/mailbox-controller/main.go
+++ b/cmd/mailbox-controller/main.go
@@ -58,6 +58,7 @@ func main() {
 	serverBindAddress := ":10203"
 	kcsName := "espw"
 	spaceProvider := "default"
+	externalAccess := false
 	fs := pflag.NewFlagSet("mailbox-controller", pflag.ExitOnError)
 	klog.InitFlags(flag.CommandLine)
 	fs.AddGoFlagSet(flag.CommandLine)
@@ -66,6 +67,7 @@ func main() {
 	fs.IntVar(&concurrency, "concurrency", concurrency, "number of syncs to run in parallel")
 	fs.StringVar(&kcsName, "core-space", kcsName, "the name of the KubeStellar core space")
 	fs.StringVar(&spaceProvider, "space-provider", spaceProvider, "the name of the KubeStellar space provider")
+	fs.BoolVar(&externalAccess, "external-access", externalAccess, "the access to the spaces. True for external, default false for in cluster access")
 
 	spaceMgtOpts := clientopts.NewClientOpts("space-mgt", "access to the space reference space")
 	spaceMgtOpts.AddFlags(fs)
@@ -97,7 +99,7 @@ func main() {
 		logger.Error(err, "Failed to create space management API client config from flags")
 		os.Exit(3)
 	}
-	spaceclient, err := spaceclient.NewMultiSpace(ctx, spaceManagementConfig)
+	spaceclient, err := spaceclient.NewMultiSpace(ctx, spaceManagementConfig, externalAccess)
 	if err != nil {
 		logger.Error(err, "Failed to create space-aware client")
 		os.Exit(10)

--- a/cmd/mailbox-controller/main.go
+++ b/cmd/mailbox-controller/main.go
@@ -67,7 +67,7 @@ func main() {
 	fs.IntVar(&concurrency, "concurrency", concurrency, "number of syncs to run in parallel")
 	fs.StringVar(&kcsName, "core-space", kcsName, "the name of the KubeStellar core space")
 	fs.StringVar(&spaceProvider, "space-provider", spaceProvider, "the name of the KubeStellar space provider")
-	fs.BoolVar(&externalAccess, "external-access", externalAccess, "the access to the spaces. True for external, default false for in cluster access")
+	fs.BoolVar(&externalAccess, "external-access", externalAccess, "the access to the spaces. True when the space-provider is hosted in a space while the controller is running outside of that space")
 
 	spaceMgtOpts := clientopts.NewClientOpts("space-mgt", "access to the space reference space")
 	spaceMgtOpts.AddFlags(fs)

--- a/cmd/placement-translator/main.go
+++ b/cmd/placement-translator/main.go
@@ -89,6 +89,7 @@ func main() {
 	serverBindAddress := ":10204"
 	kcsName := "espw"
 	spaceProvider := "default"
+	externalAccess := false
 	fs := pflag.NewFlagSet("placement-translator", pflag.ExitOnError)
 	klog.InitFlags(flag.CommandLine)
 	fs.AddGoFlagSet(flag.CommandLine)
@@ -96,6 +97,7 @@ func main() {
 	fs.IntVar(&concurrency, "concurrency", concurrency, "number of syncs to run in parallel")
 	fs.StringVar(&kcsName, "core-space", kcsName, "the name of the KubeStellar core space")
 	fs.StringVar(&spaceProvider, "space-provider", spaceProvider, "the name of the KubeStellar space provider")
+	fs.BoolVar(&externalAccess, "external-access", externalAccess, "the access to the spaces. True for external, default false for in cluster access")
 
 	spaceMgtClientOpts := NewClientOpts("space-mgt", "access to the space reference space")
 	spaceMgtClientOpts.AddFlags(fs)
@@ -125,7 +127,7 @@ func main() {
 		logger.Error(err, "Failed to create space management API client config from flags")
 		os.Exit(3)
 	}
-	spaceclient, err := spaceclient.NewMultiSpace(ctx, spaceManagementConfig)
+	spaceclient, err := spaceclient.NewMultiSpace(ctx, spaceManagementConfig, externalAccess)
 	if err != nil {
 		logger.Error(err, "Failed to create space-aware client")
 		os.Exit(4)

--- a/cmd/placement-translator/main.go
+++ b/cmd/placement-translator/main.go
@@ -97,7 +97,7 @@ func main() {
 	fs.IntVar(&concurrency, "concurrency", concurrency, "number of syncs to run in parallel")
 	fs.StringVar(&kcsName, "core-space", kcsName, "the name of the KubeStellar core space")
 	fs.StringVar(&spaceProvider, "space-provider", spaceProvider, "the name of the KubeStellar space provider")
-	fs.BoolVar(&externalAccess, "external-access", externalAccess, "the access to the spaces. True for external, default false for in cluster access")
+	fs.BoolVar(&externalAccess, "external-access", externalAccess, "the access to the spaces. True when the space-provider is hosted in a space while the controller is running outside of that space")
 
 	spaceMgtClientOpts := NewClientOpts("space-mgt", "access to the space reference space")
 	spaceMgtClientOpts.AddFlags(fs)

--- a/pkg/placement/what-resolver_test.go
+++ b/pkg/placement/what-resolver_test.go
@@ -152,7 +152,7 @@ func TestWhatResolver(t *testing.T) {
 	kbSpaceRelation := kbuser.NewKubeBindSpaceRelation(ctx, fakeUpKubeClient)
 	spaceProviderNs := "spaceprovider-fake"
 	// TODO fake
-	spaceclient, _ := msclient.NewMultiSpace(ctx, nil)
+	spaceclient, _ := msclient.NewMultiSpace(ctx, nil, true)
 
 	whatResolver := NewWhatResolver(ctx, epPreInformer, spaceclient, spaceProviderNs, kbSpaceRelation, 3)
 	edgeInformerFactory.Start(ctx.Done())

--- a/space-framework/cmd/space-client-test/main.go
+++ b/space-framework/cmd/space-client-test/main.go
@@ -44,7 +44,7 @@ func main() {
 
 	// Create the MC aware client --> initiate the underlying MC aware library
 	// The library actively watches for space updates, and maintain an updated list of accessible spaces
-	spclient, err := spaceclient.NewMultiSpace(ctx, managementSpaceConfig)
+	spclient, err := spaceclient.NewMultiSpace(ctx, managementSpaceConfig, true)
 	if err != nil {
 		logger.Error(err, "get client failed")
 		panic(err)

--- a/space-framework/pkg/msclientlib/controller.go
+++ b/space-framework/pkg/msclientlib/controller.go
@@ -153,9 +153,7 @@ func (c *controller) handleAdd(space interface{}, spaceKey string) {
 	// add space reference to cache
 	c.cacheSpaceReference(nSpace, spaceKey)
 
-	// TODO We assume the space is in a pod in the same cluster where the controllers are deployed
-	// Need to add flags to indicate it
-	config, err := c.msClient.getRestConfigFromSecret(true, nSpace)
+	config, err := c.msClient.getRestConfigFromSecret(nSpace)
 	if err != nil {
 		runtime.HandleError(err)
 		return


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
This PR introduces new boolean flag for KubeStellar controllers. This flag indicates whether a controller needs external or in-cluster access to the spaces. The flag value is `true` for external, or default `false` for in cluster access.

## Related issue(s)

Fixes #
