### PR TITLE
✨ enable local image and chart

### DIFF
--- a/scripts/add-helm-code.sh
+++ b/scripts/add-helm-code.sh
@@ -21,13 +21,28 @@
 # Working directory does not matter.
 
 HOME_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )/.." && pwd )"
+# Directory containing the yaml file
+dir=${HOME_DIR}/chart/templates
 
-if [ "$#" -lt 1 ]; then
-    echo "adds/remove helm tags to cluster scoped files such as ClusterRole and CLusterRoleBinding"
-    echo "Usage: $(basename $0) add | remove"
-    exit
-fi
-CMD=$1
+while (( $# > 0 )); do
+	case "$1" in
+	(-h|--help)
+		echo "adds/remove helm tags to cluster scoped files such as ClusterRole and CLusterRoleBinding"
+		echo "Usage: $(basename $0) [--dir chart_directory] add | remove"
+		exit 0;;
+	(--dir)
+		if (( $# >1 ))
+		then dir="${2}/templates"; shift
+		else echo "$0: missing chart_ directory" >&2; exit 1
+		fi;;
+	(-*)
+		echo "$0: flag syntax error" >&2
+		exit 1;;
+	(*)
+		CMD=$1
+	esac
+	shift
+done
 
 cleanup_helm_tags() {
   file=$1
@@ -36,8 +51,6 @@ cleanup_helm_tags() {
 }
 
 
-# Directory containing the yaml file
-dir=${HOME_DIR}/chart/templates
 
 # file to process
 op_file=${dir}/controller-manager.yaml


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
Issuing ko-build-local now builds a local images with a tag that is based on the local timestamp.
The created images is loaded into the kubeflex cluster using make kind-load-image. 
The image is installed into the WDS using make install-local-chart.  The BUILD_TIME_TAG image is the one used.  

## Related issue(s)

Fixes #1740 
