### PR TITLE
🐛 Add cleaning for Job objects

### DIFF
--- a/pkg/transport/filtering/job.go
+++ b/pkg/transport/filtering/job.go
@@ -1,0 +1,41 @@
+/*
+Copyright 2024 The KubeStellar Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package filtering
+
+import (
+	"github.com/go-logr/logr"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+func cleanJob(logger logr.Logger, object *unstructured.Unstructured) {
+	objectU := object.UnstructuredContent()
+	podLabels, found, err := unstructured.NestedMap(objectU, "spec", "template", "metadata", "labels")
+	if err != nil || !found {
+		logger.V(3).Error(nil, "Job lacks expected template labels", "namespace", object.GetNamespace(), "name", object.GetName(), "found", found, "err", err)
+		return
+	}
+	delete(podLabels, "batch.kubernetes.io/controller-uid")
+	delete(podLabels, "batch.kubernetes.io/job-name")
+	delete(podLabels, "controller-uid")
+	delete(podLabels, "job-name")
+	err = unstructured.SetNestedMap(objectU, podLabels, "spec", "template", "metadata", "labels")
+	if err != nil {
+		logger.Error(err, "Inconceivable! Failed to update existing pod labels in Job", "namespace", object.GetNamespace(), "name", object.GetName())
+	}
+	object.SetUnstructuredContent(objectU)
+}

--- a/pkg/transport/filtering/job.go
+++ b/pkg/transport/filtering/job.go
@@ -17,28 +17,19 @@ limitations under the License.
 package filtering
 
 import (
-	"github.com/go-logr/logr"
-
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
-func cleanJob(logger logr.Logger, object *unstructured.Unstructured) {
+func cleanJob(object *unstructured.Unstructured) {
 	objectU := object.UnstructuredContent()
-	podLabels, found, err := unstructured.NestedMap(objectU, "spec", "template", "metadata", "labels")
+	podLabels, found, _ := unstructured.NestedMap(objectU, "spec", "template", "metadata", "labels")
 	if !found {
-		return
-	}
-	if err != nil {
-		logger.V(3).Error(nil, "Job object does not have expected struture, no spec.template.metadata.labels", "namespace", object.GetNamespace(), "name", object.GetName(), "err", err)
 		return
 	}
 	delete(podLabels, "batch.kubernetes.io/controller-uid")
 	delete(podLabels, "batch.kubernetes.io/job-name")
 	delete(podLabels, "controller-uid")
 	delete(podLabels, "job-name")
-	err = unstructured.SetNestedMap(objectU, podLabels, "spec", "template", "metadata", "labels")
-	if err != nil { // that condition can never be true
-		panic(err)
-	}
+	_ = unstructured.SetNestedMap(objectU, podLabels, "spec", "template", "metadata", "labels")
 	object.SetUnstructuredContent(objectU)
 }

--- a/pkg/transport/filtering/job.go
+++ b/pkg/transport/filtering/job.go
@@ -20,16 +20,55 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
+func badJobKey(key string) bool {
+	return key == "controller-uid" || key == "batch.kubernetes.io/controller-uid"
+}
+
 func cleanJob(object *unstructured.Unstructured) {
 	objectU := object.UnstructuredContent()
-	podLabels, found, _ := unstructured.NestedMap(objectU, "spec", "template", "metadata", "labels")
-	if !found {
-		return
+	changed := false
+	selector, foundSelector, _ := unstructured.NestedMap(objectU, "spec", "selector")
+	if foundSelector {
+		if matchLabels, found, _ := unstructured.NestedMap(selector, "matchLabels"); found {
+			if cleanLabels(matchLabels) {
+				_ = unstructured.SetNestedMap(objectU, matchLabels, "spec", "selector", "matchLabels")
+				changed = true
+			}
+		}
+		if matchExpressions, found, _ := unstructured.NestedSlice(selector, "matchExpressions"); found {
+			cleanedExpressions := make([]any, 0, len(matchExpressions))
+			for _, expr := range matchExpressions {
+				exprM := expr.(map[string]any)
+				key, _, _ := unstructured.NestedString(exprM, "key")
+				if !badJobKey(key) {
+					cleanedExpressions = append(cleanedExpressions, expr)
+				}
+			}
+			if len(cleanedExpressions) != len(matchExpressions) {
+				unstructured.SetNestedSlice(objectU, cleanedExpressions, "spec", "selector", "matchExpressions")
+				changed = true
+			}
+		}
 	}
-	delete(podLabels, "batch.kubernetes.io/controller-uid")
-	delete(podLabels, "batch.kubernetes.io/job-name")
-	delete(podLabels, "controller-uid")
-	delete(podLabels, "job-name")
-	_ = unstructured.SetNestedMap(objectU, podLabels, "spec", "template", "metadata", "labels")
-	object.SetUnstructuredContent(objectU)
+	podLabels, foundlabels, _ := unstructured.NestedMap(objectU, "spec", "template", "metadata", "labels")
+	if foundlabels {
+		if cleanLabels(podLabels) {
+			_ = unstructured.SetNestedMap(objectU, podLabels, "spec", "template", "metadata", "labels")
+			changed = true
+		}
+	}
+	if changed {
+		object.SetUnstructuredContent(objectU)
+	}
+}
+
+func cleanLabels(labels map[string]any) bool {
+	changed := false
+	for key := range labels {
+		if badJobKey(key) {
+			delete(labels, key)
+			changed = true
+		}
+	}
+	return changed
 }

--- a/pkg/transport/filtering/object_filtering_map.go
+++ b/pkg/transport/filtering/object_filtering_map.go
@@ -17,8 +17,6 @@ limitations under the License.
 package filtering
 
 import (
-	"github.com/go-logr/logr"
-
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -28,7 +26,7 @@ import (
 // The function cleans the specific fields in place (object is modified).
 // If the object was retrieved using a lister, it's the caller responsibility
 // to do a DeepCopy before calling this function.
-type cleanObjectSpecificsFunction func(logger logr.Logger, object *unstructured.Unstructured)
+type cleanObjectSpecificsFunction func(object *unstructured.Unstructured)
 
 func NewObjectFilteringMap() *ObjectFilteringMap {
 	filteringMap := map[schema.GroupVersionKind]cleanObjectSpecificsFunction{
@@ -45,11 +43,11 @@ type ObjectFilteringMap struct {
 	gvkToFilteringFunc map[schema.GroupVersionKind]cleanObjectSpecificsFunction // map from GVK to clean object function
 }
 
-func (filteringMap *ObjectFilteringMap) CleanObjectSpecifics(logger logr.Logger, object *unstructured.Unstructured) {
+func (filteringMap *ObjectFilteringMap) CleanObjectSpecifics(object *unstructured.Unstructured) {
 	filteringFunction, found := filteringMap.gvkToFilteringFunc[object.GetObjectKind().GroupVersionKind()]
 	if !found {
 		return // if no filtering function was defined for this gvk, do not clean any field
 	}
 	// otherwise, need to clean specific fields from this object
-	filteringFunction(logger, object)
+	filteringFunction(object)
 }

--- a/pkg/transport/filtering/object_filtering_map.go
+++ b/pkg/transport/filtering/object_filtering_map.go
@@ -17,6 +17,7 @@ limitations under the License.
 package filtering
 
 import (
+	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -30,8 +31,8 @@ type cleanObjectSpecificsFunction func(object *unstructured.Unstructured)
 
 func NewObjectFilteringMap() *ObjectFilteringMap {
 	filteringMap := map[schema.GroupVersionKind]cleanObjectSpecificsFunction{
-		corev1.SchemeGroupVersion.WithKind("Service"): cleanServiceFields,
-		corev1.SchemeGroupVersion.WithKind("Job"):     cleanJob,
+		corev1.SchemeGroupVersion.WithKind("Service"): cleanService,
+		batchv1.SchemeGroupVersion.WithKind("Job"):    cleanJob,
 	}
 
 	return &ObjectFilteringMap{
@@ -44,7 +45,8 @@ type ObjectFilteringMap struct {
 }
 
 func (filteringMap *ObjectFilteringMap) CleanObjectSpecifics(object *unstructured.Unstructured) {
-	filteringFunction, found := filteringMap.gvkToFilteringFunc[object.GetObjectKind().GroupVersionKind()]
+	gvk := object.GetObjectKind().GroupVersionKind()
+	filteringFunction, found := filteringMap.gvkToFilteringFunc[gvk]
 	if !found {
 		return // if no filtering function was defined for this gvk, do not clean any field
 	}

--- a/pkg/transport/filtering/object_filtering_map.go
+++ b/pkg/transport/filtering/object_filtering_map.go
@@ -17,6 +17,8 @@ limitations under the License.
 package filtering
 
 import (
+	"github.com/go-logr/logr"
+
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -26,11 +28,12 @@ import (
 // The function cleans the specific fields in place (object is modified).
 // If the object was retrieved using a lister, it's the caller responsibility
 // to do a DeepCopy before calling this function.
-type cleanObjectSpecificsFunction func(object *unstructured.Unstructured)
+type cleanObjectSpecificsFunction func(logger logr.Logger, object *unstructured.Unstructured)
 
 func NewObjectFilteringMap() *ObjectFilteringMap {
 	filteringMap := map[schema.GroupVersionKind]cleanObjectSpecificsFunction{
 		corev1.SchemeGroupVersion.WithKind("Service"): cleanServiceFields,
+		corev1.SchemeGroupVersion.WithKind("Job"):     cleanJob,
 	}
 
 	return &ObjectFilteringMap{
@@ -42,11 +45,11 @@ type ObjectFilteringMap struct {
 	gvkToFilteringFunc map[schema.GroupVersionKind]cleanObjectSpecificsFunction // map from GVK to clean object function
 }
 
-func (filteringMap *ObjectFilteringMap) CleanObjectSpecifics(object *unstructured.Unstructured) {
+func (filteringMap *ObjectFilteringMap) CleanObjectSpecifics(logger logr.Logger, object *unstructured.Unstructured) {
 	filteringFunction, found := filteringMap.gvkToFilteringFunc[object.GetObjectKind().GroupVersionKind()]
 	if !found {
 		return // if no filtering function was defined for this gvk, do not clean any field
 	}
 	// otherwise, need to clean specific fields from this object
-	filteringFunction(object)
+	filteringFunction(logger, object)
 }

--- a/pkg/transport/filtering/service.go
+++ b/pkg/transport/filtering/service.go
@@ -17,6 +17,8 @@ limitations under the License.
 package filtering
 
 import (
+	"github.com/go-logr/logr"
+
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
@@ -25,7 +27,7 @@ const (
 	preserveNodePortValue   = "nodeport"
 )
 
-func cleanServiceFields(object *unstructured.Unstructured) {
+func cleanServiceFields(logger logr.Logger, object *unstructured.Unstructured) {
 	// Fields to remove
 	fieldsToDelete := []string{"clusterIP", "clusterIPs", "ipFamilies",
 		"externalTrafficPolicy", "internalTrafficPolicy", "ipFamilyPolicy", "sessionAffinity"}

--- a/pkg/transport/filtering/service.go
+++ b/pkg/transport/filtering/service.go
@@ -17,8 +17,6 @@ limitations under the License.
 package filtering
 
 import (
-	"github.com/go-logr/logr"
-
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
@@ -27,7 +25,7 @@ const (
 	preserveNodePortValue   = "nodeport"
 )
 
-func cleanServiceFields(logger logr.Logger, object *unstructured.Unstructured) {
+func cleanServiceFields(object *unstructured.Unstructured) {
 	// Fields to remove
 	fieldsToDelete := []string{"clusterIP", "clusterIPs", "ipFamilies",
 		"externalTrafficPolicy", "internalTrafficPolicy", "ipFamilyPolicy", "sessionAffinity"}

--- a/pkg/transport/filtering/service.go
+++ b/pkg/transport/filtering/service.go
@@ -25,7 +25,7 @@ const (
 	preserveNodePortValue   = "nodeport"
 )
 
-func cleanServiceFields(object *unstructured.Unstructured) {
+func cleanService(object *unstructured.Unstructured) {
 	// Fields to remove
 	fieldsToDelete := []string{"clusterIP", "clusterIPs", "ipFamilies",
 		"externalTrafficPolicy", "internalTrafficPolicy", "ipFamilyPolicy", "sessionAffinity"}

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -2,3 +2,4 @@
 
 - [multi-cluster deployment](multi-cluster-deployment)
 - [singleton status return](singleton-status)
+- [Object cleaning](object-fields-filtering)

--- a/test/e2e/object-fields-filtering/use-kubestellar.sh
+++ b/test/e2e/object-fields-filtering/use-kubestellar.sh
@@ -18,7 +18,7 @@ set -e # exit on error
 
 :
 : -------------------------------------------------------------------------
-: "Create a bindingpolicy in wds1 to deliver a service to one WEC."
+: "Create a bindingpolicy in wds1 to deliver a Service and a Job object to one WEC."
 :
 kubectl --context wds1 apply -f - <<EOF
 apiVersion: control.kubestellar.io/v1alpha1
@@ -35,7 +35,7 @@ EOF
 
 :
 : -------------------------------------------------------------------------
-: "Deploy the service"
+: "Define the API objects in wds1"
 :
 kubectl --context wds1 apply -f - <<EOF
 apiVersion: v1
@@ -60,11 +60,34 @@ spec:
       port: 80
       targetPort: 80
   type: NodePort
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: pi
+  namespace: object-filtering
+  labels:
+    app.kubernetes.io/name: object-fields-filtering-test
+spec:
+  template:
+    spec:
+      containers:
+      - name: pi
+        image: perl:5.34.0
+        command: ["perl",  "-Mbignum=bpi", "-wle", "print bpi(2000)"]
+      restartPolicy: Never
+  backoffLimit: 4
 EOF
 
 :
 : -------------------------------------------------------------------------
-: "Verify that the service has been created in cluster1"
+: "Verify that the Service object has been created in cluster1"
 :
 wait-for-cmd 'kubectl --context cluster1 get services -n object-filtering hello-world'
-: "SUCCESS: Confirmed service created on cluster1."
+:
+: -------------------------------------------------------------------------
+: "Verify that the Job object has been created in cluster1"
+:
+wait-for-cmd 'kubectl --context cluster1 get jobs -n object-filtering pi'
+:
+: "SUCCESS: Confirmed Service and Job created on cluster1."


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
This PR updates the generic transport controller code to remove the apiserver-maintained fields of a JobSpec.

The corresponding test enhancement will be done in #1824 or follow-on.

## Related issue(s)

This is an alternative to #1803, which we decided not to pursue (in favor of #1812).

Fixes #1766 
