### PR TITLE
✨ transport handling of converging actual state to the desired state

### DIFF
--- a/pkg/transport/generic_transport_controller.go
+++ b/pkg/transport/generic_transport_controller.go
@@ -46,10 +46,11 @@ import (
 )
 
 const (
-	ControllerName                 = "transport-controller"
-	transportFinalizer             = "transport.kubestellar.io/object-cleanup"
-	originOwnerReferenceAnnotation = "transport.kubestellar.io/originOwnerReferencePlacementDecisionKey"
-	originWdsAnnotation            = "transport.kubestellar.io/originWdsName"
+	ControllerName                  = "transport-controller"
+	transportFinalizer              = "transport.kubestellar.io/object-cleanup"
+	originOwnerReferenceLabel       = "transport.kubestellar.io/originOwnerReferencePlacementDecisionKey"
+	originWdsLabel                  = "transport.kubestellar.io/originWdsName"
+	originOwnerGenerationAnnotation = "transport.kubestellar.io/originOwnerReferencePlacementDecisionGeneration"
 )
 
 // NewTransportController returns a new transport controller
@@ -59,7 +60,7 @@ func NewTransportController(ctx context.Context, placementDecisionInformer edgev
 	emptyWrappedObject := transport.WrapObjects(make([]*unstructured.Unstructured, 0)) // empty wrapped object to get GVR from it.
 	wrappedObjectGVR, err := getGvrFromWrappedObject(transportClientset, emptyWrappedObject)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get transport wrapped object GVR - %w", err)
+		return nil, fmt.Errorf("failed to get wrapped object GVR - %w", err)
 	}
 
 	dynamicInformerFactory := dynamicinformer.NewDynamicSharedInformerFactory(transportDynamicClient, 0)
