### PR TITLE
🌱 Make transport-controller -v=4 in E2E tests

### DIFF
--- a/test/e2e/common/setup-kubestellar.sh
+++ b/test/e2e/common/setup-kubestellar.sh
@@ -105,7 +105,7 @@ cd "${KUBESTELLAR_DIR}"
 pwd
 rm -rf ${OCM_TRANSPORT_PLUGIN_DIR}
 echo "running ocm transport plugin..."
-./ocm-transport-plugin --transport-context imbs1 --wds-context wds1 --wds-name wds1 &> transport.log &
+./ocm-transport-plugin --transport-context imbs1 --wds-context wds1 --wds-name wds1 -v=4 &> transport.log &
 
 echo "transport controller is running as background process."
 


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
This PR increases the verbosity of the transport controller's log in the E2E tests. Log verbosity is good in tests.

## Related issue(s)

Fixes #
