### PR TITLE
✨ Accurate labeling on ManifestWorks

### DIFF
--- a/pkg/ocm/ocm.go
+++ b/pkg/ocm/ocm.go
@@ -28,6 +28,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
@@ -141,6 +142,18 @@ func RemoveChar(s string, c rune) string {
 		return s
 	}
 	return s[:i] + s[i+1:]
+}
+
+func GetClusterByName(ocmClient client.Client, clusterName string) (clusterv1.ManagedCluster, error) {
+	cluster := clusterv1.ManagedCluster{}
+	nn := types.NamespacedName{
+		Namespace: "",
+		Name:      clusterName,
+	}
+	if err := ocmClient.Get(context.TODO(), nn, &cluster); err != nil {
+		return cluster, err
+	}
+	return cluster, nil
 }
 
 func ListClustersBySelectors(ocmClient client.Client, selectors []metav1.LabelSelector) ([]string, error) {

--- a/pkg/placement/controller.go
+++ b/pkg/placement/controller.go
@@ -30,6 +30,7 @@ import (
 	apiextensionsclientset "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
@@ -441,7 +442,46 @@ func (c *Controller) reconcile(ctx context.Context, key util.Key) error {
 	}
 
 	c.logger.Info("Delivering", "object", util.GenerateObjectInfoString(obj), "to clusters", clusters)
-	deliverObjectToManagedClusters(c.logger, c.ocmClient, obj, clusters, managedByPlacements, c.wdsName, singletonStatus)
+	for _, clName := range clusters {
+		// find which placement(s) select this managedCluster
+		placementNames := []string{}
+		for _, plName := range managedByPlacements {
+			plObj, err := c.getPlacementByName(plName)
+			if err != nil {
+				return err
+			}
+			pl, err := runtimeObjectToPlacement(plObj)
+			if err != nil {
+				return err
+			}
+			cl, err := ocm.GetClusterByName(c.ocmClient, clName)
+			if err != nil {
+				return err
+			}
+			// a placement selects a managedCluster iff the managedCluster is selected by every single selector
+			// i.e. selectors are ANDed
+			matches := true
+			for _, s := range pl.Spec.ClusterSelectors {
+				selector, err := metav1.LabelSelectorAsSelector(&s)
+				if err != nil {
+					return err
+				}
+				if !selector.Matches(labels.Set(cl.Labels)) {
+					matches = false
+					break
+				}
+			}
+			if matches {
+				placementNames = append(placementNames, plName)
+			}
+		}
+		manifest := ocm.WrapObject(obj)
+		util.SetManagedByPlacementLabels(manifest, c.wdsName, placementNames, singletonStatus)
+		err := reconcileManifest(c.ocmClient, manifest, clName)
+		if err != nil {
+			c.logger.Error(err, "Error delivering object to mailbox")
+		}
+	}
 
 	return nil
 }

--- a/pkg/placement/controller.go
+++ b/pkg/placement/controller.go
@@ -442,48 +442,7 @@ func (c *Controller) reconcile(ctx context.Context, key util.Key) error {
 	}
 
 	c.logger.Info("Delivering", "object", util.GenerateObjectInfoString(obj), "to clusters", clusters)
-	for _, clName := range clusters {
-		// find which placement(s) select this managedCluster
-		placementNames := []string{}
-		for _, plName := range managedByPlacements {
-			plObj, err := c.getPlacementByName(plName)
-			if err != nil {
-				return err
-			}
-			pl, err := runtimeObjectToPlacement(plObj)
-			if err != nil {
-				return err
-			}
-			cl, err := ocm.GetClusterByName(c.ocmClient, clName)
-			if err != nil {
-				return err
-			}
-			// a placement selects a managedCluster iff the managedCluster is selected by every single selector
-			// i.e. selectors are ANDed
-			matches := true
-			for _, s := range pl.Spec.ClusterSelectors {
-				selector, err := metav1.LabelSelectorAsSelector(&s)
-				if err != nil {
-					return err
-				}
-				if !selector.Matches(labels.Set(cl.Labels)) {
-					matches = false
-					break
-				}
-			}
-			if matches {
-				placementNames = append(placementNames, plName)
-			}
-		}
-		manifest := ocm.WrapObject(obj)
-		util.SetManagedByPlacementLabels(manifest, c.wdsName, placementNames, singletonStatus)
-		err := reconcileManifest(c.ocmClient, manifest, clName)
-		if err != nil {
-			c.logger.Error(err, "Error delivering object to mailbox")
-		}
-	}
-
-	return nil
+	return c.deliverObjectToManagedClusters(obj, clusters, managedByPlacements, singletonStatus)
 }
 
 func (c *Controller) getObjectFromKey(key util.Key) (runtime.Object, error) {
@@ -541,4 +500,54 @@ func (c *Controller) GetInformers() map[string]*cache.SharedIndexInformer {
 func pickSingleCluster(clusters []string) []string {
 	sort.Strings(clusters)
 	return []string{clusters[0]}
+}
+
+func (c *Controller) deliverObjectToManagedClusters(
+	obj runtime.Object,
+	managedClusters, managedByPlacements []string,
+	singletonStatus bool) error {
+	for _, clName := range managedClusters {
+		// find which placement(s) select this managedCluster
+		placementNames := []string{}
+		for _, plName := range managedByPlacements {
+			plObj, err := c.getPlacementByName(plName)
+			if err != nil {
+				return err
+			}
+			pl, err := runtimeObjectToPlacement(plObj)
+			if err != nil {
+				return err
+			}
+			cl, err := ocm.GetClusterByName(c.ocmClient, clName)
+			if err != nil {
+				return err
+			}
+			// a placement selects a managedCluster iff the managedCluster is selected by every single selector
+			// i.e. selectors are ANDed
+			matches := true
+			for _, s := range pl.Spec.ClusterSelectors {
+				selector, err := metav1.LabelSelectorAsSelector(&s)
+				if err != nil {
+					return err
+				}
+				if !selector.Matches(labels.Set(cl.Labels)) {
+					matches = false
+					break
+				}
+			}
+			if matches {
+				placementNames = append(placementNames, plName)
+			}
+		}
+		if len(placementNames) == 0 {
+			return nil
+		}
+		manifest := ocm.WrapObject(obj)
+		util.SetManagedByPlacementLabels(manifest, c.wdsName, placementNames, singletonStatus)
+		err := reconcileManifest(c.ocmClient, manifest, clName)
+		if err != nil {
+			c.logger.Error(err, "Error delivering object to mailbox")
+		}
+	}
+	return nil
 }

--- a/pkg/placement/manifest.go
+++ b/pkg/placement/manifest.go
@@ -26,20 +26,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/kubestellar/kubestellar/pkg/ocm"
-	"github.com/kubestellar/kubestellar/pkg/util"
 )
-
-func deliverObjectToManagedClusters(logger logr.Logger, cl client.Client, obj runtime.Object,
-	managedClusters, managedByPlacements []string, wdsName string, singletonStatus bool) {
-	manifest := ocm.WrapObject(obj)
-	util.SetManagedByPlacementLabels(manifest, wdsName, managedByPlacements, singletonStatus)
-	for _, managedCluster := range managedClusters {
-		err := reconcileManifest(cl, manifest, managedCluster)
-		if err != nil {
-			logger.Error(err, "Error delivering object to mailbox")
-		}
-	}
-}
 
 func deleteObjectOnManagedClusters(logger logr.Logger, cl client.Client, obj runtime.Object, managedClusters []string) {
 	for _, managedCluster := range managedClusters {

--- a/pkg/placement/placement.go
+++ b/pkg/placement/placement.go
@@ -85,6 +85,19 @@ func (c *Controller) requeueForPlacementChanges() error {
 	return nil
 }
 
+func (c *Controller) getPlacementByName(name string) (runtime.Object, error) {
+	pLister := c.listers["edge.kubestellar.io/v1alpha1/Placement"]
+	if pLister == nil {
+		return nil, fmt.Errorf("could not get lister for placememt")
+	}
+	lister := *pLister
+	got, err := lister.Get(name)
+	if err != nil {
+		return nil, err
+	}
+	return got, nil
+}
+
 func (c *Controller) listPlacements() ([]runtime.Object, error) {
 	pLister := c.listers["edge.kubestellar.io/v1alpha1/Placement"]
 	if pLister == nil {


### PR DESCRIPTION
## Summary
This PR applies accurate 'managed-by' labels on Manifestworks which are delivered by the placement controller, thus handles #1541.

#1541 already clearly described the issue. Below is a visualization/example of that situation.
<img width="675" alt="image" src="https://github.com/kubestellar/kubestellar/assets/8633434/13581db5-8eff-47a6-9dda-22de5121cac6">

## Related issue(s)
Closes #1541 
