### PR TITLE
🐛 add informer on managedclusters

### DIFF
--- a/pkg/ocm/ocm.go
+++ b/pkg/ocm/ocm.go
@@ -21,7 +21,10 @@ import (
 	"fmt"
 	"os"
 	"strings"
+	"time"
 
+	clientset "open-cluster-management.io/api/client/cluster/clientset/versioned"
+	informers "open-cluster-management.io/api/client/cluster/informers/externalversions"
 	clusterv1 "open-cluster-management.io/api/cluster/v1"
 	workv1 "open-cluster-management.io/api/work/v1"
 
@@ -35,6 +38,10 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
 
 	"github.com/kubestellar/kubestellar/pkg/util"
+)
+
+const (
+	defaultResyncPeriod = time.Duration(0)
 )
 
 // wrapObject creates a ManifestWork with a single manifest containing the given object
@@ -91,6 +98,10 @@ func ZeroFields(obj runtime.Object) runtime.Object {
 		util.RemoveRuntimeGeneratedFieldsFromService(zeroed)
 	}
 	return zeroed
+}
+
+func GetOCMInformerFactory(clientset clientset.Interface) informers.SharedInformerFactory {
+	return informers.NewSharedInformerFactory(clientset, defaultResyncPeriod)
 }
 
 func GetOCMClient(kubeconfig *rest.Config) *client.Client {

--- a/pkg/util/labels.go
+++ b/pkg/util/labels.go
@@ -86,3 +86,18 @@ func SplitLabelKeyAndValue(keyvalue string) (Label, error) {
 	label.Value = parts[1]
 	return label, nil
 }
+
+func SelectorsMatchLabels(selectors []metav1.LabelSelector, labelsSet labels.Set) (bool, error) {
+	matches := true
+	for _, selectorApi := range selectors {
+		selector, err := metav1.LabelSelectorAsSelector(&selectorApi)
+		if err != nil {
+			return false, err
+		}
+		if !selector.Matches(labelsSet) {
+			matches = false
+			break
+		}
+	}
+	return matches, nil
+}

--- a/test/e2e/multi-cluster-deployment/update-delete.sh
+++ b/test/e2e/multi-cluster-deployment/update-delete.sh
@@ -23,7 +23,22 @@ source "${COMMON_SRCS}/setup-shell.sh"
 # Test cases for the update/delete of the bindingpolicy and the workload objects.
 # This test script should be executed after a successful execution of the use-kubestellar.sh script, located in the current directory.
 
+#
+#  Update of the managedcluster object in the OCM hub should update the bindings
+#
+: -------------------------------------------------------------------------
+: Test update of the managedcluster:
+: Change the location-group label on one of the managed cluster and verify the Binding objects 
+: are properly updated.
 :
+kubectl --context imbs1 label managedcluster cluster2 location-group=blah name=cluster2 --overwrite
+wait-for-cmd '[ "$(kubectl --context wds1 get bindings.control -o yaml | grep clusterId  | wc -l)" == 1 ]'
+kubectl --context imbs1 label managedcluster cluster2 location-group=edge name=cluster2 --overwrite
+wait-for-cmd '[ "$(kubectl --context wds1 get bindings.control -o yaml | grep clusterId  | wc -l)" == 2 ]'
+:
+: Test passed
+
+
 #
 #  Update of the workload object on WDS should update the object on the WECs
 #


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
Add an informer on managedclusters so when it changes (IUD) the BindingPolicies are re-evaluated.
Test case added to test/e2e/multi-cluster-deployment.

## Related issue(s)

Fixes #1679 
