### PR TITLE
🐛 added `WorkloadGeneration` field to the downsync objects section of PlacementDecision

### DIFF
--- a/api/edge/v1alpha1/types.go
+++ b/api/edge/v1alpha1/types.go
@@ -205,9 +205,9 @@ type PlacementDecisionSpec struct {
 }
 
 // DownsyncObjectReferences explicitly defines the objects to be down-synced.
-// The ClusterScope list defines the cluster-scope objects, NamespacedObjects packs individual objects
-// identifiable by namespace & name, and generation represents the internal spec generation of the listed
-// objects in the ClusterScope and NamespaceScope lists.
+// The ClusterScope list defines the cluster-scope objects, NamespaceScope list
+// defines the namespace-scope objects and generation represents the internal spec
+// generation of the listed objects in the ClusterScope and NamespaceScope lists.
 type DownsyncObjectReferences struct {
 	// `clusterScope` holds a list of individual cluster-scoped objects
 	// to downsync, organized by resource.

--- a/api/edge/v1alpha1/types.go
+++ b/api/edge/v1alpha1/types.go
@@ -205,8 +205,9 @@ type PlacementDecisionSpec struct {
 }
 
 // DownsyncObjectReferences explicitly defines the objects to be down-synced.
-// The ClusterScope list defines the cluster-scope objects, while NamespacedObjects packs individual objects
-// identifiable by namespace & name.
+// The ClusterScope list defines the cluster-scope objects, NamespacedObjects packs individual objects
+// identifiable by namespace & name, and generation represents the internal spec generation of the listed
+// objects in the ClusterScope and NamespaceScope lists.
 type DownsyncObjectReferences struct {
 	// `clusterScope` holds a list of individual cluster-scoped objects
 	// to downsync, organized by resource.
@@ -218,6 +219,15 @@ type DownsyncObjectReferences struct {
 	// `NamespaceScope` matches if and only if at least one member matches.
 	// +optional
 	NamespaceScope []NamespaceScopeDownsyncObjects `json:"namespaceScope,omitempty"`
+
+	// `ObjectsInternalSpecGeneration` is a sequence number representing a specific generation of the downsync objects internal spec.
+	// For example, if ClusterScope and NamespaceScope lists haven't changed but the
+	// internal spec of at least one object has changed, this field should be incremented.
+	// ObjectsInternalSpecGeneration should be updated upon a change in the spec of one
+	// of the objects from ClusterScope and NamespaceScope in order to trigger the
+	// distribution of the updated object.
+	// +optional
+	ObjectsInternalSpecGeneration int64 `json:"generation,omitempty"`
 }
 
 // NamespaceScopeDownsyncObjects matches some objects of one particular namespaced object.

--- a/api/edge/v1alpha1/types.go
+++ b/api/edge/v1alpha1/types.go
@@ -206,8 +206,10 @@ type PlacementDecisionSpec struct {
 
 // DownsyncObjectReferences explicitly defines the objects to be down-synced.
 // The ClusterScope list defines the cluster-scope objects, NamespaceScope list
-// defines the namespace-scope objects and generation represents the internal spec
-// generation of the listed objects in the ClusterScope and NamespaceScope lists.
+// defines the namespace-scope objects and WorkloadGeneration represents the
+// generation of the objects in the ClusterScope and NamespaceScope lists.
+// Upon a change in any of workload objects that should be distributed
+// (e.g., spec, annotations or labels) the workload generation field should be incremented.
 type DownsyncObjectReferences struct {
 	// `clusterScope` holds a list of individual cluster-scoped objects
 	// to downsync, organized by resource.
@@ -220,14 +222,15 @@ type DownsyncObjectReferences struct {
 	// +optional
 	NamespaceScope []NamespaceScopeDownsyncObjects `json:"namespaceScope,omitempty"`
 
-	// `ObjectsInternalSpecGeneration` is a sequence number representing a specific generation of the downsync objects internal spec.
-	// For example, if ClusterScope and NamespaceScope lists haven't changed but the
-	// internal spec of at least one object has changed, this field should be incremented.
-	// ObjectsInternalSpecGeneration should be updated upon a change in the spec of one
-	// of the objects from ClusterScope and NamespaceScope in order to trigger the
-	// distribution of the updated object.
+	// `WorkloadGeneration` is a sequence number representing a specific generation of
+	// the workload objects to be downsynced.
+	// For example, if ClusterScope and NamespaceScope lists haven't changed but at least
+	// one object has changed, this field should be incremented.
+	// Upon a change in any of workload objects that should be distributed
+	// (e.g., spec, annotations or labels) the workload generation field should be incremented.
+	// `WorkloadGeneration` field is monotonically increasing.
 	// +optional
-	ObjectsInternalSpecGeneration int64 `json:"generation,omitempty"`
+	WorkloadGeneration int64 `json:"workloadGeneration,omitempty"`
 }
 
 // NamespaceScopeDownsyncObjects matches some objects of one particular namespaced object.

--- a/config/crd/bases/edge.kubestellar.io_placementdecisions.yaml
+++ b/config/crd/bases/edge.kubestellar.io_placementdecisions.yaml
@@ -81,6 +81,17 @@ spec:
                       - version
                       type: object
                     type: array
+                  generation:
+                    description: '`ObjectsInternalSpecGeneration` is a sequence number
+                      representing a specific generation of the downsync objects internal
+                      spec. For example, if ClusterScope and NamespaceScope lists
+                      haven''t changed but the internal spec of at least one object
+                      has changed, this field should be incremented. ObjectsInternalSpecGeneration
+                      should be updated upon a change in the spec of one of the objects
+                      from ClusterScope and NamespaceScope in order to trigger the
+                      distribution of the updated object.'
+                    format: int64
+                    type: integer
                   namespaceScope:
                     description: '`NamespaceScope` matches if and only if at least
                       one member matches.'

--- a/config/crd/bases/edge.kubestellar.io_placementdecisions.yaml
+++ b/config/crd/bases/edge.kubestellar.io_placementdecisions.yaml
@@ -81,17 +81,6 @@ spec:
                       - version
                       type: object
                     type: array
-                  generation:
-                    description: '`ObjectsInternalSpecGeneration` is a sequence number
-                      representing a specific generation of the downsync objects internal
-                      spec. For example, if ClusterScope and NamespaceScope lists
-                      haven''t changed but the internal spec of at least one object
-                      has changed, this field should be incremented. ObjectsInternalSpecGeneration
-                      should be updated upon a change in the spec of one of the objects
-                      from ClusterScope and NamespaceScope in order to trigger the
-                      distribution of the updated object.'
-                    format: int64
-                    type: integer
                   namespaceScope:
                     description: '`NamespaceScope` matches if and only if at least
                       one member matches.'
@@ -134,6 +123,17 @@ spec:
                       - version
                       type: object
                     type: array
+                  workloadGeneration:
+                    description: '`WorkloadGeneration` is a sequence number representing
+                      a specific generation of the workload objects to be downsynced.
+                      For example, if ClusterScope and NamespaceScope lists haven''t
+                      changed but at least one object has changed, this field should
+                      be incremented. Upon a change in any of workload objects that
+                      should be distributed (e.g., spec, annotations or labels) the
+                      workload generation field should be incremented. `WorkloadGeneration`
+                      field is monotonically increasing.'
+                    format: int64
+                    type: integer
                 type: object
             type: object
         type: object

--- a/pkg/crd/files/edge.kubestellar.io_placementdecisions.yaml
+++ b/pkg/crd/files/edge.kubestellar.io_placementdecisions.yaml
@@ -81,6 +81,17 @@ spec:
                       - version
                       type: object
                     type: array
+                  generation:
+                    description: '`ObjectsInternalSpecGeneration` is a sequence number
+                      representing a specific generation of the downsync objects internal
+                      spec. For example, if ClusterScope and NamespaceScope lists
+                      haven''t changed but the internal spec of at least one object
+                      has changed, this field should be incremented. ObjectsInternalSpecGeneration
+                      should be updated upon a change in the spec of one of the objects
+                      from ClusterScope and NamespaceScope in order to trigger the
+                      distribution of the updated object.'
+                    format: int64
+                    type: integer
                   namespaceScope:
                     description: '`NamespaceScope` matches if and only if at least
                       one member matches.'

--- a/pkg/crd/files/edge.kubestellar.io_placementdecisions.yaml
+++ b/pkg/crd/files/edge.kubestellar.io_placementdecisions.yaml
@@ -81,17 +81,6 @@ spec:
                       - version
                       type: object
                     type: array
-                  generation:
-                    description: '`ObjectsInternalSpecGeneration` is a sequence number
-                      representing a specific generation of the downsync objects internal
-                      spec. For example, if ClusterScope and NamespaceScope lists
-                      haven''t changed but the internal spec of at least one object
-                      has changed, this field should be incremented. ObjectsInternalSpecGeneration
-                      should be updated upon a change in the spec of one of the objects
-                      from ClusterScope and NamespaceScope in order to trigger the
-                      distribution of the updated object.'
-                    format: int64
-                    type: integer
                   namespaceScope:
                     description: '`NamespaceScope` matches if and only if at least
                       one member matches.'
@@ -134,6 +123,17 @@ spec:
                       - version
                       type: object
                     type: array
+                  workloadGeneration:
+                    description: '`WorkloadGeneration` is a sequence number representing
+                      a specific generation of the workload objects to be downsynced.
+                      For example, if ClusterScope and NamespaceScope lists haven''t
+                      changed but at least one object has changed, this field should
+                      be incremented. Upon a change in any of workload objects that
+                      should be distributed (e.g., spec, annotations or labels) the
+                      workload generation field should be incremented. `WorkloadGeneration`
+                      field is monotonically increasing.'
+                    format: int64
+                    type: integer
                 type: object
             type: object
         type: object


### PR DESCRIPTION
This field is required in order to trigger reconciliation in cases where the list of objects to downsync hasn't changed (their identifiers hasn't changed), but spec of at least one of the objects has changed. in such cases we need to trigger distribution of the updates changes.

<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

## Related issue(s)

Fixes #1671 