### PR TITLE
:sparkles: preparation for work on where-resolver for pluggable transport

### DIFF
--- a/pkg/pluggable-transport-where-resolver/README.md
+++ b/pkg/pluggable-transport-where-resolver/README.md
@@ -1,0 +1,6 @@
+This package is a duplication of `where-resolver`.
+In this package we change the implementation so that it maintains the where-resolutions in EdgePlacementDecision 
+resources, and not SinglePlacementSlices.
+
+
+Once this package is code-reviewed and tested, it will be merged into the `where-resolver` package, and then deleted.

--- a/pkg/pluggable-transport-where-resolver/controller.go
+++ b/pkg/pluggable-transport-where-resolver/controller.go
@@ -1,0 +1,247 @@
+/*
+Copyright 2022 The KubeStellar Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package pluggable_transport_where_resolver
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	apiequality "k8s.io/apimachinery/pkg/api/equality"
+	"k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/util/workqueue"
+	"k8s.io/klog/v2"
+
+	edgev2alpha1 "github.com/kubestellar/kubestellar/pkg/apis/edge/v2alpha1"
+	edgev2alpha1informers "github.com/kubestellar/kubestellar/pkg/client/informers/externalversions/edge/v2alpha1"
+	edgev2alpha1listers "github.com/kubestellar/kubestellar/pkg/client/listers/edge/v2alpha1"
+	"github.com/kubestellar/kubestellar/pkg/kbuser"
+	msclient "github.com/kubestellar/kubestellar/space-framework/pkg/msclientlib"
+)
+
+const (
+	ControllerName = "where-resolver"
+)
+
+type triggeringKind string
+
+const (
+	triggeringKindEdgePlacement triggeringKind = "EdgePlacement"
+	triggeringKindLocation      triggeringKind = "Location"
+	triggeringKindSyncTarget    triggeringKind = "SyncTarget"
+)
+
+type queueItem struct {
+	triggeringKind triggeringKind
+	key            string
+}
+
+type controller struct {
+	context         context.Context
+	queue           workqueue.RateLimitingInterface
+	kbSpaceRelation kbuser.KubeBindSpaceRelation
+	spaceClient     msclient.KubestellarSpaceInterface
+	spaceProviderNs string
+
+	singlePlacementSliceLister  edgev2alpha1listers.SinglePlacementSliceLister
+	singlePlacementSliceIndexer cache.Indexer
+
+	edgePlacementLister  edgev2alpha1listers.EdgePlacementLister
+	edgePlacementIndexer cache.Indexer
+
+	locationLister  edgev2alpha1listers.LocationLister
+	locationIndexer cache.Indexer
+
+	synctargetLister  edgev2alpha1listers.SyncTargetLister
+	synctargetIndexer cache.Indexer
+}
+
+func NewController(
+	context context.Context,
+	spaceClient msclient.KubestellarSpaceInterface,
+	spaceProviderNs string,
+	edgePlacementAccess edgev2alpha1informers.EdgePlacementInformer,
+	singlePlacementSliceAccess edgev2alpha1informers.SinglePlacementSliceInformer,
+	locationAccess edgev2alpha1informers.LocationInformer,
+	syncTargetAccess edgev2alpha1informers.SyncTargetInformer,
+	kbSpaceRelation kbuser.KubeBindSpaceRelation,
+) (*controller, error) {
+	context = klog.NewContext(context, klog.FromContext(context).WithValues("controller", ControllerName))
+	queue := workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), ControllerName)
+
+	c := &controller{
+		context:         context,
+		queue:           queue,
+		kbSpaceRelation: kbSpaceRelation,
+		spaceClient:     spaceClient,
+		spaceProviderNs: spaceProviderNs,
+
+		edgePlacementLister:  edgePlacementAccess.Lister(),
+		edgePlacementIndexer: edgePlacementAccess.Informer().GetIndexer(),
+
+		singlePlacementSliceLister:  singlePlacementSliceAccess.Lister(),
+		singlePlacementSliceIndexer: singlePlacementSliceAccess.Informer().GetIndexer(),
+
+		locationLister:  locationAccess.Lister(),
+		locationIndexer: locationAccess.Informer().GetIndexer(),
+
+		synctargetLister:  syncTargetAccess.Lister(),
+		synctargetIndexer: syncTargetAccess.Informer().GetIndexer(),
+	}
+
+	edgePlacementAccess.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc:    c.enqueueEdgePlacement,
+		UpdateFunc: func(_, newObj interface{}) { c.enqueueEdgePlacement(newObj) },
+		DeleteFunc: c.enqueueEdgePlacement,
+	})
+
+	locationAccess.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc: c.enqueueLocation,
+		UpdateFunc: func(old, obj interface{}) {
+			oldLoc := old.(*edgev2alpha1.Location)
+			newLoc := obj.(*edgev2alpha1.Location)
+			if !apiequality.Semantic.DeepEqual(oldLoc.Spec, newLoc.Spec) || !apiequality.Semantic.DeepEqual(oldLoc.Labels, newLoc.Labels) {
+				c.enqueueLocation(obj)
+			}
+		},
+		DeleteFunc: c.enqueueLocation,
+	})
+
+	syncTargetAccess.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc: c.enqueueSyncTarget,
+		UpdateFunc: func(old, obj interface{}) {
+			oldST := old.(*edgev2alpha1.SyncTarget)
+			newST := obj.(*edgev2alpha1.SyncTarget)
+			if !apiequality.Semantic.DeepEqual(oldST.Spec, newST.Spec) || !apiequality.Semantic.DeepEqual(oldST.Labels, newST.Labels) {
+				c.enqueueSyncTarget((obj))
+			}
+		},
+		DeleteFunc: c.enqueueSyncTarget,
+	})
+
+	return c, nil
+}
+
+func (c *controller) enqueueEdgePlacement(obj interface{}) {
+	key, err := cache.DeletionHandlingMetaNamespaceKeyFunc(obj)
+	if err != nil {
+		runtime.HandleError(err)
+		return
+	}
+
+	klog.FromContext(c.context).V(2).Info("queueing EdgePlacement", "key", key)
+	c.queue.Add(
+		queueItem{
+			triggeringKind: triggeringKindEdgePlacement,
+			key:            key,
+		},
+	)
+}
+
+func (c *controller) enqueueLocation(obj interface{}) {
+	key, err := cache.DeletionHandlingMetaNamespaceKeyFunc(obj)
+	if err != nil {
+		runtime.HandleError(err)
+		return
+	}
+
+	klog.FromContext(c.context).V(2).Info("queueing Location", "key", key)
+	c.queue.Add(
+		queueItem{
+			triggeringKind: triggeringKindLocation,
+			key:            key,
+		},
+	)
+}
+
+func (c *controller) enqueueSyncTarget(obj interface{}) {
+	key, err := cache.DeletionHandlingMetaNamespaceKeyFunc(obj)
+	if err != nil {
+		runtime.HandleError(err)
+		return
+	}
+
+	klog.FromContext(c.context).V(2).Info("queueing SyncTarget", "key", key)
+	c.queue.Add(
+		queueItem{
+			triggeringKind: triggeringKindSyncTarget,
+			key:            key,
+		},
+	)
+}
+
+// Run starts the controller, which stops when c.context.Done() is closed.
+func (c *controller) Run(numThreads int) {
+	defer runtime.HandleCrash()
+	defer c.queue.ShutDown()
+
+	logger := klog.FromContext(c.context)
+	logger.Info("starting controller")
+	defer logger.Info("shutting down controller")
+
+	for i := 0; i < numThreads; i++ {
+		go wait.UntilWithContext(c.context, c.runWorker, time.Second)
+	}
+
+	<-c.context.Done()
+}
+
+func (c *controller) runWorker(ctx context.Context) {
+	for c.processNextWorkItem(ctx) {
+	}
+}
+
+func (c *controller) processNextWorkItem(ctx context.Context) bool {
+	// Wait until there is a new item in the working queue
+	i, quit := c.queue.Get()
+	if quit {
+		return false
+	}
+	item := i.(queueItem)
+	key := item.key
+
+	ctx = klog.NewContext(ctx, klog.FromContext(ctx).WithValues("triggeringKind", item.triggeringKind, "key", key))
+	klog.FromContext(ctx).V(2).Info("processing queueItem")
+
+	// No matter what, tell the queue we're done with this key, to unblock
+	// other workers.
+	defer c.queue.Done(i)
+
+	if err := c.process(ctx, item); err != nil {
+		runtime.HandleError(fmt.Errorf("%q controller didn't sync %q, err: %w", ControllerName, key, err))
+		c.queue.AddRateLimited(i)
+		return true
+	}
+	c.queue.Forget(i)
+	return true
+}
+
+func (c *controller) process(ctx context.Context, item queueItem) error {
+	tk, key := item.triggeringKind, item.key
+	var err error
+	switch tk {
+	case triggeringKindEdgePlacement:
+		err = c.reconcileOnEdgePlacement(ctx, key)
+	case triggeringKindLocation:
+		err = c.reconcileOnLocation(ctx, key)
+	case triggeringKindSyncTarget:
+		err = c.reconcileOnSyncTarget(ctx, key)
+	}
+	return err
+}

--- a/pkg/pluggable-transport-where-resolver/reconcile_on_edgeplacement.go
+++ b/pkg/pluggable-transport-where-resolver/reconcile_on_edgeplacement.go
@@ -1,0 +1,182 @@
+/*
+Copyright 2023 The KubeStellar Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package pluggable_transport_where_resolver
+
+import (
+	"context"
+	"errors"
+
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/klog/v2"
+
+	edgev2alpha1 "github.com/kubestellar/kubestellar/pkg/apis/edge/v2alpha1"
+	edgeclientset "github.com/kubestellar/kubestellar/pkg/client/clientset/versioned"
+	"github.com/kubestellar/kubestellar/pkg/kbuser"
+)
+
+func (c *controller) reconcileOnEdgePlacement(ctx context.Context, epKey string) error {
+	logger := klog.FromContext(ctx)
+	_, epName, err := cache.SplitMetaNamespaceKey(epKey)
+	if err != nil {
+		logger.Error(err, "invalid EdgePlacement key")
+		return err
+	}
+	logger = logger.WithValues("edgePlacement", epName)
+	ctx = klog.NewContext(ctx, logger)
+	logger.V(2).Info("reconciling")
+
+	/*
+		On EdgePlacement 'ep' change:
+		1) from cache, find loc(s) that being selected by ep
+
+		2) from cache, for each of the found loc, find st(s) that being selected by the loc
+
+		3) update store, with loc(s) that being selected by ep
+
+		4) update apiserver
+
+		Need data structure: none.
+	*/
+
+	store.l.Lock()
+	defer store.l.Unlock() // TODO(waltforme): Is it safe to shorten the critical section?
+
+	ep, err := c.edgePlacementLister.Get(epName)
+	if err != nil {
+		if k8serrors.IsNotFound(err) {
+			logger.V(1).Info("EdgePlacement not found")
+			logger.V(3).Info("dropping EdgePlacement from store")
+			store.dropEp(epKey)
+			return nil
+		} else {
+			logger.Error(err, "failed to get EdgePlacement")
+			return err
+		}
+	}
+
+	// 1)
+	locsAll, err := c.locationLister.List(labels.Everything())
+	if err != nil {
+		logger.Error(err, "failed to list Locations in all workspaces")
+		return err
+	}
+	locsFilteredByEp, err := filterLocsByEp(locsAll, ep)
+	if err != nil {
+		logger.Error(err, "failed to find Locations for EdgePlacement")
+	}
+	locsSelecting := packLocKeys(locsFilteredByEp)
+
+	singles := []edgev2alpha1.SinglePlacement{}
+	for _, loc := range locsFilteredByEp {
+		// 2)
+		allSts, err := c.synctargetLister.List(labels.Everything())
+		if err != nil {
+			logger.Error(err, "Failed to list SyncTargets in local cache")
+			return err
+		}
+		stsSelecting, err := filterStsByLoc(allSts, loc)
+		if err != nil {
+			logger.Error(err, "failed to find SyncTargets for Location", "location", loc.Name)
+			return err
+		}
+		singles = append(singles, c.makeSinglePlacementsForLoc(loc, stsSelecting)...)
+	}
+
+	// 3)
+	for loc, eps := range store.epsBySelectedLoc {
+		if _, ok := locsSelecting[loc]; !ok {
+			delete(eps, epKey)
+		}
+	}
+	for loc := range locsSelecting {
+		if store.epsBySelectedLoc[loc] == nil {
+			store.epsBySelectedLoc[loc] = map[string]empty{epKey: {}}
+		} else {
+			store.epsBySelectedLoc[loc][epKey] = empty{}
+		}
+	}
+
+	// 4)
+	originalName, kbSpaceID, err := kbuser.AnalyzeClusterScopedObject(ep)
+	if err != nil {
+		logger.Error(err, "Object does not appear to be a provider's copy of a consumer's object", "edgePlacement", ep.Name)
+		return err
+	}
+	spaceID := c.kbSpaceRelation.SpaceIDFromKubeBind(kbSpaceID)
+	if spaceID == "" {
+		relErr := errors.New("failed to obtain space ID from kube-bind reference")
+		logger.Error(relErr, "Failed to get consumer space ID from a provider's copy", "edgePlacement", originalName)
+		return relErr
+	}
+
+	spaceConfig, err := c.spaceClient.ConfigForSpace(spaceID, c.spaceProviderNs)
+	if err != nil {
+		return err
+	}
+	edgeClientset, err := edgeclientset.NewForConfig(spaceConfig)
+	if err != nil {
+		return err
+	}
+	originalEP, err := edgeClientset.EdgeV2alpha1().EdgePlacements().Get(ctx, originalName, metav1.GetOptions{})
+	if err != nil {
+		logger.Error(err, "failed to get consumer's object", "edgePlacement", originalName)
+		return err
+	}
+	_, err = c.singlePlacementSliceLister.Get(epName)
+	if err != nil {
+		if k8serrors.IsNotFound(err) { // create
+			logger.V(1).Info("creating SinglePlacementSlice")
+			sps := &edgev2alpha1.SinglePlacementSlice{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: originalName,
+					OwnerReferences: []metav1.OwnerReference{
+						{
+							APIVersion: edgev2alpha1.SchemeGroupVersion.String(),
+							Kind:       "EdgePlacement",
+							Name:       originalName,
+							UID:        originalEP.UID,
+						},
+					},
+				},
+				Destinations: singles,
+			}
+			_, err = edgeClientset.EdgeV2alpha1().SinglePlacementSlices().Create(ctx, sps, metav1.CreateOptions{})
+			if err != nil {
+				if !k8serrors.IsAlreadyExists(err) {
+					logger.Error(err, "failed creating SinglePlacementSlice")
+					return err
+				}
+			} else {
+				logger.V(1).Info("created SinglePlacementSlice")
+			}
+		} else {
+			logger.Error(err, "failed getting SinglePlacementSlice")
+			return err
+		}
+	} else { // update
+		err := c.patchSpsDestinations(singles, spaceID, originalName)
+		if err != nil {
+			logger.Error(err, "failed updating SinglePlacementSlice")
+			return err
+		}
+	}
+
+	return nil
+}

