### PR TITLE
🐛 Replace references to ks-0.20 with main

### DIFF
--- a/.github/workflows/pr-test-singleton-status.yml
+++ b/.github/workflows/pr-test-singleton-status.yml
@@ -7,10 +7,10 @@ on:
   # To confirm any changes to docs build successfully, without deploying them
   pull_request:
     branches:
-      - ks-0.20
+      - main
   push:
     branches:
-      - ks-0.20
+      - main
     tags:
       - 'v*'
 

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -7,10 +7,10 @@ on:
   # To confirm any changes to docs build successfully, without deploying them
   pull_request:
     branches:
-      - ks-0.20
+      - main
   push:
     branches:
-      - ks-0.20
+      - main
     tags:
       - 'v*'
 

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ The supported documents are as follows.
 - [the multi-cluster end-to-end test](test/e2e/multi-cluster-deployment/README.md)
 - [the singleton status return end-to-end test](test/e2e/singleton-status/README.md)
 
-The interim user documents for v0.20.0-alpha.1 are here: [https://github.com/kubestellar/kubestellar/tree/ks-0.20/docs/content/v0.20](https://github.com/kubestellar/kubestellar/tree/ks-0.20/docs/content/v0.20)
+The interim user documents for v0.20.0-alpha.1 are here: [docs/content/v0.20](docs/content/v0.20)
 
 ## Roadmap for the Project
 TBD

--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@
 ## Multi-cluster Configuration Management for Edge, Multi-Cloud, and Hybrid Cloud
 <br/>
 
+**NOTE**: the website kubestellar.io is temporarily out of order.
+
 [![Go Report Card](https://goreportcard.com/badge/github.com/kubestellar/kubestellar)](https://goreportcard.com/report/github.com/kubestellar/kubestellar)
 [![Go Reference](https://pkg.go.dev/badge/github.com/kubestellar/kubestellar.svg)](https://pkg.go.dev/github.com/kubestellar/kubestellar)
 [![License](https://img.shields.io/github/license/kubestellar/kubestellar)](/LICENSE)

--- a/test/e2e/multi-cluster-deployment/README.md
+++ b/test/e2e/multi-cluster-deployment/README.md
@@ -14,11 +14,10 @@ cd test/e2e/multi-cluster-deployment
 
 ## Running the test steps manually
 ### Setup Kubestellar
-- Clone the repo and checkout the ks-0.20 branch
+- Clone the repo and cd to it. Naturally, if the branch that you are reading is not `main` then use that branch.
 ```
 git clone git@github.com:kubestellar/kubestellar.git
 cd kubestellar
-git checkout -b ks-0.20 origin/ks-0.20
 ```
 
 Create a Kind hosting cluster with nginx ingress controller and KubeFlex operator.

--- a/test/e2e/multi-cluster-deployment/run-test.sh
+++ b/test/e2e/multi-cluster-deployment/run-test.sh
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 # This is an end to end test of multi cluster deployement.  
-# For readable instructions, please visit https://github.com/kubestellar/kubestellar/tree/ks-0.20/docs/content/v0.20
+# For readable instructions, please visit ../../../docs/content/v0.20
 
 set -x # so users can see what is going on
 set -e # exit on error

--- a/test/e2e/singleton-status/run-test.sh
+++ b/test/e2e/singleton-status/run-test.sh
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 # This is an end to end test of multi cluster deployement.  
-# For readable instructions, please visit https://github.com/kubestellar/kubestellar/tree/ks-0.20/docs/content/v0.20
+# For readable instructions, please visit ../../../docs/content/v0.20
 
 set -x # so users can see what is going on
 set -e # exit on error


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
This PR replaces references to branch `ks-0.20` with references to branch `main` or relative references.

This is part of the merging of branch `ks-0.20` into `main`.

## Related issue(s)

Fixes #
