### PR TITLE
🌱 Improved ordering of go imports

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -296,7 +296,7 @@ $(OPENSHIFT_GOIMPORTS):
 
 .PHONY: imports
 imports: $(OPENSHIFT_GOIMPORTS) verify-go-versions
-	$(OPENSHIFT_GOIMPORTS) -i github.com/kcp-dev -m github.com/kubestellar/kubestellar
+	$(OPENSHIFT_GOIMPORTS) -i github.com/kubestellar/kubeflex -m github.com/kubestellar/kubestellar
 
 .PHONY: verify-imports
 verify-imports:
@@ -329,5 +329,6 @@ build: bin-dir require-jq require-go require-git verify-go-versions  ## Build th
 .PHONY: bin-dir
 bin-dir:
 	mkdir -p bin
+
 
 include Makefile.venv

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -21,7 +21,6 @@ import (
 	"os"
 	"path/filepath"
 
-	tenancyv1alpha1 "github.com/kubestellar/kubeflex/api/v1alpha1"
 	homedir "github.com/mitchellh/go-homedir"
 
 	"k8s.io/apimachinery/pkg/runtime"
@@ -33,6 +32,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
 
 	"github.com/openshift/client-go/security/clientset/versioned"
+
+	tenancyv1alpha1 "github.com/kubestellar/kubeflex/api/v1alpha1"
 
 	edgev1alpha1 "github.com/kubestellar/kubestellar/api/v1alpha1"
 )

--- a/pkg/crd/crds.go
+++ b/pkg/crd/crds.go
@@ -25,7 +25,6 @@ import (
 	"time"
 
 	"github.com/go-logr/logr"
-	kfutil "github.com/kubestellar/kubeflex/pkg/util"
 
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	apiextensionsclientset "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
@@ -35,6 +34,8 @@ import (
 	"k8s.io/apimachinery/pkg/util/yaml"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
+
+	kfutil "github.com/kubestellar/kubeflex/pkg/util"
 
 	"github.com/kubestellar/kubestellar/pkg/util"
 )

--- a/pkg/util/kubeconfig.go
+++ b/pkg/util/kubeconfig.go
@@ -22,7 +22,6 @@ import (
 	"time"
 
 	"github.com/go-logr/logr"
-	kfv1aplha1 "github.com/kubestellar/kubeflex/api/v1alpha1"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
@@ -32,6 +31,8 @@ import (
 	"k8s.io/client-go/tools/clientcmd"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	kfv1aplha1 "github.com/kubestellar/kubeflex/api/v1alpha1"
 
 	kslclient "github.com/kubestellar/kubestellar/pkg/client"
 )


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
This PR updates the rule for ordering go-language import, putting kubeflex in place of kcp.

This PR is built on #1603 (because I have been plagued by the test flakiness) and will be rebased after that merges.

## Related issue(s)

Fixes #
