### PR TITLE
:bug: Fix lack of singleton ManifestWork object removal upon Placement deletion

### DIFF
--- a/pkg/placement/placement.go
+++ b/pkg/placement/placement.go
@@ -251,18 +251,15 @@ func deleteManifestOrLabel(managedByLabelKey string, manifest workv1.ManifestWor
 func isAlsoManagedByOtherPlacements(labels map[string]string, managedByLabelKey string) bool {
 	for key := range labels {
 		if key == managedByLabelKey {
-			// This is the key for the instance we know about
+			// This is the key for the Placement we know about
 			continue
 		}
 		if key == util.PlacementLabelSingletonStatus {
 			// This is a singleton marker, ignore it...
-			// Given this is present, we should only have a single Placement
-			// key beyond this singleton marker, but we'll continue to check
-			// for other keys to be safe.
 			continue
 		}
 		if strings.HasPrefix(key, util.PlacementLabelKeyBase) {
-			// This is a key managed by Kubestellar, but not for the instance
+			// This is a key managed by Kubestellar, but not for the Placement
 			// we already know about
 			return true
 		}

--- a/pkg/placement/placement.go
+++ b/pkg/placement/placement.go
@@ -251,9 +251,19 @@ func deleteManifestOrLabel(managedByLabelKey string, manifest workv1.ManifestWor
 func isAlsoManagedByOtherPlacements(labels map[string]string, managedByLabelKey string) bool {
 	for key := range labels {
 		if key == managedByLabelKey {
+			// This is the key for the instance we know about
+			continue
+		}
+		if key == util.PlacementLabelSingletonStatus {
+			// This is a singleton marker, ignore it...
+			// Given this is present, we should only have a single Placement
+			// key beyond this singleton marker, but we'll continue to check
+			// for other keys to be safe.
 			continue
 		}
 		if strings.HasPrefix(key, util.PlacementLabelKeyBase) {
+			// This is a key managed by Kubestellar, but not for the instance
+			// we already know about
 			return true
 		}
 	}


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

The ManifestWork object in the IMBS does not get deleted automatically when `wantSingletonReportedState: true` upon the user deleting the associated Placement object from the WDS. This corrects that bug.

## Related issue(s)

Fixes #1596 
