### PR TITLE
✨ add startup option to select allowed resources

### DIFF
--- a/cmd/kubestellar-operator/main.go
+++ b/cmd/kubestellar-operator/main.go
@@ -65,7 +65,7 @@ func main() {
 	flag.StringVar(&probeAddr, "health-probe-bind-address", ":8081", "The address the probe endpoint binds to.")
 	flag.StringVar(&wdsName, "wds-name", "", "name of the workload description space to connect to")
 	flag.StringVar(&wdsLabel, "wds-label", "", "label of the workload description space to connect to")
-	flag.StringVar(&allowedGroupsString, "api-groups", "", "list of allowed api groups, comma separated. If not specified, all api groups are allowed.")
+	flag.StringVar(&allowedGroupsString, "api-groups", "", "list of allowed api groups, comma separated. Empty string means all API groups are allowed")
 	flag.BoolVar(&enableLeaderElection, "leader-elect", false,
 		"Enable leader election for controller manager. "+
 			"Enabling this will ensure there is only one active controller manager.")

--- a/cmd/kubestellar-operator/main.go
+++ b/cmd/kubestellar-operator/main.go
@@ -60,12 +60,12 @@ func main() {
 	var probeAddr string
 	var wdsName string
 	var wdsLabel string
-	var resourceGroups string
+	var allowedGroupsString string
 	flag.StringVar(&metricsAddr, "metrics-bind-address", ":8080", "The address the metric endpoint binds to.")
 	flag.StringVar(&probeAddr, "health-probe-bind-address", ":8081", "The address the probe endpoint binds to.")
 	flag.StringVar(&wdsName, "wds-name", "", "name of the workload description space to connect to")
 	flag.StringVar(&wdsLabel, "wds-label", "", "label of the workload description space to connect to")
-	flag.StringVar(&resourceGroups, "resource-groups", "", "list of allowed resource groups, comma separated. If not specified, all resources are allowed.")
+	flag.StringVar(&allowedGroupsString, "api-groups", "", "list of allowed api groups, comma separated. If not specified, all api groups are allowed.")
 	flag.BoolVar(&enableLeaderElection, "leader-elect", false,
 		"Enable leader election for controller manager. "+
 			"Enabling this will ensure there is only one active controller manager.")
@@ -79,7 +79,7 @@ func main() {
 	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&opts)))
 
 	// parse allowed resources string
-	allowedResources := util.ParseResourceGroupsString(resourceGroups)
+	allowedGroupsSet := util.ParseAPIGroupsString(allowedGroupsString)
 
 	// setup manager
 	// manager here is mainly used for leader election and health checks
@@ -134,7 +134,7 @@ func main() {
 	setupLog.Info("Got config for IMBS", "name", imbsName)
 
 	// start the binding controller
-	bindingController, err := binding.NewController(mgr, wdsRestConfig, imbsRestConfig, wdsName, allowedResources)
+	bindingController, err := binding.NewController(mgr, wdsRestConfig, imbsRestConfig, wdsName, allowedGroupsSet)
 	if err != nil {
 		setupLog.Error(err, "unable to create binding controller")
 		os.Exit(1)

--- a/cmd/kubestellar-operator/main.go
+++ b/cmd/kubestellar-operator/main.go
@@ -60,12 +60,12 @@ func main() {
 	var probeAddr string
 	var wdsName string
 	var wdsLabel string
-	var resources string
+	var resourceGroups string
 	flag.StringVar(&metricsAddr, "metrics-bind-address", ":8080", "The address the metric endpoint binds to.")
 	flag.StringVar(&probeAddr, "health-probe-bind-address", ":8081", "The address the probe endpoint binds to.")
 	flag.StringVar(&wdsName, "wds-name", "", "name of the workload description space to connect to")
 	flag.StringVar(&wdsLabel, "wds-label", "", "label of the workload description space to connect to")
-	flag.StringVar(&resources, "resources", "", "list of allowed resources, in the form <resource>.<api group>/version, comma separated. If not specified, all resources are allowed.")
+	flag.StringVar(&resourceGroups, "resource-groups", "", "list of allowed resource groups, comma separated. If not specified, all resources are allowed.")
 	flag.BoolVar(&enableLeaderElection, "leader-elect", false,
 		"Enable leader election for controller manager. "+
 			"Enabling this will ensure there is only one active controller manager.")
@@ -79,11 +79,7 @@ func main() {
 	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&opts)))
 
 	// parse allowed resources string
-	allowedResources, err := util.ParseResourcesString(resources)
-	if err != nil {
-		setupLog.Error(err, "error parsing allowed resources")
-		os.Exit(1)
-	}
+	allowedResources := util.ParseResourceGroupsString(resourceGroups)
 
 	// setup manager
 	// manager here is mainly used for leader election and health checks

--- a/cmd/kubestellar-operator/main.go
+++ b/cmd/kubestellar-operator/main.go
@@ -60,10 +60,12 @@ func main() {
 	var probeAddr string
 	var wdsName string
 	var wdsLabel string
+	var resources string
 	flag.StringVar(&metricsAddr, "metrics-bind-address", ":8080", "The address the metric endpoint binds to.")
 	flag.StringVar(&probeAddr, "health-probe-bind-address", ":8081", "The address the probe endpoint binds to.")
 	flag.StringVar(&wdsName, "wds-name", "", "name of the workload description space to connect to")
 	flag.StringVar(&wdsLabel, "wds-label", "", "label of the workload description space to connect to")
+	flag.StringVar(&resources, "resources", "", "list of allowed resources, in the form <resource>.<api group>/version, comma separated. If not specified, all resources are allowed.")
 	flag.BoolVar(&enableLeaderElection, "leader-elect", false,
 		"Enable leader election for controller manager. "+
 			"Enabling this will ensure there is only one active controller manager.")
@@ -75,6 +77,13 @@ func main() {
 	flag.Parse()
 
 	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&opts)))
