### PR TITLE
✨ Use prebuilt images for kube-bind related binaries

### DIFF
--- a/docs/content/Coding Milestones/PoC2023q1/example1-subs/example1-post-provider.md
+++ b/docs/content/Coding Milestones/PoC2023q1/example1-subs/example1-post-provider.md
@@ -54,12 +54,8 @@ The command below makes kube-bind binaries and dex binary available in `$PATH`.
 rm -rf kube-bind
 git clone https://github.com/waltforme/kube-bind.git && \
 pushd kube-bind && \
-mkdir bin && \
-IGNORE_GO_VERSION=1 go build -o ./bin/example-backend ./cmd/example-backend/main.go && \
-git checkout origin/syncmore && \
-IGNORE_GO_VERSION=1 go build -o ./bin/konnector ./cmd/konnector/main.go && \
-git checkout origin/autobind && \
-IGNORE_GO_VERSION=1 go build -o ./bin/kubectl-bind ./cmd/kubectl-bind/main.go && \
+git checkout kubestellar && \
+IGNORE_GO_VERSION=1 make build
 export PATH=$(pwd)/bin:$PATH && \
 popd && \
 git clone https://github.com/dexidp/dex.git && \


### PR DESCRIPTION
## Summary
Previously, kube-bind binaries are built from three different branches from waltforme/kube-bind, namely `autobind`, `syncmore` and `main`. Now the three branches are consolidated into one branch `kubestellar`.

With that, we first simplify the builds in example1.

Next, on the `kubestellar` branch, images were built for the kube-bind binaries. In `core.Dockerfile`, we then use the prebuilt kube-bind images to accelerate the build of kubestellar core image. Also, we use a prebuilt dex image for the same reason.

Note that the prebuilt kube-bind images are multi-platform images, including ppc64le, so #1487 is resolved.

A side effect of this PR is the reduced build time for `make kubestellar-image`, which is now roughly half an hour on my setup.
```
[+] Building 2060.3s (139/139) FINISHED                                      docker-container:kubestellar
```

## Related issue(s)
#1499 