### PR TITLE
📖  clarification on architecture doc for ServerPreferredResources

### DIFF
--- a/docs/content/v0.20/architecture.md
+++ b/docs/content/v0.20/architecture.md
@@ -249,7 +249,8 @@ to understand).
 At startup, the controller code sets up the dynamic informers, the event
 handler and the work queue as follows:
 
-- lists all API resources
+- lists all API preferred resources (using discovery client's ServerPreferredResources()
+  to return only one preferred storage version for API group)
 - Filters out some resources
 - For each resource:
   - Creates GVK key


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

Explain that informers are started only on a subset of  ServerPreferredResources


