### PR TITLE
🌱 update the use of ObjectMeta Finalizers in space framework

### DIFF
--- a/space-framework/pkg/space-manager/provider.go
+++ b/space-framework/pkg/space-manager/provider.go
@@ -249,7 +249,7 @@ func (p *provider) processProviderWatchEvents() {
 					// When a physical space is removed we remove its finalizer
 					// from the space object. when the space returns, we
 					// need to restore the finalizer.
-					refspace.ObjectMeta.Finalizers = append(refspace.ObjectMeta.Finalizers, finalizerName)
+					refspace.SetFinalizers(append(refspace.GetFinalizers(), finalizerName))
 				}
 				refspace.Status.Phase = spacev1alpha1apis.SpacePhaseReady
 				_, err = p.c.clientset.SpaceV1alpha1().Spaces(p.nameSpace).Update(ctx, refspace, metav1.UpdateOptions{})
@@ -265,10 +265,10 @@ func (p *provider) processProviderWatchEvents() {
 			if refspace.Spec.Type == spacev1alpha1apis.SpaceTypeManaged {
 				_ = p.deleteSpaceSecrets(refspace)
 				// If managed then we need to remove the finalizer.
-				f := refspace.ObjectMeta.Finalizers
-				for i := 0; i < len(refspace.ObjectMeta.Finalizers); i++ {
-					if f[i] == finalizerName {
-						refspace.ObjectMeta.Finalizers = append(f[:i], f[i+1:]...)
+				finalizersList := refspace.GetFinalizers()
+				for i := 0; i < len(finalizersList); i++ {
+					if finalizersList[i] == finalizerName {
+						refspace.SetFinalizers(append(finalizersList[:i], finalizersList[i+1:]...))
 						i--
 					}
 				}

--- a/space-framework/pkg/space-manager/reconcile_space.go
+++ b/space-framework/pkg/space-manager/reconcile_space.go
@@ -33,7 +33,7 @@ const SpacePathAnnotationKey = "kubestellar.io/space-path"
 
 // containsFinalizer: returns true if the finalizer list contains the space finalizer
 func containsFinalizer(space *spacev1alpha1.Space, finalizer string) bool {
-	finalizersList := space.ObjectMeta.Finalizers
+	finalizersList := space.GetFinalizers()
 	for _, f := range finalizersList {
 		if f == finalizer {
 			return true


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

use finalizers by the dedicated GetFinalizers/SetFinalizers functions and not directly.
this is the best practice for working with objects that implements the `meta` interface.

## Related issue(s)

Fixes #
