### PR TITLE
🐛 Put -v in kustomize YAML for the Helm chart

### DIFF
--- a/config/default/manager_auth_proxy_patch.yaml
+++ b/config/default/manager_auth_proxy_patch.yaml
@@ -54,3 +54,4 @@ spec:
         - "--leader-elect"
         - "--wds-name={{.Values.ControlPlaneName}}"
         - "--api-groups={{.Values.APIGroups}}"
+        - -v=2

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -26,7 +26,7 @@ spec:
         runAsNonRoot: true
       containers:
       - args:
-        - --leader-elect
+        - will be set by ../default/manager_auth_proxy_patch.yaml
         image: controller:latest
         imagePullPolicy: IfNotPresent
         name: manager


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
This PR fixes the kustomization file that gets invoked by `make chart`, to keep putting the `-v=2` among the command line arguments of the kubestellar controller-manager.

This PR also updates the _other_ file that looks like a customization file for the same Deployment to point the reader to the kustomize input that matters.

## Related issue(s)

Fixes #
