### PR TITLE
✨ Handle CRDs at scale

### DIFF
--- a/pkg/binding/controller.go
+++ b/pkg/binding/controller.go
@@ -99,17 +99,26 @@ type Controller struct {
 func NewController(parentLogger logr.Logger, wdsRestConfig *rest.Config, imbsRestConfig *rest.Config,
 	wdsName string, allowedGroupsSet sets.Set[string]) (*Controller, error) {
 
-	dynamicClient, err := dynamic.NewForConfig(wdsRestConfig)
-	if err != nil {
-		return nil, err
-	}
-
 	kubernetesClient, err := kubernetes.NewForConfig(wdsRestConfig)
 	if err != nil {
 		return nil, err
 	}
 
 	extClient, err := apiextensionsclientset.NewForConfig(wdsRestConfig)
+	if err != nil {
+		return nil, err
+	}
+
+	burst, err := countGVRsViaAggregatedDiscovery(wdsRestConfig) // use # of GVRs as burst is tested to be working well
+	if err != nil {
+		parentLogger.Error(err, "Not able to count GVRs via aggregated discovery") // but we can still continue
+	}
+	wdsRestConfig.Burst = adjustBurstIfNecessary(burst)
+
+	// dynamicClient needs higher burst because dynamicClient is repeatedly used to create informers
+	// for each of the GVRs, all at the beginning of the controller run
+	parentLogger.V(3).Info("Setting parameter of the client's token bucket rate limiter", "Burst", wdsRestConfig.Burst)
+	dynamicClient, err := dynamic.NewForConfig(wdsRestConfig)
 	if err != nil {
 		return nil, err
 	}
@@ -122,6 +131,39 @@ func NewController(parentLogger logr.Logger, wdsRestConfig *rest.Config, imbsRes
 	ocmClient := *ocm.GetOCMClient(imbsRestConfig)
 
 	return makeController(parentLogger, dynamicClient, kubernetesClient, extClient, ocmClientset, ocmClient, wdsName, allowedGroupsSet)
+}
+
+func countGVRsViaAggregatedDiscovery(config *rest.Config) (int, error) {
+	countClient, err := kubernetes.NewForConfig(config)
+	if err != nil {
+		return 0, fmt.Errorf("error creating client to count number of GVRs: %w", err)
+	}
+	if countClient.DiscoveryClient.UseLegacyDiscovery {
+		return 0, fmt.Errorf("client using aggregated discovery")
+	}
+	apiResourceLists, err := countClient.Discovery().ServerPreferredResources()
+	if err != nil {
+		return 0, fmt.Errorf("error listing server perferred resources: %w", err)
+	}
+	n := 0
+	for _, list := range apiResourceLists {
+		n += len(list.APIResources)
+	}
+	return n, nil
+}
+
+func adjustBurstIfNecessary(burst int) int {
+	// in case too small
+	if burst < rest.DefaultBurst {
+		return rest.DefaultBurst
+	}
+	// in case too large
+	// https://github.com/kubernetes/kubernetes/pull/105520/files
+	// https://github.com/kubernetes/kubernetes/blob/5d527dcf1265d7fcd0e6c8ec511ce16cc6a40699/staging/src/k8s.io/cli-runtime/pkg/genericclioptions/config_flags.go#L477
+	if burst > 300 {
+		return 300
+	}
+	return burst
 }
 
 func makeController(parentLogger logr.Logger,

--- a/pkg/binding/controller.go
+++ b/pkg/binding/controller.go
@@ -572,7 +572,7 @@ func (c *Controller) reconcile(ctx context.Context, key util.Key) error {
 		logger.Info("Handled bindingpolicy", "object", util.RefToRuntimeObj(obj))
 		return nil
 	} else if util.IsCRD(obj) {
-		if err := c.handleCRD(obj); err != nil {
+		if err := c.handleCRD(ctx, obj); err != nil {
 			return fmt.Errorf("failed to handle CRD: %w", err) // error logging after this call
 			// will add name.
 		}

--- a/pkg/util/resources.go
+++ b/pkg/util/resources.go
@@ -19,6 +19,7 @@ package util
 import (
 	"strings"
 
+	"k8s.io/apiextensions-apiserver/pkg/apis/apiextensions"
 	"k8s.io/apimachinery/pkg/util/sets"
 
 	"github.com/kubestellar/kubestellar/api/control/v1alpha1"
@@ -54,8 +55,5 @@ func addRequiredResourceGroups(allowedResourceGroups sets.Set[string]) {
 	// groups are watched
 
 	allowedResourceGroups.Insert(v1alpha1.GroupVersion.Group)
-
-	// disabled until https://github.com/kubestellar/kubestellar/issues/1705 is resolved
-	// to avoid client-side throttling
-	//allowedResourceGroups.Insert(apiextensions.GroupName)
+	allowedResourceGroups.Insert(apiextensions.GroupName)
 }

--- a/pkg/util/resources.go
+++ b/pkg/util/resources.go
@@ -39,8 +39,8 @@ func ParseAPIGroupsString(apiGroups string) sets.Set[string] {
 	return groupsSet
 }
 
-// IsResourceGroupAllowed checks if a API group is allowed
-// an empty or nil allowedResources slice is equivalent to allow all,
+// IsResourceGroupAllowed checks if a API group is explicitly allowed by user,
+// an empty or nil allowedResources slice is equivalent to allow all.
 func IsAPIGroupAllowed(apiGroup string, allowedAPIGroups sets.Set[string]) bool {
 	if len(allowedAPIGroups) == 0 {
 		return true

--- a/pkg/util/resources_test.go
+++ b/pkg/util/resources_test.go
@@ -33,12 +33,12 @@ func TestParseAPIGroupsString(t *testing.T) {
 		{
 			name:     "valid input with api group",
 			input:    "apps,networking.k8s.io,policy",
-			expected: sets.New("apps", "networking.k8s.io", "policy", "control.kubestellar.io"),
+			expected: sets.New("apps", "networking.k8s.io", "policy", "control.kubestellar.io", "apiextensions.k8s.io"),
 		},
 		{
 			name:     "valid input with empty api group",
 			input:    "apps,,policy",
-			expected: sets.New("apps", "", "policy", "control.kubestellar.io"),
+			expected: sets.New("apps", "", "policy", "control.kubestellar.io", "apiextensions.k8s.io"),
 		},
 		{
 			name:     "empty input",

--- a/test/integration/controller-manager/crd-handling_test.go
+++ b/test/integration/controller-manager/crd-handling_test.go
@@ -1,0 +1,228 @@
+/*
+Copyright 2024 The KubeStellar Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cmtest
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	apiextensionsapi "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	apiextensionsclientset "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	runtime "k8s.io/apimachinery/pkg/runtime"
+	k8sjson "k8s.io/apimachinery/pkg/runtime/serializer/json"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/klog/v2/ktesting"
+	kastesting "k8s.io/kubernetes/cmd/kube-apiserver/app/testing"
+	"k8s.io/kubernetes/test/integration/framework"
+
+	"github.com/kubestellar/kubestellar/pkg/binding"
+	"github.com/kubestellar/kubestellar/pkg/util"
+)
+
+// An integration test for the binding controller.
+// This test uses an in-process kube-apiserver created by k8s.io/kubernetes/cmd/kube-apiserver/app/testing.
+// That code launches an external insecure etcd server.
+// YOU MUST HAVE THE ETCD BINARY ON YOUR `$PATH`.
+//
+// This test exercises the crd handling functionality.
+func TestCRDHandling(t *testing.T) {
+	testWriter := framework.NewTBWriter(t)
+	logger, ctx := ktesting.NewTestContext(t)
+	logger.Info("Starting etcd server")
+	framework.StartEtcd(t, testWriter)
+	logger.Info("Starting TestController")
+	t.Log("Beginning TestController")
+	ctx, cancel := context.WithCancel(ctx)
+	testServer, err := kastesting.StartTestServer(t, kastesting.NewDefaultTestServerOptions(), []string{}, framework.SharedEtcd())
+	if err != nil {
+		t.Fatalf("Failed to kastesting.StartTestServer: %s", err)
+	}
+	fullTeardwon := func() {
+		cancel()
+		testServer.TearDownFn()
+	}
+	t.Cleanup(fullTeardwon)
+	config := testServer.ClientConfig
+	if err != nil {
+		t.Fatalf("Failed to create Kubernetes client: %s", err)
+	}
+	logger.Info("Started test server", "config", config)
+	configCopy := *config
+	config4json := &configCopy
+	config4json.ContentType = "application/json"
+	logger.Info("REST config for JSON marshaling", "config", config4json)
+	if err != nil {
+		t.Fatalf("Failed to create KubeStellar client: %s", err)
+	}
+	apiextClient, err := apiextensionsclientset.NewForConfig(config)
+	if err != nil {
+		t.Fatalf("Failed to create apiextensions client: %s", err)
+	}
+	scheme := runtime.NewScheme()
+	err = apiextensionsapi.AddToScheme(scheme)
+	if err != nil {
+		t.Fatalf("Failed to apiextensionsapi.AddToScheme(scheme): %s", err)
+	}
+	serializer := k8sjson.NewYAMLSerializer(k8sjson.DefaultMetaFactory, scheme, scheme)
+	createCRD(t, ctx, "ManagedCluster", managedClusterCRDURL, serializer, apiextClient)
+	createCRD(t, ctx, "ManifestWork", manifestWorkCRDURL, serializer, apiextClient)
+	time.Sleep(5 * time.Second)
+	ctlr, err := binding.NewController(logger, config4json, config, "test-wds", nil)
+	if err != nil {
+		t.Fatalf("Failed to create controller: %s", err)
+	}
+	logger.Info("About to EnsureCRDs")
+	err = ctlr.EnsureCRDs(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Log("CRDs ensured")
+	err = ctlr.Start(ctx, 4)
+	if err != nil {
+		t.Fatal(err)
+	}
+	time.Sleep(5 * time.Second)
+
+	initNumInformers := len(ctlr.GetInformers())
+	initNumListers := len(ctlr.GetListers())
+	logger.Info("Check controller's initial watch", "initNumInformers", initNumInformers, "initNumListers", initNumListers)
+	if initNumInformers != initNumListers {
+		t.Fatalf("Mismatch, initNumInformers=%d, initNumListers=%d", initNumInformers, initNumListers)
+	}
+
+	crd, _ := createCRDFromLiteral(t, ctx, "CR1", crd1Literal, serializer, apiextClient)
+	crdKey := util.KeyForGroupVersionKind(crd.Spec.Group, crd.Spec.Versions[0].Name, crd.Spec.Names.Kind)
+
+	err = wait.PollUntilContextTimeout(ctx, 2*time.Second, time.Minute, false, func(ctx context.Context) (done bool, err error) {
+		informers, listers := ctlr.GetInformers(), ctlr.GetListers()
+		numInformers, numListers := len(informers), len(listers)
+		if numInformers != initNumInformers+1 {
+			logger.Info("Doesn't increase", "numInformers", numInformers, "initNumInformers", initNumInformers)
+			return false, nil
+		}
+		if numListers != initNumListers+1 {
+			logger.Info("Doesn't increase", "numListers", numListers, "initNumListers", initNumListers)
+			return false, nil
+		}
+		if numInformers != numListers {
+			logger.Info("Mismatch", "numInformers", numInformers, "numListers", numListers)
+			return false, nil
+		}
+		if _, ok := informers[crdKey]; !ok {
+			logger.Info("Informer is missing", "crdKey", crdKey)
+			return false, nil
+		}
+		if _, ok := listers[crdKey]; !ok {
+			logger.Info("Lister is missing", "crdKey", crdKey)
+			return false, nil
+		}
+		return true, nil
+	})
+	if err != nil {
+		t.Fatalf("Incorrect informers/listers for %s", crdKey)
+	}
+
+	apiextClient.ApiextensionsV1().CustomResourceDefinitions().Delete(ctx, crd.Name, metav1.DeleteOptions{})
+
+	err = wait.PollUntilContextTimeout(ctx, 2*time.Second, time.Minute, false, func(ctx context.Context) (done bool, err error) {
+		informers, listers := ctlr.GetInformers(), ctlr.GetListers()
+		numInformers, numListers := len(informers), len(listers)
+		if numInformers != initNumInformers {
+			logger.Info("Doesn't reset", "numInformers", numInformers, "initNumInformers", initNumInformers)
+			return false, nil
+		}
+		if numListers != initNumListers {
+			logger.Info("Doesn't reset", "numListers", numListers, "initNumListers", initNumListers)
+			return false, nil
+		}
+		if numInformers != numListers {
+			logger.Info("Mismatch", "numInformers", numInformers, "numListers", numListers)
+			return false, nil
+		}
+		if _, ok := informers[crdKey]; ok {
+			logger.Info("Informer still exists", "crdKey", crdKey)
+			return false, nil
+		}
+		if _, ok := listers[crdKey]; ok {
+			logger.Info("Lister still exists", "crdKey", crdKey)
+			return false, nil
+		}
+		return true, nil
+	})
+	if err != nil {
+		t.Fatalf("Incorrect informers/listers for %s", crdKey)
+	}
+
+	logger.Info("Success")
+}
+
+func createCRDFromLiteral(t *testing.T, ctx context.Context, kind, literal string, serializer *k8sjson.Serializer,
+	apiextClient apiextensionsclientset.Interface) (*apiextensionsapi.CustomResourceDefinition, error) {
+	crdAny, _, err := serializer.Decode([]byte(literal), &crdGVK, &apiextensionsapi.CustomResourceDefinition{})
+	if err != nil {
+		t.Fatalf("Failed to Decode %s CRD: %s", kind, err)
+	}
+	crd := crdAny.(*apiextensionsapi.CustomResourceDefinition)
+	created, err := apiextClient.ApiextensionsV1().CustomResourceDefinitions().Create(ctx, crd, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("Failed to create %s CRD: %s", kind, err)
+	}
+	return created, nil
+}
+
+const crd1Literal string = `
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: cr1s.synthetic-crd.com
+spec:
+  group: synthetic-crd.com
+  names:
+    kind: CR1
+    listKind: CR1List
+    plural: cr1s
+    singular: cr1
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true
+    schema:
+      openAPIV3Schema:
+        type: object
+        properties:
+          spec:
+            type: object
+            properties:
+              tier:
+                type: string
+                enum:
+                - Dedicated
+                - Shared
+                default: Shared
+          status:
+            type: object
+            properties:
+              phase:
+                type: string
+        required:
+        - spec
+    subresources:
+      status: {}
+`


### PR DESCRIPTION
## Summary
Large number of CRDs (e.g. in an OpenShift cluster) may cause issues like #1705 . This PR makes several changes to handle large number or CRDs.

### What's done in this PR
Three things are done in this PR:
1. Change the way that the binding controller handles CRD objects. Previously, for each CRD object, the controller computes the symmetric difference of existing resources and watched resources, in a holistic manner. That requires repeated requests to apiserver for discovery. With this change, the controller focuses on the CRD object only, in a incremental manner, which saves the requests to the apiserver and is more efficient.
2. Make the client-side rate limiter adaptive to: the number of GVRs in the apiserver when the binding controller starts. Together with 1, the client-side throttling is eliminated (see the 'Result' section below for details).
3. Write tests for the binding controller to test the changed behavior.

### Result
Before the change, I can observe the client-side throttling at the start of the binding controller.
- For a cluster which supports aggregated discovery, the throttling is primarily triggered when the reflectors are doing list and watch.
- For a cluster which doesn't support aggregated discovery, additional throttling (also longer waits) is trigger by the initial, intensive, reconciliation cycles for CRD objects.
```
I0228 14:55:43.122143  761795 request.go:629] Waited for 8.152398561s due to client-side throttling, not priority and fairness, request: GET:https://wds1.localtest.me:9443/apis/synthetic-crd.com/v1alpha1/cr11s?limit=500&resourceVersion=0
I0228 14:55:43.322485  761795 request.go:629] Waited for 8.352711234s due to client-side throttling, not priority and fairness, request: GET:https://wds1.localtest.me:9443/apis/synthetic-crd.com/v1alpha1/cr30s?limit=500&resourceVersion=0
I0228 14:55:43.522831  761795 request.go:629] Waited for 8.552861282s due to client-side throttling, not priority and fairness, request: GET:https://wds1.localtest.me:9443/apis/synthetic-crd.com/v1alpha1/cr72s?limit=500&resourceVersion=0
I0228 14:55:43.522865  761795 request.go:697] Waited for 8.552861282s due to client-side throttling, not priority and fairness, request: GET:https://wds1.localtest.me:9443/apis/synthetic-crd.com/v1alpha1/cr72s?limit=500&resourceVersion=0
I0228 14:55:43.722340  761795 request.go:629] Waited for 8.752317832s due to client-side throttling, not priority and fairness, request: GET:https://wds1.localtest.me:9443/apis/synthetic-crd.com/v1alpha1/cr25s?limit=500&resourceVersion=0
I0228 14:55:43.922619  761795 request.go:629] Waited for 8.952537192s due to client-side throttling, not priority and fairness, request: GET:https://wds1.localtest.me:9443/apis/synthetic-crd.com/v1alpha1/cr65s?limit=500&resourceVersion=0
I0228 14:55:44.122122  761795 request.go:629] Waited for 9.152017818s due to client-side throttling, not priority and fairness, request: GET:https://wds1.localtest.me:9443/apis/synthetic-crd.com/v1alpha1/cr21s?limit=500&resourceVersion=0
I0228 14:55:44.322700  761795 request.go:629] Waited for 9.352440908s due to client-side throttling, not priority and fairness, request: GET:https://wds1.localtest.me:9443/apis/synthetic-crd.com/v1alpha1/cr67s?limit=500&resourceVersion=0
I0228 14:55:44.521954  761795 request.go:629] Waited for 9.551632207s due to client-side throttling, not priority and fairness, request: GET:https://wds1.localtest.me:9443/apis/synthetic-crd.com/v1alpha1/cr39s?limit=500&resourceVersion=0
I0228 14:55:44.722205  761795 request.go:629] Waited for 9.750876057s due to client-side throttling, not priority and fairness, request: GET:https://wds1.localtest.me:9443/apis/synthetic-crd.com/v1alpha1/cr73s?limit=500&resourceVersion=0
I0228 14:55:44.722233  761795 request.go:697] Waited for 9.750876057s due to client-side throttling, not priority and fairness, request: GET:https://wds1.localtest.me:9443/apis/synthetic-crd.com/v1alpha1/cr73s?limit=500&resourceVersion=0
I0228 14:55:44.922686  761795 request.go:629] Waited for 9.951253423s due to client-side throttling, not priority and fairness, request: GET:https://wds1.localtest.me:9443/apis/synthetic-crd.com/v1alpha1/cr44s?limit=500&resourceVersion=0
I0228 14:55:45.122104  761795 request.go:629] Waited for 10.150663768s due to client-side throttling, not priority and fairness, request: GET:https://wds1.localtest.me:9443/apis/synthetic-crd.com/v1alpha1/cr76s?limit=500&resourceVersion=0
```
I synthesized the CRDs in group `synthetic-crd.com` above. I populated roughly 100 CRDs into the WDS.

After the changes, the client-side throttling is gone.

Closes #1705