--- a/pkg/pluggable-transport-where-resolver/reconcile_on_location.go
+++ b/pkg/pluggable-transport-where-resolver/reconcile_on_location.go
@@ -1,0 +1,397 @@
+/*
+Copyright 2023 The KubeStellar Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package pluggable_transport_where_resolver
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/klog/v2"
+
+	edgev2alpha1 "github.com/kubestellar/kubestellar/pkg/apis/edge/v2alpha1"
+	edgeclientset "github.com/kubestellar/kubestellar/pkg/client/clientset/versioned"
+	"github.com/kubestellar/kubestellar/pkg/kbuser"
+)
+
+func (c *controller) reconcileOnLocation(ctx context.Context, locKey string) error {
+	logger := klog.FromContext(ctx)
+	_, lName, err := cache.SplitMetaNamespaceKey(locKey)
+	if err != nil {
+		logger.Error(err, "invalid Location key")
+		return err
+	}
+	logger = logger.WithValues("location", lName)
+	logger.V(2).Info("reconciling")
+
+	/*
+		On location 'loc' change:
+		1) from store, find ep(s) that selected loc
+
+		2a) from cache, find st(s) that being selected by loc
+		2b) from cache, find ep(s) that selecting loc
+
+		3) update store
+		3a) update store, with ep(s) that selecting loc
+		3b) update store, with st(s) that being selected by loc
+
+		4) update apiserver
+		4a) for each of its obsolete ep, remove sp(s)
+		4b) for each of its ongoing ep, update sp(s)
+		4c) for each of its new ep, ensure the existence of sp(s)
+
+		Need data structure:
+		- map from a location to its eps
+
+		TODO(waltforme): Maybe I can merge 4b) and 4c)
+	*/
+
+	store.l.Lock()
+	defer store.l.Unlock() // TODO(waltforme): Is it safe to shorten the critical section?
+
+	locDeleted := false
+	loc, err := c.locationLister.Get(lName)
+	if err != nil {
+		if k8serrors.IsNotFound(err) {
+			logger.V(1).Info("Location not found")
+			locDeleted = true
+		} else {
+			logger.Error(err, "failed to get Location")
+			return err
+		}
+	}
+	locOriginalName, kbSpaceID, err := kbuser.AnalyzeClusterScopedObject(loc)
+	if err != nil {
+		return err
+	}
+	locSpaceID := c.kbSpaceRelation.SpaceIDFromKubeBind(kbSpaceID)
+	if locSpaceID == "" {
+		return errors.New("failed to obtain space ID from kube-bind reference")
+	}
+
+	// 1)
+	epsSelectedLoc := store.epsBySelectedLoc[locKey]
+
+	// 2a)
+	stsFilteredByLoc := []*edgev2alpha1.SyncTarget{}
+	if !locDeleted {
+		allSts, err := c.synctargetLister.List(labels.Everything())
+		if err != nil {
+			logger.Error(err, "failed to list SyncTargets")
+			return err
+		}
+		stsFilteredByLoc, err = filterStsByLoc(allSts, loc)
+		if err != nil {
+			logger.Error(err, "failed to find SyncTargets for Location")
+			return err
+		}
+	}
+	stsSelecting := packStKeys(stsFilteredByLoc)
+
+	// 2b)
+	epsFilteredByLoc := []*edgev2alpha1.EdgePlacement{}
+	if !locDeleted {
+		epsAll, err := c.edgePlacementLister.List(labels.Everything())
+		if err != nil {
+			logger.Error(err, "failed to list EdgePlacements in all workspaces")
+			return err
+		}
+		epsFilteredByLoc, err = filterEpsByLoc(epsAll, loc)
+		if err != nil {
+			logger.Error(err, "failed to find EdgePlacements for Location")
+		}
+	}
+	epsSelectingLoc := packEpKeys(epsFilteredByLoc)
+
+	// 3)
+	if !locDeleted {
+		logger.V(3).Info("updating store")
+		// 3a)
+		store.epsBySelectedLoc[locKey] = epsSelectingLoc
+		// 3b)
+		for st, locs := range store.locsBySelectedSt {
+			if _, ok := stsSelecting[st]; !ok {
+				delete(locs, locKey)
+			}
+		}
+		for st := range stsSelecting {
+			if store.locsBySelectedSt[st] == nil {
+				store.locsBySelectedSt[st] = map[string]empty{locKey: {}}
+			} else {
+				store.locsBySelectedSt[st][locKey] = empty{}
+			}
+		}
+	} else {
+		logger.V(3).Info("dropping Location from store")
+		store.dropLoc(locKey)
+	}
+
+	// 4)
+	singles := c.makeSinglePlacementsForLoc(loc, stsFilteredByLoc)
+
+	for ep := range epsSelectedLoc {
+		if _, ok := epsSelectingLoc[ep]; !ok {
+			// 4a)
+			// an (obsolete) ep doesn't select loc anymore
+			// we need to remove all relevant sp(s) from the corresponding sps where 'relevant' means an sp has loc
+			logger.V(1).Info("stop selecting Location", "edgePlacement", ep)
+			_, name, err := cache.SplitMetaNamespaceKey(ep)
+			if err != nil {
+				logger.Error(err, "invalid EdgePlacement key")
+				return err
+			}
+			currentSPS, err := c.singlePlacementSliceLister.Get(name)
+			if err != nil {
+				logger.Error(err, "failed to get SinglePlacementSlice", "singlePlacementSlice", name)
+				return err
+			}
+			// get consumer's space ID by currentSPS
+			originalName, spaceID, err := c.getConsumerSpaceForSPS(currentSPS)
+			if err != nil {
+				logger.Error(err, "failed to get consumer space ID from a provider's copy", "singlePlacementSlice", name)
+				return err
+			}
+
+			nextSPS := cleanSPSByLoc(currentSPS, locSpaceID, locOriginalName)
+			err = c.patchSpsDestinations(nextSPS.Destinations, spaceID, originalName)
+			if err != nil {
+				logger.Error(err, "failed to update SinglePlacementSlice", "singlePlacementSlice", nextSPS.Name)
+				return err
+			} else {
+				logger.V(1).Info("updated SinglePlacementSlice", "singlePlacementSlice", nextSPS.Name)
+			}
+		} else {
+			// 4b)
+			// an (ongoing) ep continues to select loc
+			// loc selected a set of synctargets, AND is selecting another set of synctargets
+			// the two sets of synctargets may or may not overlap
+			// thus, we need to clean then extend the corresponding sps
+			logger.V(1).Info("continue to select Location", "edgePlacement", ep)
+			_, name, err := cache.SplitMetaNamespaceKey(ep)
+			if err != nil {
+				logger.Error(err, "invalid EdgePlacement key")
+				return err
+			}
+			currentSPS, err := c.singlePlacementSliceLister.Get(name)
+			if err != nil {
+				logger.Error(err, "failed to get SinglePlacementSlice", "singlePlacementSlice", name)
+				return err
+			}
+			// get consumer's space ID by currentSPS
+			originalName, spaceID, err := c.getConsumerSpaceForSPS(currentSPS)
+			if err != nil {
+				logger.Error(err, "failed to get consumer space ID from a provider's copy", "singlePlacementSlice", name)
+				return err
+			}
+			nextSPS := cleanSPSByLoc(currentSPS, locSpaceID, locOriginalName)
+			nextSPS = extendSPS(nextSPS, singles)
+			err = c.patchSpsDestinations(nextSPS.Destinations, spaceID, originalName)
+			if err != nil {
+				logger.Error(err, "failed to update SinglePlacementSlice", "singlePlacementSlice", nextSPS.Name)
+				return err
+			} else {
+				logger.V(1).Info("updated SinglePlacementSlice", "singlePlacementSlice", nextSPS.Name)
+			}
+		}
+	}
+
+	for ep := range epsSelectingLoc {
+		if _, ok := epsSelectedLoc[ep]; !ok {
+			// 4c)
+			// a (new) ep begins to select loc
+			// we need to ensure the existence of sp(s) in the corresponding sps
+			logger.V(1).Info("begin to select Location", "edgePlacement", ep)
+			_, name, err := cache.SplitMetaNamespaceKey(ep)
+			if err != nil {
+				logger.Error(err, "invalid EdgePlacement key")
+				return err
+			}
+			currentSPS, err := c.singlePlacementSliceLister.Get(name)
+			if err != nil {
+				logger.Error(err, "failed to get SinglePlacementSlice", "singlePlacementSlice", name)
+				return err
+			}
+			// get consumer's space ID by currentSPS
+			originalName, spaceID, err := c.getConsumerSpaceForSPS(currentSPS)
+			if err != nil {
+				logger.Error(err, "failed to get consumer space ID from a provider's copy", "singlePlacementSlice", name)
+				return err
+			}
+
+			nextSPS := cleanSPSByLoc(currentSPS, locSpaceID, locOriginalName)
+			nextSPS = extendSPS(nextSPS, singles)
+			err = c.patchSpsDestinations(nextSPS.Destinations, spaceID, originalName)
+			if err != nil {
+				logger.Error(err, "failed to update SinglePlacementSlice", "singlePlacementSlice", nextSPS.Name)
+				return err
+			} else {
+				logger.V(1).Info("updated SinglePlacementSlice", "singlePlacementSlice", nextSPS.Name)
+			}
+		}
+	}
+
+	return nil
+}
+
+// filterStsByLoc returns those SyncTargets that selected by the Location
+func filterStsByLoc(sts []*edgev2alpha1.SyncTarget, loc *edgev2alpha1.Location) ([]*edgev2alpha1.SyncTarget, error) {
+	filtered := []*edgev2alpha1.SyncTarget{}
+
+	_, locKBSpaceID, err := kbuser.AnalyzeClusterScopedObject(loc)
+	if err != nil {
+		return filtered, err
+	}
+
+	for _, st := range sts {
+		_, stKBSpaceID, err := kbuser.AnalyzeClusterScopedObject(st)
+		if err != nil {
+			return filtered, err
+		}
+
+		if stKBSpaceID != locKBSpaceID {
+			continue
+		}
+		s := loc.Spec.InstanceSelector
+		selector, err := metav1.LabelSelectorAsSelector(s)
+		if err != nil {
+			return filtered, err
+		}
+		if selector.Matches(labels.Set(st.Labels)) {
+			filtered = append(filtered, st)
+		}
+	}
+	return filtered, nil
+}
+
+// filterEpsByLoc returns those EdgePlacements that select the Location
+func filterEpsByLoc(eps []*edgev2alpha1.EdgePlacement, loc *edgev2alpha1.Location) ([]*edgev2alpha1.EdgePlacement, error) {
+	filtered := []*edgev2alpha1.EdgePlacement{}
+	for _, ep := range eps {
+		for _, s := range ep.Spec.LocationSelectors {
+			selector, err := metav1.LabelSelectorAsSelector(&s)
+			if err != nil {
+				return filtered, err
+			}
+			if selector.Matches(labels.Set(loc.Labels)) {
+				filtered = append(filtered, ep)
+				break
+			}
+		}
+	}
+	return filtered, nil
+}
+
+// packEpKeys extracts keys from given EdgePlacements and put the keys in a map
+func packEpKeys(eps []*edgev2alpha1.EdgePlacement) map[string]empty {
+	keys := map[string]empty{}
+	for _, ep := range eps {
+		key, _ := cache.MetaNamespaceKeyFunc(ep)
+		keys[key] = empty{}
+	}
+	return keys
+}
+
+// packStKeys extracts keys from given SyncTargets and put the keys in a map
+func packStKeys(sts []*edgev2alpha1.SyncTarget) map[string]empty {
+	keys := map[string]empty{}
+	for _, st := range sts {
+		key, _ := cache.MetaNamespaceKeyFunc(st)
+		keys[key] = empty{}
+	}
+	return keys
+}
+
+// cleanSPSByLoc removes all singleplacements that has the specified location, from a singleplacementslice
+func cleanSPSByLoc(sps *edgev2alpha1.SinglePlacementSlice, locSpaceID, lName string) *edgev2alpha1.SinglePlacementSlice {
+	nextDests := []edgev2alpha1.SinglePlacement{}
+	for _, sp := range sps.Destinations {
+		if sp.Cluster != locSpaceID || sp.LocationName != lName {
+			nextDests = append(nextDests, sp)
+		}
+	}
+	sps.Destinations = nextDests
+	return sps
+}
+
+func (c *controller) makeSinglePlacementsForLoc(locSelectingSts *edgev2alpha1.Location, sts []*edgev2alpha1.SyncTarget) []edgev2alpha1.SinglePlacement {
+	made := []edgev2alpha1.SinglePlacement{}
+	if locSelectingSts == nil || len(sts) == 0 {
+		return made
+	}
+	locOriginalName, kbSpaceID, err := kbuser.AnalyzeClusterScopedObject(locSelectingSts)
+	if err != nil {
+		return made
+	}
+	locSpaceID := c.kbSpaceRelation.SpaceIDFromKubeBind(kbSpaceID)
+	if locSpaceID == "" {
+		return made
+	}
+	for _, st := range sts {
+		stOriginalName, _, err := kbuser.AnalyzeClusterScopedObject(st)
+		if err != nil {
+			continue
+		}
+		sp := edgev2alpha1.SinglePlacement{
+			Cluster:        locSpaceID,
+			LocationName:   locOriginalName,
+			SyncTargetName: stOriginalName,
+			SyncTargetUID:  st.UID,
+		}
+		made = append(made, sp)
+	}
+	return made
+}
+
+func (c *controller) getConsumerSpaceForSPS(sps *edgev2alpha1.SinglePlacementSlice) (string, string, error) {
+	name, kbSpaceID, err := kbuser.AnalyzeClusterScopedObject(sps)
+	if err != nil {
+		return "", "", err
+	}
+	spaceID := c.kbSpaceRelation.SpaceIDFromKubeBind(kbSpaceID)
+	if spaceID == "" {
+		return "", "", errors.New("failed to get consumer space ID from a provider's copy")
+	}
+	return name, spaceID, nil
+}
+
+func (c *controller) patchSpsDestinations(destinations []edgev2alpha1.SinglePlacement, spaceID string, spsName string) error {
+	destBytes, err := json.Marshal(destinations)
+	if err != nil {
+		return err
+	}
+	patch := []byte(fmt.Sprintf(`{"destinations": %s}`, destBytes))
+
+	spaceConfig, err := c.spaceClient.ConfigForSpace(spaceID, c.spaceProviderNs)
+	if err != nil {
+		return err
+	}
+	edgeClientset, err := edgeclientset.NewForConfig(spaceConfig)
+	if err != nil {
+		return err
+	}
+	_, err = edgeClientset.EdgeV2alpha1().SinglePlacementSlices().Patch(c.context, spsName, types.MergePatchType, patch, metav1.PatchOptions{})
+	if err != nil {
+		return err
+	}
+	return nil
+}

