### PR TITLE
✨ Context and Logging improvements

### DIFF
--- a/core-helm-chart/templates/operator.yaml
+++ b/core-helm-chart/templates/operator.yaml
@@ -202,6 +202,7 @@ spec:
         - --leader-elect
         - --wds-name={{.Values.ControlPlaneName}}
         - --api-groups={{.Values.APIGroups}}
+        - -v=2
         image: ghcr.io/kubestellar/kubestellar/kubestellar-operator:0.20.0-alpha.1
         imagePullPolicy: IfNotPresent
         livenessProbe:

--- a/pkg/binding/selectors.go
+++ b/pkg/binding/selectors.go
@@ -57,7 +57,7 @@ func (c *Controller) matchSelectors(obj runtime.Object) (sets.Set[string], []str
 		}
 
 		managedByPlacementList = append(managedByPlacementList, placement.GetName())
-		c.logger.Info("Matched", "object", util.GenerateObjectInfoString(obj), "for placement", placement.GetName())
+		c.logger.Info("Matched", "object", util.RefToRuntimeObj(obj), "for placement", placement.GetName())
 
 		clusters, err := ocm.FindClustersBySelectors(c.ocmClient, placement.Spec.ClusterSelectors)
 		if err != nil {
@@ -98,7 +98,7 @@ func (c *Controller) updateDecisions(obj runtime.Object) error {
 				// enqueue placement-decision to be synced since object was removed from its placement's resolution
 				c.logger.V(4).Info("enqueued PlacementDecision for syncing due to the removal of an "+
 					"object from its resolution", "placement-decision", placement.GetName(),
-					"object", util.GenerateObjectInfoString(obj))
+					"object", util.RefToRuntimeObj(obj))
 				c.enqueuePlacementDecision(placement.GetName())
 			}
 			continue
@@ -112,19 +112,19 @@ func (c *Controller) updateDecisions(obj runtime.Object) error {
 				// starting this iteration and BEFORE getting to the NoteObject function,
 				// which occurs if a placement was deleted in this time-window.
 				utilruntime.HandleError(fmt.Errorf("failed to note object (%s) - %w",
-					util.GenerateObjectInfoString(obj), err))
+					util.RefToRuntimeObj(obj), err))
 				continue
 			}
 
 			return fmt.Errorf("failed to update resolution for placement %s for object %v: %v",
-				placement.GetName(), util.GenerateObjectInfoString(obj), err)
+				placement.GetName(), util.RefToRuntimeObj(obj), err)
 		}
 
 		if resolutionUpdated {
 			// enqueue placement-decision to be synced since an object was added to its placement's resolution
 			c.logger.V(4).Info("enqueued PlacementDecision for syncing due to a noting of an "+
 				"object in its resolution", "placement-decision", placement.GetName(),
-				"object", util.GenerateObjectInfoString(obj))
+				"object", util.RefToRuntimeObj(obj))
 			c.enqueuePlacementDecision(placement.GetName())
 		}
 	}

--- a/pkg/crd/crds.go
+++ b/pkg/crd/crds.go
@@ -56,8 +56,8 @@ const (
 	FieldManager = "kubestellar"
 )
 
-func ApplyCRDs(dynamicClient dynamic.Interface, clientset kubernetes.Interface, clientsetExt apiextensionsclientset.Interface, logger logr.Logger) error {
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+func ApplyCRDs(ctx context.Context, dynamicClient dynamic.Interface, clientset kubernetes.Interface, clientsetExt apiextensionsclientset.Interface, logger logr.Logger) error {
+	ctxLimited, cancel := context.WithTimeout(ctx, 30*time.Second)
 	defer cancel()
 
 	crds, err := readCRDs()
@@ -80,7 +80,7 @@ func ApplyCRDs(dynamicClient dynamic.Interface, clientset kubernetes.Interface, 
 		}
 
 		// wait until name accepted
-		err = waitForCRDAccepted(ctx, clientsetExt, crd.GetName())
+		err = waitForCRDAccepted(ctxLimited, clientsetExt, crd.GetName())
 		if err != nil {
 			return err
 		}

--- a/pkg/util/keys.go
+++ b/pkg/util/keys.go
@@ -18,7 +18,6 @@ package util
 
 import (
 	"fmt"
-	"strings"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -105,23 +104,6 @@ func KeyFromGVKandNamespacedName(gvk schema.GroupVersionKind, name types.Namespa
 	}
 
 	return fmt.Sprintf("%s/%s/%s/%s", gvk.Group, gvk.Version, gvk.Kind, name.String())
-}
-
-// Used for generating a single string unique representation of the object for logging info.
-//
-// Deprecated: use RefToRuntimeObj instead.
-func GenerateObjectInfoString(obj runtime.Object) string {
-	group := obj.GetObjectKind().GroupVersionKind().Group
-	kind := strings.ToLower(obj.GetObjectKind().GroupVersionKind().Kind)
-	mObj := obj.(metav1.Object)
-
-	prefix := kind
-	if group != "" {
-		prefix = fmt.Sprintf("%s.%s", kind, group)
-
-	}
-
-	return fmt.Sprintf("[%s] %s/%s", mObj.GetNamespace(), prefix, mObj.GetName())
 }
 
 func RefToRuntimeObj(obj runtime.Object) GVKObjRef {


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
This PR makes a few improvements in Context handling and logging.

It uses one `context.Context` created in `func main` and passed down in the usual way, instead of making many new `context.Background()` in several places.

FYI: https://go.dev/ref/spec#Receive_operator says that it is valid to apply the receive operator to a `nil` channel, and it will (as you would expect) never actually receive anything. This PR simplifies more complex code that used `Context.WithCancel` unnecessarily.

This PR switches from zap to using normal klog leveled and structured logging, getting better log messages: the timestamps have microsencond precision rather than whole second, and the source filename is mentioned.

Log statements that refer to an API object have been changed to not stringify the reference unless and until it is decided that this is actually needed.

This PR adds logging of the command line flag values at the start of the controller-manager.

This PR also turns up the logging level on the controller-manager.

This PR also fixes a couple of bugs where the key/value alternation of the `Info` method was not being followed (half the values appeared where a key belonged).

## Related issue(s)

Fixes #
