### PR TITLE
🌱 updated kube bind `AnalyzeObject` func not to return the namespace of the original object.

### DIFF
--- a/cmd/mailbox-controller/controller.go
+++ b/cmd/mailbox-controller/controller.go
@@ -256,7 +256,7 @@ func (ctl *mbCtl) sync(ctx context.Context, refany any) bool {
 	}
 	// Now we have established that the SyncTarget exists and is not being deleted
 	if space == nil {
-		_, stOriginalName, _, err := kbuser.AnalyzeObjectID(syncTarget)
+		stOriginalName, _, err := kbuser.AnalyzeClusterScopedObject(syncTarget)
 		if err != nil {
 			logger.Error(err, "Object does not appear to be a provider's copy of a consumer's object", "syncTarget", syncTarget.Name)
 			return false
@@ -372,7 +372,7 @@ func (ctl *mbCtl) ensureBinding(ctx context.Context, spacename string) bool {
 
 func (ctl *mbCtl) mbsNameOfSynctarget(st *edgev2alpha1.SyncTarget) (string, error) {
 	logger := klog.FromContext(ctl.context)
-	_, _, kbSpaceID, err := kbuser.AnalyzeObjectID(st)
+	_, kbSpaceID, err := kbuser.AnalyzeClusterScopedObject(st)
 	if err != nil {
 		logger.Error(err, "object does not appear to be a provider's copy of a consumer's object", "syncTarget", st.Name)
 		return "", err

--- a/docs/content/Coding Milestones/PoC2023q1/outline.md
+++ b/docs/content/Coding Milestones/PoC2023q1/outline.md
@@ -176,8 +176,8 @@ mapping can be inverted with the following interface.
 ```go
 
 // AnalyzeClusterScopedObject examines a cluster-scoped object in a kube-bind service provider cluster
-// and returns the object's ID as known in the service consumer cluster and the kube-bind ID for the
-// consumer, or an error if the object does not appear to be a provider's copy of a consumer's object.
+// and returns the object's name as known in the service consumer cluster and the kube-bind space id for
+// the consumer, or an error if the object does not appear to be a provider's copy of a consumer's object.
 func AnalyzeClusterScopedObject(obj metav1.Object) (name, kbSpaceID string, err error) {..}
 
 // ComposeClusterScopedName translates the name of a cluster-scoped object

--- a/docs/content/Coding Milestones/PoC2023q1/outline.md
+++ b/docs/content/Coding Milestones/PoC2023q1/outline.md
@@ -175,11 +175,10 @@ mapping can be inverted with the following interface.
 
 ```go
 
-// AnalyzeObjectID examines an object in a kube-bind service provider
-// cluster and returns the object's ID as known in the service consumer
-// cluster and the kube-bind ID for the consumer, or an error if
-// the object does not appear to be a provider's copy of a consumer's object.
-func AnalyzeObjectID(obj metav1.Object) (namespace, name, kbSpaceID string, err error) {..}
+// AnalyzeClusterScopedObject examines a cluster-scoped object in a kube-bind service provider cluster
+// and returns the object's ID as known in the service consumer cluster and the kube-bind ID for the
+// consumer, or an error if the object does not appear to be a provider's copy of a consumer's object.
+func AnalyzeClusterScopedObject(obj metav1.Object) (name, kbSpaceID string, err error) {..}
 
 // ComposeClusterScopedName translates the name of a cluster-scoped object
 // from what appears in the service consumer cluster to what appears in the

--- a/pkg/kbuser/object_ids.go
+++ b/pkg/kbuser/object_ids.go
@@ -24,38 +24,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-// If in the future a need arises to analyze both cluster-scoped and namespace-scoped objects, switch to using
-// the following AnalyzeObjectID function instead of the existing AnalyzeClusterScopedObject function.
-
-// AnalyzeObjectID examines an object in a kube-bind service provider
-// cluster and returns the object's ID as known in the service consumer
-// cluster and the kube-bind ID for the consumer, or an error if
-// the object does not appear to be a provider's copy of a consumer's object.
-// func AnalyzeObjectID(obj metav1.Object) (namespace, name, kbSpaceID string, err error) {
-// 	if annotations := obj.GetAnnotations(); annotations != nil {
-// 		kbSpaceID = annotations["kube-bind.io/cluster-namespace"]
-// 	}
-// 	if kbSpaceID == "" {
-// 		return "", "", "", errors.New("no 'kube-bind.io/cluster-namespace' annotation found")
-// 	}
-// 	namespace = obj.GetNamespace()
-// 	name = obj.GetName()
-// 	var ok bool
-// 	if namespace == "" { // no namespace, cluster scoped object
-// 		name, ok = cutPrefix(name, kbSpaceID+"-")
-// 		if !ok {
-// 			err = fmt.Errorf("name %q does not have prefix for comsumer %q", name, kbSpaceID)
-// 		}
-// 		return
-// 	}
-// 	// otherwise, it's a namespace scoped object
-// 	if namespace, ok = cutPrefix(namespace, kbSpaceID+"-"); !ok {
-// 		err = fmt.Errorf("namespace %q does not have prefix for comsumer %q", namespace, kbSpaceID)
-// 	}
-
-// 	return
-// }
-
 // AnalyzeClusterScopedObject examines a cluster-scoped object in a kube-bind service provider cluster
 // and returns the object's ID as known in the service consumer cluster and the kube-bind ID for the
 // consumer, or an error if the object does not appear to be a provider's copy of a consumer's object.
@@ -91,3 +59,35 @@ func cutPrefix(s, sep string) (string, bool) {
 func ComposeClusterScopedName(kbSpaceID string, name string) string {
 	return kbSpaceID + "-" + name
 }
+
+// If in the future a need arises to analyze both cluster-scoped and namespace-scoped objects, switch to using
+// the following AnalyzeObjectID function instead of the existing AnalyzeClusterScopedObject function.
+
+// AnalyzeObjectID examines an object in a kube-bind service provider
+// cluster and returns the object's ID as known in the service consumer
+// cluster and the kube-bind ID for the consumer, or an error if
+// the object does not appear to be a provider's copy of a consumer's object.
+// func AnalyzeObjectID(obj metav1.Object) (namespace, name, kbSpaceID string, err error) {
+// 	if annotations := obj.GetAnnotations(); annotations != nil {
+// 		kbSpaceID = annotations["kube-bind.io/cluster-namespace"]
+// 	}
+// 	if kbSpaceID == "" {
+// 		return "", "", "", errors.New("no 'kube-bind.io/cluster-namespace' annotation found")
+// 	}
+// 	namespace = obj.GetNamespace()
+// 	name = obj.GetName()
+// 	var ok bool
+// 	if namespace == "" { // no namespace, cluster scoped object
+// 		name, ok = cutPrefix(name, kbSpaceID+"-")
+// 		if !ok {
+// 			err = fmt.Errorf("name %q does not have prefix for comsumer %q", name, kbSpaceID)
+// 		}
+// 		return
+// 	}
+// 	// otherwise, it's a namespace scoped object
+// 	if namespace, ok = cutPrefix(namespace, kbSpaceID+"-"); !ok {
+// 		err = fmt.Errorf("namespace %q does not have prefix for comsumer %q", namespace, kbSpaceID)
+// 	}
+
+// 	return
+// }

--- a/pkg/kbuser/object_ids.go
+++ b/pkg/kbuser/object_ids.go
@@ -25,8 +25,8 @@ import (
 )
 
 // AnalyzeClusterScopedObject examines a cluster-scoped object in a kube-bind service provider cluster
-// and returns the object's ID as known in the service consumer cluster and the kube-bind ID for the
-// consumer, or an error if the object does not appear to be a provider's copy of a consumer's object.
+// and returns the object's name as known in the service consumer cluster and the kube-bind space id for
+// the consumer, or an error if the object does not appear to be a provider's copy of a consumer's object.
 func AnalyzeClusterScopedObject(obj metav1.Object) (name, kbSpaceID string, err error) {
 	if annotations := obj.GetAnnotations(); annotations != nil {
 		kbSpaceID = annotations["kube-bind.io/cluster-namespace"]

--- a/pkg/kbuser/object_ids.go
+++ b/pkg/kbuser/object_ids.go
@@ -42,14 +42,14 @@ import (
 // 	name = obj.GetName()
 // 	var ok bool
 // 	if namespace == "" { // no namespace, cluster scoped object
-// 		name, ok = strings.CutPrefix(name, kbSpaceID+"-")
+// 		name, ok = cutPrefix(name, kbSpaceID+"-")
 // 		if !ok {
 // 			err = fmt.Errorf("name %q does not have prefix for comsumer %q", name, kbSpaceID)
 // 		}
 // 		return
 // 	}
 // 	// otherwise, it's a namespace scoped object
-// 	if namespace, ok = strings.CutPrefix(namespace, kbSpaceID+"-"); !ok {
+// 	if namespace, ok = cutPrefix(namespace, kbSpaceID+"-"); !ok {
 // 		err = fmt.Errorf("namespace %q does not have prefix for comsumer %q", namespace, kbSpaceID)
 // 	}
 
@@ -69,11 +69,18 @@ func AnalyzeClusterScopedObject(obj metav1.Object) (name, kbSpaceID string, err 
 	if obj.GetNamespace() != "" {
 		return "", "", errors.New("object is namespaced-scoped and not cluster-scoped")
 	}
-	if name, ok := strings.CutPrefix(obj.GetName(), kbSpaceID+"-"); !ok {
+	if name, ok := cutPrefix(obj.GetName(), kbSpaceID+"-"); !ok {
 		err = fmt.Errorf("name %q does not have prefix for comsumer %q", name, kbSpaceID)
 	}
 
 	return
+}
+
+func cutPrefix(s, sep string) (string, bool) {
+	if strings.HasPrefix(s, sep) {
+		return s[len(sep):], true
+	}
+	return s, false
 }
 
 // ComposeClusterScopedName translates the name of a cluster-scoped object

--- a/pkg/placement/what-resolver.go
+++ b/pkg/placement/what-resolver.go
@@ -502,7 +502,7 @@ func (wr *whatResolver) processEdgePlacement(ctx context.Context, epName ObjectN
 	}
 	epFound := err == nil
 	//change to consumer SpaceID
-	_, epOriginalName, kbSpaceID, err := kbuser.AnalyzeObjectID(ep)
+	epOriginalName, kbSpaceID, err := kbuser.AnalyzeClusterScopedObject(ep)
 	if err != nil {
 		logger.Error(err, "Object does not appear to be a provider's copy of a consumer's object")
 		return true

--- a/pkg/placement/where-resolver.go
+++ b/pkg/placement/where-resolver.go
@@ -177,7 +177,7 @@ func (wr *whereResolver) process(ctx context.Context, item queueItem) bool {
 		return true // I think these errors are not transient
 	}
 	//change to consumer SpaceID
-	_, spsOriginalName, kbSpaceID, err := kbuser.AnalyzeObjectID(sps)
+	spsOriginalName, kbSpaceID, err := kbuser.AnalyzeClusterScopedObject(sps)
 	if err != nil {
 		logger.Error(err, "Object does not appear to be a provider's copy of a consumer's object")
 		return true

--- a/pkg/placement/workload-projector.go
+++ b/pkg/placement/workload-projector.go
@@ -208,7 +208,7 @@ func NewWorkloadProjector(
 			obj = dfu.Obj
 		}
 		syncfg := obj.(*edgeapi.SyncerConfig)
-		_, sourceName, kbIDForMBS, err := kbuser.AnalyzeObjectID(syncfg)
+		sourceName, kbIDForMBS, err := kbuser.AnalyzeClusterScopedObject(syncfg)
 		if err != nil {
 			logger.Error(err, "SyncerConfig name does not look like kube-bind projection", "name", syncfg.Name)
 			return

--- a/pkg/where-resolver/reconcile_on_edgeplacement.go
+++ b/pkg/where-resolver/reconcile_on_edgeplacement.go
@@ -114,7 +114,7 @@ func (c *controller) reconcileOnEdgePlacement(ctx context.Context, epKey string)
 	}
 
 	// 4)
-	_, originalName, kbSpaceID, err := kbuser.AnalyzeObjectID(ep)
+	originalName, kbSpaceID, err := kbuser.AnalyzeClusterScopedObject(ep)
 	if err != nil {
 		logger.Error(err, "Object does not appear to be a provider's copy of a consumer's object", "edgePlacement", ep.Name)
 		return err

--- a/pkg/where-resolver/reconcile_on_location.go
+++ b/pkg/where-resolver/reconcile_on_location.go
@@ -80,7 +80,7 @@ func (c *controller) reconcileOnLocation(ctx context.Context, locKey string) err
 			return err
 		}
 	}
-	_, locOriginalName, kbSpaceID, err := kbuser.AnalyzeObjectID(loc)
+	locOriginalName, kbSpaceID, err := kbuser.AnalyzeClusterScopedObject(loc)
 	if err != nil {
 		return err
 	}
@@ -257,13 +257,13 @@ func (c *controller) reconcileOnLocation(ctx context.Context, locKey string) err
 func filterStsByLoc(sts []*edgev2alpha1.SyncTarget, loc *edgev2alpha1.Location) ([]*edgev2alpha1.SyncTarget, error) {
 	filtered := []*edgev2alpha1.SyncTarget{}
 
-	_, _, locKBSpaceID, err := kbuser.AnalyzeObjectID(loc)
+	_, locKBSpaceID, err := kbuser.AnalyzeClusterScopedObject(loc)
 	if err != nil {
 		return filtered, err
 	}
 
 	for _, st := range sts {
-		_, _, stKBSpaceID, err := kbuser.AnalyzeObjectID(st)
+		_, stKBSpaceID, err := kbuser.AnalyzeClusterScopedObject(st)
 		if err != nil {
 			return filtered, err
 		}
@@ -338,7 +338,7 @@ func (c *controller) makeSinglePlacementsForLoc(locSelectingSts *edgev2alpha1.Lo
 	if locSelectingSts == nil || len(sts) == 0 {
 		return made
 	}
-	_, locOriginalName, kbSpaceID, err := kbuser.AnalyzeObjectID(locSelectingSts)
+	locOriginalName, kbSpaceID, err := kbuser.AnalyzeClusterScopedObject(locSelectingSts)
 	if err != nil {
 		return made
 	}
@@ -347,7 +347,7 @@ func (c *controller) makeSinglePlacementsForLoc(locSelectingSts *edgev2alpha1.Lo
 		return made
 	}
 	for _, st := range sts {
-		_, stOriginalName, _, err := kbuser.AnalyzeObjectID(st)
+		stOriginalName, _, err := kbuser.AnalyzeClusterScopedObject(st)
 		if err != nil {
 			continue
 		}
@@ -363,7 +363,7 @@ func (c *controller) makeSinglePlacementsForLoc(locSelectingSts *edgev2alpha1.Lo
 }
 
 func (c *controller) getConsumerSpaceForSPS(sps *edgev2alpha1.SinglePlacementSlice) (string, string, error) {
-	_, name, kbSpaceID, err := kbuser.AnalyzeObjectID(sps)
+	name, kbSpaceID, err := kbuser.AnalyzeClusterScopedObject(sps)
 	if err != nil {
 		return "", "", err
 	}

--- a/pkg/where-resolver/reconcile_on_synctarget.go
+++ b/pkg/where-resolver/reconcile_on_synctarget.go
@@ -74,7 +74,7 @@ func (c *controller) reconcileOnSyncTarget(ctx context.Context, stKey string) er
 			return err
 		}
 	}
-	_, stOriginalName, kbSpaceID, err := kbuser.AnalyzeObjectID(st)
+	stOriginalName, kbSpaceID, err := kbuser.AnalyzeClusterScopedObject(st)
 	if err != nil {
 		return err
 	}
@@ -288,7 +288,7 @@ func (c *controller) makeSinglePlacementsForSt(locsSelectingSt []*edgev2alpha1.L
 	if len(locsSelectingSt) == 0 || st == nil {
 		return made
 	}
-	_, stOriginalName, kbSpaceID, err := kbuser.AnalyzeObjectID(st)
+	stOriginalName, kbSpaceID, err := kbuser.AnalyzeClusterScopedObject(st)
 	if err != nil {
 		return made
 	}
@@ -297,7 +297,7 @@ func (c *controller) makeSinglePlacementsForSt(locsSelectingSt []*edgev2alpha1.L
 		return made
 	}
 	for _, loc := range locsSelectingSt {
-		_, locOriginalName, _, err := kbuser.AnalyzeObjectID(loc)
+		locOriginalName, _, err := kbuser.AnalyzeClusterScopedObject(loc)
 		if err != nil {
 			continue
 		}


### PR DESCRIPTION
this return value wasn't used anywhere in the code. in case the need arises in the future, the original function was commented out.

<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

the namespace of the original object wasn't used anywhere in the code. 
in case the need arises in the future, the original function was commented out.

## Related issue(s)

Fixes #
