### PR TITLE
:bug: Fix Syncer to avoid adding entry to nil map

### DIFF
--- a/pkg/syncer/syncers/downsyncer.go
+++ b/pkg/syncer/syncers/downsyncer.go
@@ -300,7 +300,11 @@ func (ds *DownSyncer) computeUpdatedResource(upstreamResource *unstructured.Unst
 			return downstreamResource, true
 		} else {
 			ds.logger.V(2).Info(fmt.Sprintf("  update only annnotation %q in downstream since downsync-overwrite in downstream is still marked as true", upstreamResource.GetName()))
-			annotations[downsyncOverwriteKey] = "false"
+			if annotations == nil { // This situation occurs if a downstream object exists but annotations is empty.
+				annotations = map[string]string{downsyncOverwriteKey: "false"}
+			} else {
+				annotations[downsyncOverwriteKey] = "false"
+			}
 			_updatedResource := *downstreamResource
 			_updatedResource.SetAnnotations(annotations)
 			return &_updatedResource, false


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

Syncer to avoid adding an entry to nil map
  - There is a case that an object is annotated as `downsync-overwrite` in MBS but the object on WEC has empty annotation. In this case, Syncer crashed due to adding an entry to nil map at [downsyncer.go#L303](https://github.com/kubestellar/kubestellar/blob/release-0.14/pkg/syncer/syncers/downsyncer.go#L303)

We were reported that Syncer was crashed by MCAD integration teams and found that the above is the root cause.  


## Related issue(s)

Fixes #
