### PR TITLE
🌱 Update go version to track Kubernetes release 1.28

### DIFF
--- a/.prow.yaml
+++ b/.prow.yaml
@@ -5,7 +5,7 @@ presubmits:
     clone_uri: "https://github.com/kubestellar/kubestellar"
     spec:
       containers:
-        - image: ghcr.io/kcp-dev/infra/build:1.19.9-2
+        - image: ghcr.io/kcp-dev/infra/build:1.20.9-3
           command:
             - make
             - verify-boilerplate
@@ -24,7 +24,7 @@ presubmits:
     clone_uri: "https://github.com/kubestellar/kubestellar"
     spec:
       containers:
-        - image: ghcr.io/kcp-dev/infra/build:1.19.9-2
+        - image: ghcr.io/kcp-dev/infra/build:1.20.9-3
           command:
             - make
             - lint
@@ -41,7 +41,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: ghcr.io/kcp-dev/infra/build:1.19.9-2
+        - image: ghcr.io/kcp-dev/infra/build:1.20.9-3
           command:
             - make
             - test

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/kubestellar/kubestellar
 
-go 1.19
+go 1.20
 
 require (
 	github.com/go-logr/logr v1.3.0


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
This PR updates the `go.mod` to require at least go 1.20, to be consistent with Kuberentes release 1.28 (which is what is imported).

## Related issue(s)

Fixes #