+
+	// parse allowed resources string
+	allowedResources, err := util.ParseResourcesString(resources)
+	if err != nil {
+		setupLog.Error(err, "error parsing allowed resources")
+		os.Exit(1)
+	}
 
 	// setup manager
 	// manager here is mainly used for leader election and health checks
@@ -129,7 +138,7 @@ func main() {
 	setupLog.Info("Got config for IMBS", "name", imbsName)
 
 	// start the binding controller
-	bindingController, err := binding.NewController(mgr, wdsRestConfig, imbsRestConfig, wdsName)
+	bindingController, err := binding.NewController(mgr, wdsRestConfig, imbsRestConfig, wdsName, allowedResources)
 	if err != nil {
 		setupLog.Error(err, "unable to create binding controller")
 		os.Exit(1)
@@ -161,4 +170,5 @@ func main() {
 		setupLog.Error(err, "problem running manager")
 		os.Exit(1)
 	}
+	select {}
 }

--- a/config/default/manager_auth_proxy_patch.yaml
+++ b/config/default/manager_auth_proxy_patch.yaml
@@ -53,4 +53,4 @@ spec:
         - "--metrics-bind-address=127.0.0.1:8080"
         - "--leader-elect"
         - "--wds-name={{.Values.ControlPlaneName}}"
-        - "--resource-groups={{.Values.ResourceGroups}}"
+        - "--api-groups={{.Values.APIGroups}}"

--- a/config/default/manager_auth_proxy_patch.yaml
+++ b/config/default/manager_auth_proxy_patch.yaml
@@ -53,3 +53,4 @@ spec:
         - "--metrics-bind-address=127.0.0.1:8080"
         - "--leader-elect"
         - "--wds-name={{.Values.ControlPlaneName}}"
+        - "--resource-groups={{.Values.ResourceGroups}}"

--- a/core-helm-chart/templates/operator.yaml
+++ b/core-helm-chart/templates/operator.yaml
@@ -201,7 +201,7 @@ spec:
         - --metrics-bind-address=127.0.0.1:8080
         - --leader-elect
         - --wds-name={{.Values.ControlPlaneName}}
-        - --resource-groups={{.Values.ResourceGroups}}
+        - --api-groups={{.Values.APIGroups}}
         image: ghcr.io/kubestellar/kubestellar/kubestellar-operator:0.20.0-alpha.1
         imagePullPolicy: IfNotPresent
         livenessProbe:

--- a/core-helm-chart/templates/operator.yaml
+++ b/core-helm-chart/templates/operator.yaml
@@ -201,6 +201,7 @@ spec:
         - --metrics-bind-address=127.0.0.1:8080
         - --leader-elect
         - --wds-name={{.Values.ControlPlaneName}}
+        - --resource-groups={{.Values.ResourceGroups}}
         image: ghcr.io/kubestellar/kubestellar/kubestellar-operator:0.20.0-alpha.1
         imagePullPolicy: IfNotPresent
         livenessProbe:

--- a/core-helm-chart/values.yaml
+++ b/core-helm-chart/values.yaml
@@ -5,9 +5,9 @@
 # name of control plane to set as WDS
 ControlPlaneName: wds1
 
-# list of allowed resource groups, comma separated.
-# If not specified, all resources are allowed. 
+# list of allowed Kubernetes api groups, comma separated.
+# If not specified, all api groups are allowed. 
 # When set by --set with helm CLI, use the format
 # "<group1>\, <group2>\, <groupN>" with "" and escaped \,
-ResourceGroups:
+APIGroups:
 

--- a/core-helm-chart/values.yaml
+++ b/core-helm-chart/values.yaml
@@ -2,5 +2,12 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
+# name of control plane to set as WDS
 ControlPlaneName: wds1
+
+# list of allowed resource groups, comma separated.
+# If not specified, all resources are allowed. 
+# When set by --set with helm CLI, use the format
+# "<group1>\, <group2>\, <groupN>" with "" and escaped \,
+ResourceGroups:
 

--- a/core-helm-chart/values.yaml
+++ b/core-helm-chart/values.yaml
@@ -8,6 +8,6 @@ ControlPlaneName: wds1
 # list of allowed Kubernetes api groups, comma separated.
 # If not specified, all api groups are allowed. 
 # When set by --set with helm CLI, use the format
-# "<group1>\, <group2>\, <groupN>" with "" and escaped \,
+# "<group1>\,<group2>\,<groupN>" with "" and escaped \,
 APIGroups:
 

--- a/pkg/binding/controller.go
+++ b/pkg/binding/controller.go
@@ -87,26 +87,15 @@ type Controller struct {
 	informers         map[string]cache.SharedIndexInformer
 	stoppers          map[string]chan struct{}
 	placementResolver PlacementResolver
-<<<<<<< HEAD:pkg/binding/controller.go
-
-	workqueue     workqueue.RateLimitingInterface
-	initializedTs time.Time
-	wdsName       string
-}
-
-// Create a new binding controller
-func NewController(mgr ctrlm.Manager, wdsRestConfig *rest.Config, imbsRestConfig *rest.Config, wdsName string) (*Controller, error) {
-=======
 	workqueue         workqueue.RateLimitingInterface
 	initializedTs     time.Time
 	wdsName           string
-	allowedResources  map[string]bool
+	allowedGroupsSet  sets.Set[string]
 }
 
 // Create a new placement controller
 func NewController(mgr ctrlm.Manager, wdsRestConfig *rest.Config, imbsRestConfig *rest.Config,
-	wdsName string, allowedResources map[string]bool) (*Controller, error) {
->>>>>>> 8a41ee7a4 (use api group only to filter resources):pkg/placement/controller.go
+	wdsName string, allowedGroupsSet sets.Set[string]) (*Controller, error) {
 	ratelimiter := workqueue.NewMaxOfRateLimiter(
 		workqueue.NewItemExponentialFailureRateLimiter(5*time.Millisecond, 1000*time.Second),
 		&workqueue.BucketRateLimiter{Limiter: rate.NewLimiter(rate.Limit(50), 300)},
@@ -205,12 +194,9 @@ func (c *Controller) run(workers int) error {
 			if _, excluded := excludedResourceNames[resource.Name]; excluded {
 				continue
 			}
-<<<<<<< HEAD:pkg/binding/controller.go
-=======
-			if !util.IsResourceGroupAllowed(gv.Group, c.allowedResources) {
+			if !util.IsAPIGroupAllowed(gv.Group, c.allowedGroupsSet) {
 				continue
 			}
->>>>>>> 8a41ee7a4 (use api group only to filter resources):pkg/placement/controller.go
 			informable := verbsSupportInformers(resource.Verbs)
 			if informable {
 				key := util.KeyForGroupVersionKind(gv.Group, gv.Version, resource.Kind)

--- a/pkg/binding/controller.go
+++ b/pkg/binding/controller.go
@@ -76,18 +76,18 @@ const placementDecisionQueueingDelay = 2 * time.Second
 // Controller watches all objects, finds associated placements, when matched a placement wraps and
 // places objects into mailboxes
 type Controller struct {
-	ctx              context.Context
-	logger           logr.Logger
-	ocmClient        client.Client
-	dynamicClient    dynamic.Interface
-	kubernetesClient kubernetes.Interface
-	extClient        apiextensionsclientset.Interface
-	listers          map[string]cache.GenericLister
-	gvkGvrMapper     util.GvkGvrMapper
-	informers        map[string]cache.SharedIndexInformer
-	stoppers         map[string]chan struct{}
-
+	ctx               context.Context
+	logger            logr.Logger
+	ocmClient         client.Client
+	dynamicClient     dynamic.Interface
+	kubernetesClient  kubernetes.Interface
+	extClient         apiextensionsclientset.Interface
+	listers           map[string]cache.GenericLister
+	gvkGvrMapper      util.GvkGvrMapper
+	informers         map[string]cache.SharedIndexInformer
+	stoppers          map[string]chan struct{}
 	placementResolver PlacementResolver
+<<<<<<< HEAD:pkg/binding/controller.go
 
 	workqueue     workqueue.RateLimitingInterface
 	initializedTs time.Time
@@ -96,6 +96,17 @@ type Controller struct {
 
 // Create a new binding controller
 func NewController(mgr ctrlm.Manager, wdsRestConfig *rest.Config, imbsRestConfig *rest.Config, wdsName string) (*Controller, error) {
+=======
+	workqueue         workqueue.RateLimitingInterface
+	initializedTs     time.Time
+	wdsName           string
+	allowedResources  map[string]bool
+}
+
+// Create a new placement controller
+func NewController(mgr ctrlm.Manager, wdsRestConfig *rest.Config, imbsRestConfig *rest.Config,
+	wdsName string, allowedResources map[string]bool) (*Controller, error) {
+>>>>>>> 8a41ee7a4 (use api group only to filter resources):pkg/placement/controller.go
 	ratelimiter := workqueue.NewMaxOfRateLimiter(
 		workqueue.NewItemExponentialFailureRateLimiter(5*time.Millisecond, 1000*time.Second),
 		&workqueue.BucketRateLimiter{Limiter: rate.NewLimiter(rate.Limit(50), 300)},
@@ -194,6 +205,12 @@ func (c *Controller) run(workers int) error {
 			if _, excluded := excludedResourceNames[resource.Name]; excluded {
 				continue
 			}
+<<<<<<< HEAD:pkg/binding/controller.go
+=======
+			if !util.IsResourceGroupAllowed(gv.Group, c.allowedResources) {
+				continue
+			}
+>>>>>>> 8a41ee7a4 (use api group only to filter resources):pkg/placement/controller.go
 			informable := verbsSupportInformers(resource.Verbs)
 			if informable {
 				key := util.KeyForGroupVersionKind(gv.Group, gv.Version, resource.Kind)

--- a/pkg/binding/crd.go
+++ b/pkg/binding/crd.go
@@ -93,7 +93,7 @@ func (c *Controller) checkAPIResourcesForUpdates() ([]APIResource, []string, err
 			if _, excluded := excludedResourceNames[resource.Name]; excluded {
 				continue
 			}
-			if !util.IsResourceGroupAllowed(gv.Group, c.allowedResources) {
+			if !util.IsAPIGroupAllowed(gv.Group, c.allowedGroupsSet) {
 				continue
 			}
 			informable := verbsSupportInformers(resource.Verbs)

--- a/pkg/binding/crd.go
+++ b/pkg/binding/crd.go
@@ -93,6 +93,10 @@ func (c *Controller) checkAPIResourcesForUpdates() ([]APIResource, []string, err
 			if _, excluded := excludedResourceNames[resource.Name]; excluded {
 				continue
 			}
+			if !util.IsResourceAllowed(schema.GroupVersionResource{Group: gv.Group,
+				Version: gv.Version, Resource: resource.Name}, c.allowedResources) {
+				continue
+			}
 			informable := verbsSupportInformers(resource.Verbs)
 			if informable {
 				key := util.KeyForGroupVersionKind(gv.Group, gv.Version, resource.Kind)

--- a/pkg/binding/crd.go
+++ b/pkg/binding/crd.go
@@ -93,8 +93,7 @@ func (c *Controller) checkAPIResourcesForUpdates() ([]APIResource, []string, err
 			if _, excluded := excludedResourceNames[resource.Name]; excluded {
 				continue
 			}
-			if !util.IsResourceAllowed(schema.GroupVersionResource{Group: gv.Group,
-				Version: gv.Version, Resource: resource.Name}, c.allowedResources) {
+			if !util.IsResourceGroupAllowed(gv.Group, c.allowedResources) {
 				continue
 			}
 			informable := verbsSupportInformers(resource.Verbs)

--- a/pkg/binding/placement.go
+++ b/pkg/binding/placement.go
@@ -395,7 +395,7 @@ func (c *Controller) testObject(obj mrObject, tests []v1alpha1.DownsyncObjectTes
 		if len(test.NamespaceSelectors) > 0 {
 			if objNS == nil {
 				var err error
-				objNS, err = c.kubernetesClient.CoreV1().Namespaces().Get(nil, objNSName, metav1.GetOptions{})
+				objNS, err = c.kubernetesClient.CoreV1().Namespaces().Get(context.TODO(), objNSName, metav1.GetOptions{})
 				if err != nil {
 					c.logger.Info("Object namespace not found, assuming object does not match", "gvk", gvk, "objNS", objNSName, "objName", objName)
 					continue

--- a/pkg/util/resources.go
+++ b/pkg/util/resources.go
@@ -33,10 +33,8 @@ func ParseAPIGroupsString(apiGroups string) sets.Set[string] {
 		return nil
 	}
 
-	groupsSet := sets.Set[string]{}
-	for _, g := range strings.Split(apiGroups, ",") {
-		groupsSet.Insert(g)
-	}
+	groupsSet := sets.New(strings.Split(apiGroups, ",")...)
+
 	addRequiredResourceGroups(groupsSet)
 
 	return groupsSet

--- a/pkg/util/resources.go
+++ b/pkg/util/resources.go
@@ -21,9 +21,8 @@ import (
 
 	"k8s.io/apimachinery/pkg/util/sets"
 
-	//"k8s.io/apiextensions-apiserver/pkg/apis/apiextensions"
-
 	"github.com/kubestellar/kubestellar/api/control/v1alpha1"
+	//"k8s.io/apiextensions-apiserver/pkg/apis/apiextensions"
 )
 
 // ParseAPIGroupsString takes a comma separated string list of api groups in the form of

--- a/pkg/util/resources.go
+++ b/pkg/util/resources.go
@@ -37,6 +37,7 @@ func ParseAPIGroupsString(apiGroups string) sets.Set[string] {
 	for _, g := range strings.Split(apiGroups, ",") {
 		groupsSet.Insert(g)
 	}
+	addRequiredResourceGroups(groupsSet)
 
 	return groupsSet
 }
@@ -47,8 +48,6 @@ func IsAPIGroupAllowed(apiGroup string, allowedAPIGroups sets.Set[string]) bool 
 	if len(allowedAPIGroups) == 0 {
 		return true
 	}
-	addRequiredResourceGroups(allowedAPIGroups)
-
 	return allowedAPIGroups.Has(apiGroup)
 }
 

--- a/pkg/util/resources.go
+++ b/pkg/util/resources.go
@@ -1,0 +1,124 @@
+/*
+Copyright 2024 The KubeStellar Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"fmt"
+	"strings"
+
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	"github.com/kubestellar/kubestellar/api/control/v1alpha1"
+)
+
+// ParseResourcesString takes a comma separated string list of resources in the form of
+// <resource>.<api group>/<version> or <resource>/<version> and returns a slice of schema.GroupVersionResource
+func ParseResourcesString(resources string) ([]schema.GroupVersionResource, error) {
+	if resources == "" {
+		return nil, nil
+	}
+
+	var result []schema.GroupVersionResource
+
+	// trim single and double quotes to make this safe from
+	// user passing the resource option quoted in the container args
+	resources = strings.Trim(resources, `'"`)
+
+	parts := strings.Split(resources, ",")
+	for _, part := range parts {
+		part = strings.TrimSpace(part)
+		subparts := strings.SplitN(part, "/", 2)
+		if len(subparts) != 2 {
+			return nil, fmt.Errorf("invalid resource format: %s", part)
+		}
+		resourceGroup := subparts[0]
+		version := subparts[1]
+		if version == "" {
+			return nil, fmt.Errorf("no version found: %s", part)
+		}
+
+		subparts = strings.SplitN(resourceGroup, ".", 2)
+		var resource, group string
+		if len(subparts) == 2 {
+			// The part has the form of <resource>.<api group>
+			resource = subparts[0]
+			group = subparts[1]
+		} else if len(subparts) == 1 {
+			// The part has the form of <resource>
+			resource = subparts[0]
+			group = "" // The api group is empty
+		} else {
+			return nil, fmt.Errorf("invalid resource/group format: %s", resourceGroup)
+		}
+
+		gvr := schema.GroupVersionResource{
+			Group:    group,
+			Version:  version,
+			Resource: resource,
+		}
+		result = append(result, gvr)
+	}
+
+	return result, nil
+}
+
+// IsResourceAllowed checks if an infomer for the resource is allowed to start.
+// an empty or nil allowedResources slice is equivalent to allow all,
+func IsResourceAllowed(gvr schema.GroupVersionResource, allowedResources []schema.GroupVersionResource) bool {
+	if allowedResources == nil || allowedResources != nil && len(allowedResources) == 0 {
+		return true
+	}
+
+	allowedResources = appendRequiredResources(allowedResources)
+
+	for _, allowedResource := range allowedResources {
+		if gvr.Group == allowedResource.Group &&
+			(allowedResource.Version == AnyVersion || gvr.Version == allowedResource.Version) &&
+			gvr.Resource == allowedResource.Resource {
+			return true
+		}
+	}
+
+	return false
+}
+
+// append the minimal set of resources that are required to operate
+func appendRequiredResources(allowedResources []schema.GroupVersionResource) []schema.GroupVersionResource {
+	// if resources are provided, we need to ensure that at least CRD and Placement
+	// resources are watched
+
+	slice := []schema.GroupVersionResource{}
+	slice = append(slice, allowedResources...)
+
+	gvr := schema.GroupVersionResource{
+		Group:    v1alpha1.GroupVersion.Group,
+		Version:  v1alpha1.GroupVersion.Version,
+		Resource: PlacementResource,
+	}
+	slice = append(slice, gvr)
+
+	// disabled until https://github.com/kubestellar/kubestellar/issues/1705 is resolved
+	// to avoid client-side throttling
+	// gvr = schema.GroupVersionResource{
+	// 	Group:    CRDGroup,
+	// 	Version:  AnyVersion,
+	// 	Resource: CRDResource,
+	// }
+	// slice = append(slice, gvr)
+
+	return slice
+}

--- a/pkg/util/resources_test.go
+++ b/pkg/util/resources_test.go
@@ -19,33 +19,27 @@ package util
 import (
 	"reflect"
 	"testing"
+
+	"k8s.io/apimachinery/pkg/util/sets"
 )
 
-// TestParseResourceGroupsString tests the TestParseResourceGroupsString function
-func TestParseResourceGroupsString(t *testing.T) {
+// TestParseAPIGroupsString tests the TestParseAPIGroupsString function
+func TestParseAPIGroupsString(t *testing.T) {
 	// Define some test cases with inputs and expected outputs
 	testCases := []struct {
 		name     string
 		input    string
-		expected map[string]bool
+		expected sets.Set[string]
 	}{
 		{
-			name:  "valid input with api group",
-			input: "apps, networking.k8s.io, policy",
-			expected: map[string]bool{
-				"apps":              true,
-				"networking.k8s.io": true,
-				"policy":            true,
-			},
+			name:     "valid input with api group",
+			input:    "apps, networking.k8s.io, policy",
+			expected: sets.New("apps", "networking.k8s.io", "policy"),
 		},
 		{
-			name:  "valid input with empty api group",
-			input: "apps, ,policy",
-			expected: map[string]bool{
-				"apps":   true,
-				"":       true,
-				"policy": true,
-			},
+			name:     "valid input with empty api group",
+			input:    "apps, ,policy",
+			expected: sets.New("apps", "", "policy"),
 		},
 		{
 			name:     "empty input",
@@ -57,7 +51,7 @@ func TestParseResourceGroupsString(t *testing.T) {
 	// Iterate over the test cases, run the function with the input and compare expected vs. returned
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			actual := ParseResourceGroupsString(tc.input)
+			actual := ParseAPIGroupsString(tc.input)
 
 			// Check if the output matches the expected output
 			if !reflect.DeepEqual(actual, tc.expected) {
@@ -67,47 +61,39 @@ func TestParseResourceGroupsString(t *testing.T) {
 	}
 }
 
-// TestIsResourceGroupAllowed tests the IsResourceGroupAllowed function
-func TestIsResourceGroupAllowed(t *testing.T) {
+// TestIsAPIGroupAllowed tests the IsAPIGroupAllowed function
+func TestIsAPIGroupAllowed(t *testing.T) {
 	// Define some test cases with inputs and expected outputs
 	testCases := []struct {
-		name                  string
-		resourceGroup         string
-		allowedResourceGroups map[string]bool
-		expected              bool
+		name             string
+		resourceGroup    string
+		allowedAPIGroups sets.Set[string]
+		expected         bool
 	}{
 		{
-			name:          "resource group is allowed by non-empty map",
-			resourceGroup: "apps",
-			allowedResourceGroups: map[string]bool{
-				"apps":              true,
-				"networking.k8s.io": true,
-				"policy":            true,
-			},
-			expected: true,
+			name:             "api group is allowed by non-empty map",
+			resourceGroup:    "apps",
+			allowedAPIGroups: sets.New("apps", "networking.k8s.io", "policy"),
+			expected:         true,
 		},
 		{
-			name:                  "resource group is allowed by nil map",
-			resourceGroup:         "apps",
-			allowedResourceGroups: nil,
-			expected:              true,
+			name:             "api group is allowed by nil map",
+			resourceGroup:    "apps",
+			allowedAPIGroups: nil,
+			expected:         true,
 		},
 		{
-			name:          "kubestellar resource group is always allowed",
-			resourceGroup: "control.kubestellar.io",
-			allowedResourceGroups: map[string]bool{
-				"apps":              true,
-				"networking.k8s.io": true,
-				"policy":            true,
-			},
-			expected: true,
+			name:             "kubestellar resource group is always allowed",
+			resourceGroup:    "control.kubestellar.io",
+			allowedAPIGroups: sets.New("apps", "networking.k8s.io", "policy"),
+			expected:         true,
 		},
 	}
 
 	// Iterate over the test cases and run the function with the input
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			actual := IsResourceGroupAllowed(tc.resourceGroup, tc.allowedResourceGroups)
+			actual := IsAPIGroupAllowed(tc.resourceGroup, tc.allowedAPIGroups)
 
 			// Check if the output matches the expected output
 			if actual != tc.expected {

--- a/pkg/util/resources_test.go
+++ b/pkg/util/resources_test.go
@@ -19,127 +19,45 @@ package util
 import (
 	"reflect"
 	"testing"
-
-	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
-// TestParseResourcesString tests the ParseResourcesString function
-func TestParseResourcesString(t *testing.T) {
+// TestParseResourceGroupsString tests the TestParseResourceGroupsString function
+func TestParseResourceGroupsString(t *testing.T) {
 	// Define some test cases with inputs and expected outputs
 	testCases := []struct {
 		name     string
 		input    string
-		expected []schema.GroupVersionResource
-		err      bool
+		expected map[string]bool
 	}{
 		{
 			name:  "valid input with api group",
-			input: "pods.core/v1, deployments.apps/v1, services.core/v1",
-			expected: []schema.GroupVersionResource{
-				{
-					Group:    "core",
-					Version:  "v1",
-					Resource: "pods",
-				},
-				{
-					Group:    "apps",
-					Version:  "v1",
-					Resource: "deployments",
-				},
-				{
-					Group:    "core",
-					Version:  "v1",
-					Resource: "services",
-				},
+			input: "apps, networking.k8s.io, policy",
+			expected: map[string]bool{
+				"apps":              true,
+				"networking.k8s.io": true,
+				"policy":            true,
 			},
-			err: false,
 		},
 		{
-			name:  "valid input without api group",
-			input: "pods/v1, nodes/v1, events/v1",
-			expected: []schema.GroupVersionResource{
-				{
-					Group:    "",
-					Version:  "v1",
-					Resource: "pods",
-				},
-				{
-					Group:    "",
-					Version:  "v1",
-					Resource: "nodes",
-				},
-				{
-					Group:    "",
-					Version:  "v1",
-					Resource: "events",
-				},
+			name:  "valid input with empty api group",
+			input: "apps, ,policy",
+			expected: map[string]bool{
+				"apps":   true,
+				"":       true,
+				"policy": true,
 			},
-			err: false,
-		},
-		{
-			name:  "valid input with api group with dot",
-			input: "flowschemas.flowcontrol.apiserver.k8s.io/v1beta1, prioritylevelconfigurations.flowcontrol.apiserver.k8s.io/v1beta1",
-			expected: []schema.GroupVersionResource{
-				{
-					Group:    "flowcontrol.apiserver.k8s.io",
-					Version:  "v1beta1",
-					Resource: "flowschemas",
-				},
-				{
-					Group:    "flowcontrol.apiserver.k8s.io",
-					Version:  "v1beta1",
-					Resource: "prioritylevelconfigurations",
-				},
-			},
-			err: false,
-		},
-		{
-			name:  "valid input with extra quotes",
-			input: "\"flowschemas.flowcontrol.apiserver.k8s.io/v1beta1\"",
-			expected: []schema.GroupVersionResource{
-				{
-					Group:    "flowcontrol.apiserver.k8s.io",
-					Version:  "v1beta1",
-					Resource: "flowschemas",
-				},
-			},
-			err: false,
-		},
-		{
-			name:     "invalid resource format",
-			input:    "pods.core/v1, deployments.apps/v1, services",
-			expected: nil,
-			err:      true,
-		},
-		{
-			name:     "invalid group/version format",
-			input:    "pods.core/v1, deployments.apps/v1, services.core",
-			expected: nil,
-			err:      true,
-		},
-		{
-			name:     "invalid resource/version format",
-			input:    "pods.core/v1, deployments.apps/v1, services/",
-			expected: nil,
-			err:      true,
 		},
 		{
 			name:     "empty input",
 			input:    "",
 			expected: nil,
-			err:      false,
 		},
 	}
 
 	// Iterate over the test cases, run the function with the input and compare expected vs. returned
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			actual, err := ParseResourcesString(tc.input)
-
-			// Check if the error matches the expected error
-			if (err != nil) != tc.err {
-				t.Fatalf("returned error does not match: %v", err)
-			}
+			actual := ParseResourceGroupsString(tc.input)
 
 			// Check if the output matches the expected output
 			if !reflect.DeepEqual(actual, tc.expected) {
@@ -149,133 +67,47 @@ func TestParseResourcesString(t *testing.T) {
 	}
 }
 
-// TestIsResourceAllowed tests the IsResourceAllowed function
-func TestIsResourceAllowed(t *testing.T) {
+// TestIsResourceGroupAllowed tests the IsResourceGroupAllowed function
+func TestIsResourceGroupAllowed(t *testing.T) {
 	// Define some test cases with inputs and expected outputs
 	testCases := []struct {
-		name             string
-		resource         schema.GroupVersionResource
-		allowedResources []schema.GroupVersionResource
-		expected         bool
+		name                  string
+		resourceGroup         string
+		allowedResourceGroups map[string]bool
+		expected              bool
 	}{
 		{
-			name: "resource is allowed by non-empty slice",
-			resource: schema.GroupVersionResource{
-				Group:    "core",
-				Version:  "v1",
-				Resource: "pods",
-			},
-			allowedResources: []schema.GroupVersionResource{
-				{
-					Group:    "core",
-					Version:  "v1",
-					Resource: "pods",
-				},
-				{
-					Group:    "apps",
-					Version:  "v1",
-					Resource: "deployments",
-				},
+			name:          "resource group is allowed by non-empty map",
+			resourceGroup: "apps",
+			allowedResourceGroups: map[string]bool{
+				"apps":              true,
+				"networking.k8s.io": true,
+				"policy":            true,
 			},
 			expected: true,
 		},
 		{
-			name: "Any version is allowed",
-			resource: schema.GroupVersionResource{
-				Group:    "core",
-				Version:  "v1beta1",
-				Resource: "pods",
-			},
-			allowedResources: []schema.GroupVersionResource{
-				{
-					Group:    "core",
-					Version:  "*",
-					Resource: "pods",
-				},
+			name:                  "resource group is allowed by nil map",
+			resourceGroup:         "apps",
+			allowedResourceGroups: nil,
+			expected:              true,
+		},
+		{
+			name:          "kubestellar resource group is always allowed",
+			resourceGroup: "control.kubestellar.io",
+			allowedResourceGroups: map[string]bool{
+				"apps":              true,
+				"networking.k8s.io": true,
+				"policy":            true,
 			},
 			expected: true,
-		},
-		{
-			name: "placements are always allowed for non empty list",
-			resource: schema.GroupVersionResource{
-				Group:    "control.kubestellar.io",
-				Version:  "v1alpha1",
-				Resource: "placements",
-			},
-			allowedResources: []schema.GroupVersionResource{
-				{
-					Group:    "core",
-					Version:  "*",
-					Resource: "pods",
-				},
-			},
-			expected: true,
-		},
-		// disabled until https://github.com/kubestellar/kubestellar/issues/1705 is resolved
-		// to avoid client-side throttling
-		// {
-		// 	name: "customresourcedefinitions are always allowed for non empty list",
-		// 	resource: schema.GroupVersionResource{
-		// 		Group:    "apiextensions.k8s.io",
-		// 		Version:  "v1",
-		// 		Resource: "customresourcedefinitions",
-		// 	},
-		// 	allowedResources: []schema.GroupVersionResource{
-		// 		{
-		// 			Group:    "core",
-		// 			Version:  "*",
-		// 			Resource: "pods",
-		// 		},
-		// 	},
-		// 	expected: true,
-		// },
-		{
-			name: "resource is not allowed by non-empty slice",
-			resource: schema.GroupVersionResource{
-				Group:    "core",
-				Version:  "v1",
-				Resource: "nodes",
-			},
-			allowedResources: []schema.GroupVersionResource{
-				{
-					Group:    "core",
-					Version:  "v1",
-					Resource: "pods",
-				},
-				{
-					Group:    "apps",
-					Version:  "v1",
-					Resource: "deployments",
-				},
-			},
-			expected: false,
-		},
-		{
-			name: "resource is allowed by empty slice",
-			resource: schema.GroupVersionResource{
-				Group:    "core",
-				Version:  "v1",
-				Resource: "nodes",
-			},
-			allowedResources: []schema.GroupVersionResource{},
-			expected:         true,
-		},
-		{
-			name: "resource is allowed by nil slice",
-			resource: schema.GroupVersionResource{
-				Group:    "core",
-				Version:  "v1",
-				Resource: "nodes",
-			},
-			allowedResources: nil,
-			expected:         true,
 		},
 	}
 
 	// Iterate over the test cases and run the function with the input
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			actual := IsResourceAllowed(tc.resource, tc.allowedResources)
+			actual := IsResourceGroupAllowed(tc.resourceGroup, tc.allowedResourceGroups)
 
 			// Check if the output matches the expected output
 			if actual != tc.expected {

--- a/pkg/util/resources_test.go
+++ b/pkg/util/resources_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package util
 
 import (
-	"reflect"
 	"testing"
 
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -33,13 +32,13 @@ func TestParseAPIGroupsString(t *testing.T) {
 	}{
 		{
 			name:     "valid input with api group",
-			input:    "apps, networking.k8s.io, policy",
-			expected: sets.New("apps", "networking.k8s.io", "policy"),
+			input:    "apps,networking.k8s.io,policy",
+			expected: sets.New("apps", "networking.k8s.io", "policy", "control.kubestellar.io"),
 		},
 		{
 			name:     "valid input with empty api group",
-			input:    "apps, ,policy",
-			expected: sets.New("apps", "", "policy"),
+			input:    "apps,,policy",
+			expected: sets.New("apps", "", "policy", "control.kubestellar.io"),
 		},
 		{
 			name:     "empty input",
@@ -54,7 +53,7 @@ func TestParseAPIGroupsString(t *testing.T) {
 			actual := ParseAPIGroupsString(tc.input)
 
 			// Check if the output matches the expected output
-			if !reflect.DeepEqual(actual, tc.expected) {
+			if !actual.Equal(tc.expected) {
 				t.Errorf("expected: %v, got: %v", tc.expected, actual)
 			}
 		})
@@ -80,12 +79,6 @@ func TestIsAPIGroupAllowed(t *testing.T) {
 			name:             "api group is allowed by nil map",
 			resourceGroup:    "apps",
 			allowedAPIGroups: nil,
-			expected:         true,
-		},
-		{
-			name:             "kubestellar resource group is always allowed",
-			resourceGroup:    "control.kubestellar.io",
-			allowedAPIGroups: sets.New("apps", "networking.k8s.io", "policy"),
 			expected:         true,
 		},
 	}

--- a/pkg/util/resources_test.go
+++ b/pkg/util/resources_test.go
@@ -1,0 +1,286 @@
+/*
+Copyright 2024 The KubeStellar Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"reflect"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+// TestParseResourcesString tests the ParseResourcesString function
+func TestParseResourcesString(t *testing.T) {
+	// Define some test cases with inputs and expected outputs
+	testCases := []struct {
+		name     string
+		input    string
+		expected []schema.GroupVersionResource
+		err      bool
+	}{
+		{
+			name:  "valid input with api group",
+			input: "pods.core/v1, deployments.apps/v1, services.core/v1",
+			expected: []schema.GroupVersionResource{
+				{
+					Group:    "core",
+					Version:  "v1",
+					Resource: "pods",
+				},
+				{
+					Group:    "apps",
+					Version:  "v1",
+					Resource: "deployments",
+				},
+				{
+					Group:    "core",
+					Version:  "v1",
+					Resource: "services",
+				},
+			},
+			err: false,
+		},
+		{
+			name:  "valid input without api group",
+			input: "pods/v1, nodes/v1, events/v1",
+			expected: []schema.GroupVersionResource{
+				{
+					Group:    "",
+					Version:  "v1",
+					Resource: "pods",
+				},
+				{
+					Group:    "",
+					Version:  "v1",
+					Resource: "nodes",
+				},
+				{
+					Group:    "",
+					Version:  "v1",
+					Resource: "events",
+				},
+			},
+			err: false,
+		},
+		{
+			name:  "valid input with api group with dot",
+			input: "flowschemas.flowcontrol.apiserver.k8s.io/v1beta1, prioritylevelconfigurations.flowcontrol.apiserver.k8s.io/v1beta1",
+			expected: []schema.GroupVersionResource{
+				{
+					Group:    "flowcontrol.apiserver.k8s.io",
+					Version:  "v1beta1",
+					Resource: "flowschemas",
+				},
+				{
+					Group:    "flowcontrol.apiserver.k8s.io",
+					Version:  "v1beta1",
+					Resource: "prioritylevelconfigurations",
+				},
+			},
+			err: false,
+		},
+		{
+			name:  "valid input with extra quotes",
+			input: "\"flowschemas.flowcontrol.apiserver.k8s.io/v1beta1\"",
+			expected: []schema.GroupVersionResource{
+				{
+					Group:    "flowcontrol.apiserver.k8s.io",
+					Version:  "v1beta1",
+					Resource: "flowschemas",
+				},
+			},
+			err: false,
+		},
+		{
+			name:     "invalid resource format",
+			input:    "pods.core/v1, deployments.apps/v1, services",
+			expected: nil,
+			err:      true,
+		},
+		{
+			name:     "invalid group/version format",
+			input:    "pods.core/v1, deployments.apps/v1, services.core",
+			expected: nil,
+			err:      true,
+		},
+		{
+			name:     "invalid resource/version format",
+			input:    "pods.core/v1, deployments.apps/v1, services/",
+			expected: nil,
+			err:      true,
+		},
+		{
+			name:     "empty input",
+			input:    "",
+			expected: nil,
+			err:      false,
+		},
+	}
+
+	// Iterate over the test cases, run the function with the input and compare expected vs. returned
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			actual, err := ParseResourcesString(tc.input)
+
+			// Check if the error matches the expected error
+			if (err != nil) != tc.err {
+				t.Fatalf("returned error does not match: %v", err)
+			}
+
+			// Check if the output matches the expected output
+			if !reflect.DeepEqual(actual, tc.expected) {
+				t.Errorf("expected: %v, got: %v", tc.expected, actual)
+			}
+		})
+	}
+}
+
+// TestIsResourceAllowed tests the IsResourceAllowed function
+func TestIsResourceAllowed(t *testing.T) {
+	// Define some test cases with inputs and expected outputs
+	testCases := []struct {
+		name             string
+		resource         schema.GroupVersionResource
+		allowedResources []schema.GroupVersionResource
+		expected         bool
+	}{
+		{
+			name: "resource is allowed by non-empty slice",
+			resource: schema.GroupVersionResource{
+				Group:    "core",
+				Version:  "v1",
+				Resource: "pods",
+			},
+			allowedResources: []schema.GroupVersionResource{
+				{
+					Group:    "core",
+					Version:  "v1",
+					Resource: "pods",
+				},
+				{
+					Group:    "apps",
+					Version:  "v1",
+					Resource: "deployments",
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "Any version is allowed",
+			resource: schema.GroupVersionResource{
+				Group:    "core",
+				Version:  "v1beta1",
+				Resource: "pods",
+			},
+			allowedResources: []schema.GroupVersionResource{
+				{
+					Group:    "core",
+					Version:  "*",
+					Resource: "pods",
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "placements are always allowed for non empty list",
+			resource: schema.GroupVersionResource{
+				Group:    "control.kubestellar.io",
+				Version:  "v1alpha1",
+				Resource: "placements",
+			},
+			allowedResources: []schema.GroupVersionResource{
+				{
+					Group:    "core",
+					Version:  "*",
+					Resource: "pods",
+				},
+			},
+			expected: true,
+		},
+		// disabled until https://github.com/kubestellar/kubestellar/issues/1705 is resolved
+		// to avoid client-side throttling
+		// {
+		// 	name: "customresourcedefinitions are always allowed for non empty list",
+		// 	resource: schema.GroupVersionResource{
+		// 		Group:    "apiextensions.k8s.io",
+		// 		Version:  "v1",
+		// 		Resource: "customresourcedefinitions",
+		// 	},
+		// 	allowedResources: []schema.GroupVersionResource{
+		// 		{
+		// 			Group:    "core",
+		// 			Version:  "*",
+		// 			Resource: "pods",
+		// 		},
+		// 	},
+		// 	expected: true,
+		// },
+		{
+			name: "resource is not allowed by non-empty slice",
+			resource: schema.GroupVersionResource{
+				Group:    "core",
+				Version:  "v1",
+				Resource: "nodes",
+			},
+			allowedResources: []schema.GroupVersionResource{
+				{
+					Group:    "core",
+					Version:  "v1",
+					Resource: "pods",
+				},
+				{
+					Group:    "apps",
+					Version:  "v1",
+					Resource: "deployments",
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "resource is allowed by empty slice",
+			resource: schema.GroupVersionResource{
+				Group:    "core",
+				Version:  "v1",
+				Resource: "nodes",
+			},
+			allowedResources: []schema.GroupVersionResource{},
+			expected:         true,
+		},
+		{
+			name: "resource is allowed by nil slice",
+			resource: schema.GroupVersionResource{
+				Group:    "core",
+				Version:  "v1",
+				Resource: "nodes",
+			},
+			allowedResources: nil,
+			expected:         true,
+		},
+	}
+
+	// Iterate over the test cases and run the function with the input
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			actual := IsResourceAllowed(tc.resource, tc.allowedResources)
+
+			// Check if the output matches the expected output
+			if actual != tc.expected {
+				t.Errorf("expected: %v, got: %v", tc.expected, actual)
+			}
+		})
+	}
+}

--- a/pkg/util/unstructured.go
+++ b/pkg/util/unstructured.go
@@ -30,6 +30,7 @@ import (
 
 const (
 	CRDKind                              = "CustomResourceDefinition"
+	CRDResource                          = "customresourcedefinitions"
 	CRDGroup                             = "apiextensions.k8s.io"
 	AnyVersion                           = "*"
 	ServiceVersion                       = "v1"

--- a/pkg/util/unstructured.go
+++ b/pkg/util/unstructured.go
@@ -19,6 +19,7 @@ package util
 import (
 	"fmt"
 
+	"k8s.io/apiextensions-apiserver/pkg/apis/apiextensions"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -31,7 +32,6 @@ import (
 const (
 	CRDKind                              = "CustomResourceDefinition"
 	CRDResource                          = "customresourcedefinitions"
-	CRDGroup                             = "apiextensions.k8s.io"
 	AnyVersion                           = "*"
 	ServiceVersion                       = "v1"
 	ServiceKind                          = "Service"
@@ -61,7 +61,7 @@ type SourceRef struct {
 }
 
 func IsCRD(o interface{}) bool { // CRDs might have different versions. therefore, using "any" in CRD version
-	return matchesGVK(o, CRDGroup, AnyVersion, CRDKind)
+	return matchesGVK(o, apiextensions.GroupName, AnyVersion, CRDKind)
 }
 
 func IsPlacement(o interface{}) bool {


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

Add startup option with flag `--resources` to start informers only for selected resources. This feature is mostly useful when the WDS has a large number of API resources and users want to track only a subset of resources. For example, in an OCP cluster used as WDS with ~ 380 API resources, as we recently found in issue #1697.

Also, improve logging with contextual logging for Placement and Status controllers, and fix a race condition found on Status controller that showed up in testing after enabling the `--resource` flag.

## Related issue(s)

Fixes #1697 
