### PR TITLE
🌱 Remove reticence and add debug logging in binding controller

### DIFF
--- a/hack/run-integration-tests.sh
+++ b/hack/run-integration-tests.sh
@@ -40,4 +40,4 @@ tar xzf etcd.tar.gz
 export PATH=${PATH}:${PWD}/etcd-v3.5.9-linux-amd64
 rm etcd.tar.gz
 
-CONTROLLER_TEST_NUM_OBJECTS=12 go test -v ./test/integration/controller-manager -args -v=5
+CONTROLLER_TEST_NUM_OBJECTS=18 go test -v ./test/integration/controller-manager -args -v=5

--- a/pkg/binding/binding.go
+++ b/pkg/binding/binding.go
@@ -25,6 +25,7 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/klog/v2"
 
 	"github.com/kubestellar/kubestellar/api/control/v1alpha1"
 	"github.com/kubestellar/kubestellar/pkg/util"
@@ -104,6 +105,8 @@ func (c *Controller) updateOrCreateBinding(ctx context.Context, bdg *v1alpha1.Bi
 		return fmt.Errorf("failed to convert Binding to Unstructured: %w", err)
 	}
 
+	logger := klog.FromContext(ctx)
+
 	_, err = c.dynamicClient.Resource(schema.GroupVersionResource{
 		Group:    v1alpha1.SchemeGroupVersion.Group,
 		Version:  bdg.GetObjectKind().GroupVersionKind().Version,
@@ -120,14 +123,14 @@ func (c *Controller) updateOrCreateBinding(ctx context.Context, bdg *v1alpha1.Bi
 				return fmt.Errorf("failed to create binding: %w", err)
 			}
 
-			c.logger.Info("created binding", "name", bdg.GetName())
+			logger.Info("created binding", "name", bdg.GetName())
 			return nil
 		} else {
 			return fmt.Errorf("failed to update binding: %w", err)
 		}
 	}
 
-	c.logger.Info("updated binding", "name", bdg.GetName())
+	logger.Info("updated binding", "name", bdg.GetName())
 	return nil
 }
 

--- a/pkg/binding/selectors.go
+++ b/pkg/binding/selectors.go
@@ -25,6 +25,7 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/klog/v2"
 
 	"github.com/kubestellar/kubestellar/pkg/util"
 )
@@ -39,8 +40,10 @@ func (c *Controller) updateResolutions(ctx context.Context, obj runtime.Object) 
 	if err != nil {
 		return err
 	}
+	logger := klog.FromContext(ctx)
 
 	objMR := obj.(mrObject)
+	objBeingDeleted := isBeingDeleted(obj)
 
 	isSelectedBySingletonBinding := false
 
@@ -56,10 +59,14 @@ func (c *Controller) updateResolutions(ctx context.Context, obj runtime.Object) 
 			// TODO: optimize
 			if resolutionUpdated := c.bindingPolicyResolver.RemoveObject(bindingPolicy.GetName(), obj); resolutionUpdated {
 				// enqueue binding to be synced since object was removed from its bindingpolicy's resolution
-				c.logger.V(4).Info("enqueued Binding for syncing due to the removal of an "+
+				logger.V(4).Info("Enqueuing Binding for syncing due to the removal of an "+
 					"object from its resolution", "binding", bindingPolicy.GetName(),
 					"object", util.RefToRuntimeObj(obj))
 				c.enqueueBinding(bindingPolicy.GetName())
+			} else {
+				logger.V(4).Info("Not enqueuing Binding for syncing due to the removal of an "+
+					"object from its resolution", "binding", bindingPolicy.GetName(),
+					"object", util.RefToRuntimeObj(obj))
 			}
 			continue
 		}
@@ -82,14 +89,14 @@ func (c *Controller) updateResolutions(ctx context.Context, obj runtime.Object) 
 
 		if resolutionUpdated {
 			// enqueue binding to be synced since an object was added to its bindingpolicy's resolution
-			c.logger.V(4).Info("enqueued Binding for syncing due to a noting of an "+
+			logger.V(4).Info("enqueued Binding for syncing due to a noting of an "+
 				"object in its resolution", "binding", bindingPolicy.GetName(),
-				"object", util.RefToRuntimeObj(obj))
+				"object", util.RefToRuntimeObj(obj), "objBeingDeleted", objBeingDeleted)
 			c.enqueueBinding(bindingPolicy.GetName())
 		}
 
 		// make sure object has singleton status if needed
-		if !isBeingDeleted(obj) &&
+		if !objBeingDeleted &&
 			c.bindingPolicyResolver.ResolutionRequiresSingletonReportedState(bindingPolicy.GetName()) {
 			if err := c.handleSingletonLabel(ctx, obj, bindingPolicy.GetName()); err != nil {
 				return fmt.Errorf("failed to add singleton label to object: %w", err)
@@ -103,7 +110,7 @@ func (c *Controller) updateResolutions(ctx context.Context, obj runtime.Object) 
 	// we need to remove the singleton label from the object if it exists.
 	// NOTE that this takes care of the case where the object was previously selected by a singleton binding
 	// and is no longer selected by any binding.
-	if !isBeingDeleted(obj) && !isSelectedBySingletonBinding {
+	if !objBeingDeleted && !isSelectedBySingletonBinding {
 		if err := c.handleSingletonLabel(ctx, obj, emptyBindingPolicyName); err != nil {
 			return fmt.Errorf("failed to remove singleton label from object: %w", err)
 		}


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
This PR removes the suppression of enqueuing workload object references because it was a bug: nothing guarantees that the object reference is enqueud later.

This PR also makes some debug logging improvements, primarily adding some debug logging. Also some switching from the controller's logger to the worker's logger, to help investigate possible concurrency bugs.

## Related issue(s)

Fixes #
