### PR TITLE
🌱 Add preflight check to update-codegen-clients.sh

### DIFF
--- a/docs/content/v0.20/packaging.md
+++ b/docs/content/v0.20/packaging.md
@@ -1,13 +1,5 @@
 # Packaging and Delivery
 
-## Local copy of KubeStellar git repo
-
-Because of [a restriction in one of the code generators that we
-use](https://github.com/kubernetes/code-generator/blob/v0.28.2/kube_codegen.sh#L394-L395),
-a contributor who works on API changes needs to have their local copy
-of the git repo in a directory whose name ends with the Go package
-name --- that is, ends with `github.com/kubestellar/kubestellar/`.
-
 ## status-addon
 
 The [status-addon](https://github.ibm.com/dettori/status-addon) repo is the source of a RedHat-style operator. 
@@ -17,6 +9,14 @@ The operator is delivered by a Helm chart at `quay.io/pdettori/status-addon-char
 There is also a container image involved.
 
 ## KubeStellar
+
+### Local copy of KubeStellar git repo
+
+Because of [a restriction in one of the code generators that we
+use](https://github.com/kubernetes/code-generator/blob/v0.28.2/kube_codegen.sh#L394-L395),
+a contributor who works on API changes needs to have their local copy
+of the git repo in a directory whose name ends with the Go package
+name --- that is, ends with `github.com/kubestellar/kubestellar/`.
 
 ### Derived files
 

--- a/hack/update-codegen-clients.sh
+++ b/hack/update-codegen-clients.sh
@@ -19,7 +19,18 @@ set -o nounset
 set -o pipefail
 set -o xtrace
 
-SCRIPT_ROOT=$(dirname "${BASH_SOURCE[0]}")/..
+SCRIPT_ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+
+if [ "$SCRIPT_ROOT" = "${SCRIPT_ROOT%/github.com/kubestellar/kubestellar}" ]; then
+    cat >&2 <<EOF
+Your local copy of the kubestellar repository needs to be elsewhere.
+It is currently at '$SCRIPT_ROOT'.
+Due to a restriction in k8s.io/code-generator (its Issue 165),
+your local copy needs to be in a directory whose pathname
+ends in '/github.com/kubestellar/kubestellar'.
+EOF
+    exit 1
+fi
 
 source "${CODE_GEN_DIR}/kube_codegen.sh"
 


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
This PR adds a preflight check to hack/update-codegen-clients.sh,
objecting if the local repo pathname is not good for code-generator.

This PR also fixes a little organizational bug in `packaging.md`.

## Related issue(s)

Fixes #
