### PR TITLE
🐛 Update E2E test workflows with right go version

### DIFF
--- a/.github/workflows/pr-test-multicluster.yml
+++ b/.github/workflows/pr-test-multicluster.yml
@@ -23,7 +23,7 @@ jobs:
       
       - uses: actions/setup-go@v5
         with:
-          go-version: v1.19
+          go-version: v1.20
           cache: true
 
       - name: Install kubectl

--- a/.github/workflows/pr-test-singleton-status.yml
+++ b/.github/workflows/pr-test-singleton-status.yml
@@ -23,7 +23,7 @@ jobs:
       
       - uses: actions/setup-go@v5
         with:
-          go-version: v1.19
+          go-version: v1.20
           cache: true
 
       - name: Install kubectl


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
This PR updates the GitHub workflows that run the E2E tests to specify the same version of Go as is in `go.mod`.

This is good because `go vet ./...` fails in #1769 without it (something in Kubernetes needs something introduced in go 1.20).

## Related issue(s)

Fixes #
