### PR TITLE
🐛 Fix cross-complie for innerbuild

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -87,8 +87,6 @@ export CODE_GENERATOR # so hack scripts can use it
 
 ARCH := $(shell go env GOARCH)
 OS := $(shell go env GOOS)
-TARGETARCH ?= $(ARCH)
-TARGETOS ?= $(OS)
 
 BUILD_DATE := $(shell date -u +'%Y-%m-%dT%H:%M:%SZ')
 LDFLAGS := \
@@ -131,7 +129,7 @@ userbuild: require-jq require-go require-git verify-go-versions ## Build executa
 
 innerbuild: WHAT ?= ./cmd/kubestellar-version ./cmd/kubestellar-where-resolver ./cmd/mailbox-controller ./cmd/placement-translator
 innerbuild: require-jq require-go require-git verify-go-versions ## Build all executables
-	GOOS=$(TARGETOS) GOARCH=$(TARGETARCH) CGO_ENABLED=0 go build $(BUILDFLAGS) -ldflags="$(LDFLAGS)" -o bin $(WHAT)
+	GOOS=$(OS) GOARCH=$(ARCH) CGO_ENABLED=0 go build $(BUILDFLAGS) -ldflags="$(LDFLAGS)" -o bin $(WHAT)
 	cp scripts/overlap/* bin/
 	cp scripts/inner/*   bin/
 .PHONY: innerbuild

--- a/Makefile
+++ b/Makefile
@@ -87,6 +87,8 @@ export CODE_GENERATOR # so hack scripts can use it
 
 ARCH := $(shell go env GOARCH)
 OS := $(shell go env GOOS)
+TARGETARCH ?= $(ARCH)
+TARGETOS ?= $(OS)
 
 BUILD_DATE := $(shell date -u +'%Y-%m-%dT%H:%M:%SZ')
 LDFLAGS := \
@@ -129,7 +131,7 @@ userbuild: require-jq require-go require-git verify-go-versions ## Build executa
 
 innerbuild: WHAT ?= ./cmd/kubestellar-version ./cmd/kubestellar-where-resolver ./cmd/mailbox-controller ./cmd/placement-translator
 innerbuild: require-jq require-go require-git verify-go-versions ## Build all executables
-	GOOS=$(OS) GOARCH=$(ARCH) CGO_ENABLED=0 go build $(BUILDFLAGS) -ldflags="$(LDFLAGS)" -o bin $(WHAT)
+	GOOS=$(TARGETOS) GOARCH=$(TARGETARCH) CGO_ENABLED=0 go build $(BUILDFLAGS) -ldflags="$(LDFLAGS)" -o bin $(WHAT)
 	cp scripts/overlap/* bin/
 	cp scripts/inner/*   bin/
 .PHONY: innerbuild

--- a/core.Dockerfile
+++ b/core.Dockerfile
@@ -58,7 +58,7 @@ ADD test/            test/
 ADD .git/            .git/
 ADD .gitattributes Makefile Makefile.venv go.mod go.sum .
 
-RUN make innerbuild GOOS=$TARGETOS GOARCH=$TARGETARCH GIT_DIRTY=$GIT_DIRTY IGNORE_GO_VERSION=yesplease
+RUN make innerbuild TARGETOS=$TARGETOS TARGETARCH=$TARGETARCH GIT_DIRTY=$GIT_DIRTY IGNORE_GO_VERSION=yesplease
 
 FROM ghcr.io/waltforme/kube-bind/example-backend:latest AS example-backend-binary
 

--- a/core.Dockerfile
+++ b/core.Dockerfile
@@ -58,7 +58,7 @@ ADD test/            test/
 ADD .git/            .git/
 ADD .gitattributes Makefile Makefile.venv go.mod go.sum .
 
-RUN make innerbuild TARGETOS=$TARGETOS TARGETARCH=$TARGETARCH GIT_DIRTY=$GIT_DIRTY IGNORE_GO_VERSION=yesplease
+RUN make innerbuild OS=$TARGETOS ARCH=$TARGETARCH GIT_DIRTY=$GIT_DIRTY IGNORE_GO_VERSION=yesplease
 
 FROM ghcr.io/waltforme/kube-bind/example-backend:latest AS example-backend-binary
 


### PR DESCRIPTION
## Summary
We have this bug because `GOOS` and `GOARCH` are not variable names in the Makefile. As a result, `make innerbuild` was always building KS binaries for the **build** platform, but not the target platform.

This PR fixes this bug.

BTW, in #1522, we saw the message `KubeStellar is now ready to take requests` from the init container. But the init container doesn't check the three KS controllers. That's why this bug was overlooked there.

To be sure the bug is fixed in this PR, following checks are done on a Ubuntu VM with amd64 CPU. The image is built on a MacBook with M1 Max chip:
```
ubuntu@ip-172-31-67-225:~$ kc -n kubestellar get deploy
NAME          READY   UP-TO-DATE   AVAILABLE   AGE
kubestellar   1/1     1            1           19m
ubuntu@ip-172-31-67-225:~$ kc -n kubestellar get po
NAME                           READY   STATUS    RESTARTS   AGE
kubestellar-6f78c67c7d-w4qst   6/6     Running   0          19m
ubuntu@ip-172-31-67-225:~$ kc -n kubestellar logs deploy/kubestellar -c placement-translator --tail 5
I0111 20:04:45.790825     177 shared_informer.go:289] Caches are synced for placement-translator(sync)
I0111 20:04:45.790971     177 shared_informer.go:282] Waiting for caches to sync for what-resolver
I0111 20:04:45.791028     177 shared_informer.go:289] Caches are synced for what-resolver
I0111 20:04:45.791122     177 shared_informer.go:282] Waiting for caches to sync for where-resolver
I0111 20:04:45.791158     177 shared_informer.go:289] Caches are synced for where-resolver
ubuntu@ip-172-31-67-225:~$ kc cp kubestellar/kubestellar-6f78c67c7d-w4qst:/home/kubestellar/bin/placement-translator ./pt -c init
tar: Removing leading `/' from member names
ubuntu@ip-172-31-67-225:~$ file ./pt
./pt: ELF 64-bit LSB executable, x86-64, version 1 (SYSV), statically linked, Go BuildID=aYXbgEVbQDrKAxJrIqbw/3uTIais9NNkN9z9FelzZ/SqDT4MzUqV5ARxk6HKN_/pvAzMnjv8rphlJxnvQCc, with debug_info, not stripped
ubuntu@ip-172-31-67-225:~$ kc -n kubestellar get deploy kubestellar -oyaml | yq .spec.template.spec | grep image:
    image: quay.io/kubestellar/space-framework:sp-mgt-pr2
    image: quay.io/kubestellar/kubestellar:git-e63f47e6f-clean
    image: quay.io/kubestellar/kubestellar:git-e63f47e6f-clean
    image: quay.io/kubestellar/kubestellar:git-e63f47e6f-clean
    image: quay.io/kubestellar/kubestellar:git-e63f47e6f-clean
    image: quay.io/kubestellar/kubestellar:git-e63f47e6f-clean
ubuntu@ip-172-31-67-225:~$ 
```

## Related issue(s)
#1499
