### PR TITLE
🌱 Brushup e2e 1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ DEFAULT_NAMESPACE=default
 # Default WDS name to use for make deploy (mainly for local testing) 
 DEFAULT_WDS_NAME=wds1
 # default kind hosting cluster name
-DEFAULT_KIND_CLUSTER ?= kubeflex
+KIND_HOSTING_CLUSTER ?= kubeflex
 
 # We need bash for some conditional logic below.
 SHELL := /usr/bin/env bash -e
@@ -151,9 +151,9 @@ test: manifests generate fmt vet envtest ## Run tests.
 run: manifests generate fmt vet ## Run a controller from your host.
 	go run ./cmd/kubestellar-operator/main.go $(ARGS)
 
-.PHONY: ko-build
-ko-build: test ## Build docker image with ko
-	KO_DOCKER_REPO=ko.local ko build --push=false -B ./cmd/${CMD_NAME} -t ${IMAGE_TAG} --platform linux/amd64,linux/arm64
+.PHONY: ko-build-local
+ko-build-local: test ## Build local container image with ko
+	KO_DOCKER_REPO=ko.local ko build -B ./cmd/${CMD_NAME} -t ${IMAGE_TAG}
 	docker tag ko.local/${CMD_NAME}:${IMAGE_TAG} ${IMG}
 
 .PHONY: docker-push
@@ -161,13 +161,13 @@ docker-push: ## Push docker image
 	docker push ${IMG}
 
 .PHONY: ko-build-push
-ko-build-push: test ## Build and push docker image with ko
+ko-build-push: test ## Build and push container image with ko
 	KO_DOCKER_REPO=${DOCKER_REGISTRY} ko build -B ./cmd/${CMD_NAME} -t ${IMAGE_TAG} --platform linux/amd64,linux/arm64
 
 # this is used for local testing 
 .PHONY: kind-load-image
 kind-load-image: 
-	kind load --name ${DEFAULT_KIND_CLUSTER} docker-image ${IMG}
+	kind load --name ${KIND_HOSTING_CLUSTER} docker-image ${IMG}
 
 .PHONY: chart
 chart: manifests kustomize
@@ -209,7 +209,6 @@ undeploy: ## Undeploy manager from the K8s cluster specified in ~/.kube/config. 
 .PHONY: install-local-chart
 install-local-chart: kind-load-image
 	helm upgrade --install kubestellar -n ${DEFAULT_WDS_NAME}-system ./core-helm-chart  --set ControlPlaneName=${DEFAULT_WDS_NAME}
-	kubectl -n ${DEFAULT_WDS_NAME}-system patch deployment kubestellar-controller-manager --type='json' -p='[{"op": "replace", "path": "/spec/template/spec/containers/1/imagePullPolicy", "value":"Never"}]'
 
 ##@ Build Dependencies
 

--- a/Makefile
+++ b/Makefile
@@ -153,7 +153,7 @@ run: manifests generate fmt vet ## Run a controller from your host.
 
 .PHONY: ko-build-local
 ko-build-local: test ## Build local container image with ko
-	KO_DOCKER_REPO=ko.local ko build -B ./cmd/${CMD_NAME} -t ${IMAGE_TAG}
+	$(shell (docker version | { ! grep -qi podman; } ) || echo "DOCKER_HOST=unix://$$HOME/.local/share/containers/podman/machine/qemu/podman.sock ") KO_DOCKER_REPO=ko.local ko build -B ./cmd/${CMD_NAME} -t ${IMAGE_TAG}
 	docker tag ko.local/${CMD_NAME}:${IMAGE_TAG} ${IMG}
 
 .PHONY: docker-push

--- a/Makefile
+++ b/Makefile
@@ -204,11 +204,12 @@ deploy: manifests kustomize ## Deploy manager to the K8s cluster specified in ~/
 undeploy: ## Undeploy manager from the K8s cluster specified in ~/.kube/config. Call with ignore-not-found=true to ignore resource not found errors during deletion.
 	$(KUSTOMIZE) build config/default | kubectl delete --ignore-not-found=$(ignore-not-found) -f -
 
