### PR TITLE
🌱 Update prow jobs to use latest ghcr.io/kcp-dev/infra/build

### DIFF
--- a/.prow.yaml
+++ b/.prow.yaml
@@ -5,7 +5,7 @@ presubmits:
     clone_uri: "https://github.com/kubestellar/kubestellar"
     spec:
       containers:
-        - image: ghcr.io/kcp-dev/infra/build:1.20.9-3
+        - image: ghcr.io/kcp-dev/infra/build:1.20.13-1
           command:
             - make
             - verify-boilerplate
@@ -24,7 +24,7 @@ presubmits:
     clone_uri: "https://github.com/kubestellar/kubestellar"
     spec:
       containers:
-        - image: ghcr.io/kcp-dev/infra/build:1.20.9-3
+        - image: ghcr.io/kcp-dev/infra/build:1.20.13-1
           command:
             - make
             - lint
@@ -41,7 +41,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: ghcr.io/kcp-dev/infra/build:1.20.9-3
+        - image: ghcr.io/kcp-dev/infra/build:1.20.13-1
           command:
             - make
             - test


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
This PR updates the Prow jobs to use the infra container image that has the current point release of the minimal required version of go. This is the latest edition of the intfra container image that is available.

## Related issue(s)

Fixes #
