### PR TITLE
✨Implemented Placement-Decision Logic

### DIFF
--- a/.github/workflows/pr-test-multicluster.yml
+++ b/.github/workflows/pr-test-multicluster.yml
@@ -44,3 +44,24 @@ jobs:
         run: |
           cd test/e2e/multi-cluster-deployment 
           KFLEX_DISABLE_CHATTY=true ./run-test.sh 
+
+      - name: Investigate the kubestellar container
+        if: always()
+        run: |
+          echo kubectl contexts:
+          kubectl config get-contexts
+          echo
+          echo pods:
+          kubectl --context kind-kubeflex get pods -A
+          kpod=$(kubectl --context kind-kubeflex get pod -n wds1-system --selector=control-plane=controller-manager -o jsonpath='{.items[0].metadata.name}')
+          echo
+          echo kubestellar controller log:
+          kubectl --context kind-kubeflex logs -n wds1-system $kpod
+          echo
+          kubectl --context wds1 get placements -o yaml
+          echo
+          kubectl --context wds1 get placementdecisions -o yaml
+          echo
+          kubectl --context imbs1 get manifestworks -o yaml
+          echo
+          kubectl --context imbs1 get workstatuses -A -o yaml

--- a/.github/workflows/pr-test-singleton-status.yml
+++ b/.github/workflows/pr-test-singleton-status.yml
@@ -44,3 +44,24 @@ jobs:
         run: |
           cd test/e2e/singleton-status
           KFLEX_DISABLE_CHATTY=true ./run-test.sh 
+
+      - name: Investigate the kubestellar container
+        if: always()
+        run: |
+          echo kubectl contexts:
+          kubectl config get-contexts
+          echo
+          echo pods:
+          kubectl --context kind-kubeflex get pods -A
+          kpod=$(kubectl --context kind-kubeflex get pod -n wds1-system --selector=control-plane=controller-manager -o jsonpath='{.items[0].metadata.name}')
+          echo
+          echo kubestellar controller log:
+          kubectl --context kind-kubeflex logs -n wds1-system $kpod
+          echo
+          kubectl --context wds1 get placements -o yaml
+          echo
+          kubectl --context wds1 get placementdecisions -o yaml
+          echo
+          kubectl --context imbs1 get manifestworks -o yaml
+          echo
+          kubectl --context imbs1 get workstatuses -A -o yaml

