### PR TITLE
🌱 Restrict CI workflows to legacy KubeStellar, for release-0.14

### DIFF
--- a/.github/workflows/docs-ecutable-example1.yml
+++ b/.github/workflows/docs-ecutable-example1.yml
@@ -8,14 +8,12 @@ on:
   # To confirm any changes to docs build successfully, without deploying them
   pull_request:
     branches:
-      - main
-      - "release-*"
+      - "release-0.1*"
   push:
     branches:
-      - main
-      - "release-*"
+      - "release-0.1*"
     tags:
-      - 'v*'
+      - 'v0.1*'
 
 env:
   docs-ecutable-filename: example1

--- a/.github/workflows/docs-ecutable-user-quickstart-test.yml
+++ b/.github/workflows/docs-ecutable-user-quickstart-test.yml
@@ -8,14 +8,12 @@ on:
   # To confirm any changes to docs build successfully, without deploying them
   pull_request:
     branches:
-      - "release-*"
-      - "main"
+      - "release-0.1*"
   push:
     branches:
-      - "release-*"
-      - "main"
+      - "release-0.1*"
     tags:
-      - 'v*'
+      - 'v0.1*'
       
 env:
   docs-ecutable-filename: user-quickstart-test


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
This PR adjusts when the example1 and user-quickstart-test workflows trigger, to restrict that to legacy KubeStellar. These workflows are currently disabled in the GitHub web UI and we would like to re-enable them for maintenance of legacy KubeStellar.

I do not understand GitHub workflows well enough to know whether I need to make this change to `main` or `release-0.14` or both. Unless and until I learn otherwise, I will attempt both. The complement to this PR is #1652 .

This is part of issue #1585 

## Related issue(s)

Fixes #
