### PR TITLE
🌱 removed the use of ObjectMeta directly in space-framework (part2)

### DIFF
--- a/space-framework/pkg/space-manager/reconcile_space.go
+++ b/space-framework/pkg/space-manager/reconcile_space.go
@@ -58,7 +58,7 @@ func (c *controller) reconcileSpace(key string) error {
 		return errors.New("unexpected object type. expected Space")
 	}
 
-	if space.ObjectMeta.DeletionTimestamp != nil {
+	if !space.GetDeletionTimestamp().IsZero() {
 		c.logger.V(2).Info("reconcile Space delete", "resource", space.Name)
 		err := c.processDeleteSpace(space)
 		if err != nil {
@@ -124,7 +124,7 @@ func (c *controller) processAddOrUpdateSpace(space *spacev1alpha1.Space) error {
 
 			// Update status Initializing
 			if !containsFinalizer(space, spaceFinalizerName) {
-				space.ObjectMeta.Finalizers = append(space.ObjectMeta.Finalizers, spaceFinalizerName)
+				space.SetFinalizers(append(space.GetFinalizers(), spaceFinalizerName))
 			}
 			space.Status.Phase = spacev1alpha1.SpacePhaseInitializing
 			_, err = c.clientset.


### PR DESCRIPTION
best practices is to use the Get/Set functions instead of ObjectMeta directly.
in addition, in order to check whether an object has marked for deletion, one should use the built-in IsZero() function

<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

## Related issue(s)

Fixes #
