### PR TITLE
✨ Change the explicitly coded API group for WorkStatus

### DIFF
--- a/pkg/util/unstructured.go
+++ b/pkg/util/unstructured.go
@@ -39,7 +39,7 @@ const (
 	BindingPolicyResource                = "bindingpolicies"
 	BindingKind                          = "Binding"
 	BindingResource                      = "bindings"
-	WorkStatusGroup                      = "edge.kubestellar.io" // TODO: update/import after status-addon is rehomed and its api group for WorkStatus is updated
+	WorkStatusGroup                      = "control.kubestellar.io"
 	WorkStatusVersion                    = "v1alpha1"
 	WorkStatusResource                   = "workstatuses"
 	AnnotationToPreserveValuesKey        = "annotations.kubestellar.io/preserve"
@@ -204,7 +204,7 @@ func CheckWorkStatusIPresent(config *rest.Config) bool {
 	}
 
 	gvr := schema.GroupVersionResource{
-		Group:    "edge.kubestellar.io", // TODO: update/import after status-addon is rehomed and its api group for WorkStatus is updated
+		Group:    "control.kubestellar.io",
 		Version:  "v1alpha1",
 		Resource: "workstatuses",
 	}

--- a/test/e2e/common/setup-kubestellar.sh
+++ b/test/e2e/common/setup-kubestellar.sh
@@ -49,9 +49,7 @@ kflex create imbs1 --type vcluster -p ocm $disable_chatty_status
 : Install singleton status return addon in IMBS1
 :
 wait-for-cmd kubectl --context imbs1 api-resources "|" grep managedclusteraddons
-helm --kube-context imbs1 upgrade --install status-addon -n open-cluster-management oci://ghcr.io/kubestellar/ocm-status-addon-chart --version v0.2.0-rc1
-
-
+helm --kube-context imbs1 upgrade --install status-addon -n open-cluster-management oci://ghcr.io/kubestellar/ocm-status-addon-chart --version v0.2.0-rc2
 
 :
 : -------------------------------------------------------------------------
@@ -112,4 +110,3 @@ then
     echo "Failed to see two clusters."
     exit 1
 fi
-


### PR DESCRIPTION
This PR changes the explicitly coded API group for WorkStatus to `control.kubestellar.io`.

Also updates the helm chart for status addon (in the e2e tests) which incorporated the 'original' WorkStatus API group change.

Fixes #1701.
