### PR TITLE
🐛 Remove troublesome quoting

### DIFF
--- a/test/e2e/multi-cluster-deployment/update-delete.sh
+++ b/test/e2e/multi-cluster-deployment/update-delete.sh
@@ -32,9 +32,9 @@ source "${COMMON_SRCS}/setup-shell.sh"
 : are properly updated.
 :
 kubectl --context imbs1 label managedcluster cluster2 location-group=blah name=cluster2 --overwrite
-wait-for-cmd '[ "$(kubectl --context wds1 get bindings.control -o yaml | grep clusterId  | wc -l)" == 1 ]'
+wait-for-cmd '[ $(kubectl --context wds1 get bindings.control -o yaml | grep clusterId  | wc -l) == 1 ]'
 kubectl --context imbs1 label managedcluster cluster2 location-group=edge name=cluster2 --overwrite
-wait-for-cmd '[ "$(kubectl --context wds1 get bindings.control -o yaml | grep clusterId  | wc -l)" == 2 ]'
+wait-for-cmd '[ $(kubectl --context wds1 get bindings.control -o yaml | grep clusterId  | wc -l) == 2 ]'
 :
 : Test passed
 


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
This PR fixes a new section of the multi-cluster-deployment E2E test, removing quoting that captured spaces where that is not appropriate.

## Related issue(s)

Fixes #
