### PR TITLE
🌱 Refactor and rename common part of transport controller

### DIFF
--- a/docs/content/v0.20/architecture.md
+++ b/docs/content/v0.20/architecture.md
@@ -486,7 +486,7 @@ status updates for one object do not require updates of a whole bundle.
 ### Transport Controller - PLANNED TO BE ADDED
 
 The transport controller is pluggable and allows the option to plug different
-implementations of the transport interface. In order to implement transport plugin, the plugin should supply the following:
+implementations of the transport interface. The interface between the plugin and the generic code is [a Go language interface](../../pkg/transport/transport.go) that the plugin has to implement. This interface requires the following from the plugin.
 - Upon registration of a new WEC, plugin should create a namespace for the WEC in the ITS and delete the namespace once the WEC registration goes away (mailbox namespace per WEC);
 - Plugin must be able to wrap any number of objects into a single wrapped object;
 - Have an agent that can be used to pull the wrapped objects from the mailbox namespace and apply them to the WEC. A single example for such an agent is an agent that runs on the WEC and watches the wrapped object in the corresponding namespace in the central hub and is able to unwrap it and apply the objects to the WEC. 
@@ -494,8 +494,8 @@ implementations of the transport interface. In order to implement transport plug
 
 The above list is required in order to comply with [<u>SIG Multi-Cluster Work API</u>](https://multicluster.sigs.k8s.io/concepts/work-api/).
 
-In order to implement a KubeStellar transport plugin, one has to implement code that supplies a function to wrap any number of objects into a single wrapped objects. 
-The transport interface that should be implemented can be seen [here](https://github.com/kubestellar/kubestellar/blob/main/pkg/transport/transport.go).  
+Each plugin has an executable with a `main` func that calls [the generic code](../../pkg/transport/cmd/generic-main.go), passing the plugin object that implements the plugin interface.
+
 KubeStellar currently has one transport plugin implementation which is based on CNCF Sandbox project [Open Cluster Management](https://open-cluster-management.io). OCM transport plugin implements the above interface and supplies a function to start the transport controller using the specific OCM implementation. Code is available [here](https://github.com/kubestellar/ocm-transport-plugin).  
 We expect to have more transport plugin options in the future.
 

--- a/pkg/transport/cmd/generic-main.go
+++ b/pkg/transport/cmd/generic-main.go
@@ -28,19 +28,18 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/klog/v2"
 
-	transportoptions "github.com/kubestellar/kubestellar/cmd/transport/options"
 	ksclientset "github.com/kubestellar/kubestellar/pkg/generated/clientset/versioned"
 	ksinformers "github.com/kubestellar/kubestellar/pkg/generated/informers/externalversions"
 	"github.com/kubestellar/kubestellar/pkg/transport"
 )
 
-// The following code is responsible for running transport controller with pluggable
-// implementation and contains the base functionality.
-// Run function gets the transport-specific implementation and uses it to initialize
+// The following code is responsible for running a transport controller with a given
+// transport plugin and contains the base or generic functionality.
+// The GenericMain function gets the transport-specific implementation and uses it to initialize
 // the generic transport controller which is responsible for processing the
 // Binding added/updated/deleted events.
-// In order to use Run function, one has to call it in the following format:
-// cmd.Run(YourTransportSpecificImplementation())
+// In order to use the GenericMain function, one has to call it in the following format:
+// GenericMain(YourTransportSpecificImplementation())
 
 // Example for this can be seen here:
 // https://github.com/kubestellar/ocm-transport-plugin/blob/main/cmd/main.go
@@ -49,11 +48,11 @@ const (
 	defaultResyncPeriod = time.Duration(0)
 )
 
-func Run(transportImplementation transport.Transport) {
+func GenericMain(transportImplementation transport.Transport) {
 	logger := klog.Background().WithName(transport.ControllerName)
 	ctx := klog.NewContext(context.Background(), logger)
 
-	options := transportoptions.NewTransportOptions()
+	options := NewTransportOptions()
 	fs := pflag.NewFlagSet(transport.ControllerName, pflag.ExitOnError)
 	klog.InitFlags(flag.CommandLine)
 	fs.AddGoFlagSet(flag.CommandLine)

--- a/pkg/transport/cmd/options.go
+++ b/pkg/transport/cmd/options.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package options
+package cmd
 
 import (
 	"github.com/spf13/pflag"


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
This PR moves the generic transport controller code that was in `cmd/` to `pkg/transport/cmd/`.

This PR also updates the architecture document to be a little more explicit about the structure here.

## Related issue(s)

Fixes #1750
