### PR TITLE
✨ added object denaturing extensible mechanism

### DIFF
--- a/pkg/transport/denaturing/object_denaturing_map.go
+++ b/pkg/transport/denaturing/object_denaturing_map.go
@@ -1,0 +1,54 @@
+/*
+Copyright 2024 The KubeStellar Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package denaturing
+
+import (
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+// cleanObjectSpecificsFunction is a function for cleaning fields from a specific object.
+// The function cleans the specific fields in place (object is modified).
+// If the object was retrieved using a lister, it's the caller responsibility
+// to do a DeepCopy before calling this function.
+type cleanObjectSpecificsFunction func(object *unstructured.Unstructured)
+
+func NewObjectDenaturingMap() *ObjectDenaturingMap {
+	serviceTypeMeta := v1.TypeMeta{Kind: "Service", APIVersion: "v1"}
+
+	denaturingMap := map[string]cleanObjectSpecificsFunction{
+		serviceTypeMeta.GroupVersionKind().String(): cleanServiceFields,
+	}
+
+	return &ObjectDenaturingMap{
+		gvkToDenaturingFunc: denaturingMap,
+	}
+}
+
+type ObjectDenaturingMap struct {
+	gvkToDenaturingFunc map[string]cleanObjectSpecificsFunction // map from GVK as string to clean object function
+}
+
+func (denaturingMap *ObjectDenaturingMap) CleanObjectSpecifics(object *unstructured.Unstructured) {
+	gvkAsString := object.GetObjectKind().GroupVersionKind().String()
+	denaturingFunction, found := denaturingMap.gvkToDenaturingFunc[gvkAsString]
+	if !found {
+		return // if no denaturing function was defined for this gvk, do not clean any field
+	}
+	// otherwise, need to clean specific fields from this object
+	denaturingFunction(object)
+}

--- a/pkg/transport/denaturing/service.go
+++ b/pkg/transport/denaturing/service.go
@@ -1,0 +1,49 @@
+/*
+Copyright 2024 The KubeStellar Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package denaturing
+
+import (
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+const (
+	preserveFieldAnnotation = "control.kubestellar.io/preserve"
+	preserveNodePortValue   = "nodeport"
+)
+
+func cleanServiceFields(object *unstructured.Unstructured) {
+	// Fields to remove
+	fieldsToDelete := []string{"clusterIP", "clusterIPs", "ipFamilies",
+		"externalTrafficPolicy", "internalTrafficPolicy", "ipFamilyPolicy", "sessionAffinity"}
+
+	for _, field := range fieldsToDelete {
+		unstructured.RemoveNestedField(object.Object, "spec", field)
+	}
+
+	// Set the nodePort to an empty string unelss the annotation "kubestellar.io/annotations/preserve=nodeport" is present
+	if !(object.GetAnnotations() != nil && object.GetAnnotations()[preserveFieldAnnotation] == preserveNodePortValue) {
+		if ports, found, _ := unstructured.NestedSlice(object.Object, "spec", "ports"); found {
+			for i, port := range ports {
+				if portMap, ok := port.(map[string]interface{}); ok {
+					portMap["nodePort"] = nil
+					ports[i] = portMap
+				}
+			}
+			unstructured.SetNestedSlice(object.Object, ports, "spec", "ports")
+		}
+	}
+}


### PR DESCRIPTION
This PR adds object denaturing extensible mechanism that is used in transport controller.

<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

This PR suggests an alternative approach to #1803. 
In short - This PR introduces a simple and extensible mechanism to denature objects before adding them to a wrapped object. this is done using a map from GVK to a "cleanObjectSpecifics" function with almost zero changes to the transport controller. the most important part is that even if we end up with tens of objects that have to be denatured, this would still be outside of the transport controller code, which keeps the controller code clean, easy to read and to maintain.

Ideally each different GVK would be in its own file (under `pkg/transport/denaturing`), which is also self documented.
it allows us to easily understand which objects require denaturing, and for each what is the specific denaturing logic.

In this PR I also implemented the Service denaturing using the suggested mechanism.
Intentionally, I did *NOT* implement the Job denaturing and left it for someone else to do, to make sure the mechanism is simple enough and easy for understanding also by others. 

## Related issue(s)

Fixes #1451 
