### PR TITLE
:sparkles: Reduce agent footprint for OCM transport

### DIFF
--- a/docs/content/direct/example-wecs.md
+++ b/docs/content/direct/example-wecs.md
@@ -13,7 +13,7 @@ register them with the hub as descibed in the
    for cluster in "${clusters[@]}"; do
       kind create cluster --name ${cluster}
       kubectl config rename-context kind-${cluster} ${cluster}
-      clusteradm --context imbs1 get token | grep '^clusteradm join' | sed "s/<cluster_name>/${cluster}/" | awk '{print $0 " --context '${cluster}' '${flags}'"}' | sh
+      clusteradm --context imbs1 get token | grep '^clusteradm join' | sed "s/<cluster_name>/${cluster}/" | awk '{print $0 " --context '${cluster}' --singleton '${flags}'"}' | sh
    done   
    ```
 

--- a/test/e2e/common/setup-kubestellar.sh
+++ b/test/e2e/common/setup-kubestellar.sh
@@ -118,7 +118,7 @@ function create_cluster() {
   cluster=$1
   kind create cluster --name $cluster
   kubectl config rename-context kind-${cluster} $cluster
-  clusteradm --context imbs1 get token | grep '^clusteradm join' | sed "s/<cluster_name>/${cluster}/" | awk '{print $0 " --context '${cluster}' --force-internal-endpoint-lookup"}' | sh
+  clusteradm --context imbs1 get token | grep '^clusteradm join' | sed "s/<cluster_name>/${cluster}/" | awk '{print $0 " --context '${cluster}' --singleton --force-internal-endpoint-lookup"}' | sh
 }
 
 create_cluster cluster1


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
Add `--singleton` flag in `clusteradm join` command.
According to OCM docs https://open-cluster-management.io/getting-started/installation/register-a-cluster/ :
"To reduce the footprint of agent in the managed cluster, singleton mode is introduced since v0.12.0. In the singleton mode, the work and registration agent will be run as a single pod in the managed cluster."

Without `--singleton` flag:
```
kubectl --context cluster1 get deployments -n open-cluster-management-agent
NAME                            READY   UP-TO-DATE   AVAILABLE   AGE
klusterlet-registration-agent   1/1     1            1           19h
klusterlet-work-agent           1/1     1            1           19h
```
With `--singleton` flag:
```
kubectl --context cluster1 get deployments -n open-cluster-management-agent
NAME               READY   UP-TO-DATE   AVAILABLE   AGE
klusterlet-agent   1/1     1            1           81m
```
## Related issue(s)

Fixes https://github.com/kubestellar/kubestellar/issues/1540