--- a/pkg/crd/crds.go
+++ b/pkg/crd/crds.go
@@ -164,7 +164,7 @@ func waitForCRDAccepted(ctx context.Context, clientset apiextensionsclientset.In
 		}
 
 		for _, condition := range crd.Status.Conditions {
-			if condition.Type == apiextensionsv1.NamesAccepted && condition.Status == apiextensionsv1.ConditionTrue {
+			if condition.Type == apiextensionsv1.Established && condition.Status == apiextensionsv1.ConditionTrue {
 				return true, nil
 			}
 		}

--- a/pkg/ocm/ocm.go
+++ b/pkg/ocm/ocm.go
@@ -29,6 +29,7 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
@@ -156,7 +157,7 @@ func GetClusterByName(ocmClient client.Client, clusterName string) (clusterv1.Ma
 	return cluster, nil
 }
 
-func ListClustersBySelectors(ocmClient client.Client, selectors []metav1.LabelSelector) ([]string, error) {
+func FindClustersBySelectors(ocmClient client.Client, selectors []metav1.LabelSelector) (sets.Set[string], error) {
 	clusters := &clusterv1.ManagedClusterList{}
 	labelSelectors := []labels.Selector{}
 	for _, s := range selectors {
@@ -176,10 +177,12 @@ func ListClustersBySelectors(ocmClient client.Client, selectors []metav1.LabelSe
 	if len(clusters.Items) == 0 {
 		return nil, nil
 	}
-	clusterNames := []string{}
+
+	clusterNames := sets.New[string]()
 	for _, cluster := range clusters.Items {
-		clusterNames = append(clusterNames, cluster.GetName())
+		clusterNames.Insert(cluster.GetName())
 	}
+
 	return clusterNames, nil
 }
 

--- a/pkg/placement/controller.go
+++ b/pkg/placement/controller.go
@@ -249,7 +249,7 @@ func (c *Controller) run(workers int) error {
 
 	// populate the PlacementResolver with entries for existing placements
 	if err := c.populatePlacementResolverWithExistingPlacements(); err != nil {
-		return fmt.Errorf("failed to populate the PlacementResolver for the existing placements")
+		return fmt.Errorf("failed to populate the PlacementResolver for the existing placements: %w", err)
 	}
 
 	c.logger.Info("Starting workers", "count", workers)

--- a/pkg/placement/manifest.go
+++ b/pkg/placement/manifest.go
@@ -23,13 +23,16 @@ import (
 	workv1 "open-cluster-management.io/api/work/v1"
 
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/kubestellar/kubestellar/pkg/ocm"
 )
 
-func deleteObjectOnManagedClusters(logger logr.Logger, cl client.Client, obj runtime.Object, managedClusters []string) {
-	for _, managedCluster := range managedClusters {
+// TODO (maroon): this file should be deleted when transport is ready
+func deleteObjectOnManagedClusters(logger logr.Logger, cl client.Client, obj runtime.Object,
+	managedClusters sets.Set[string]) {
+	for managedCluster := range managedClusters {
 		err := deleteManifestForObject(cl, obj, managedCluster)
 		if err != nil {
 			logger.Error(err, "Error deleting object on mailbox")

--- a/pkg/placement/placement-decision.go
+++ b/pkg/placement/placement-decision.go
@@ -1,0 +1,153 @@
+/*
+Copyright 2023 The KubeStellar Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package placement
+
+import (
+	"context"
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	"github.com/kubestellar/kubestellar/api/control/v1alpha1"
+	"github.com/kubestellar/kubestellar/pkg/util"
+)
+
+// syncPlacementDecision syncs a placement-decision object with what is resolved by the placement-resolver.
+func (c *Controller) syncPlacementDecision(key util.Key) error {
+	var unstructuredObj *unstructured.Unstructured
+	if !c.placementResolver.ResolutionExists(key.NamespacedName.Name) {
+		// if a resolution is not associated to the placement-decision's name
+		// then the placement has been deleted, and the placement-decision
+		// will eventually be garbage collected. We can safely ignore this.
+
+		return nil
+	}
+
+	obj, err := c.getObjectFromKey(key)
+	if errors.IsNotFound(err) {
+		unstructuredObj = util.EmptyUnstructuredObjectFromKey(key)
+	} else if err != nil {
+		return fmt.Errorf("failed to get runtime.Object from key with gvk (%v) and namespaced-name (%v): %w",
+			key.GVK, key.NamespacedName, err)
+	} else {
+		// perform the type assertion only if getObjectFromKey did not fail
+		var ok bool
+		unstructuredObj, ok = obj.(*unstructured.Unstructured)
+		if !ok {
+			return fmt.Errorf("the given runtime.Object (%#v) is not a pointer to Unstructured", obj)
+		}
+	}
+
+	placementDecision, err := unstructuredObjectToPlacementDecision(unstructuredObj)
+	if err != nil {
+		return fmt.Errorf("failed to convert from Unstructured to PlacementDecision: %w", err)
+	}
+
+	// placement decision name matches that of the placement 1:1, therefore its NamespacedName is the same.
+	placementIdentifier := placementDecision.GetName()
+
+	// generate placement decision spec from resolver
+	generatedPlacementDecisionSpec, err := c.placementResolver.GeneratePlacementDecision(placementIdentifier)
+	if err != nil {
+		return fmt.Errorf("failed to generate PlacementDecisionSpec: %w", err)
+	}
+
+	// calculate if the resolved decision is different from the current one
+	if !c.placementResolver.ComparePlacementDecision(placementIdentifier, &placementDecision.Spec) {
+		// update the placement decision object in the cluster by updating spec
+		if err = c.updateOrCreatePlacementDecision(placementDecision, generatedPlacementDecisionSpec); err != nil {
+			return fmt.Errorf("failed to update or create placement decision: %w", err)
+		}
+
+		return nil
+	}
+
+	c.logger.Info("placement decision is up to date", "name", placementDecision.GetName())
+	return nil
+}
+
+// updateOrCreatePlacementDecision updates or creates a placement-decision object in the cluster.
+// If the object already exists, it is updated. Otherwise, it is created.
+func (c *Controller) updateOrCreatePlacementDecision(pd *v1alpha1.PlacementDecision,
+	generatedPlacementDecisionSpec *v1alpha1.PlacementDecisionSpec) error {
+	// use the passed placement decision and set its spec
+	pd.Spec = *generatedPlacementDecisionSpec
+
+	// set owner reference
+	ownerReference, err := c.placementResolver.GetOwnerReference(pd.GetName())
+	if err != nil {
+		return fmt.Errorf("failed to get OwnerReference: %w", err)
+	}
+	pd.SetOwnerReferences([]metav1.OwnerReference{ownerReference})
+
+	// update or create placement decision
+	unstructuredPlacementDecision, err := placementDecisionToUnstructuredObject(pd)
+	if err != nil {
+		return fmt.Errorf("failed to convert PlacementDecision to Unstructured: %w", err)
+	}
+
+	_, err = c.dynamicClient.Resource(schema.GroupVersionResource{
+		Group:    v1alpha1.SchemeGroupVersion.Group,
+		Version:  pd.GetObjectKind().GroupVersionKind().Version,
+		Resource: util.PlacementDecisionResource,
+	}).Update(context.Background(), unstructuredPlacementDecision, metav1.UpdateOptions{})
+	if err != nil {
+		if errors.IsNotFound(err) {
+			_, err = c.dynamicClient.Resource(schema.GroupVersionResource{
+				Group:    v1alpha1.SchemeGroupVersion.Group,
+				Version:  pd.GetObjectKind().GroupVersionKind().Version,
+				Resource: util.PlacementDecisionResource,
+			}).Create(context.Background(), unstructuredPlacementDecision, metav1.CreateOptions{})
+			if err != nil {
+				return fmt.Errorf("failed to create placement decision: %w", err)
+			}
+
+			c.logger.Info("created placement decision", "name", pd.GetName())
+			return nil
+		} else {
+			return fmt.Errorf("failed to update placement decision: %w", err)
+		}
+	}
+
+	c.logger.Info("updated placement decision", "name", pd.GetName())
+	return nil
+}
+
+func unstructuredObjectToPlacementDecision(unstructuredObj *unstructured.Unstructured) (*v1alpha1.PlacementDecision, error) {
+	var placementDecision *v1alpha1.PlacementDecision
+	if err := runtime.DefaultUnstructuredConverter.FromUnstructured(unstructuredObj.UnstructuredContent(),
+		&placementDecision); err != nil {
+		return nil, fmt.Errorf("failed to convert Unstructured to PlacementDecision: %w", err)
+	}
+
+	return placementDecision, nil
+}
+
+func placementDecisionToUnstructuredObject(placementDecision *v1alpha1.PlacementDecision) (*unstructured.Unstructured, error) {
+	innerObj, err := runtime.DefaultUnstructuredConverter.ToUnstructured(placementDecision)
+	if err != nil {
+		return nil, fmt.Errorf("failed to convert PlacementDecision to map[string]interface{}: %w", err)
+	}
+
+	return &unstructured.Unstructured{
+		Object: innerObj,
+	}, nil
+}

--- a/pkg/placement/placement-resolution.go
+++ b/pkg/placement/placement-resolution.go
@@ -1,0 +1,370 @@
+/*
+Copyright 2023 The KubeStellar Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package placement
+
+import (
+	"fmt"
+	"sync"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/sets"
+
+	"github.com/kubestellar/kubestellar/api/control/v1alpha1"
+	"github.com/kubestellar/kubestellar/pkg/util"
+)
+
+// placementResolution stores the selected objects and destinations for a single placement.
+// The mutex should be read locked before reading, and write locked before writing to any field.
+type placementResolution struct {
+	sync.RWMutex
+
+	// map key is GVK/namespace/name as outputted by util.key.GvkNamespacedNameKey()
+	objectIdentifierToKey map[string]*util.Key
+	destinations          sets.Set[string]
+
+	// workloadGeneration is a local counter that reflects that internal
+	// changes occurred to the objects referenced in the objectIdentifierToKey
+	// map. That means, this field is incremented whenever an already noted
+	// object is called for noting again.
+	workloadGeneration int64
+
+	// ownerReference identifies the placement that this resolution is
+	// associated with as an owning object.
+	ownerReference *metav1.OwnerReference
+}
+
+// noteObject adds/deletes an object to/from the resolution.
+// The return bool indicates whether the placement resolution was changed.
+// This function is thread-safe.
+func (resolution *placementResolution) noteObject(obj runtime.Object) (bool, error) {
+	resolution.Lock()
+	defer resolution.Unlock()
+
+	key, err := util.KeyForGroupVersionKindNamespaceName(obj)
+	if err != nil {
+		return false, fmt.Errorf("failed to get key for object: %w", err)
+	}
+
+	// formatted-key to use for mapping
+	formattedKey := key.GvkNamespacedNameKey()
+	_, exists := resolution.objectIdentifierToKey[formattedKey]
+
+	// avoid further processing for keys of objects being deleted that do not have a deleted object
+	if isBeingDeleted(obj) {
+		delete(resolution.objectIdentifierToKey, formattedKey)
+
+		return exists, nil
+	}
+
+	if exists {
+		// the object is already in the resolution but the object content changed
+		resolution.workloadGeneration++
+	}
+
+	// add object to map
+	resolution.objectIdentifierToKey[formattedKey] = &key
+	// Internal changes to noted objects are also changes to the resolution.
+	return true, nil
+}
+
+// removeObject deletes an object from the resolution if it exists.
+// The return bool indicates whether the placement resolution was changed.
+// This function is thread-safe.
+func (resolution *placementResolution) removeObject(obj runtime.Object) bool {
+	resolution.Lock()
+	defer resolution.Unlock()
+
+	key, err := util.KeyForGroupVersionKindNamespaceName(obj)
+	if err != nil {
+		return false // assume object was never added
+	}
+
+	// formatted-key to use for mapping
+	formattedKey := key.GvkNamespacedNameKey()
+	_, exists := resolution.objectIdentifierToKey[formattedKey]
+
+	delete(resolution.objectIdentifierToKey, formattedKey)
+	return exists
+}
+
+// setDestinations updates the destinations list in the resolution.
+// The given destinations set is expected not to be mutated after this call.
+func (resolution *placementResolution) setDestinations(destinations sets.Set[string]) {
+	resolution.Lock()
+	defer resolution.Unlock()
+
+	resolution.destinations = destinations
+}
+
+// toPlacementDecisionSpec converts the resolution to a placement decision
+// spec. This function is thread-safe.
+func (resolution *placementResolution) toPlacementDecisionSpec(gvkGvrMapper util.GvkGvrMapper) (*v1alpha1.PlacementDecisionSpec, error) {
+	resolution.RLock()
+	defer resolution.RUnlock()
+
+	workload := v1alpha1.DownsyncObjectReferences{
+		WorkloadGeneration: resolution.workloadGeneration,
+		// rest of fields calculated below
+	}
+
+	// the following optimize the building of the workload by maintaining pointers to the object-wrapper structs
+	// that are keyed by GVR
+	clusterScopeDownsyncObjectsMap := map[schema.GroupVersionResource]*v1alpha1.ClusterScopeDownsyncObjects{}
+	// Since namespaceScopeDownsyncObjectsMap groups objects by NS, these maps are used to efficiently locate the
+	// * struct by GVR
+	// * objects slice by namespace (for GVR)
+	namespaceScopeDownsyncObjectsMap := map[schema.GroupVersionResource]*v1alpha1.NamespaceScopeDownsyncObjects{}
+	nsObjectsLocationInSlice := map[string]int{} // key is GVR/ns to avoid 2D maps
+
+	// iterate over all objects and build workload efficiently. No (GVR, namespace, name) tuple is
+	// duplicated in the objectIdentifierToKey map, due to the uniqueness of the Key. Therefore, whenever an object is about to
+	// be appended to an objects slice, we simply append.
+	for _, key := range resolution.objectIdentifierToKey {
+		gvr, found := gvkGvrMapper.GetGvr(key.GVK)
+		if !found {
+			return nil, fmt.Errorf("failed to get GVR for GVK %s", key.GvkKey())
+		}
+
+		// check if object is cluster-scoped or namespaced by checking namespace
+		if key.NamespacedName.Namespace == metav1.NamespaceNone {
+			resolution.handleClusterScopedObject(gvr, key, &workload, clusterScopeDownsyncObjectsMap)
+			continue
+		}
+
+		resolution.handleNamespacedObject(gvr, key, &workload, namespaceScopeDownsyncObjectsMap, nsObjectsLocationInSlice)
+	}
+
+	return &v1alpha1.PlacementDecisionSpec{
+		Workload:     workload,
+		Destinations: destinationsStringSetToDestinations(resolution.destinations),
+	}, nil
+}
+
+// handleClusterScopedObject handles a cluster-scoped object by adding it to the workload.
+// ClusterScopeDownsyncObjectsMap is used to efficiently locate the object in the workload.
+func (resolution *placementResolution) handleClusterScopedObject(gvr schema.GroupVersionResource,
+	key *util.Key,
+	workload *v1alpha1.DownsyncObjectReferences,
+	clusterScopeDownsyncObjectsMap map[schema.GroupVersionResource]*v1alpha1.ClusterScopeDownsyncObjects) {
+	// check if obj GVR already exists in map
+	if csdObjects, found := clusterScopeDownsyncObjectsMap[gvr]; found {
+		// GVR exists, append cluster-scope object
+		csdObjects.ObjectNames = append(csdObjects.ObjectNames, key.NamespacedName.Name)
+		return
+	}
+	// GVR doesn't exist, this is the first time
+	// add ClusterScopeDownsyncResource to the workload
+	workload.ClusterScope = append(workload.ClusterScope, v1alpha1.ClusterScopeDownsyncObjects{
+		GroupVersionResource: metav1.GroupVersionResource{
+			Group:    gvr.Group,
+			Version:  gvr.Version,
+			Resource: gvr.Resource,
+		},
+		ObjectNames: []string{key.NamespacedName.Name},
+	})
+
+	// retain a pointer to the added ClusterScopeDownsyncResource for efficiency
+	clusterScopeDownsyncObjectsMap[gvr] = &workload.ClusterScope[len(workload.ClusterScope)-1]
+}
+
+// handleNamespacedObject handles a namespaced object by adding it to the workload.
+// namespaceScopeDownsyncObjectsMap and nsObjectsLocationInSlice are used to efficiently locate the object in the workload.
+func (resolution *placementResolution) handleNamespacedObject(gvr schema.GroupVersionResource,
+	key *util.Key,
+	workload *v1alpha1.DownsyncObjectReferences,
+	namespaceScopeDownsyncObjectsMap map[schema.GroupVersionResource]*v1alpha1.NamespaceScopeDownsyncObjects,
+	nsObjectsLocationInSlice map[string]int) {
+	gvrAndNSKey := util.KeyFromGVRandNS(gvr, key.NamespacedName.Namespace)
+	if nsdObjects, found := namespaceScopeDownsyncObjectsMap[gvr]; found {
+		// GVR mapping is found, check NS mapping
+		if nsIdx, found := nsObjectsLocationInSlice[gvrAndNSKey]; found {
+			// NS mapping is found, append name
+			nsdObjects.ObjectsByNamespace[nsIdx].Names = append(nsdObjects.ObjectsByNamespace[nsIdx].Names,
+				key.NamespacedName.Name)
+			return
+		}
+
+		// namespace mapping is not found, create new (ns, names) entry for object
+		nsdObjects.ObjectsByNamespace = append(nsdObjects.ObjectsByNamespace, v1alpha1.NamespaceAndNames{
+			Namespace: key.NamespacedName.Namespace,
+			Names:     []string{key.NamespacedName.Name},
+		})
+
+		// update index mapping
+		nsObjectsLocationInSlice[gvrAndNSKey] = len(nsdObjects.ObjectsByNamespace) - 1
+		return
+	}
+
+	// GVR mapping isn't found, create new entry for this obj (and NS map)
+	// add namespaceScopeDownsyncObjectsMap to the workload
+	workload.NamespaceScope = append(workload.NamespaceScope, v1alpha1.NamespaceScopeDownsyncObjects{
+		GroupVersionResource: metav1.GroupVersionResource{
+			Group:    gvr.Group,
+			Version:  gvr.Version,
+			Resource: gvr.Resource,
+		},
+		ObjectsByNamespace: []v1alpha1.NamespaceAndNames{
+			{
+				Namespace: key.NamespacedName.Namespace,
+				Names:     []string{key.NamespacedName.Name},
+			},
+		},
+	})
+
+	// retain a pointer to the added namespaceScopeDownsyncObjectsMap for efficiency
+	namespaceScopeDownsyncObjectsMap[gvr] = &workload.NamespaceScope[len(workload.NamespaceScope)-1]
+	// update ns mapping
+	nsObjectsLocationInSlice[gvrAndNSKey] = 0 // first entry
+}
+
+func (resolution *placementResolution) matchesPlacementDecisionSpec(placementDecisionSpec *v1alpha1.PlacementDecisionSpec,
+	gvkGvrMapper util.GvkGvrMapper) bool {
+	resolution.RLock()
+	defer resolution.RUnlock()
+
+	// check workloadGeneration
+	if resolution.workloadGeneration != placementDecisionSpec.Workload.WorkloadGeneration {
+		return false
+	}
+
+	// check destinations
+	if !destinationsMatch(resolution.destinations, placementDecisionSpec.Destinations) {
+		return false
+	}
+
+	// check workload
+	return workloadMatchesPlacementDecisionSpec(&placementDecisionSpec.Workload, resolution.objectIdentifierToKey, gvkGvrMapper)
+}
+
+// destinationsMatch returns true if the destinations in the resolution
+// match the destinations in the placement decision spec.
+func destinationsMatch(resolvedDestinations sets.Set[string], placementDecisionDestinations []v1alpha1.Destination) bool {
+	if len(resolvedDestinations) != len(placementDecisionDestinations) {
+		return false
+	}
+
+	for _, destination := range placementDecisionDestinations {
+		if !resolvedDestinations.Has(destination.ClusterId) {
+			return false
+		}
+	}
+
+	return true
+}
+
+// workloadMatchesPlacementDecisionSpec returns true if the workload in the
+// resolution matches the workload in the placement decision spec.
+func workloadMatchesPlacementDecisionSpec(placementDecisionSpecWorkload *v1alpha1.DownsyncObjectReferences,
+	objectIdentifierToKeyMap map[string]*util.Key, gvkGvrMapper util.GvkGvrMapper) bool {
+	// check lengths
+	clusterScopedObjectsCount := 0
+	for _, clusterScopeDownsyncObjects := range placementDecisionSpecWorkload.ClusterScope {
+		clusterScopedObjectsCount += len(clusterScopeDownsyncObjects.ObjectNames)
+	}
+
+	namespacedObjectsCount := 0
+	for _, namespaceScopeDownsyncObjects := range placementDecisionSpecWorkload.NamespaceScope {
+		for _, objectsByNamespace := range namespaceScopeDownsyncObjects.ObjectsByNamespace {
+			namespacedObjectsCount += len(objectsByNamespace.Names)
+		}
+	}
+
+	if len(objectIdentifierToKeyMap) != clusterScopedObjectsCount+namespacedObjectsCount {
+		return false
+	}
+
+	// again we can check match by making sure all objects are mapped, since entries are unique and the length is equal.
+	// check cluster-scoped all exist
+	if !placementDecisionClusterScopeIsMapped(placementDecisionSpecWorkload.ClusterScope, objectIdentifierToKeyMap,
+		gvkGvrMapper) {
+		return false
+	}
+
+	// check namespace-scoped all exist
+	return namespaceScopeMatchesPlacementDecisionSpec(placementDecisionSpecWorkload.NamespaceScope, objectIdentifierToKeyMap,
+		gvkGvrMapper)
+}
+
+// clusterScopeMatchesPlacementDecisionSpec returns true if the cluster-scope
+// section in the placement decision spec all exist in the resolution.
+func placementDecisionClusterScopeIsMapped(placementDecisionSpecClusterScope []v1alpha1.ClusterScopeDownsyncObjects,
+	objectIdentifierToKeyMap map[string]*util.Key, gvkGvrMapper util.GvkGvrMapper) bool {
+	for _, clusterScopeDownsyncObjects := range placementDecisionSpecClusterScope {
+		gvr := schema.GroupVersionResource(clusterScopeDownsyncObjects.GroupVersionResource)
+		gvk, found := gvkGvrMapper.GetGvk(gvr)
+
+		if !found {
+			return false // if not found then not mapped and not in resolution
+		}
+
+		for _, objName := range clusterScopeDownsyncObjects.ObjectNames {
+			formattedKey := util.KeyFromGVKandNamespacedName(gvk, types.NamespacedName{
+				Namespace: metav1.NamespaceNone,
+				Name:      objName,
+			})
+
+			if _, found := objectIdentifierToKeyMap[formattedKey]; !found {
+				return false
+			}
+		}
+	}
+
+	return true
+}
+
+// namespaceScopeMatchesPlacementDecisionSpec returns true if the namespace-scope
+// section in the placement decision spec all exist in the resolution.
+func namespaceScopeMatchesPlacementDecisionSpec(placementDecisionSpecNamespaceScope []v1alpha1.NamespaceScopeDownsyncObjects,
+	objectIdentifierToKeyMap map[string]*util.Key, gvkGvrMapper util.GvkGvrMapper) bool {
+	for _, namespaceScopeDownsyncObjects := range placementDecisionSpecNamespaceScope {
+		gvr := schema.GroupVersionResource(namespaceScopeDownsyncObjects.GroupVersionResource)
+		gvk, found := gvkGvrMapper.GetGvk(gvr)
+
+		if !found {
+			return false // if GVK mapping is not found then we cant know if this object is
+			// mapped or not, therefore returning false is the safe (and correct) option
+		}
+
+		// iterate over namespaced objects and check if they are mapped
+		for _, nsAndNames := range namespaceScopeDownsyncObjects.ObjectsByNamespace {
+			for _, objName := range nsAndNames.Names {
+				formattedKey := util.KeyFromGVKandNamespacedName(gvk, types.NamespacedName{
+					Namespace: nsAndNames.Namespace,
+					Name:      objName,
+				})
+
+				if _, found := objectIdentifierToKeyMap[formattedKey]; !found {
+					return false
+				}
+			}
+		}
+	}
+
+	return true
+}
+
+func destinationsStringSetToDestinations(destinations sets.Set[string]) []v1alpha1.Destination {
+	dests := make([]v1alpha1.Destination, 0, len(destinations))
+	for d := range destinations {
+		dests = append(dests, v1alpha1.Destination{ClusterId: d})
+	}
+
+	return dests
+}

--- a/pkg/placement/placement-resolver.go
+++ b/pkg/placement/placement-resolver.go
@@ -1,0 +1,278 @@
+/*
+Copyright 2023 The KubeStellar Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package placement
+
+import (
+	"fmt"
+	"strings"
+	"sync"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/sets"
+
+	"github.com/kubestellar/kubestellar/api/control/v1alpha1"
+	"github.com/kubestellar/kubestellar/pkg/util"
+)
+
+const placementResolutionNotFoundErrorPrefix = "placement resolution is not found"
+
+// A PlacementResolver holds a collection of placement resolutions.
+// The collection is indexed by placementKey string, the resolver does not
+// care what the strings are. The resolution for a given key can be updated,
+// exported and compared to the PlacementDecision representation.
+// All functions in this interface are thread-safe, and nothing mutates any
+// method-parameter during a call to one of them.
+type PlacementResolver interface {
+	// GeneratePlacementDecision returns the placement decision for the given
+	// placement key. This function can fail due to internal caches temporarily being
+	// out of sync.
+	//
+	// If no resolution is associated with the given key, an error is returned.
+	GeneratePlacementDecision(placementKey string) (*v1alpha1.PlacementDecisionSpec, error)
+	// GetOwnerReference returns the owner reference for the given placement key.
+	// If no resolution is associated with the given key, an error is returned.
+	GetOwnerReference(placementKey string) (metav1.OwnerReference, error)
+	// ComparePlacementDecision compares the given placement decision spec
+	// with the maintained placement decision for the given placement key.
+	// The returned value is true only if:
+	//
+	// - The destinations in the PlacementDecisionSpec are an exact match
+	//of those in the resolution.
+	//
+	// - The same is true for every selected object.
+	//
+	// It is possible to output a false negative due to a temporary state of
+	// internal caches being out of sync.
+	ComparePlacementDecision(placementKey string,
+		placementDecisionSpec *v1alpha1.PlacementDecisionSpec) bool
+
+	// NotePlacement associates a new resolution with the given placement,
+	// if none is associated.
+	NotePlacement(placement *v1alpha1.Placement)
+
+	// NoteObject updates the maintained placement's objects resolution for the
+	// given placement key. If the object is being deleted, it is removed from
+	// the resolution if exists.
+	//
+	// The returned bool indicates whether the placement resolution was changed.
+	// If no resolution is associated with the given key, an error is returned.
+	NoteObject(placementKey string, obj runtime.Object) (bool, error)
+	// RemoveObject removes the given object from the maintained placement's
+	// objects resolution for the given placement key.
+	//
+	// The returned bool indicates whether the placement resolution was changed.
+	RemoveObject(placementKey string, obj runtime.Object) bool
+	// SetDestinations updates the maintained placement's
+	// destinations resolution for the given placement key.
+	// The given destinations set is expected not to be mutated after this call.
+	SetDestinations(placementKey string, destinations sets.Set[string])
+
+	// ResolutionExists returns true if a resolution is associated with the
+	// given placement key.
+	ResolutionExists(placementKey string) bool
+	// DeleteResolution deletes the resolution associated with the given key,
+	// if it exists.
+	DeleteResolution(placementKey string)
+}
+
+func NewPlacementResolver(gvkGvrMapper util.GvkGvrMapper) PlacementResolver {
+	return &placementResolver{
+		gvkGvrMapper:          gvkGvrMapper,
+		placementToResolution: make(map[string]*placementResolution),
+	}
+}
+
+type placementResolver struct {
+	sync.RWMutex
+	gvkGvrMapper          util.GvkGvrMapper
+	placementToResolution map[string]*placementResolution
+}
+
+// GeneratePlacementDecision returns the placement decision for the given
+// placement key. If a key is not associated to a resolution, the latter is
+// created. This function can fail due to internal caches temporarily being
+// out of sync.
+func (resolver *placementResolver) GeneratePlacementDecision(placementKey string) (
+	*v1alpha1.PlacementDecisionSpec, error) {
+	placementResolution := resolver.getResolution(placementKey) // thread-safe
+
+	if placementResolution == nil {
+		return nil, fmt.Errorf("%s - placement-key: %s", placementResolutionNotFoundErrorPrefix, placementKey)
+	}
+
+	placementDecisionSpec, err := placementResolution.toPlacementDecisionSpec(resolver.gvkGvrMapper)
+
+	if err != nil {
+		return nil, fmt.Errorf("failed to create PlacementDecisionSpec for placement %v: %w",
+			placementKey, err)
+	}
+
+	return placementDecisionSpec, nil
+}
+
+// GetOwnerReference returns the owner reference for the given placement key.
+// If no resolution is associated with the given key, an error is returned.
+func (resolver *placementResolver) GetOwnerReference(placementKey string) (metav1.OwnerReference, error) {
+	placementResolution := resolver.getResolution(placementKey) // thread-safe
+
+	if placementResolution == nil {
+		return metav1.OwnerReference{}, fmt.Errorf("%s - placement-key: %s", placementResolutionNotFoundErrorPrefix, placementKey)
+	}
+
+	return *placementResolution.ownerReference, nil
+}
+
+// ComparePlacementDecision compares the given placement decision spec
+// with the maintained placement decision for the given placement key.
+// The returned value is true only if:
+//
+// - The destinations in the PlacementDecisionSpec are an exact match
+// of those in the resolution.
+//
+// - The same is true for every selected object.
+//
+// It is possible to output a false negative due to a temporary state of
+// internal caches being out of sync.
+func (resolver *placementResolver) ComparePlacementDecision(placementKey string,
+	placementDecisionSpec *v1alpha1.PlacementDecisionSpec) bool {
+	placementResolution := resolver.getResolution(placementKey) // thread-safe
+
+	if placementResolution == nil {
+		return false
+	}
+
+	return placementResolution.matchesPlacementDecisionSpec(placementDecisionSpec, resolver.gvkGvrMapper)
+}
+
+// NotePlacement associates a new resolution with the given placement,
+// if none is associated.
+func (resolver *placementResolver) NotePlacement(placement *v1alpha1.Placement) {
+	if resolution := resolver.getResolution(placement.GetName()); resolution != nil {
+		return
+	}
+
+	resolver.createResolution(placement)
+}
+
+// NoteObject updates the maintained placement's objects resolution for the
+// given placement key. If the object is being deleted, it is removed from
+// the resolution if exists.
+//
+// The returned bool indicates whether the placement resolution was changed.
+func (resolver *placementResolver) NoteObject(placementKey string,
+	obj runtime.Object) (bool, error) {
+	placementResolution := resolver.getResolution(placementKey) // thread-safe
+
+	if placementResolution == nil {
+		// placementKey is not associated with any resolution
+		return false, fmt.Errorf("%s - placement-key: %s", placementResolutionNotFoundErrorPrefix, placementKey)
+	}
+
+	// noteObject is thread-safe
+	changed, err := placementResolution.noteObject(obj)
+	if err != nil {
+		return false, fmt.Errorf("failed to update resolution for placement %v: %w", placementKey, err)
+	}
+
+	return changed, nil
+}
+
+// RemoveObject removes the given object from the maintained placement's
+// objects resolution for the given placement key.
+//
+// The returned bool indicates whether the placement resolution was changed.
+func (resolver *placementResolver) RemoveObject(placementKey string,
+	obj runtime.Object) bool {
+	placementResolution := resolver.getResolution(placementKey) // thread-safe
+
+	if placementResolution == nil {
+		return false
+	}
+
+	// removeObject is thread-safe
+	return placementResolution.removeObject(obj)
+}
+
+// SetDestinations updates the maintained placement's
+// destinations resolution for the given placement key.
+// The given destinations set is expected not to be mutated after this call.
+func (resolver *placementResolver) SetDestinations(placementKey string,
+	destinations sets.Set[string]) {
+	placementResolution := resolver.getResolution(placementKey) // thread-safe
+
+	if placementResolution == nil {
+		return
+	}
+
+	placementResolution.setDestinations(destinations)
+}
+
+// ResolutionExists returns true if a resolution is associated with the
+// given placement key.
+func (resolver *placementResolver) ResolutionExists(placementKey string) bool {
+	if resolver.getResolution(placementKey) == nil {
+		return false
+	}
+
+	return true
+}
+
+// DeleteResolution deletes the resolution associated with the given key,
+// if it exists.
+func (resolver *placementResolver) DeleteResolution(placementKey string) {
+	resolver.Lock() // lock for modifying map
+	defer resolver.Unlock()
+
+	delete(resolver.placementToResolution, placementKey)
+}
+
+// getResolution retrieves the resolution associated with the given key.
+// If the resolution does not exist, nil is returned.
+func (resolver *placementResolver) getResolution(placementKey string) *placementResolution {
+	resolver.RLock()         // lock for reading map
+	defer resolver.RUnlock() // unlock after accessing map
+
+	return resolver.placementToResolution[placementKey]
+}
+
+func (resolver *placementResolver) createResolution(placement *v1alpha1.Placement) *placementResolution {
+	resolver.Lock() // lock for modifying map
+	defer resolver.Unlock()
+
+	// double-check existence to handle race conditions (common pattern)
+	if placementResolution, exists := resolver.placementToResolution[placement.GetName()]; exists {
+		return placementResolution
+	}
+
+	ownerReference := metav1.NewControllerRef(placement, placement.GroupVersionKind())
+	ownerReference.BlockOwnerDeletion = &[]bool{false}[0]
+
+	placementResolution := &placementResolution{
+		objectIdentifierToKey: make(map[string]*util.Key),
+		destinations:          sets.New[string](),
+		workloadGeneration:    1,
+		ownerReference:        ownerReference,
+	}
+	resolver.placementToResolution[placement.GetName()] = placementResolution
+
+	return placementResolution
+}
+
+func errorIsPlacementResolutionNotFound(err error) bool {
+	return strings.HasPrefix(err.Error(), placementResolutionNotFoundErrorPrefix)
+}

--- a/pkg/placement/placement.go
+++ b/pkg/placement/placement.go
@@ -43,34 +43,60 @@ import (
 
 const (
 	waitBeforeTrackingPlacements = 5 * time.Second
-	PlacementKind                = "Placement"
 	KSFinalizer                  = "placement.kubestellar.io/kscontroller"
 )
 
 // Handle placement as follows:
-//  1. requeue all objects to account for changes in placement
-//  2. handle finalizers and deletion of objects associated with the placement
+//
+//  1. if placement is not being deleted:
+//
+//     - update the (where) resolution of the placement and queue the
+//     associated placement decision for syncing.
+//
+//     - requeue workload objects to account for changes in placement
+//
+//     otherwise:
+//
+//     - delete the resolution of the placement.
+//
+//  2. handle finalizers and deletion of objects associated with the placement.
+//
 //  3. for updates on label selectors, re-evaluate if existing objects should be removed
 //     from clusters.
 func (c *Controller) handlePlacement(obj runtime.Object) error {
-	placement := obj.DeepCopyObject()
+	placement, err := runtimeObjectToPlacement(obj)
+	if err != nil {
+		return err
+	}
 
 	// handle requeing for changes in placement, excluding deletion
 	if !isBeingDeleted(obj) {
+		// update placement resolution destinations since placement was updated
+		clusterSet, err := ocm.FindClustersBySelectors(c.ocmClient, placement.Spec.ClusterSelectors)
+		if err != nil {
+			return err
+		}
+
+		// note placement decision in resolver in case it isn't associated with
+		// any resolution
+		c.placementResolver.NotePlacement(placement)
+		// set destinations and enqueue placement-decision for syncing
+		c.placementResolver.SetDestinations(placement.GetName(), clusterSet)
+		c.enqueuePlacementDecision(placement.GetName())
+
+		// requeue objects for re-evaluation
 		if err := c.requeueForPlacementChanges(); err != nil {
 			return err
 		}
+	} else {
+		c.placementResolver.DeleteResolution(placement.GetName())
 	}
 
 	if err := c.handlePlacementFinalizer(placement); err != nil {
 		return err
 	}
 
-	if err := c.cleanUpObjectsNoLongerMatching(placement); err != nil {
-		return err
-	}
-
-	return nil
+	return c.cleanUpObjectsNoLongerMatching(placement)
 }
 
 func (c *Controller) requeueForPlacementChanges() error {
@@ -79,10 +105,10 @@ func (c *Controller) requeueForPlacementChanges() error {
 	if now.Sub(c.initializedTs) < waitBeforeTrackingPlacements {
 		return nil
 	}
-	if err := c.requeueAll(); err != nil {
-		return err
-	}
-	return nil
+
+	// requeue all objects to account for changes in placement.
+	// this does not include placement/placement-decision objects.
+	return c.requeueWorkloadObjects()
 }
 
 func (c *Controller) getPlacementByName(name string) (runtime.Object, error) {
@@ -121,13 +147,13 @@ func runtimeObjectToPlacement(obj runtime.Object) (*v1alpha1.Placement, error) {
 	return placement, nil
 }
 
-// read objects from all listers and enqueue the keys
-// this is useful for when a new placement is added
-// or a placement is updated
-func (c *Controller) requeueAll() error {
+// read objects from all workload listers and enqueue
+// the keys this is useful for when a new placement is
+// added or a placement is updated
+func (c *Controller) requeueWorkloadObjects() error {
 	for key, lister := range c.listers {
-		// do not requeue placement
-		if key == util.GetPlacementListerKey() {
+		// do not requeue placement or placement-decisions
+		if key == util.GetPlacementListerKey() || key == util.GetPlacementDecisionListerKey() {
 			fmt.Printf("Matched key %s\n", key)
 			continue
 		}
@@ -143,28 +169,23 @@ func (c *Controller) requeueAll() error {
 }
 
 // finalizer logic
-func (c *Controller) handlePlacementFinalizer(obj runtime.Object) error {
-	mObj := obj.(metav1.Object)
-	cObj, err := convertToClientObject(obj)
-	if err != nil {
-		return err
-	}
-	if mObj.GetDeletionTimestamp() != nil {
-		if controllerutil.ContainsFinalizer(cObj, KSFinalizer) {
-			if err := c.deleteExternalResources(obj); err != nil {
+func (c *Controller) handlePlacementFinalizer(placement *v1alpha1.Placement) error {
+	if placement.GetDeletionTimestamp() != nil {
+		if controllerutil.ContainsFinalizer(placement, KSFinalizer) {
+			if err := c.deleteExternalResources(placement); err != nil {
 				return err
 			}
-			controllerutil.RemoveFinalizer(cObj, KSFinalizer)
-			if err = updatePlacement(c.dynamicClient, obj); err != nil {
+			controllerutil.RemoveFinalizer(placement, KSFinalizer)
+			if err := updatePlacement(c.dynamicClient, placement); err != nil {
 				return err
 			}
 		}
 		return nil
 	}
 
-	if !controllerutil.ContainsFinalizer(cObj, KSFinalizer) {
-		controllerutil.AddFinalizer(cObj, KSFinalizer)
-		if err = updatePlacement(c.dynamicClient, obj); err != nil {
+	if !controllerutil.ContainsFinalizer(placement, KSFinalizer) {
+		controllerutil.AddFinalizer(placement, KSFinalizer)
+		if err := updatePlacement(c.dynamicClient, placement); err != nil {
 			return err
 		}
 	}
@@ -179,29 +200,36 @@ func convertToClientObject(obj runtime.Object) (client.Object, error) {
 	return clientObj, nil
 }
 
-func updatePlacement(client dynamic.Interface, obj runtime.Object) error {
+func updatePlacement(client dynamic.Interface, placement *v1alpha1.Placement) error {
 	gvr := schema.GroupVersionResource{
 		Group:    v1alpha1.GroupVersion.Group,
-		Version:  obj.GetObjectKind().GroupVersionKind().Version,
-		Resource: "placements",
+		Version:  v1alpha1.GroupVersion.Version,
+		Resource: util.PlacementResource,
 	}
-	unstructuredObj, ok := obj.(*unstructured.Unstructured)
-	if !ok {
-		return fmt.Errorf("unexpected type for obj, expected *unstructured.Unstructured")
+
+	innerObj, err := runtime.DefaultUnstructuredConverter.ToUnstructured(placement)
+	if err != nil {
+		return fmt.Errorf("failed to convert Placement to unstructured: %w", err)
 	}
+
+	unstructuredObj := &unstructured.Unstructured{
+		Object: innerObj,
+	}
+
 	client.Resource(gvr).Namespace("").Update(context.Background(), unstructuredObj, metav1.UpdateOptions{})
 	return nil
 }
 
-func (c *Controller) deleteExternalResources(obj runtime.Object) error {
-	list, err := listManifestsForPlacement(c.ocmClient, c.wdsName, obj)
+func (c *Controller) deleteExternalResources(placement *v1alpha1.Placement) error {
+	list, err := listManifestsForPlacement(c.ocmClient, c.wdsName, placement)
 	if err != nil {
 		return err
 	}
-	mObj := obj.(metav1.Object)
-	labelKey := util.GenerateManagedByPlacementLabelKey(c.wdsName, mObj.GetName())
+
+	labelKey := util.GenerateManagedByPlacementLabelKey(c.wdsName, placement.GetName())
 	for _, manifest := range list.Items {
-		c.logger.Info("Trying to delete manifest", "manifest name", manifest.Name, "namespace", manifest.Namespace, "for placement", mObj.GetName())
+		c.logger.Info("Trying to delete manifest", "manifest name", manifest.Name,
+			"namespace", manifest.Namespace, "for placement", placement.GetName())
 		if err := deleteManifestOrLabel(labelKey, manifest, c.ocmClient); err != nil {
 			return err
 		}
@@ -209,10 +237,9 @@ func (c *Controller) deleteExternalResources(obj runtime.Object) error {
 	return nil
 }
 
-func listManifestsForPlacement(ocmClient client.Client, wdsName string, obj runtime.Object) (*workv1.ManifestWorkList, error) {
-	mObj := obj.(metav1.Object)
+func listManifestsForPlacement(ocmClient client.Client, wdsName string, placement *v1alpha1.Placement) (*workv1.ManifestWorkList, error) {
 	list := &workv1.ManifestWorkList{}
-	labelKey := util.GenerateManagedByPlacementLabelKey(wdsName, mObj.GetName())
+	labelKey := util.GenerateManagedByPlacementLabelKey(wdsName, placement.GetName())
 
 	// TODO - the ocm client used this way is not using cache. Replace with informer/lister based
 	// on dynamic client to make sure to use the cache
@@ -265,7 +292,7 @@ func isAlsoManagedByOtherPlacements(labels map[string]string, managedByLabelKey 
 }
 
 // Handle removal of objects no longer matching cluster/selector
-func (c *Controller) cleanUpObjectsNoLongerMatching(placement runtime.Object) error {
+func (c *Controller) cleanUpObjectsNoLongerMatching(placement *v1alpha1.Placement) error {
 	// allow some time before checking to settle
 	now := time.Now()
 	if now.Sub(c.initializedTs) < waitBeforeTrackingPlacements {
@@ -314,13 +341,9 @@ func extractObjectFromManifest(manifest workv1.ManifestWork) (*runtime.Object, e
 	return &rObj, nil
 }
 
-func (c *Controller) checkObjectMatchesWhatAndWhere(placementObj, obj runtime.Object, manifest workv1.ManifestWork) (bool, error) {
+func (c *Controller) checkObjectMatchesWhatAndWhere(placement *v1alpha1.Placement, obj runtime.Object, manifest workv1.ManifestWork) (bool, error) {
 	// default is doing nothing, that is, return match ==true
 	match := true
-	placement, err := runtimeObjectToPlacement(placementObj)
-	if err != nil {
-		return match, err
-	}
 
 	// check the What matches
 	objMR := obj.(mrObject)
@@ -332,11 +355,11 @@ func (c *Controller) checkObjectMatchesWhatAndWhere(placementObj, obj runtime.Ob
 
 	// check the Where matches
 	clusterName := getClusterNameFromManifest(manifest)
-	matchedClusters, err := ocm.ListClustersBySelectors(c.ocmClient, placement.Spec.ClusterSelectors)
+	matchedClusters, err := ocm.FindClustersBySelectors(c.ocmClient, placement.Spec.ClusterSelectors)
 	if err != nil {
 		return match, err
 	}
-	if !util.StringInSlice(clusterName, matchedClusters) {
+	if !matchedClusters.Has(clusterName) {
 		c.logger.Info("The 'Where' no longer matches. Object marked for removal.", "object", util.GenerateObjectInfoString(obj), "for placement", placement.GetName(), "cluster", clusterName)
 		return false, nil
 	}
@@ -354,8 +377,8 @@ func (c *Controller) testObject(obj mrObject, tests []v1alpha1.DownsyncObjectTes
 	objName := obj.GetName()
 	objLabels := obj.GetLabels()
 	gvk := obj.GetObjectKind().GroupVersionKind()
-	gvkKey := util.KeyForGroupVersionKind(gvk.Group, gvk.Version, gvk.Kind)
-	objGVR, haveGVR := c.gvksMap[gvkKey]
+
+	objGVR, haveGVR := c.gvkGvrMapper.GetGvr(gvk)
 	if !haveGVR {
 		c.logger.Info("No GVR, assuming object does not match", "gvk", gvk, "objNS", objNSName, "objName", objName)
 		return false

--- a/pkg/placement/selectors.go
+++ b/pkg/placement/selectors.go
@@ -17,7 +17,11 @@ limitations under the License.
 package placement
 
 import (
+	"fmt"
+
 	"k8s.io/apimachinery/pkg/runtime"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/apimachinery/pkg/util/sets"
 
 	"github.com/kubestellar/kubestellar/pkg/ocm"
 	"github.com/kubestellar/kubestellar/pkg/util"
@@ -26,14 +30,16 @@ import (
 // matches an object to each placement and returns the list of matching clusters (if any)
 // the list of placements that manage the object and if singleton status required
 // (the latter forces the selection  of only one cluster)
-func (c *Controller) matchSelectors(obj runtime.Object) ([]string, []string, bool, error) {
+// TODO (maroon): this should be deleted when transport is ready
+func (c *Controller) matchSelectors(obj runtime.Object) (sets.Set[string], []string, bool, error) {
 	managedByPlacementList := []string{}
 	objMR := obj.(mrObject)
 	placements, err := c.listPlacements()
 	if err != nil {
 		return nil, nil, false, err
 	}
-	clustersMap := map[string]string{}
+
+	clusterSet := sets.New[string]()
 	// if a placement wants single reported status we force to select only one cluster
 	wantSingletonStatus := false
 	for _, item := range placements {
@@ -49,26 +55,79 @@ func (c *Controller) matchSelectors(obj runtime.Object) ([]string, []string, boo
 		if placement.Spec.WantSingletonReportedState {
 			wantSingletonStatus = true
 		}
+
 		managedByPlacementList = append(managedByPlacementList, placement.GetName())
 		c.logger.Info("Matched", "object", util.GenerateObjectInfoString(obj), "for placement", placement.GetName())
-		list, err := ocm.ListClustersBySelectors(c.ocmClient, placement.Spec.ClusterSelectors)
+
+		clusters, err := ocm.FindClustersBySelectors(c.ocmClient, placement.Spec.ClusterSelectors)
 		if err != nil {
 			return nil, nil, false, err
 		}
-		if list == nil {
+
+		if clusters == nil {
 			continue
 		}
-		for _, s := range list {
-			clustersMap[s] = ""
-		}
+
+		clusterSet = clusterSet.Union(clusters)
 	}
-	return GetKeys(clustersMap), managedByPlacementList, wantSingletonStatus, nil
+
+	return clusterSet, managedByPlacementList, wantSingletonStatus, nil
 }
 
-func GetKeys(m map[string]string) []string {
-	keys := make([]string, 0, len(m))
-	for k := range m {
-		keys = append(keys, k)
+// when an object is updated, we iterate over all placements and update placement-resolutions that
+// are affected by the update. Every affected placement decision is then queued to be synced.
+func (c *Controller) updateDecisions(obj runtime.Object) error {
+	placements, err := c.listPlacements()
+	if err != nil {
+		return err
 	}
-	return keys
+
+	objMR := obj.(mrObject)
+
+	for _, item := range placements {
+		placement, err := runtimeObjectToPlacement(item)
+		if err != nil {
+			return err
+		}
+
+		matchedSome := c.testObject(objMR, placement.Spec.Downsync)
+		if !matchedSome {
+			// if previously selected, remove
+			// TODO: optimize
+			if resolutionUpdated := c.placementResolver.RemoveObject(placement.GetName(), obj); resolutionUpdated {
+				// enqueue placement-decision to be synced since object was removed from its placement's resolution
+				c.logger.V(4).Info("enqueued PlacementDecision for syncing due to the removal of an "+
+					"object from its resolution", "placement-decision", placement.GetName(),
+					"object", util.GenerateObjectInfoString(obj))
+				c.enqueuePlacementDecision(placement.GetName())
+			}
+			continue
+		}
+
+		// obj is selected by placement, update the placement decision resolver
+		resolutionUpdated, err := c.placementResolver.NoteObject(placement.GetName(), obj)
+		if err != nil {
+			if errorIsPlacementResolutionNotFound(err) {
+				// this case can occur if a placement resolution was deleted AFTER
+				// starting this iteration and BEFORE getting to the NoteObject function,
+				// which occurs if a placement was deleted in this time-window.
+				utilruntime.HandleError(fmt.Errorf("failed to note object (%s) - %w",
+					util.GenerateObjectInfoString(obj), err))
+				continue
+			}
+
+			return fmt.Errorf("failed to update resolution for placement %s for object %v: %v",
+				placement.GetName(), util.GenerateObjectInfoString(obj), err)
+		}
+
+		if resolutionUpdated {
+			// enqueue placement-decision to be synced since an object was added to its placement's resolution
+			c.logger.V(4).Info("enqueued PlacementDecision for syncing due to a noting of an "+
+				"object in its resolution", "placement-decision", placement.GetName(),
+				"object", util.GenerateObjectInfoString(obj))
+			c.enqueuePlacementDecision(placement.GetName())
+		}
+	}
+
+	return nil
 }

--- a/pkg/util/gvk-gvr-mapper.go
+++ b/pkg/util/gvk-gvr-mapper.go
@@ -1,0 +1,107 @@
+/*
+Copyright 2023 The KubeStellar Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"sync"
+
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+// GvkGvrMapper is a thread-safe mapping between GVKs and GVRs.
+// This mapper is only for top-level resources and there is an expectation that
+// within this restricted scope, the relation between resource and Kind is 1:1.
+type GvkGvrMapper interface {
+	// Add adds a mapping between the given GVK and GVR.
+	// This overwrites the GVK <-> GVR mapping if pre-existing.
+	Add(gvk schema.GroupVersionKind, gvr schema.GroupVersionResource)
+	// DeleteByGvkKey deletes the mapping associated with the given GVK.
+	// The key format is that outputted by utils.KeyForGroupVersionKind.
+	DeleteByGvkKey(string)
+	// DeleteByGvrKey deletes the mapping associated with the given GVR.
+	// The key format is that outputted by utils.KeyForGroupVersionResource.
+	DeleteByGvrKey(string)
+	// GetGvr returns the GVR associated with the given GVK if it exists.
+	// The returned boolean indicates whether it exists or not.
+	GetGvr(gvk schema.GroupVersionKind) (schema.GroupVersionResource, bool)
+	// GetGvk returns the GVK associated with the given GVR if it exists.
+	// The returned boolean indicates whether it exists or not.
+	GetGvk(gvr schema.GroupVersionResource) (schema.GroupVersionKind, bool)
+}
+
+type gvkGvrMapper struct {
+	sync.RWMutex
+	gvkToGvr map[string]schema.GroupVersionResource
+	gvrToGvk map[string]schema.GroupVersionKind
+}
+
+func NewGvkGvrMapper() GvkGvrMapper {
+	return &gvkGvrMapper{
+		gvkToGvr: make(map[string]schema.GroupVersionResource),
+		gvrToGvk: make(map[string]schema.GroupVersionKind),
+	}
+}
+
+func (m *gvkGvrMapper) Add(gvk schema.GroupVersionKind, gvr schema.GroupVersionResource) {
+	m.Lock()
+	defer m.Unlock()
+
+	m.gvkToGvr[KeyForGroupVersionKind(gvk.Group, gvk.Version, gvk.Kind)] = gvr
+	m.gvrToGvk[KeyForGroupVersionResource(gvr.Group, gvr.Version, gvr.Resource)] = gvk
+}
+
+func (m *gvkGvrMapper) DeleteByGvkKey(gvkKey string) {
+	m.Lock()
+	defer m.Unlock()
+
+	gvr, found := m.gvkToGvr[gvkKey]
+	if !found {
+		return
+	}
+
+	delete(m.gvkToGvr, gvkKey)
+	delete(m.gvrToGvk, KeyForGroupVersionResource(gvr.Group, gvr.Version, gvr.Resource))
+}
+
+func (m *gvkGvrMapper) DeleteByGvrKey(gvrKey string) {
+	m.Lock()
+	defer m.Unlock()
+
+	gvk, found := m.gvrToGvk[gvrKey]
+	if !found {
+		return
+	}
+
+	delete(m.gvrToGvk, gvrKey)
+	delete(m.gvkToGvr, KeyForGroupVersionKind(gvk.Group, gvk.Version, gvk.Kind))
+}
+
+func (m *gvkGvrMapper) GetGvr(gvk schema.GroupVersionKind) (schema.GroupVersionResource, bool) {
+	m.RLock()
+	defer m.RUnlock()
+
+	gvr, ok := m.gvkToGvr[KeyForGroupVersionKind(gvk.Group, gvk.Version, gvk.Kind)]
+	return gvr, ok
+}
+
+func (m *gvkGvrMapper) GetGvk(gvr schema.GroupVersionResource) (schema.GroupVersionKind, bool) {
+	m.RLock()
+	defer m.RUnlock()
+
+	gvk, ok := m.gvrToGvk[KeyForGroupVersionResource(gvr.Group, gvr.Version, gvr.Resource)]
+	return gvk, ok
+}

--- a/pkg/util/labels.go
+++ b/pkg/util/labels.go
@@ -40,6 +40,11 @@ func GetPlacementListerKey() string {
 		v1alpha1.GroupVersion.Version, PlacementKind)
 }
 
+func GetPlacementDecisionListerKey() string {
+	return KeyForGroupVersionKind(v1alpha1.GroupVersion.Group,
+		v1alpha1.GroupVersion.Version, PlacementDecisionKind)
+}
+
 func SetManagedByPlacementLabels(obj metav1.Object, wdsName string, managedByPlacements []string, singletonStatus bool) {
 	objLabels := obj.GetLabels()
 	if objLabels == nil {

--- a/pkg/util/unstructured.go
+++ b/pkg/util/unstructured.go
@@ -37,6 +37,8 @@ const (
 	ServiceKind                          = "Service"
 	PlacementKind                        = "Placement"
 	PlacementResource                    = "placements"
+	PlacementDecisionKind                = "PlacementDecision"
+	PlacementDecisionResource            = "placementdecisions"
 	WorkStatusGroup                      = "edge.kubestellar.io" // TODO: update/import after status-addon is rehomed and its api group for WorkStatus is updated
 	WorkStatusVersion                    = "v1alpha1"
 	WorkStatusResource                   = "workstatuses"

--- a/test/e2e/common/setup-shell.sh
+++ b/test/e2e/common/setup-shell.sh
@@ -23,7 +23,7 @@ function wait-for-cmd() (
     cmd="$@"
     wait_counter=0
     while ! (eval "$cmd") ; do
-        if (($wait_counter > 200)); then
+        if (($wait_counter > 36)); then
             echo "Failed to ${cmd}."
             exit 1
         fi

--- a/test/e2e/common/setup-shell.sh
+++ b/test/e2e/common/setup-shell.sh
@@ -23,7 +23,7 @@ function wait-for-cmd() (
     cmd="$@"
     wait_counter=0
     while ! (eval "$cmd") ; do
-        if (($wait_counter > 36)); then
+        if (($wait_counter > 200)); then
             echo "Failed to ${cmd}."
             exit 1
         fi


### PR DESCRIPTION
## Summary
Implemented PlacementDecision calculation and handling logic, alongside a few fixes
 
The implementation:
- Fixes a race-condition that was present in the use of gvkMapper, while also introducing gvr-mapping
- Adds a supporting struct: PlacementDecisionResolver that maintains the resolutions of all placement-decisions
- Adds handling for placement-decision objects, which includes handling out-of-sync objects and creating/updating objects when a decision is changed
- Marks code-pieces to be deleted when Nir's transport code is ready

The flow is as follows:
An object changes -> placement-decision resolutions are updated -> modified placement-decisions are enqueued to be synced by workers -> new spec is calculated and patched for each updated resolution.

### Important Notes
~~- This PR SHOULD NOT BE MERGED~~
~~- Singleton status is not yet addressed #1680 ~~
~~- The pluggable transport #1588 needs to be enabled #1692~~
~~- The code DOES NOT disable @pdettori's mixed implementation of placement-transport~~
~~- Only after changes are reviewed and the above points are resolved, I will delete marked code~~
Update after review:
- We will merge in 2 steps: this PR inserts code that maintains PlacementDecisions, another PR will enable the pluggable transport.

- **This code inherits the flow and styling existing in the current code**
  - **Please refrain from reviewing existing code through this PR. Comments on non-changed code should be addressed in a separate issue**
     - Related code refactoring issues:
       - #1690
       - #1683 
       - #1682 
       - #1679
       - #1677 

## Related issue(s)
#1520
