### PR TITLE
:bug: binding controller: make sure deleted objects are detectable

### DIFF
--- a/pkg/binding/controller.go
+++ b/pkg/binding/controller.go
@@ -395,7 +395,12 @@ func (c *Controller) enqueueObject(obj interface{}, skipCheckIsDeleted bool) {
 			// The resource no longer exist, which means it has been deleted.
 			if errors.IsNotFound(err) {
 				deletedObj := copyObjectMetaAndType(obj.(runtime.Object))
+				// set deletion timestamp for this object to still be detected as being deleted
+				metaDeletedObj := deletedObj.(metav1.Object)
+				metaDeletedObj.SetDeletionTimestamp(&metav1.Time{Time: time.Now()})
+
 				key.DeletedObject = &deletedObj
+
 				c.workqueue.Add(key)
 			}
 			return


### PR DESCRIPTION
## Summary
During tests in #1765 and by @effi-ofer, it was found that deleted objects that go through controller::enqueueObject are later not detectable in ::isBeingDeleted due to losing the deletiontimestamp.

This would bug out whoever expects `isBeingDeleted` to return true on deleted objects.

## Related issue(s)

Fixes #
