### PR TITLE
🐛 Don't ignore available discovery results in err case

### DIFF
--- a/pkg/apiwatch/definition-tracking.go
+++ b/pkg/apiwatch/definition-tracking.go
@@ -93,7 +93,7 @@ func MarshalSet[Key comparable](it map[Key]Empty) ([]byte, error) {
 	enc := json.NewEncoder(&builder)
 	builder.WriteRune('[')
 	first := true
-	for key, _ := range it {
+	for key := range it {
 		if first {
 			first = false
 		} else {

--- a/pkg/apiwatch/resources.go
+++ b/pkg/apiwatch/resources.go
@@ -341,7 +341,7 @@ func (am arMap) toList(logger klog.Logger, prefix []string, consume func(ksmetav
 func (rlw *resourcesListWatcher) listWithSubresources(logger klog.Logger, resourceVersionS string) ([]ksmetav1a1.APIResource, error) {
 	groupList, resourceList, err := rlw.cache.ServerGroupsAndResources()
 	if err != nil {
-		return nil, err
+		rlw.logger.V(3).Info("Did not get all api groups and resources", "err", err.Error())
 	}
 	groupToVersion := map[string]string{}
 	for _, ag := range groupList {
@@ -423,7 +423,7 @@ func definersToSlice(asSet map[objectID]Empty) []ksmetav1a1.Definer {
 func (rlw *resourcesListWatcher) listSansSubresources(resourceVersionS string) ([]ksmetav1a1.APIResource, error) {
 	groupList, err := rlw.cache.ServerPreferredResources()
 	if err != nil {
-		return nil, err
+		rlw.logger.V(3).Info("Did not get all preferred resources", "err", err.Error())
 	}
 	ans := []ksmetav1a1.APIResource{}
 	rlw.mutex.Lock()


### PR DESCRIPTION
Also simplify a for loop.

<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
This PR fixes a bug in the apiwatch package, where it was incorrectly assuming that when a discovery call returns an error the associated data structure(s) are empty. That meant that one problematic API group would make them all disappear.

This PR also simplifies a loop statement to stop the nagging from linters.

## Related issue(s)

Fixes #
