### PR TITLE
🌱 Remove the check and cleanup of the request file

### DIFF
--- a/scripts/inner/kubestellar-kube-bind
+++ b/scripts/inner/kubestellar-kube-bind
@@ -187,15 +187,6 @@ else
     echo "consumer side secret is $consumer_secret_name"
 fi
 
-if fgrep -x "${resource_to_bind}" "$request_file"; then
-    echo "The request file has junk in it; see?" >&2
-    cat "$request_file" >&2
-    mv "$request_file" "$request_file".junk
-    fgrep -x -v "${resource_to_bind}" "$request_file".junk > "$request_file"
-    echo Removed >&2
-fi
-
-
 KUBECONFIG="$consumer_kubeconfig"
 if ! sub_result="$(kubectl bind apiservice --remote-kubeconfig-namespace kube-bind --remote-kubeconfig-name $consumer_secret_name --skip-konnector -f $request_file 2>&1)"; then
     echo "Error occurred during binding $resource_to_bind for $space_name" >&2


### PR DESCRIPTION
## Summary
This PR removes the check/cleanup of one line of unwanted text in the 'request file' for `kubectl bind apiservice`.

These was a bug in the `autobind` branch in my fork of kube-bind, which emits the unwanted text. That bug is now fixed, so we don't need this check any more.
