### PR TITLE
✨ Use cross-compilation to speed up core image build

### DIFF
--- a/core.Dockerfile
+++ b/core.Dockerfile
@@ -1,7 +1,7 @@
 ###############################################################################
 # Builder image
 ###############################################################################
-FROM redhat/ubi9 AS builder
+FROM --platform=$BUILDPLATFORM redhat/ubi9 AS builder
 
 ARG TARGETOS
 ARG TARGETARCH
@@ -57,7 +57,7 @@ ADD test/            test/
 ADD .git/            .git/
 ADD .gitattributes Makefile Makefile.venv go.mod go.sum .
 
-RUN make innerbuild GIT_DIRTY=$GIT_DIRTY IGNORE_GO_VERSION=yesplease
+RUN make innerbuild GOOS=$TARGETOS GOARCH=$TARGETARCH GIT_DIRTY=$GIT_DIRTY IGNORE_GO_VERSION=yesplease
 
 FROM ghcr.io/waltforme/kube-bind/example-backend:latest AS example-backend-binary
 


### PR DESCRIPTION
## Summary
This PR uses cross-compilation instead of emulation to speed up `make kubestellar-image`.

On my MacBook with an M1 Max chip it now takes 200+ seconds to build the image:
```
[+] Building 214.7s (145/145) FINISHED                                       docker-container:kubestellar
```

The time above is now mostly consumed by `make innerbuild` --- as it should be.

The time above doesn't include the extra time to push to quay.io. Pushing time varies from machine to machine. On my MacBook at home it takes roughly 200 secnods; on my dev Ubuntu on AWS it takes roughly 100 seconds.

## Related issue(s)
#1499 