### PR TITLE
✨ Restore deploy-docs and serve-docs make targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -259,6 +259,19 @@ update-contextual-logging: $(LOGCHECK)
 lint: $(GOLANGCI_LINT) $(STATICCHECK) $(LOGCHECK)
 	./hack/verify-contextual-logging.sh
 
+VENVDIR=$(abspath docs/venv)
+REQUIREMENTS_TXT=docs/requirements.txt
+
+.PHONY: serve-docs
+serve-docs: venv
+	. $(VENV)/activate; \
+	VENV=$(VENV) REMOTE=$(REMOTE) BRANCH=$(BRANCH) docs/scripts/serve-docs.sh
+
+.PHONY: deploy-docs
+deploy-docs: venv
+	. $(VENV)/activate; \
+	REMOTE=$(REMOTE) BRANCH=$(BRANCH) docs/scripts/deploy-docs.sh
+
 .PHONY: verify-go-versions
 verify-go-versions:
 	hack/verify-go-versions.sh
@@ -316,3 +329,5 @@ build: bin-dir require-jq require-go require-git verify-go-versions  ## Build th
 .PHONY: bin-dir
 bin-dir:
 	mkdir -p bin
+
+include Makefile.venv


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
This PR attempts to restore the `deploy-docs` Makefile target, so that the `docs-gen-and-push.yml` workflow will work again.

I am not sure how to safely test this. `make serve-docs` never worked for me, and I dared not try `make deploy-docs` for fear of messing up the website.

## Related issue(s)

Fixes #
