### PR TITLE
🐛 Download yq for specific target platform

### DIFF
--- a/core.Dockerfile
+++ b/core.Dockerfile
@@ -14,7 +14,8 @@ WORKDIR /home/kubestellar
 
 RUN mkdir -p .kcp && \
     dnf install -y git golang jq procps && \
-    go install github.com/mikefarah/yq/v4@v4.34.2 && \
+    curl -SL -o /usr/local/bin/yq "https://github.com/mikefarah/yq/releases/download/v4.34.2/yq_${TARGETOS}_${TARGETARCH}" && \
+    chmod +x /usr/local/bin/yq && \
     curl -SL -o /usr/local/bin/kubectl "https://dl.k8s.io/release/v1.25.3/bin/${TARGETPLATFORM}/kubectl" && \
     chmod +x /usr/local/bin/kubectl && \
     curl -SL -o easy-rsa.tar.gz "https://github.com/OpenVPN/easy-rsa/releases/download/v3.1.5/EasyRSA-3.1.5.tgz" && \
@@ -79,8 +80,8 @@ RUN dnf install -y jq procps && \
 
 # copy binaries, dex configurations, and kube-bind CRDs from the builder image
 COPY --from=builder /home/kubestellar/easy-rsa                           easy-rsa/
-COPY --from=builder /root/go/bin                                         /usr/local/bin/
 COPY --from=builder /usr/local/bin/kubectl                               /usr/local/bin/kubectl
+COPY --from=builder /usr/local/bin/yq                                    /usr/local/bin/yq
 COPY --from=builder /home/kubestellar/kcp/bin                            kcp/bin/
 COPY --from=builder /home/kubestellar/kcp-plugins/bin                    kcp/bin/
 COPY --from=builder /home/kubestellar/bin                                bin/


### PR DESCRIPTION
## Summary
This PR fixes a bug described here: https://github.com/kubestellar/kubestellar/pull/1509#issuecomment-1887634647

Thanks for @MikeSpreitzer 's time to try and diagnose.

I built the image with tag `git-b0b5d47a7-clean` on my Mac with M1 Max, then helm installed KS on my Ubuntu dev machine with amd64 CPU:
```
ubuntu@ip-172-31-67-225:~/kubestellar$ while ! kubectl exec -n kubestellar $(kubectl get pod --selector=app=kubestellar -o jsonpath='{.items[0].metadata.name}' -n kubestellar) -c init -- ls /home/kubestellar/ready &> /dev/null; do
    sleep 10
    echo -n "."
done
echo "KubeStellar is now ready to take requests"
.........KubeStellar is now ready to take requests
ubuntu@ip-172-31-67-225:~/kubestellar$ kc -n kubestellar get deploy kubestellar -oyaml | yq .spec.template.spec | grep image:
    image: quay.io/kubestellar/space-framework:sp-mgt-pr2
    image: quay.io/kubestellar/kubestellar:git-b0b5d47a7-clean
    image: quay.io/kubestellar/kubestellar:git-b0b5d47a7-clean
    image: quay.io/kubestellar/kubestellar:git-b0b5d47a7-clean
    image: quay.io/kubestellar/kubestellar:git-b0b5d47a7-clean
    image: quay.io/kubestellar/kubestellar:git-b0b5d47a7-clean
```