--- a/pkg/pluggable-transport-where-resolver/reconcile_on_synctarget.go
+++ b/pkg/pluggable-transport-where-resolver/reconcile_on_synctarget.go
@@ -1,0 +1,340 @@
+/*
+Copyright 2023 The KubeStellar Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package pluggable_transport_where_resolver
+
+import (
+	"context"
+	"errors"
+
+	k8sapierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/klog/v2"
+
+	edgev2alpha1 "github.com/kubestellar/kubestellar/pkg/apis/edge/v2alpha1"
+	"github.com/kubestellar/kubestellar/pkg/kbuser"
+)
+
+func (c *controller) reconcileOnSyncTarget(ctx context.Context, stKey string) error {
+	logger := klog.FromContext(ctx)
+	_, stName, err := cache.SplitMetaNamespaceKey(stKey)
+	if err != nil {
+		logger.Error(err, "invalid SyncTarget key")
+		return err
+	}
+	logger = logger.WithValues("syncTarget", stName)
+	logger.V(2).Info("reconciling")
+
+	/*
+		On synctarget 'st' change:
+		1) from store, find ep(s) that used st
+
+		2a) from cache, find loc(s) that selecting st
+		2b) from store and cache, find ep(s) that using st
+
+		3) update store, with loc(s) that selecting st
+
+		4) update apiserver
+		4a) for each of its obsolete ep, remove sp(s)
+		4b) for each of its ongoing ep, update sp(s)
+		4c) for each of its new ep, ensure the existence of sp(s)
+
+		Need data structure:
+		- map from a synctarget to its locations
+
+		TODO(waltforme): Maybe I can merge 4b) and 4c)
+	*/
+
+	store.l.Lock()
+	defer store.l.Unlock() // TODO(waltforme): Is it safe to shorten the critical section?
+
+	stDeleted := false
+	st, err := c.synctargetLister.Get(stName)
+	if err != nil {
+		if k8sapierrors.IsNotFound(err) {
+			logger.V(1).Info("SyncTarget not found")
+			stDeleted = true
+		} else {
+			logger.Error(err, "failed to get SyncTarget")
+			return err
+		}
+	}
+	stOriginalName, kbSpaceID, err := kbuser.AnalyzeClusterScopedObject(st)
+	if err != nil {
+		return err
+	}
+	stSpaceID := c.kbSpaceRelation.SpaceIDFromKubeBind(kbSpaceID)
+	if stSpaceID == "" {
+		return errors.New("failed to obtain space ID from kube-bind reference")
+	}
+
+	// 1)
+	epsUsedSt := store.findEpsUsedSt(stKey)
+
+	// 2a)
+	locsFilteredBySt := []*edgev2alpha1.Location{}
+	if !stDeleted {
+		locsInStws, err := c.locationLister.List(labels.Everything())
+		if err != nil {
+			logger.Error(err, "failed to list Locations")
+			return err
+		}
+		locsFilteredBySt, err = filterLocsBySt(locsInStws, st)
+		if err != nil {
+			logger.Error(err, "failed to find Locations for SyncTarget")
+			return err
+		}
+	}
+	locsSelectingSt := packLocKeys(locsFilteredBySt)
+
+	// 2b)
+	epsUsingSt := map[string]empty{}
+	if !stDeleted {
+		for _, loc := range locsFilteredBySt {
+			locKey, _ := cache.MetaNamespaceKeyFunc(loc)
+			eps := store.epsBySelectedLoc[locKey]
+			epsUsingSt = unionTwo(epsUsingSt, eps)
+		}
+	}
+
+	// 3)
+	if !stDeleted {
+		logger.V(3).Info("updating store")
+		store.locsBySelectedSt[stKey] = locsSelectingSt
+	} else {
+		logger.V(3).Info("dropping SyncTarget from store")
+		store.dropSt(stKey)
+	}
+
+	// 4)
+	for ep := range epsUsedSt {
+		if _, ok := epsUsingSt[ep]; !ok {
+			// 4a)
+			// for an (obsolite) ep in epsUsedSt but not in epsUsingSt
+			// remove all relevant sp(s) from that ep, so that that ep doesn't use st
+			// an obsolite ep doesn't use st anymore because its locs don't select the st anymore
+			logger.V(1).Info("stop using SyncTarget", "edgePlacement", ep)
+			_, name, err := cache.SplitMetaNamespaceKey(ep)
+			if err != nil {
+				logger.Error(err, "invalid EdgePlacement key")
+				return err
+			}
+			currentSPS, err := c.singlePlacementSliceLister.Get(name)
+			if err != nil {
+				logger.Error(err, "failed to get SinglePlacementSlice", "singlePlacementSlice", name)
+				return err
+			}
+			nextSPS := cleanSPSBySt(currentSPS, stSpaceID, stOriginalName)
+			originalName, spaceID, err := c.getConsumerSpaceForSPS(currentSPS)
+			if err != nil {
+				logger.Error(err, "failed to get consumer space ID from a provider's copy", "singlePlacementSlice", name)
+				return err
+			}
+			err = c.patchSpsDestinations(nextSPS.Destinations, spaceID, originalName)
+			if err != nil {
+				logger.Error(err, "failed to update SinglePlacementSlice", "singlePlacementSlice", nextSPS.Name)
+				return err
+			} else {
+				logger.V(1).Info("updated SinglePlacementSlice", "singlePlacementSlice", nextSPS.Name)
+			}
+		} else {
+			// 4b)
+			// for an (ongoing) ep in both epsUsedSt and epsUsingSt
+			// the ep continues to use this st,
+			// because at least one locs selected the st, AND at least one locs are selecting the st
+			// but the two sets of locs may or may not overlap
+			// thus, we need to clean then extend the corresponding sps
+			logger.V(1).Info("continue to use SyncTarget", "edgePlacement", ep)
+			_, name, err := cache.SplitMetaNamespaceKey(ep)
+			if err != nil {
+				logger.Error(err, "invalid EdgePlacement key")
+				return err
+			}
+			currentSPS, err := c.singlePlacementSliceLister.Get(name)
+			if err != nil {
+				logger.Error(err, "failed to get SinglePlacementSlice", "singlePlacementSlice", name)
+				return err
+			}
+			nextSPS := cleanSPSBySt(currentSPS, stSpaceID, stOriginalName)
+
+			epObj, err := c.edgePlacementLister.Get(name)
+			if err != nil {
+				logger.Error(err, "failed to get EdgePlacement", "edgePlacement", name)
+				return err
+			}
+			locsFilteredByStAndEp, err := filterLocsByEp(locsFilteredBySt, epObj)
+			if err != nil {
+				logger.Error(err, "failed to find Locations selected by EdgePlacement", "edgePlacement", epObj.Name)
+				return err
+			}
+			additionalSingles := c.makeSinglePlacementsForSt(locsFilteredByStAndEp, st)
+			nextSPS = extendSPS(nextSPS, additionalSingles)
+
+			originalName, spaceID, err := c.getConsumerSpaceForSPS(currentSPS)
+			if err != nil {
+				logger.Error(err, "failed to get consumer space ID from a provider's copy", "singlePlacementSlice", name)
+				return err
+			}
+			err = c.patchSpsDestinations(nextSPS.Destinations, spaceID, originalName)
+			if err != nil {
+				logger.Error(err, "failed to update SinglePlacementSlice", "singlePlacementSlice", nextSPS.Name)
+				return err
+			} else {
+				logger.V(1).Info("updated SinglePlacementSlice", "singlePlacementSlice", nextSPS.Name)
+			}
+		}
+	}
+
+	for ep := range epsUsingSt {
+		if _, ok := epsUsedSt[ep]; !ok {
+			// 4c)
+			// for a (new) ep in epsUsingSt but not in epsUsedSt
+			// ensure the existence of sp(s) in the ep's sps
+			logger.V(1).Info("begin to use SyncTarget", "edgePlacement", ep)
+			_, name, err := cache.SplitMetaNamespaceKey(ep)
+			if err != nil {
+				logger.Error(err, "invalid EdgePlacement key")
+				return err
+			}
+			currentSPS, err := c.singlePlacementSliceLister.Get(name)
+			if err != nil {
+				logger.Error(err, "failed to get SinglePlacementSlice", "singlePlacementSlice", name)
+				return err
+			}
+			nextSPS := cleanSPSBySt(currentSPS, stSpaceID, stOriginalName)
+
+			epObj, err := c.edgePlacementLister.Get(name)
+			if err != nil {
+				logger.Error(err, "failed to get EdgePlacement", "edgePlacement", name)
+				return err
+			}
+			locsFilteredByStAndEp, err := filterLocsByEp(locsFilteredBySt, epObj)
+			if err != nil {
+				logger.Error(err, "failed to find Locations selected by EdgePlacement", "edgePlacement", epObj.Name)
+				return err
+			}
+			additionalSingles := c.makeSinglePlacementsForSt(locsFilteredByStAndEp, st)
+			nextSPS = extendSPS(nextSPS, additionalSingles)
+
+			originalName, spaceID, err := c.getConsumerSpaceForSPS(currentSPS)
+			if err != nil {
+				logger.Error(err, "failed to get consumer space ID from a provider's copy", "singlePlacementSlice", name)
+				return err
+			}
+			err = c.patchSpsDestinations(nextSPS.Destinations, spaceID, originalName)
+			if err != nil {
+				logger.Error(err, "failed to update SinglePlacementSlice", "singlePlacementSlice", nextSPS.Name)
+				return err
+			} else {
+				logger.V(1).Info("updated SinglePlacementSlice", "singlePlacementSlice", nextSPS.Name)
+			}
+		}
+	}
+
+	return nil
+}
+
+// filterLocsBySt returns those Locations that select the SyncTarget
+func filterLocsBySt(locs []*edgev2alpha1.Location, st *edgev2alpha1.SyncTarget) ([]*edgev2alpha1.Location, error) {
+	filtered := []*edgev2alpha1.Location{}
+	for _, l := range locs {
+		s := l.Spec.InstanceSelector
+		selector, err := metav1.LabelSelectorAsSelector(s)
+		if err != nil {
+			return filtered, err
+		}
+		if selector.Matches(labels.Set(st.Labels)) {
+			filtered = append(filtered, l)
+		}
+	}
+	return filtered, nil
+}
+
+// filterLocsByEp returns those Locations that are selected by the EdgePlacement
+func filterLocsByEp(locs []*edgev2alpha1.Location, ep *edgev2alpha1.EdgePlacement) ([]*edgev2alpha1.Location, error) {
+	filtered := []*edgev2alpha1.Location{}
+	for _, l := range locs {
+		for _, s := range ep.Spec.LocationSelectors {
+			selector, err := metav1.LabelSelectorAsSelector(&s)
+			if err != nil {
+				return filtered, err
+			}
+			if selector.Matches(labels.Set(l.Labels)) {
+				filtered = append(filtered, l)
+				break
+			}
+		}
+	}
+	return filtered, nil
+}
+
+func (c *controller) makeSinglePlacementsForSt(locsSelectingSt []*edgev2alpha1.Location, st *edgev2alpha1.SyncTarget) []edgev2alpha1.SinglePlacement {
+	made := []edgev2alpha1.SinglePlacement{}
+	if len(locsSelectingSt) == 0 || st == nil {
+		return made
+	}
+	stOriginalName, kbSpaceID, err := kbuser.AnalyzeClusterScopedObject(st)
+	if err != nil {
+		return made
+	}
+	stSpaceID := c.kbSpaceRelation.SpaceIDFromKubeBind(kbSpaceID)
+	if stSpaceID == "" {
+		return made
+	}
+	for _, loc := range locsSelectingSt {
+		locOriginalName, _, err := kbuser.AnalyzeClusterScopedObject(loc)
+		if err != nil {
+			continue
+		}
+		sp := edgev2alpha1.SinglePlacement{
+			Cluster:        stSpaceID,
+			LocationName:   locOriginalName,
+			SyncTargetName: stOriginalName,
+			SyncTargetUID:  st.UID,
+		}
+		made = append(made, sp)
+	}
+	return made
+}
+
+// packLocKeys extracts keys from given Locations and put the keys in a map
+func packLocKeys(locs []*edgev2alpha1.Location) map[string]empty {
+	keys := map[string]empty{}
+	for _, l := range locs {
+		key, _ := cache.MetaNamespaceKeyFunc(l)
+		keys[key] = empty{}
+	}
+	return keys
+}
+
+// cleanSPSBySt removes all singleplacements that has the specified synctarget, from a singleplacementslice
+func cleanSPSBySt(sps *edgev2alpha1.SinglePlacementSlice, stSpaceID, stName string) *edgev2alpha1.SinglePlacementSlice {
+	nextDests := []edgev2alpha1.SinglePlacement{}
+	for _, sp := range sps.Destinations {
+		if sp.Cluster != stSpaceID || sp.SyncTargetName != stName {
+			nextDests = append(nextDests, sp)
+		}
+	}
+	sps.Destinations = nextDests
+	return sps
+}
+
+func extendSPS(sps *edgev2alpha1.SinglePlacementSlice, singles []edgev2alpha1.SinglePlacement) *edgev2alpha1.SinglePlacementSlice {
+	sps.Destinations = append(sps.Destinations, singles...)
+	return sps
+}