@@ -169,9 +170,9 @@ func (c *genericTransportController) enqueuePlacementDecision(obj interface{}) {
 // https://github.com/kubernetes/community/blob/8cafef897a22026d42f5e5bb3f104febe7e29830/contributors/devel/controllers.md
 func (c *genericTransportController) handleWrappedObject(obj interface{}) {
 	wrappedObject := obj.(metav1.Object)
-	ownerPlacementDecisionKey, found := wrappedObject.GetAnnotations()[originOwnerReferenceAnnotation] // safe if GetAnnotations() returns nil
+	ownerPlacementDecisionKey, found := wrappedObject.GetLabels()[originOwnerReferenceLabel] // safe if GetLabels() returns nil
 	if !found {
-		c.logger.Info("failed to extract placementdecision key from transport wrapped object", "Name", wrappedObject.GetName(),
+		c.logger.Info("failed to extract placementdecision key from wrapped object", "Name", wrappedObject.GetName(),
 			"Namespace", wrappedObject.GetNamespace())
 		return
 	}
@@ -282,12 +283,12 @@ func (c *genericTransportController) process(ctx context.Context, obj interface{
 func (c *genericTransportController) syncHandler(ctx context.Context, objectName string) error {
 	// Get the PlacementDecision object with this name from WDS
 	placementDecision, err := c.placementDecisionLister.Get(objectName)
-	if err != nil {
-		if errors.IsNotFound(err) { // the object was deleted and it had no finalizer on it. this means transport controller
-			// finished cleanup of wrapped objects from mailbox namespaces. no need to do anything in this state.
-			return nil
-		}
-		// in case of a different error, log it and retry.
+
+	if errors.IsNotFound(err) { // the object was deleted and it had no finalizer on it. this means transport controller
+		// finished cleanup of wrapped objects from mailbox namespaces. no need to do anything in this state.
+		return nil
+	}
+	if err != nil { // in case of a different error, log it and retry.
 		return fmt.Errorf("failed to get PlacementDecision object '%s' - %w", objectName, err)
 	}
 
@@ -304,13 +305,11 @@ func isObjectBeingDeleted(object metav1.Object) bool {
 }
 
 func (c *genericTransportController) deleteWrappedObjectsAndFinalizer(ctx context.Context, placementDecision *v1alpha1.PlacementDecision) error {
-	for _, destination := range placementDecision.Spec.Destinations { // TODO need to revisit the destination struct and see how to use it properly
-		if err := c.transportClient.Resource(c.wrappedObjectGVR).Namespace(destination.ClusterId).Delete(ctx, fmt.Sprintf("%s-%s", placementDecision.GetName(), c.wdsName),
-			metav1.DeleteOptions{}); err != nil { // wrapped object name is in the format (PlacementDecision.GetName()-WdsName). see updateWrappedObject func for explanation.
-			if !errors.IsNotFound(err) { // if object is already not there, we do not report an error cause desired state was achieved.
-				return fmt.Errorf("failed to delete wrapped object '%s' in destination WEC with namespace '%s' - %w", fmt.Sprintf("%s-%s", placementDecision.GetName(),
-					c.wdsName), destination.ClusterId, err)
-			}
+	for _, destination := range placementDecision.Spec.Destinations {
+		if err := c.deleteWrappedObject(ctx, destination.ClusterId, fmt.Sprintf("%s-%s", placementDecision.GetName(), c.wdsName)); err != nil {
+			// wrapped object name is in the format (PlacementDecision.GetName()-WdsName). see updateWrappedObject func for explanation.
+			return fmt.Errorf("failed to delete wrapped object '%s' in destination WEC mailbox namespace '%s' - %w", fmt.Sprintf("%s-%s", placementDecision.GetName(),
+				c.wdsName), destination.ClusterId, err)
 		}
 	}
 
@@ -321,14 +320,22 @@ func (c *genericTransportController) deleteWrappedObjectsAndFinalizer(ctx contex
 	return nil
 }
 
+func (c *genericTransportController) deleteWrappedObject(ctx context.Context, namespace string, objectName string) error {
+	err := c.transportClient.Resource(c.wrappedObjectGVR).Namespace(namespace).Delete(ctx, objectName, metav1.DeleteOptions{})
+	if err != nil && !errors.IsNotFound(err) { // if object is already not there, we do not report an error cause desired state was achieved.
+		return fmt.Errorf("failed to delete wrapped object '%s' from namespace '%s' - %w", objectName, namespace, err)
+	}
+	return nil
+}
+
 func (c *genericTransportController) removeFinalizerFromPlacementDecision(ctx context.Context, placementDecision *v1alpha1.PlacementDecision) error {
-	return c.updatePlacementDecision(ctx, placementDecision, func(placementDecision *v1alpha1.PlacementDecision) bool {
+	return c.updatePlacementDecision(ctx, placementDecision, func(placementDecision *v1alpha1.PlacementDecision) (*v1alpha1.PlacementDecision, bool) {
 		return removeFinalizer(placementDecision, transportFinalizer)
 	})
 }
 
 func (c *genericTransportController) addFinalizerToPlacementDecision(ctx context.Context, placementDecision *v1alpha1.PlacementDecision) error {
-	return c.updatePlacementDecision(ctx, placementDecision, func(placementDecision *v1alpha1.PlacementDecision) bool {
+	return c.updatePlacementDecision(ctx, placementDecision, func(placementDecision *v1alpha1.PlacementDecision) (*v1alpha1.PlacementDecision, bool) {
 		return addFinalizer(placementDecision, transportFinalizer)
 	})
 }
@@ -337,27 +344,34 @@ func (c *genericTransportController) updateWrappedObjectsAndFinalizer(ctx contex
 	if err := c.addFinalizerToPlacementDecision(ctx, placementDecision); err != nil {
 		return fmt.Errorf("failed to add finalizer to PlacementDecision object '%s' - %w", placementDecision.GetName(), err)
 	}
-
-	objectsToPropagate, err := c.getObjectsFromWDS(ctx, placementDecision)
+	// get current state
+	currentWrappedObjectList, err := c.transportClient.Resource(c.wrappedObjectGVR).List(ctx, metav1.ListOptions{
+		LabelSelector: fmt.Sprintf("%s=%s,%s=%s", originOwnerReferenceLabel, placementDecision.GetName(), originWdsLabel, c.wdsName),
+	})
 	if err != nil {
-		return fmt.Errorf("failed to get objects to propagate to WECs from PlacementDecision object '%s' - %w", placementDecision.GetName(), err)
+		return fmt.Errorf("failed to get current wrapped objects that are owned by PlacementDecision '%s' - %w", placementDecision.GetName(), err)
 	}
-
-	wrappedObject, err := convertObjectToUnstructured(c.transport.WrapObjects(objectsToPropagate))
+	// calculate desired state
+	desiredWrappedObject, err := c.initializeWrappedObject(ctx, placementDecision)
 	if err != nil {
-		return fmt.Errorf("failed to convert wrapped object to unstructured - %w", err)
+		return fmt.Errorf("failed to build wrapped object from PlacementDecision '%s' - %w", placementDecision.GetName(), err)
 	}
-	// wrapped object name is (PlacementDecision.GetName()-WdsName).
-	// pay attention - we cannot use the PlacementDecision object name, cause we might have duplicate names coming from different WDS spaces.
-	// we add WdsName to the object name to assure name uniqueness,
-	// in order to easily get the origin PlacementDecision object name and wds, we add it as an annotations.
-	wrappedObject.SetName(fmt.Sprintf("%s-%s", placementDecision.GetName(), c.wdsName))
-	setAnnotation(wrappedObject, originOwnerReferenceAnnotation, placementDecision.GetName())
-	setAnnotation(wrappedObject, originWdsAnnotation, c.wdsName)
-
-	for _, destination := range placementDecision.Spec.Destinations { // TODO need to revisit the destination struct and see how to use it properly
-		if err := c.createOrUpdateWrappedObject(ctx, destination.ClusterId, wrappedObject); err != nil {
-			return fmt.Errorf("failed to propagate wrapped object '%s' to all required WECs - %w", wrappedObject.GetName(), err)
+	// converge actual state to the desired state
+	for _, destination := range placementDecision.Spec.Destinations {
+		currentWrappedObject := c.popWrappedObjectByNamespace(currentWrappedObjectList, destination.ClusterId)
+		if currentWrappedObject != nil && currentWrappedObject.GetAnnotations() != nil &&
+			currentWrappedObject.GetAnnotations()[originOwnerGenerationAnnotation] == desiredWrappedObject.GetAnnotations()[originOwnerGenerationAnnotation] {
+			continue // current wrapped object is already in the desired state
+		}
+		// othereise, need to create or update the wrapped object
+		if err := c.createOrUpdateWrappedObject(ctx, destination.ClusterId, desiredWrappedObject); err != nil {
+			return fmt.Errorf("failed to propagate wrapped object '%s' to all required WECs - %w", desiredWrappedObject.GetName(), err)
+		}
+	}
+	// all objects that appear in the desired state were handled. need to remove wrapped objects that are not part of the desired state
+	for _, wrappedObject := range currentWrappedObjectList.Items { // objects left in currentWrappedObjectList.Items have to be deleted
+		if err := c.deleteWrappedObject(ctx, wrappedObject.GetNamespace(), wrappedObject.GetName()); err != nil {
+			return fmt.Errorf("failed to delete wrapped object '%s' from destination WEC mailbox namespace '%s' - %w", wrappedObject.GetName(), wrappedObject.GetNamespace(), err)
 		}
 	}
 
@@ -372,9 +386,9 @@ func (c *genericTransportController) getObjectsFromWDS(ctx context.Context, plac
 			continue // no objects from this gvr, skip
 		}
 		gvr := schema.GroupVersionResource{Group: clusterScopedObject.Group, Version: clusterScopedObject.Version, Resource: clusterScopedObject.Resource}
-		dynamicClientGvrInterface := c.wdsDynamicClient.Resource(gvr)
+		gvrDynamicClient := c.wdsDynamicClient.Resource(gvr)
 		for _, objectName := range clusterScopedObject.ObjectNames {
-			object, err := dynamicClientGvrInterface.Get(ctx, objectName, metav1.GetOptions{})
+			object, err := gvrDynamicClient.Get(ctx, objectName, metav1.GetOptions{})
 			if err != nil {
 				return nil, fmt.Errorf("failed to get required cluster-scoped object '%s' with gvr %s from WDS - %w", objectName, gvr, err)
 			}
@@ -384,13 +398,13 @@ func (c *genericTransportController) getObjectsFromWDS(ctx context.Context, plac
 	// add namespace-scoped objects to the 'objectsToPropagate' slice
 	for _, namespaceScopedObject := range placementDecision.Spec.Workload.NamespaceScope {
 		gvr := schema.GroupVersionResource{Group: namespaceScopedObject.Group, Version: namespaceScopedObject.Version, Resource: namespaceScopedObject.Resource}
-		dynamicClientGvrInterface := c.wdsDynamicClient.Resource(gvr)
+		gvrDynamicClient := c.wdsDynamicClient.Resource(gvr)
 		for _, objectsByNamespace := range namespaceScopedObject.ObjectsByNamespace {
 			if objectsByNamespace.Names == nil {
 				continue // no objects from this namespace, skip
 			}
 			for _, objectName := range objectsByNamespace.Names {
-				object, err := dynamicClientGvrInterface.Namespace(objectsByNamespace.Namespace).Get(ctx, objectName, metav1.GetOptions{})
+				object, err := gvrDynamicClient.Namespace(objectsByNamespace.Namespace).Get(ctx, objectName, metav1.GetOptions{})
 				if err != nil {
 					return nil, fmt.Errorf("failed to get required namespace-scoped object '%s' in namespace '%s' with gvr '%s' from WDS - %w", objectName,
 						objectsByNamespace.Namespace, gvr, err)
@@ -401,6 +415,55 @@ func (c *genericTransportController) getObjectsFromWDS(ctx context.Context, plac
 	}
 
 	return objectsToPropagate, nil
+}
+
+func (c *genericTransportController) initializeWrappedObject(ctx context.Context, placementDecision *v1alpha1.PlacementDecision) (*unstructured.Unstructured, error) {
+	objectsToPropagate, err := c.getObjectsFromWDS(ctx, placementDecision)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get objects to propagate to WECs from PlacementDecision object '%s' - %w", placementDecision.GetName(), err)
+	}
+
+	wrappedObject, err := convertObjectToUnstructured(c.transport.WrapObjects(objectsToPropagate))
+	if err != nil {
+		return nil, fmt.Errorf("failed to convert wrapped object to unstructured - %w", err)
+	}
+	// wrapped object name is (PlacementDecision.GetName()-WdsName).
+	// pay attention - we cannot use the PlacementDecision object name, cause we might have duplicate names coming from different WDS spaces.
+	// we add WdsName to the object name to assure name uniqueness,
+	// in order to easily get the origin PlacementDecision object name and wds, we add it as an annotations.
+	wrappedObject.SetName(fmt.Sprintf("%s-%s", placementDecision.GetName(), c.wdsName))
+	setLabel(wrappedObject, originOwnerReferenceLabel, placementDecision.GetName())
+	setLabel(wrappedObject, originWdsLabel, c.wdsName)
+	setAnnotation(wrappedObject, originOwnerGenerationAnnotation, placementDecision.GetGeneration())
+
+	return wrappedObject, nil
+}
+
+// pops wrapped object by namespace from the list and returns the requested wrapped object.
+// if the object is not found, list remains the same and nil is returned.
+// since the order of items in the list is not important, the implementation is efficient and was done as follows:
+// the functions goes over the list, if the requested object is found, it's replaced with the last object in the list.
+// then the function removes the last object in the list and returns the object.
+// in worst case where object is not found, it will go over all items in the list.
+func (c *genericTransportController) popWrappedObjectByNamespace(list *unstructured.UnstructuredList, namespace string) *unstructured.Unstructured {
+	found := false
+	length := len(list.Items)
+	for i := 0; i < length; i++ {
+		if list.Items[i].GetNamespace() == namespace {
+			currentObject := list.Items[i]
+			list.Items[i] = list.Items[length-1]
+			list.Items[length-1] = currentObject
+			found = true
+			break
+		}
+	}
+	if !found {
+		return nil
+	}
+	// otherwise, object was found and was replaced with last object in the list
+	poppedObject := &list.Items[length-1]
+	list.Items = list.Items[:length-1]
+	return poppedObject
 }
 
 func (c *genericTransportController) createOrUpdateWrappedObject(ctx context.Context, namespace string, wrappedObject *unstructured.Unstructured) error {
@@ -426,18 +489,17 @@ func (c *genericTransportController) createOrUpdateWrappedObject(ctx context.Con
 	return nil
 }
 
-// updateObjectFunc is a function that updates the given object. returns true if object was updated, otherwise false.
-type updateObjectFunc func(*v1alpha1.PlacementDecision) bool
+// updateObjectFunc is a function that updates the given object.
+// returns the updated object (if it was updated) or the object as is if it wasn't, and true if object was updated, or false otherwise.
+type updateObjectFunc func(*v1alpha1.PlacementDecision) (*v1alpha1.PlacementDecision, bool)
 
 func (c *genericTransportController) updatePlacementDecision(ctx context.Context, placementDecision *v1alpha1.PlacementDecision, updateObjectFunc updateObjectFunc) error {
-	// objects returned from a PlacementDecisionLister must be treated as read-only.
-	// Therefore, create a deep copy before updating the object.
-	newPlacementDecision := placementDecision.DeepCopy()
-	if !updateObjectFunc(newPlacementDecision) { // returns an indication if object was updated or not.
+	updatedPlacementDecision, isUpdated := updateObjectFunc(placementDecision) // returns an indication if object was updated or not.
+	if !isUpdated {
 		return nil // if object was not updated, no need to update in API server, return.
 	}
 
-	_, err := c.wdsClientset.EdgeV1alpha1().PlacementDecisions().Update(ctx, newPlacementDecision, metav1.UpdateOptions{})
+	_, err := c.wdsClientset.EdgeV1alpha1().PlacementDecisions().Update(ctx, updatedPlacementDecision, metav1.UpdateOptions{})
 	if err != nil {
 		return fmt.Errorf("failed to update PlacementDecision object '%s' in WDS - %w", placementDecision.GetName(), err)
 	}
@@ -445,23 +507,27 @@ func (c *genericTransportController) updatePlacementDecision(ctx context.Context
 	return nil
 }
 
-// addFinalizer accepts an object and adds the provided finalizer if not present.
-// It returns an indication of whether it updated the object's list of finalizers.
-func addFinalizer(object metav1.Object, finalizer string) (finalizersUpdated bool) {
-	finalizers := object.GetFinalizers()
+// addFinalizer accepts PlacementDecision object and adds the provided finalizer if not present.
+// It returns the updated (or not) PlacementDecision and an indication of whether it updated the object's list of finalizers.
+func addFinalizer(placementDecision *v1alpha1.PlacementDecision, finalizer string) (*v1alpha1.PlacementDecision, bool) {
+	finalizers := placementDecision.GetFinalizers()
 	for _, item := range finalizers {
-		if item == finalizer {
-			return false
+		if item == finalizer { // finalizer already exists, no need to add
+			return placementDecision, false
 		}
 	}
-	object.SetFinalizers(append(finalizers, finalizer))
-	return true
+	// if we reached here, finalizer has to be added to the placement decision object.
+	// objects returned from a PlacementDecisionLister must be treated as read-only.
+	// Therefore, create a deep copy before updating the object.
+	updatedPlacementDecision := placementDecision.DeepCopy()
+	updatedPlacementDecision.SetFinalizers(append(finalizers, finalizer))
+	return updatedPlacementDecision, true
 }
 
-// removeFinalizer accepts an object and removes the provided finalizer if present.
-// It returns an indication of whether it updated the object's list of finalizers.
-func removeFinalizer(object metav1.Object, finalizer string) (finalizersUpdated bool) {
-	finalizersList := object.GetFinalizers()
+// removeFinalizer accepts PlacementDecision object and removes the provided finalizer if present.
+// It returns the updated (or not) PlacementDecision and an indication of whether it updated the object's list of finalizers.
+func removeFinalizer(placementDecision *v1alpha1.PlacementDecision, finalizer string) (*v1alpha1.PlacementDecision, bool) {
+	finalizersList := placementDecision.GetFinalizers()
 	length := len(finalizersList)
 
 	index := 0
@@ -472,36 +538,56 @@ func removeFinalizer(object metav1.Object, finalizer string) (finalizersUpdated 
 		finalizersList[index] = finalizersList[i]
 		index++
 	}
-	object.SetFinalizers(finalizersList[:index])
-	return length != index
+	if length == index { // finalizer wasn't found, no need to remove
+		return placementDecision, false
+	}
+	// otherwise, finalizer was found and has to be removed.
+	// objects returned from a PlacementDecisionLister must be treated as read-only.
+	// Therefore, create a deep copy before updating the object.
+	updatedPlacementDecision := placementDecision.DeepCopy()
+	updatedPlacementDecision.SetFinalizers(finalizersList[:index])
+	return updatedPlacementDecision, true
 }
 
 // setAnnotation sets metadata annotation on the given object.
-func setAnnotation(object metav1.Object, key string, value string) {
+func setAnnotation(object metav1.Object, key string, value any) {
 	annotations := object.GetAnnotations()
 	if annotations == nil {
 		annotations = make(map[string]string)
 	}
 
-	annotations[key] = value
+	annotations[key] = fmt.Sprint(value)
 
 	object.SetAnnotations(annotations)
 }
 
+// setLabel sets metadata label on the given object.
+func setLabel(object metav1.Object, key string, value any) {
+	labels := object.GetLabels()
+	if labels == nil {
+		labels = make(map[string]string)
+	}
+
+	labels[key] = fmt.Sprint(value)
+
+	object.SetLabels(labels)
+}
+
 // cleanObject is a function to clean object before adding it to a wrapped object. these fields shouldn't be propagated to WEC.
 func cleanObject(object *unstructured.Unstructured) *unstructured.Unstructured {
-	object.SetManagedFields(nil)
-	object.SetFinalizers(nil)
-	object.SetGeneration(0)
-	object.SetOwnerReferences(nil)
-	object.SetSelfLink("")
-	object.SetResourceVersion("")
-	object.SetUID("")
+	objectCopy := object.DeepCopy() // don't modify object directly. create a copy before zeroing fields
+	objectCopy.SetManagedFields(nil)
+	objectCopy.SetFinalizers(nil)
+	objectCopy.SetGeneration(0)
+	objectCopy.SetOwnerReferences(nil)
+	objectCopy.SetSelfLink("")
+	objectCopy.SetResourceVersion("")
+	objectCopy.SetUID("")
 
-	annotations := object.GetAnnotations()
+	annotations := objectCopy.GetAnnotations()
 	delete(annotations, "kubectl.kubernetes.io/last-applied-configuration")
-	object.SetAnnotations(annotations)
+	objectCopy.SetAnnotations(annotations)
 
-	return object
+	return objectCopy
 
 }

--- a/pkg/transport/generic_transport_controller.go
+++ b/pkg/transport/generic_transport_controller.go
@@ -67,7 +67,7 @@ func NewTransportController(ctx context.Context, placementDecisionInformer edgev
 	wrappedObjectGenericInformer := dynamicInformerFactory.ForResource(wrappedObjectGVR)
 
 	transportController := &genericTransportController{
-		logger:                          klog.FromContext(ctx).WithName(ControllerName),
+		logger:                          klog.FromContext(ctx),
 		placementDecisionLister:         placementDecisionInformer.Lister(),
 		placementDecisionInformerSynced: placementDecisionInformer.Informer().HasSynced,
 		wrappedObjectInformerSynced:     wrappedObjectGenericInformer.Informer().HasSynced,

--- a/pkg/transport/generic_transport_controller.go
+++ b/pkg/transport/generic_transport_controller.go
@@ -473,7 +473,9 @@ func (c *genericTransportController) createOrUpdateWrappedObject(ctx context.Con
 			return fmt.Errorf("failed to create wrapped object '%s' in destination WEC with namespace '%s' - %w", wrappedObject.GetName(), namespace, err)
 		}
 		// object not found when using get, create it
-		_, err = c.transportClient.Resource(c.wrappedObjectGVR).Namespace(namespace).Create(ctx, wrappedObject, metav1.CreateOptions{})
+		_, err = c.transportClient.Resource(c.wrappedObjectGVR).Namespace(namespace).Create(ctx, wrappedObject, metav1.CreateOptions{
+			FieldManager: ControllerName,
+		})
 		if err != nil {
 			return fmt.Errorf("failed to create wrapped object '%s' in destination WEC mailbox namespace '%s' - %w", wrappedObject.GetName(), namespace, err)
 		}
@@ -481,7 +483,9 @@ func (c *genericTransportController) createOrUpdateWrappedObject(ctx context.Con
 	}
 	// // if we reached here object already exists, try update object
 	wrappedObject.SetResourceVersion(existingWrappedObject.GetResourceVersion())
-	_, err = c.transportClient.Resource(c.wrappedObjectGVR).Namespace(namespace).Update(ctx, wrappedObject, metav1.UpdateOptions{})
+	_, err = c.transportClient.Resource(c.wrappedObjectGVR).Namespace(namespace).Update(ctx, wrappedObject, metav1.UpdateOptions{
+		FieldManager: ControllerName,
+	})
 	if err != nil {
 		return fmt.Errorf("failed to update wrapped object '%s' in destination WEC mailbox namespace '%s' - %w", wrappedObject.GetName(), namespace, err)
 	}
@@ -499,7 +503,9 @@ func (c *genericTransportController) updatePlacementDecision(ctx context.Context
 		return nil // if object was not updated, no need to update in API server, return.
 	}
 
-	_, err := c.wdsClientset.EdgeV1alpha1().PlacementDecisions().Update(ctx, updatedPlacementDecision, metav1.UpdateOptions{})
+	_, err := c.wdsClientset.EdgeV1alpha1().PlacementDecisions().Update(ctx, updatedPlacementDecision, metav1.UpdateOptions{
+		FieldManager: ControllerName,
+	})
 	if err != nil {
 		return fmt.Errorf("failed to update PlacementDecision object '%s' in WDS - %w", placementDecision.GetName(), err)
 	}


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

In #1588, the initial code that was merged into main did not handle the current state, but only the desired state.
That was done as part of splitting PRs into smaller pieces.
This PR adds the functionality of getting current state, calculating the desired state as specific in the PlacementDecision CR and converging current state to the desired state (if needed).

This PR also handled some minor points that were raised by @MikeSpreitzer as part of the code review of #1588, for example: 
- in add/remove finalizer functions the deep copy is done only if there is a need to update the object
- clean object uses deep copy in order not to update an object that was fetched using the client 

## Related issue(s)

Fixes #
