### PR TITLE
🐛  e2e tests should not check internal objects

### DIFF
--- a/test/e2e/multi-cluster-deployment/use-kubestellar.sh
+++ b/test/e2e/multi-cluster-deployment/use-kubestellar.sh
@@ -69,18 +69,7 @@ spec:
         ports:
         - containerPort: 80
 EOF
-
-:
-: -------------------------------------------------------------------------
-: "Verify that manifestworks wrapping the objects have been created in the mailbox namespaces"
-: Expect twice: one header line, one for the nginx namespace, one for the nginx deployment, one for the status agent Deployment
-: 
-if ! wait-for-cmd "expect-cmd-output 'kubectl --context imbs1 get manifestworks -n cluster1; kubectl --context imbs1 get manifestworks -n cluster2' 'wc -l | grep -wq 8'"
-then
-    echo "Failed to see expected manifestworks."
-    exit 1
-fi
-
+ 
 :
 : -------------------------------------------------------------------------
 : "Verify that the deployment has been created in both clusters"

--- a/test/e2e/singleton-status/use-kubestellar.sh
+++ b/test/e2e/singleton-status/use-kubestellar.sh
@@ -72,17 +72,6 @@ EOF
 
 :
 : -------------------------------------------------------------------------
-: "Verify that manifestworks wrapping the objects have been created in the mailbox namespaces"
-: Expect: one header line, one for the nginx namespace, one for the nginx deployment, one for the status agent Deployment
-:
-if ! wait-for-cmd "expect-cmd-output 'kubectl --context imbs1 get manifestworks -n cluster1' 'wc -l | grep -wq 4'"
-then
-    echo "Failed to see expected manifestworks."
-    exit 1
-fi
-
-:
-: -------------------------------------------------------------------------
 : "Verify that the deployment has been created in cluster1"
 :
 wait-for-cmd 'kubectl --context cluster1 get deployments -n nginx nginx-deployment'


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
The e2e tests should be checking end to end objects rather than intermediary ones like the manifestworks.  

## Related issue(s)

Fixes #