--- a/pkg/pluggable-transport-where-resolver/store.go
+++ b/pkg/pluggable-transport-where-resolver/store.go
@@ -1,0 +1,92 @@
+/*
+Copyright 2023 The KubeStellar Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package pluggable_transport_where_resolver
+
+import (
+	"sync"
+)
+
+/*
+The relationship between relevant API objects (arrows indicate selections/references):
+ep -> loc -> st
+ep: edgeplacement; loc: location; st: synctarget
+
+To facilitate incremental updates, we need to maintain internal data structures:
+
+	ep <- loc <- st
+
+or in other words,
+
+	ep <- loc
+	loc <- st
+
+*/
+
+type empty struct{}
+
+type internalData struct {
+	l                sync.Mutex
+	epsBySelectedLoc map[string]map[string]empty // ep <- loc
+	locsBySelectedSt map[string]map[string]empty // loc <- st
+}
+
+var store internalData
+
+func init() {
+	store = internalData{
+		l:                sync.Mutex{},
+		epsBySelectedLoc: map[string]map[string]empty{},
+		locsBySelectedSt: map[string]map[string]empty{},
+	}
+}
+
+func unionTwo(a, b map[string]empty) map[string]empty {
+	u := map[string]empty{}
+	for k, v := range a {
+		u[k] = v
+	}
+	for k, v := range b {
+		u[k] = v
+	}
+	return u
+}
+
+func (d *internalData) findEpsUsedSt(st string) map[string]empty {
+	eps := map[string]empty{}
+	locs := d.locsBySelectedSt[st]
+	for l := range locs {
+		eps = unionTwo(eps, d.epsBySelectedLoc[l])
+	}
+	return eps
+}
+
+func (d *internalData) dropEp(epKey string) {
+	for _, eps := range d.epsBySelectedLoc {
+		delete(eps, epKey)
+	}
+}
+
+func (d *internalData) dropLoc(locKey string) {
+	delete(d.epsBySelectedLoc, locKey)
+	for _, locs := range d.locsBySelectedSt {
+		delete(locs, locKey)
+	}
+}
+
+func (d *internalData) dropSt(stKey string) {
+	delete(d.locsBySelectedSt, stKey)
+}


### PR DESCRIPTION
## Summary
Duplicated where-resolver in order to modify to work with EdgePlacementDecision resources, without making conflicts with existing code. Refer to the new package's README for more info.