-# installs the chart from ./core-helm-chart for local dev/testing on default WDS using image loaded in kind
-# the deployment is patched to load the image pre-loaded in kind
+# installs the chart from ./core-helm-chart for local dev/testing a WDS using image loaded in kind.
+# The Helm chart should be instantiated into the KubeFlex hosting cluster.
+# If $(KUBE_CONTEXT) is set then that indicates where to install the chart; otherwise it goes to the current kubeconfig context.
 .PHONY: install-local-chart
 install-local-chart: kind-load-image
-	helm upgrade --install kubestellar -n ${DEFAULT_WDS_NAME}-system ./core-helm-chart  --set ControlPlaneName=${DEFAULT_WDS_NAME}
+	helm upgrade $(if $(KUBE_CONTEXT),--kube-context $(KUBE_CONTEXT),) --install kubestellar -n ${DEFAULT_WDS_NAME}-system ./core-helm-chart  --set ControlPlaneName=${DEFAULT_WDS_NAME}
 
 ##@ Build Dependencies
 

--- a/test/e2e/multi-cluster-deployment/README.md
+++ b/test/e2e/multi-cluster-deployment/README.md
@@ -4,13 +4,9 @@
 See the list [here](../../pre-reqs.md).
 
 ## Running the test using a script
-- Clone the repo and checkout the ks-0.20 branch
-```
-git clone git@github.com:kubestellar/kubestellar.git
-cd kubestellar
-git checkout -b ks-0.20 origin/ks-0.20
-```
-- Run the test
+
+Starting from a local directory containing the git repo, do the following.
+
 ```
 cd test/e2e/multi-cluster-deployment
 ./run-test.sh
@@ -40,7 +36,7 @@ Create a Workload Description Space wds1 directly in KubeFlex.
 kflex create wds1
 kubectl config use-context kind-kubeflex
 kubectl label cp wds1 kflex.kubestellar.io/cptype=wds
-make ko-build
+make ko-build-local
 make install-local-chart
 ```
 

--- a/test/e2e/multi-cluster-deployment/cleanup.sh
+++ b/test/e2e/multi-cluster-deployment/cleanup.sh
@@ -13,11 +13,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+set -x # echo so that users can understand what is happening
+
 echo "Cleaning up"
 
 kind delete cluster --name cluster1
 kind delete cluster --name cluster2
 kind delete cluster --name kubeflex
-kubectl config delete-context cluster1 
-kubectl config delete-context cluster2 
-rm out
+kubectl config delete-context cluster1 || true
+kubectl config delete-context cluster2 || true

--- a/test/e2e/multi-cluster-deployment/run-test.sh
+++ b/test/e2e/multi-cluster-deployment/run-test.sh
@@ -16,8 +16,9 @@
 # This is an end to end test of multi cluster deployement.  
 # For readable instructions, please visit https://github.com/kubestellar/kubestellar/tree/ks-0.20/docs/content/v0.20
 
+set -x # so users can see what is going on
 set -e # exit on error
 
+./cleanup.sh
 ./setup-kubestellar.sh
 ./workload-deployment.sh
-./cleanup.sh

--- a/test/e2e/multi-cluster-deployment/setup-kubestellar.sh
+++ b/test/e2e/multi-cluster-deployment/setup-kubestellar.sh
@@ -13,26 +13,27 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+set -x # echo so users can understand what is happening
 set -e # exit on error
 
 echo "Create a Kind hosting cluster with nginx ingress controller and KubeFlex operator"
 echo "-------------------------------------------------------------------------"
-kflex init --create-kind &> /dev/null
+kflex init --create-kind
 echo "Kubeflex kind cluster created."
 
 echo "Create an inventory & mailbox space of type vcluster running OCM (Open Cluster Management) directly in KubeFlex. Note that -p ocm runs a post-create hook on the vcluster control plane which installs OCM on it."
 echo "-------------------------------------------------------------------------"
-kflex create imbs1 --type vcluster -p ocm &> /dev/null
+kflex create imbs1 --type vcluster -p ocm
 echo "imbs1 created."
 
 echo "Create a Workload Description Space wds1 directly in KubeFlex."
 echo "-------------------------------------------------------------------------"
-kflex create wds1 &> /dev/null
+kflex create wds1
 kubectl config use-context kind-kubeflex
 kubectl label cp wds1 kflex.kubestellar.io/cptype=wds
 
 cd ../../../
