### PR TITLE
:sparkles: deleted unused code

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,8 +5,6 @@ go 1.20
 require (
 	github.com/go-logr/logr v1.3.0
 	github.com/kubestellar/kubeflex v0.3.4-0.20231215133035-02f74c29b172
-	github.com/mitchellh/go-homedir v1.1.0
-	github.com/openshift/client-go v0.0.0-20231024221206-506d798bc61c
 	github.com/spf13/pflag v1.0.5
 	golang.org/x/time v0.3.0
 	k8s.io/api v0.28.2
@@ -49,12 +47,14 @@ require (
 	github.com/mattn/go-colorable v0.1.13 // indirect
 	github.com/mattn/go-isatty v0.0.17 // indirect
 	github.com/matttproud/golang_protobuf_extensions v1.0.4 // indirect
+	github.com/mitchellh/go-homedir v1.1.0 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/onsi/ginkgo/v2 v2.13.0 // indirect
 	github.com/onsi/gomega v1.29.0 // indirect
 	github.com/openshift/api v0.0.0-20231024112103-79b9cd5e6020 // indirect
+	github.com/openshift/client-go v0.0.0-20231024221206-506d798bc61c // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/prometheus/client_golang v1.16.0 // indirect
 	github.com/prometheus/client_model v0.4.0 // indirect

--- a/pkg/binding/controller.go
+++ b/pkg/binding/controller.go
@@ -416,7 +416,7 @@ func (c *Controller) processNextWorkItem(ctx context.Context) bool {
 	return true
 }
 
-func (c *Controller) reconcile(ctx context.Context, key util.Key) error {
+func (c *Controller) reconcile(_ context.Context, key util.Key) error {
 	var obj runtime.Object
 	var err error
 	// special handling for placement-decision resource as it is the only

--- a/pkg/binding/crd.go
+++ b/pkg/binding/crd.go
@@ -19,7 +19,6 @@ package binding
 import (
 	"context"
 	"strings"
-	"time"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -30,20 +29,13 @@ import (
 	"github.com/kubestellar/kubestellar/pkg/util"
 )
 
-const (
-	waitBeforeTrackingCRDs = 5 * time.Second
-	CRDKind                = "CustomResourceDefinition"
-	CRDGroup               = "apiextensions.k8s.io"
-	CRDVersion             = "v1"
-)
-
 type APIResource struct {
 	groupVersion schema.GroupVersion
 	resource     metav1.APIResource
 }
 
 // Handle CRDs should account for CRDs being added or deleted to start/stop new informers as needed
-func (c *Controller) handleCRD(obj runtime.Object) error {
+func (c *Controller) handleCRD(_ runtime.Object) error {
 	toStartList, toStopList, err := c.checkAPIResourcesForUpdates()
 	if err != nil {
 		return err

--- a/pkg/binding/placement.go
+++ b/pkg/binding/placement.go
@@ -192,14 +192,6 @@ func (c *Controller) handlePlacementFinalizer(placement *v1alpha1.BindingPolicy)
 	return nil
 }
 
-func convertToClientObject(obj runtime.Object) (client.Object, error) {
-	clientObj, ok := obj.(client.Object)
-	if !ok {
-		return nil, fmt.Errorf("object is not a client.Object: %v", obj)
-	}
-	return clientObj, nil
-}
-
 func updatePlacement(client dynamic.Interface, placement *v1alpha1.BindingPolicy) error {
 	gvr := schema.GroupVersionResource{
 		Group:    v1alpha1.GroupVersion.Group,

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -19,34 +19,17 @@ package client
 import (
 	"fmt"
 	"os"
-	"path/filepath"
-
-	homedir "github.com/mitchellh/go-homedir"
 
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
-	"k8s.io/client-go/tools/clientcmd"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
-
-	"github.com/openshift/client-go/security/clientset/versioned"
 
 	tenancyv1alpha1 "github.com/kubestellar/kubeflex/api/v1alpha1"
 
 	controlv1alpha1 "github.com/kubestellar/kubestellar/api/control/v1alpha1"
 )
-
-func GetClientSet(kubeconfig string) *kubernetes.Clientset {
-	config := GetConfig(kubeconfig)
-	clientset, err := kubernetes.NewForConfig(config)
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "Error creating clientset: %v\n", err)
-		os.Exit(1)
-	}
-	return clientset
-}
 
 func GetClient() *client.Client {
 	config := config.GetConfigOrDie()
@@ -76,30 +59,4 @@ func GetClient() *client.Client {
 		os.Exit(1)
 	}
 	return &c
-}
-
-func GetOpendShiftSecClient(kubeconfig string) (*versioned.Clientset, error) {
-	config := GetConfig(kubeconfig)
-	return versioned.NewForConfig(config)
-}
-
-func GetConfig(kubeconfig string) *rest.Config {
-	if kubeconfig == "" {
-		kubeconfig = os.Getenv("KUBECONFIG")
-		if kubeconfig == "" {
-			home, err := homedir.Dir()
-			if err != nil {
-				fmt.Fprintf(os.Stderr, "Error finding home directory: %v\n", err)
-				os.Exit(1)
-			}
-			kubeconfig = filepath.Join(home, ".kube", "config")
-		}
-	}
-
-	config, err := clientcmd.BuildConfigFromFlags("", kubeconfig)
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "Error building kubeconfig: %v\n", err)
-		os.Exit(1)
-	}
-	return config
 }

--- a/pkg/status/controller.go
+++ b/pkg/status/controller.go
@@ -236,7 +236,7 @@ func shouldSkipUpdate(old, new interface{}) bool {
 	return newMObj.GetResourceVersion() == oldMObj.GetResourceVersion()
 }
 
-func shouldSkipDelete(obj interface{}) bool {
+func shouldSkipDelete(_ interface{}) bool {
 	return false
 }
 
@@ -320,7 +320,7 @@ func (c *Controller) processNextWorkItem(ctx context.Context) bool {
 	return true
 }
 
-func (c *Controller) reconcile(ctx context.Context, ref cache.ObjectName) error {
+func (c *Controller) reconcile(_ context.Context, ref cache.ObjectName) error {
 	obj, err := getObject(c.workStatusLister, ref.Namespace, ref.Name)
 	if err != nil {
 		// The resource no longer exist, which means it has been deleted.

--- a/pkg/util/kubeconfig.go
+++ b/pkg/util/kubeconfig.go
@@ -41,8 +41,6 @@ const (
 	ControlPlaneTypeLabel = "kflex.kubestellar.io/cptype"
 	ControlPlaneTypeIMBS  = "imbs"
 	ControlPlaneTypeWDS   = "wds"
-	kcSecretKeyDefault    = "kubeconfig"
-	kcSecretKeyVCluster   = "config"
 	// errors
 	ErrNoControlPlane        = "no control plane found. At least one control plane labeled with %s=%s must be present"
 	ErrControlPlaneNotFound  = "control plane with label %s=%s and name %s was not found"

--- a/pkg/util/labels.go
+++ b/pkg/util/labels.go
@@ -71,15 +71,6 @@ func GenerateManagedByPlacementLabelKey(wdsName, placementName string) string {
 	return fmt.Sprintf("%s/%s.%s", PlacementLabelKeyBase, wdsName, placementName)
 }
 
-func StringInSlice(str string, list []string) bool {
-	for _, v := range list {
-		if v == str {
-			return true
-		}
-	}
-	return false
-}
-
 type Label struct {
 	Key   string
 	Value string

--- a/pkg/util/unstructured.go
+++ b/pkg/util/unstructured.go
@@ -19,7 +19,6 @@ package util
 import (
 	"fmt"
 
-	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -93,16 +92,6 @@ func getObjectGVK(o interface{}) (schema.GroupVersionKind, error) {
 	}
 
 	return schema.GroupVersionKind{}, fmt.Errorf("object is of wrong type: %#v", o)
-}
-
-func ToService(obj *unstructured.Unstructured) (*corev1.Service, error) {
-	// Convert unstructured.Unstructured to a Service object
-	service := &corev1.Service{}
-	err := runtime.DefaultUnstructuredConverter.FromUnstructured(obj.UnstructuredContent(), service)
-	if err != nil {
-		return nil, err
-	}
-	return service, nil
 }
 
 func RemoveRuntimeGeneratedFieldsFromService(obj interface{}) error {


### PR DESCRIPTION
## Summary
Deleted unused functions and constants, set unused function parameters to underscore.

This was done in order to remove deletion noise from the to-be-made PR for issue #1730, which will delete a lot of functions.

## Related issue(s)
#1730
