### PR TITLE
🐛 Add `go mod tidy` when building possibly-new integration

### DIFF
--- a/test/e2e/common/setup-kubestellar.sh
+++ b/test/e2e/common/setup-kubestellar.sh
@@ -99,6 +99,7 @@ cd ocm-transport-plugin-${OCM_TRANSPORT_PLUGIN_RELEASE}
 OCM_TRANSPORT_PLUGIN_DIR="$(pwd)"
 pwd
 echo "replace github.com/kubestellar/kubestellar => ${KUBESTELLAR_DIR}/" >> go.mod
+go mod tidy
 make build
 mv ./bin/ocm-transport-plugin ${KUBESTELLAR_DIR}/ocm-transport-plugin
 cd "${KUBESTELLAR_DIR}"


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
This PR adds a `go mod tidy` into the recipe for building ks/OTP using the local version of ks/ks. This may be needed when the local version of ks/ks has different dependencies than the version that ks/OTP normally builds with. I needed it while working on #1760.

I am not a fan of this building, see https://github.com/kubestellar/kubestellar/issues/1786#issuecomment-1964802834 ; as long as we are doing this building, this extra step is sometimes needed.

## Related issue(s)

Fixes #
