### PR TITLE
🐛 Fix Syncer not to overwrite managedFields

### DIFF
--- a/pkg/syncer/syncers/common.go
+++ b/pkg/syncer/syncers/common.go
@@ -22,6 +22,7 @@ import (
 	"os"
 	"strings"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/klog/v2"
@@ -182,7 +183,7 @@ func diff(logger klog.Logger, srcResourceList *unstructured.UnstructuredList, de
 		if ok {
 			srcResource.SetResourceVersion(destResource.GetResourceVersion())
 			srcResource.SetUID(destResource.GetUID())
-			srcResource.SetManagedFields(destResource.GetManagedFields())
+			srcResource.SetManagedFields([]metav1.ManagedFieldsEntry{})
 
 			// Avoid to overwrite status field. Though, not sure this workaround is required.
 			// Actually, when Syncer donwsynces, Syncer doesn't call UpdateStatus() method. Status fields at downstream side aren't updated by downsyncing.
@@ -197,6 +198,7 @@ func diff(logger klog.Logger, srcResourceList *unstructured.UnstructuredList, de
 		} else {
 			srcResource.SetResourceVersion("")
 			srcResource.SetUID("")
+			srcResource.SetManagedFields([]metav1.ManagedFieldsEntry{})
 			setAnnotation(&srcResource)
 			newResources = append(newResources, srcResource)
 		}

--- a/pkg/syncer/syncers/downsyncer.go
+++ b/pkg/syncer/syncers/downsyncer.go
@@ -22,6 +22,7 @@ import (
 	"sync"
 
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/klog/v2"
@@ -104,6 +105,7 @@ func (ds *DownSyncer) SyncOne(resource edgev2alpha1.EdgeSyncConfigResource, conv
 				ds.logger.V(3).Info(fmt.Sprintf("  create %q in downstream since it's not found", resourceToString(resourceForDown)))
 				upstreamResource.SetResourceVersion("")
 				upstreamResource.SetUID("")
+				upstreamResource.SetManagedFields([]metav1.ManagedFieldsEntry{})
 				setDownsyncAnnotation(upstreamResource)
 				applyConversion(upstreamResource, resourceForDown)
 				if _, err := downstreamClient.Create(resourceForDown, upstreamResource); err != nil {
@@ -125,6 +127,7 @@ func (ds *DownSyncer) SyncOne(resource edgev2alpha1.EdgeSyncConfigResource, conv
 				if true || hasDownsyncAnnotation(downstreamResource) {
 					upstreamResource.SetResourceVersion(downstreamResource.GetResourceVersion())
 					upstreamResource.SetUID(downstreamResource.GetUID())
+					upstreamResource.SetManagedFields([]metav1.ManagedFieldsEntry{})
 					setDownsyncAnnotation(upstreamResource)
 					applyConversion(upstreamResource, resourceForDown)
 					_updatedResource, noDiff := ds.computeUpdatedResource(upstreamResource, downstreamResource)


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
This is the fix for Syncer not to overwrite managedFields. This bug was discovered while performance test. Thanks @dumb0002.

(This is same change as [the first commit](https://github.com/kubestellar/kubestellar/pull/1578/commits/e48f8ea765bd796958f91cc7127a6c9e1bb95fa6) in this PR (https://github.com/kubestellar/kubestellar/pull/1578))

This is @yana1205's work and is exactly the same as #1660 but that one is blocked by a bogus CI test failure and there is no way for me to re-run that git workflow.

## Related issue(s)

Fixes #