-make ko-build
+make ko-build-local
 make install-local-chart
 cd -
 echo "wds1 created."

--- a/test/e2e/multi-cluster-deployment/setup-kubestellar.sh
+++ b/test/e2e/multi-cluster-deployment/setup-kubestellar.sh
@@ -52,12 +52,12 @@ create_cluster cluster2
 echo "Wait for csr on imbs1"
 waitCounter=0
 while (($(kubectl --context imbs1 get csr 2>/dev/null | grep -c "Pending") < 2)); do
-  if (($waitCounter > 180)); then
+  if (($waitCounter > 36)); then
     echo "Failed to get csr."
     exit 1 
   fi
   ((waitCounter += 1))
-  sleep 1
+  sleep 5
 done
 
 clusteradm --context imbs1 accept --clusters cluster1

--- a/test/e2e/multi-cluster-deployment/setup-kubestellar.sh
+++ b/test/e2e/multi-cluster-deployment/setup-kubestellar.sh
@@ -29,12 +29,11 @@ echo "imbs1 created."
 echo "Create a Workload Description Space wds1 directly in KubeFlex."
 echo "-------------------------------------------------------------------------"
 kflex create wds1
-kubectl config use-context kind-kubeflex
-kubectl label cp wds1 kflex.kubestellar.io/cptype=wds
+kubectl --context kind-kubeflex label cp wds1 kflex.kubestellar.io/cptype=wds
 
 cd ../../../
 make ko-build-local
-make install-local-chart
+make install-local-chart KUBE_CONTEXT=kind-kubeflex
 cd -
 echo "wds1 created."
 
@@ -49,8 +48,6 @@ function create_cluster() {
 
 create_cluster cluster1
 create_cluster cluster2
-
-kubectl config use-context imbs1
 
 echo "Wait for csr on imbs1"
 waitCounter=0

--- a/test/e2e/multi-cluster-deployment/workload-deployment.sh
+++ b/test/e2e/multi-cluster-deployment/workload-deployment.sh
@@ -83,12 +83,12 @@ function wait_for_deployment() {
   echo "Waiting for deployment on $cluster"
   waitCounter=0
   while (($(kubectl --context $cluster wait deployment nginx-deployment -n nginx --for=condition=available --timeout=180s 2>/dev/null | grep -c "condition met") < 1)); do
-    if (($waitCounter > 180)); then
+    if (($waitCounter > 36)); then
       echo "Failed to observe deployment on ${cluster}."
       exit 1 
     fi
     ((waitCounter += 1))
-    sleep 1
+    sleep 5
   done
 }
 wait_for_deployment cluster1

--- a/test/e2e/multi-cluster-deployment/workload-deployment.sh
+++ b/test/e2e/multi-cluster-deployment/workload-deployment.sh
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+set -x # echo so that users can understand what is happening
 set -e # exit on error
 
 echo "Create a placement to deliver an app to all clusters in wds1."
@@ -94,3 +95,4 @@ wait_for_deployment cluster1
 echo "Waiting for deployment on cluster2"
 wait_for_deployment cluster2
 echo "SUCCESS: confirmed deployments on both cluster1 and cluster2."
+rm out


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
This PR makes a few minor improvements to the one e2e test.

- Move "cleanup" from the end to the start, so that users can examine and build on the state established by the test. Modify the cleanup commands so that they nominally succeed regardless of the starting state.
- Make the scripts echo their commands, so that users can understand what is going on.
- Remove the self-referential and unnecessary instructions for how to use `git`.
- Rename `DEFAULT_KIND_CLUSTER` to `KIND_HOSTING_CLUSTER` to better describe its meaning/use.
- Rename and simplify the make target `ko-build` to `ko-build-local`, because it is only used to build an image used locally in testing and ko with podman does not really succeed to build a multi-platform manifest.
- Update the make target `ko-build-local` to support users who have rootless podman pretending to be docker.
- Remove the hack of the Helm chart for installing the WDS operator. The hack was setting the ImagePullPolicy to `Never` but the default `IfNotFound` works just fine, the image gets loaded into the kind cluster before that Helm chart is instantiated there.
- Remove the use of `kubectl config use-context`, making the choice of context explicit in every kubectl and helm command.
- Slow down the wait loops. Checking every second was annoyingly chatty.

## Related issue(s)

Fixes #
