### PR TITLE
🐛 Add missing comment about Placement being not namespaced

### DIFF
--- a/api/edge/v1alpha1/types.go
+++ b/api/edge/v1alpha1/types.go
@@ -66,6 +66,7 @@ type PlacementStatus struct {
 
 // Placement is the Schema for the placementpolicies API
 // +genclient
+// +genclient:nonNamespaced
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="SYNCED",type="string",JSONPath=".status.conditions[?(@.type=='Synced')].status"

--- a/pkg/generated/clientset/versioned/typed/edge/v1alpha1/edge_client.go
+++ b/pkg/generated/clientset/versioned/typed/edge/v1alpha1/edge_client.go
@@ -37,8 +37,8 @@ type EdgeV1alpha1Client struct {
 	restClient rest.Interface
 }
 
-func (c *EdgeV1alpha1Client) Placements(namespace string) PlacementInterface {
-	return newPlacements(c, namespace)
+func (c *EdgeV1alpha1Client) Placements() PlacementInterface {
+	return newPlacements(c)
 }
 
 // NewForConfig creates a new EdgeV1alpha1Client for the given config.

--- a/pkg/generated/clientset/versioned/typed/edge/v1alpha1/fake/fake_edge_client.go
+++ b/pkg/generated/clientset/versioned/typed/edge/v1alpha1/fake/fake_edge_client.go
@@ -29,8 +29,8 @@ type FakeEdgeV1alpha1 struct {
 	*testing.Fake
 }
 
-func (c *FakeEdgeV1alpha1) Placements(namespace string) v1alpha1.PlacementInterface {
-	return &FakePlacements{c, namespace}
+func (c *FakeEdgeV1alpha1) Placements() v1alpha1.PlacementInterface {
+	return &FakePlacements{c}
 }
 
 // RESTClient returns a RESTClient that is used to communicate

--- a/pkg/generated/clientset/versioned/typed/edge/v1alpha1/fake/fake_placement.go
+++ b/pkg/generated/clientset/versioned/typed/edge/v1alpha1/fake/fake_placement.go
@@ -33,7 +33,6 @@ import (
 // FakePlacements implements PlacementInterface
 type FakePlacements struct {
 	Fake *FakeEdgeV1alpha1
-	ns   string
 }
 
 var placementsResource = v1alpha1.SchemeGroupVersion.WithResource("placements")
@@ -43,8 +42,7 @@ var placementsKind = v1alpha1.SchemeGroupVersion.WithKind("Placement")
 // Get takes name of the placement, and returns the corresponding placement object, and an error if there is any.
 func (c *FakePlacements) Get(ctx context.Context, name string, options v1.GetOptions) (result *v1alpha1.Placement, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewGetAction(placementsResource, c.ns, name), &v1alpha1.Placement{})
-
+		Invokes(testing.NewRootGetAction(placementsResource, name), &v1alpha1.Placement{})
 	if obj == nil {
 		return nil, err
 	}
@@ -54,8 +52,7 @@ func (c *FakePlacements) Get(ctx context.Context, name string, options v1.GetOpt
 // List takes label and field selectors, and returns the list of Placements that match those selectors.
 func (c *FakePlacements) List(ctx context.Context, opts v1.ListOptions) (result *v1alpha1.PlacementList, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewListAction(placementsResource, placementsKind, c.ns, opts), &v1alpha1.PlacementList{})
-
+		Invokes(testing.NewRootListAction(placementsResource, placementsKind, opts), &v1alpha1.PlacementList{})
 	if obj == nil {
 		return nil, err
 	}
@@ -76,15 +73,13 @@ func (c *FakePlacements) List(ctx context.Context, opts v1.ListOptions) (result 
 // Watch returns a watch.Interface that watches the requested placements.
 func (c *FakePlacements) Watch(ctx context.Context, opts v1.ListOptions) (watch.Interface, error) {
 	return c.Fake.
-		InvokesWatch(testing.NewWatchAction(placementsResource, c.ns, opts))
-
+		InvokesWatch(testing.NewRootWatchAction(placementsResource, opts))
 }
 
 // Create takes the representation of a placement and creates it.  Returns the server's representation of the placement, and an error, if there is any.
 func (c *FakePlacements) Create(ctx context.Context, placement *v1alpha1.Placement, opts v1.CreateOptions) (result *v1alpha1.Placement, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewCreateAction(placementsResource, c.ns, placement), &v1alpha1.Placement{})
-
+		Invokes(testing.NewRootCreateAction(placementsResource, placement), &v1alpha1.Placement{})
 	if obj == nil {
 		return nil, err
 	}
@@ -94,8 +89,7 @@ func (c *FakePlacements) Create(ctx context.Context, placement *v1alpha1.Placeme
 // Update takes the representation of a placement and updates it. Returns the server's representation of the placement, and an error, if there is any.
 func (c *FakePlacements) Update(ctx context.Context, placement *v1alpha1.Placement, opts v1.UpdateOptions) (result *v1alpha1.Placement, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewUpdateAction(placementsResource, c.ns, placement), &v1alpha1.Placement{})
-
+		Invokes(testing.NewRootUpdateAction(placementsResource, placement), &v1alpha1.Placement{})
 	if obj == nil {
 		return nil, err
 	}
@@ -106,8 +100,7 @@ func (c *FakePlacements) Update(ctx context.Context, placement *v1alpha1.Placeme
 // Add a +genclient:noStatus comment above the type to avoid generating UpdateStatus().
 func (c *FakePlacements) UpdateStatus(ctx context.Context, placement *v1alpha1.Placement, opts v1.UpdateOptions) (*v1alpha1.Placement, error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewUpdateSubresourceAction(placementsResource, "status", c.ns, placement), &v1alpha1.Placement{})
-
+		Invokes(testing.NewRootUpdateSubresourceAction(placementsResource, "status", placement), &v1alpha1.Placement{})
 	if obj == nil {
 		return nil, err
 	}
@@ -117,14 +110,13 @@ func (c *FakePlacements) UpdateStatus(ctx context.Context, placement *v1alpha1.P
 // Delete takes name of the placement and deletes it. Returns an error if one occurs.
 func (c *FakePlacements) Delete(ctx context.Context, name string, opts v1.DeleteOptions) error {
 	_, err := c.Fake.
-		Invokes(testing.NewDeleteActionWithOptions(placementsResource, c.ns, name, opts), &v1alpha1.Placement{})
-
+		Invokes(testing.NewRootDeleteActionWithOptions(placementsResource, name, opts), &v1alpha1.Placement{})
 	return err
 }
 
 // DeleteCollection deletes a collection of objects.
 func (c *FakePlacements) DeleteCollection(ctx context.Context, opts v1.DeleteOptions, listOpts v1.ListOptions) error {
-	action := testing.NewDeleteCollectionAction(placementsResource, c.ns, listOpts)
+	action := testing.NewRootDeleteCollectionAction(placementsResource, listOpts)
 
 	_, err := c.Fake.Invokes(action, &v1alpha1.PlacementList{})
 	return err
@@ -133,8 +125,7 @@ func (c *FakePlacements) DeleteCollection(ctx context.Context, opts v1.DeleteOpt
 // Patch applies the patch and returns the patched placement.
 func (c *FakePlacements) Patch(ctx context.Context, name string, pt types.PatchType, data []byte, opts v1.PatchOptions, subresources ...string) (result *v1alpha1.Placement, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewPatchSubresourceAction(placementsResource, c.ns, name, pt, data, subresources...), &v1alpha1.Placement{})
-
+		Invokes(testing.NewRootPatchSubresourceAction(placementsResource, name, pt, data, subresources...), &v1alpha1.Placement{})
 	if obj == nil {
 		return nil, err
 	}

--- a/pkg/generated/clientset/versioned/typed/edge/v1alpha1/placement.go
+++ b/pkg/generated/clientset/versioned/typed/edge/v1alpha1/placement.go
@@ -34,7 +34,7 @@ import (
 // PlacementsGetter has a method to return a PlacementInterface.
 // A group's client should implement this interface.
 type PlacementsGetter interface {
-	Placements(namespace string) PlacementInterface
+	Placements() PlacementInterface
 }
 
 // PlacementInterface has methods to work with Placement resources.
@@ -54,14 +54,12 @@ type PlacementInterface interface {
 // placements implements PlacementInterface
 type placements struct {
 	client rest.Interface
-	ns     string
 }
 
 // newPlacements returns a Placements
-func newPlacements(c *EdgeV1alpha1Client, namespace string) *placements {
+func newPlacements(c *EdgeV1alpha1Client) *placements {
 	return &placements{
 		client: c.RESTClient(),
-		ns:     namespace,
 	}
 }
 
@@ -69,7 +67,6 @@ func newPlacements(c *EdgeV1alpha1Client, namespace string) *placements {
 func (c *placements) Get(ctx context.Context, name string, options v1.GetOptions) (result *v1alpha1.Placement, err error) {
 	result = &v1alpha1.Placement{}
 	err = c.client.Get().
-		Namespace(c.ns).
 		Resource("placements").
 		Name(name).
 		VersionedParams(&options, scheme.ParameterCodec).
@@ -86,7 +83,6 @@ func (c *placements) List(ctx context.Context, opts v1.ListOptions) (result *v1a
 	}
 	result = &v1alpha1.PlacementList{}
 	err = c.client.Get().
-		Namespace(c.ns).
 		Resource("placements").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -103,7 +99,6 @@ func (c *placements) Watch(ctx context.Context, opts v1.ListOptions) (watch.Inte
 	}
 	opts.Watch = true
 	return c.client.Get().
-		Namespace(c.ns).
 		Resource("placements").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -114,7 +109,6 @@ func (c *placements) Watch(ctx context.Context, opts v1.ListOptions) (watch.Inte
 func (c *placements) Create(ctx context.Context, placement *v1alpha1.Placement, opts v1.CreateOptions) (result *v1alpha1.Placement, err error) {
 	result = &v1alpha1.Placement{}
 	err = c.client.Post().
-		Namespace(c.ns).
 		Resource("placements").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Body(placement).
@@ -127,7 +121,6 @@ func (c *placements) Create(ctx context.Context, placement *v1alpha1.Placement, 
 func (c *placements) Update(ctx context.Context, placement *v1alpha1.Placement, opts v1.UpdateOptions) (result *v1alpha1.Placement, err error) {
 	result = &v1alpha1.Placement{}
 	err = c.client.Put().
-		Namespace(c.ns).
 		Resource("placements").
 		Name(placement.Name).
 		VersionedParams(&opts, scheme.ParameterCodec).
@@ -142,7 +135,6 @@ func (c *placements) Update(ctx context.Context, placement *v1alpha1.Placement, 
 func (c *placements) UpdateStatus(ctx context.Context, placement *v1alpha1.Placement, opts v1.UpdateOptions) (result *v1alpha1.Placement, err error) {
 	result = &v1alpha1.Placement{}
 	err = c.client.Put().
-		Namespace(c.ns).
 		Resource("placements").
 		Name(placement.Name).
 		SubResource("status").
@@ -156,7 +148,6 @@ func (c *placements) UpdateStatus(ctx context.Context, placement *v1alpha1.Place
 // Delete takes name of the placement and deletes it. Returns an error if one occurs.
 func (c *placements) Delete(ctx context.Context, name string, opts v1.DeleteOptions) error {
 	return c.client.Delete().
-		Namespace(c.ns).
 		Resource("placements").
 		Name(name).
 		Body(&opts).
@@ -171,7 +162,6 @@ func (c *placements) DeleteCollection(ctx context.Context, opts v1.DeleteOptions
 		timeout = time.Duration(*listOpts.TimeoutSeconds) * time.Second
 	}
 	return c.client.Delete().
-		Namespace(c.ns).
 		Resource("placements").
 		VersionedParams(&listOpts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -184,7 +174,6 @@ func (c *placements) DeleteCollection(ctx context.Context, opts v1.DeleteOptions
 func (c *placements) Patch(ctx context.Context, name string, pt types.PatchType, data []byte, opts v1.PatchOptions, subresources ...string) (result *v1alpha1.Placement, err error) {
 	result = &v1alpha1.Placement{}
 	err = c.client.Patch(pt).
-		Namespace(c.ns).
 		Resource("placements").
 		Name(name).
 		SubResource(subresources...).

--- a/pkg/generated/informers/externalversions/edge/v1alpha1/interface.go
+++ b/pkg/generated/informers/externalversions/edge/v1alpha1/interface.go
@@ -41,5 +41,5 @@ func New(f internalinterfaces.SharedInformerFactory, namespace string, tweakList
 
 // Placements returns a PlacementInformer.
 func (v *version) Placements() PlacementInformer {
-	return &placementInformer{factory: v.factory, namespace: v.namespace, tweakListOptions: v.tweakListOptions}
+	return &placementInformer{factory: v.factory, tweakListOptions: v.tweakListOptions}
 }

--- a/pkg/generated/informers/externalversions/edge/v1alpha1/placement.go
+++ b/pkg/generated/informers/externalversions/edge/v1alpha1/placement.go
@@ -43,33 +43,32 @@ type PlacementInformer interface {
 type placementInformer struct {
 	factory          internalinterfaces.SharedInformerFactory
 	tweakListOptions internalinterfaces.TweakListOptionsFunc
-	namespace        string
 }
 
 // NewPlacementInformer constructs a new informer for Placement type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
-func NewPlacementInformer(client versioned.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
-	return NewFilteredPlacementInformer(client, namespace, resyncPeriod, indexers, nil)
+func NewPlacementInformer(client versioned.Interface, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
+	return NewFilteredPlacementInformer(client, resyncPeriod, indexers, nil)
 }
 
 // NewFilteredPlacementInformer constructs a new informer for Placement type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
-func NewFilteredPlacementInformer(client versioned.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
+func NewFilteredPlacementInformer(client versioned.Interface, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
 	return cache.NewSharedIndexInformer(
 		&cache.ListWatch{
 			ListFunc: func(options v1.ListOptions) (runtime.Object, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.EdgeV1alpha1().Placements(namespace).List(context.TODO(), options)
+				return client.EdgeV1alpha1().Placements().List(context.TODO(), options)
 			},
 			WatchFunc: func(options v1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.EdgeV1alpha1().Placements(namespace).Watch(context.TODO(), options)
+				return client.EdgeV1alpha1().Placements().Watch(context.TODO(), options)
 			},
 		},
 		&edgev1alpha1.Placement{},
@@ -79,7 +78,7 @@ func NewFilteredPlacementInformer(client versioned.Interface, namespace string, 
 }
 
 func (f *placementInformer) defaultInformer(client versioned.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewFilteredPlacementInformer(client, f.namespace, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, f.tweakListOptions)
+	return NewFilteredPlacementInformer(client, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, f.tweakListOptions)
 }
 
 func (f *placementInformer) Informer() cache.SharedIndexInformer {

--- a/pkg/generated/listers/edge/v1alpha1/expansion_generated.go
+++ b/pkg/generated/listers/edge/v1alpha1/expansion_generated.go
@@ -21,7 +21,3 @@ package v1alpha1
 // PlacementListerExpansion allows custom methods to be added to
 // PlacementLister.
 type PlacementListerExpansion interface{}
-
-// PlacementNamespaceListerExpansion allows custom methods to be added to
-// PlacementNamespaceLister.
-type PlacementNamespaceListerExpansion interface{}

--- a/pkg/generated/listers/edge/v1alpha1/placement.go
+++ b/pkg/generated/listers/edge/v1alpha1/placement.go
@@ -32,8 +32,9 @@ type PlacementLister interface {
 	// List lists all Placements in the indexer.
 	// Objects returned here must be treated as read-only.
 	List(selector labels.Selector) (ret []*v1alpha1.Placement, err error)
-	// Placements returns an object that can list and get Placements.
-	Placements(namespace string) PlacementNamespaceLister
+	// Get retrieves the Placement from the index for a given name.
+	// Objects returned here must be treated as read-only.
+	Get(name string) (*v1alpha1.Placement, error)
 	PlacementListerExpansion
 }
 
@@ -55,41 +56,9 @@ func (s *placementLister) List(selector labels.Selector) (ret []*v1alpha1.Placem
 	return ret, err
 }
 
-// Placements returns an object that can list and get Placements.
-func (s *placementLister) Placements(namespace string) PlacementNamespaceLister {
-	return placementNamespaceLister{indexer: s.indexer, namespace: namespace}
-}
-
-// PlacementNamespaceLister helps list and get Placements.
-// All objects returned here must be treated as read-only.
-type PlacementNamespaceLister interface {
-	// List lists all Placements in the indexer for a given namespace.
-	// Objects returned here must be treated as read-only.
-	List(selector labels.Selector) (ret []*v1alpha1.Placement, err error)
-	// Get retrieves the Placement from the indexer for a given namespace and name.
-	// Objects returned here must be treated as read-only.
-	Get(name string) (*v1alpha1.Placement, error)
-	PlacementNamespaceListerExpansion
-}
-
-// placementNamespaceLister implements the PlacementNamespaceLister
-// interface.
-type placementNamespaceLister struct {
-	indexer   cache.Indexer
-	namespace string
-}
-
-// List lists all Placements in the indexer for a given namespace.
-func (s placementNamespaceLister) List(selector labels.Selector) (ret []*v1alpha1.Placement, err error) {
-	err = cache.ListAllByNamespace(s.indexer, s.namespace, selector, func(m interface{}) {
-		ret = append(ret, m.(*v1alpha1.Placement))
-	})
-	return ret, err
-}
-
-// Get retrieves the Placement from the indexer for a given namespace and name.
-func (s placementNamespaceLister) Get(name string) (*v1alpha1.Placement, error) {
-	obj, exists, err := s.indexer.GetByKey(s.namespace + "/" + name)
+// Get retrieves the Placement from the index for a given name.
+func (s *placementLister) Get(name string) (*v1alpha1.Placement, error) {
+	obj, exists, err := s.indexer.GetByKey(name)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
This PR fixes the markup of the Placement interface to tell code-generator that Placement is cluster-scoped.

## Related issue(s)

Fixes #
