### PR TITLE
🌱 Fetch and use right etcd for platform

### DIFF
--- a/hack/run-integration-tests.sh
+++ b/hack/run-integration-tests.sh
@@ -24,20 +24,39 @@
 set -x
 set -e
 
-etcd_archive_url="https://github.com/etcd-io/etcd/releases/download/v3.5.9/etcd-v3.5.9-linux-amd64.tar.gz"
-wget --no-verbose $etcd_archive_url -O etcd.tar.gz
-expected_sha=d59017044eb776597eca480432081c5bb26f318ad292967029af1f62b588b042
+etcd_version=3.5.12
+platform="$(go env GOOS)-$(go env GOARCH)"
+
+case "$(go env GOOS)" in
+    (darwin|windows) fmt="zip";    extract="unzip"  ;;
+    (linux)          fmt="tar.gz"; extract="tar xzf";;
+    (*) echo "Unsupported OS $(go env GOOS)" >& 2
+	exit 1;;
+esac
+
+etcd_archive_url="https://github.com/etcd-io/etcd/releases/download/v${etcd_version}/etcd-v${etcd_version}-${platform}.${fmt}"
+wget --no-verbose $etcd_archive_url -O etcd.${fmt}
+case "$platform" in
+    (darwin-amd64)  expected_sha=96e2e5f3c68744fe0981a3d52b8815aa5d3a3bb3b4e48cee54dd29bd33dfe355;;
+    (darwin-arm64)  expected_sha=d2a2d003a237ee3aaed2859492aa63b411d2c5de016a9b44a3be72865cc33933;;
+    (linux-amd64)   expected_sha=f2ff0cb43ce119f55a85012255609b61c64263baea83aa7c8e6846c0938adca5;;
+    (linux-arm64)   expected_sha=31f30c01918771ece28d6e553e0f33be9483ced989896ecf6bbe1edb07786141;;
+    (windows-amd64) expected_sha=ab63500a3eb1cbfd9d863759fc5a039ad724c0b493b26c079bb53b19e7c21330;;
+    (*) echo "Unsupported platform $platform" >&2
+	exit 1 ;;
+esac
+
 if which sha256sum
-then got_sha=$(sha256sum     etcd.tar.gz | awk '{ print $1 }')
-else got_sha=$(shasum -a 256 etcd.tar.gz | awk '{ print $1 }')
+then got_sha=$(sha256sum     etcd.${fmt} | awk '{ print $1 }')
+else got_sha=$(shasum -a 256 etcd.${fmt} | awk '{ print $1 }')
 fi
 if [ $expected_sha != "$got_sha" ]; then
-    echo "Got SHA256 $got_sha instead of expected $expected_sha" >& 2
+    echo "Got SHA256 $got_sha instead of expected $expected_sha for platform $platform" >& 2
     exit 1
 fi
 
-tar xzf etcd.tar.gz
-export PATH=${PATH}:${PWD}/etcd-v3.5.9-linux-amd64
-rm etcd.tar.gz
+$extract etcd.${fmt}
+export PATH=${PATH}:${PWD}/etcd-v${etcd_version}-${platform}
+rm etcd.${fmt}
 
 CONTROLLER_TEST_NUM_OBJECTS=12 go test -v ./test/integration/controller-manager -args -v=5


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
This PR adjusts hack/run-integration-tests.sh to fetch the etcd binary that is right for the platform where it is being used. (Previously this worked on Macs only if/where configured to automatically emulate linux-amd64.)

This PR also switches to the latest release of etcd.

## Related issue(s)

Fixes #
