### PR TITLE
✨ add step to install post-install hooks in e2e tests and upgrade kflex to v0.4.2

### DIFF
--- a/.github/workflows/pr-test-multicluster.yml
+++ b/.github/workflows/pr-test-multicluster.yml
@@ -35,10 +35,10 @@ jobs:
       - name: Install dependencies
         run: |
           curl -L https://raw.githubusercontent.com/open-cluster-management-io/clusteradm/main/install.sh | bash
-          wget https://github.com/kubestellar/kubeflex/releases/download/v0.4.1/kubeflex_0.4.1_linux_amd64.tar.gz
-          tar -xvf kubeflex_0.4.1_linux_amd64.tar.gz bin/kflex
+          wget https://github.com/kubestellar/kubeflex/releases/download/v0.4.2/kubeflex_0.4.2_linux_amd64.tar.gz
+          tar -xvf kubeflex_0.4.2_linux_amd64.tar.gz bin/kflex
           mv bin/kflex /usr/local/bin
-          rm -fr bin kubeflex_0.4.1_linux_amd64.tar.gz 
+          rm -fr bin kubeflex_0.4.2_linux_amd64.tar.gz 
 
       - name: Run test
         run: |

--- a/.github/workflows/pr-test-singleton-status.yml
+++ b/.github/workflows/pr-test-singleton-status.yml
@@ -35,10 +35,10 @@ jobs:
       - name: Install dependencies
         run: |
           curl -L https://raw.githubusercontent.com/open-cluster-management-io/clusteradm/main/install.sh | bash
-          wget https://github.com/kubestellar/kubeflex/releases/download/v0.4.1/kubeflex_0.4.1_linux_amd64.tar.gz
-          tar -xvf kubeflex_0.4.1_linux_amd64.tar.gz bin/kflex
+          wget https://github.com/kubestellar/kubeflex/releases/download/v0.4.2/kubeflex_0.4.2_linux_amd64.tar.gz
+          tar -xvf kubeflex_0.4.2_linux_amd64.tar.gz bin/kflex
           mv bin/kflex /usr/local/bin
-          rm -fr bin kubeflex_0.4.1_linux_amd64.tar.gz 
+          rm -fr bin kubeflex_0.4.2_linux_amd64.tar.gz 
 
       - name: Run test
         run: |

--- a/docs/content/v0.20/pre-reqs.md
+++ b/docs/content/v0.20/pre-reqs.md
@@ -23,7 +23,7 @@ Checking pre-requisites for building KubeStellar:
 
 ## For Using KubeStellar
 
-- kubeflex version 0.4.1 or higher
+- kubeflex version 0.4.2 or higher
     To install kubeflex go to [https://github.com/kubestellar/kubeflex/blob/main/docs/users.md#installation](https://github.com/kubestellar/kubeflex/blob/main/docs/users.md#installation). To upgrade from an existing installation,
 follow [these instructions](https://github.com/kubestellar/kubeflex/blob/main/docs/users.md#upgrading-kubeflex). At the end of the install make sure that the kubeflex CLI, kflex, is in your path.
 

--- a/test/e2e/common/setup-kubestellar.sh
+++ b/test/e2e/common/setup-kubestellar.sh
@@ -31,6 +31,14 @@ kflex init --create-kind $disable_chatty_status
 
 :
 : -------------------------------------------------------------------------
+: Install the post-create-hooks for ocm and kubstellar controller manager
+:
+kubectl apply -f ${SRC_DIR}/../../../config/postcreate-hooks/ocm.yaml
+kubectl apply -f ${SRC_DIR}/../../../config/postcreate-hooks/kubestellar.yaml
+: Kubestellar post-create-hooks applied.
+
+:
+: -------------------------------------------------------------------------
 : 'Create an inventory & mailbox space of type vcluster running OCM (Open Cluster Management) directly in KubeFlex. Note that -p ocm runs a post-create hook on the vcluster control plane which installs OCM on it.'
 :
 kflex create imbs1 --type vcluster -p ocm $disable_chatty_status


### PR DESCRIPTION

<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

add step to install post-install hooks in e2e tests and upgrade kflex to v0.4.2

## Related issue(s)

Fixes #1737 
