### PR TITLE
🐛 replaced wget with curl in e2e setup

### DIFF
--- a/test/e2e/common/setup-kubestellar.sh
+++ b/test/e2e/common/setup-kubestellar.sh
@@ -92,7 +92,7 @@ cd "${SRC_DIR}/../../.." ## go up to KubeStellar directory
 KUBESTELLAR_DIR="$(pwd)"
 ## this is a temp solution - run as executble process. this should be replaced to run as pod, ideally using helm
 OCM_TRANSPORT_PLUGIN_RELEASE="0.1.0-rc2"
-wget https://github.com/kubestellar/ocm-transport-plugin/archive/refs/tags/v${OCM_TRANSPORT_PLUGIN_RELEASE}.tar.gz
+curl -s -O https://github.com/kubestellar/ocm-transport-plugin/archive/refs/tags/v${OCM_TRANSPORT_PLUGIN_RELEASE}.tar.gz
 tar -xf v${OCM_TRANSPORT_PLUGIN_RELEASE}.tar.gz
 rm -rf v${OCM_TRANSPORT_PLUGIN_RELEASE}.tar.gz
 cd ocm-transport-plugin-${OCM_TRANSPORT_PLUGIN_RELEASE}

--- a/test/e2e/common/setup-kubestellar.sh
+++ b/test/e2e/common/setup-kubestellar.sh
@@ -92,9 +92,7 @@ cd "${SRC_DIR}/../../.." ## go up to KubeStellar directory
 KUBESTELLAR_DIR="$(pwd)"
 ## this is a temp solution - run as executble process. this should be replaced to run as pod, ideally using helm
 OCM_TRANSPORT_PLUGIN_RELEASE="0.1.0-rc2"
-curl -s -O https://github.com/kubestellar/ocm-transport-plugin/archive/refs/tags/v${OCM_TRANSPORT_PLUGIN_RELEASE}.tar.gz
-tar -xf v${OCM_TRANSPORT_PLUGIN_RELEASE}.tar.gz
-rm -rf v${OCM_TRANSPORT_PLUGIN_RELEASE}.tar.gz
+curl -sL https://github.com/kubestellar/ocm-transport-plugin/archive/refs/tags/v${OCM_TRANSPORT_PLUGIN_RELEASE}.tar.gz | tar xz
 cd ocm-transport-plugin-${OCM_TRANSPORT_PLUGIN_RELEASE}
 OCM_TRANSPORT_PLUGIN_DIR="$(pwd)"
 pwd


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

This PR replaces the use of wget in e2e kubestellar setup with curl.
I've added the flag -s (silent, no progress bar) and -O (write the output on file system, same as wget does).

## Related issue(s)

Fixes #1833 
