### PR TITLE
:bug: fix race-conditions over Binding controller field maps

### DIFF
--- a/pkg/binding/bindingpolicy.go
+++ b/pkg/binding/bindingpolicy.go
@@ -19,7 +19,6 @@ package binding
 import (
 	"context"
 	"fmt"
-	"k8s.io/client-go/tools/cache"
 
 	"github.com/go-logr/logr"
 
@@ -33,6 +32,7 @@ import (
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/tools/cache"
 	"k8s.io/klog/v2"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 

--- a/pkg/binding/controller.go
+++ b/pkg/binding/controller.go
@@ -321,12 +321,12 @@ func (c *Controller) run(ctx context.Context, workers int, cListers chan interfa
 
 	// wait for all informers caches to be synced
 	// then send listers for the status controller to use
-	if err := c.informers.Iterator(func(_ schema.GroupVersionResource, informer cache.SharedIndexInformer) (bool, error) {
+	if err := c.informers.Iterator(func(_ schema.GroupVersionResource, informer cache.SharedIndexInformer) error {
 		if ok := cache.WaitForCacheSync(ctx.Done(), informer.HasSynced); !ok {
-			return false, fmt.Errorf("failed to wait for caches to sync")
+			return fmt.Errorf("failed to wait for caches to sync")
 		}
 
-		return true, nil // continue iterating
+		return nil // continue iterating
 	}); err != nil {
 		return err // no need to wrap because it is already clear
 	}

--- a/pkg/binding/controller.go
+++ b/pkg/binding/controller.go
@@ -87,10 +87,12 @@ type Controller struct {
 	dynamicClient    dynamic.Interface      // used for CRD, Binding[Policy], workload
 	kubernetesClient kubernetes.Interface   // used for Namespaces, and Discovery
 
-	extClient             apiextensionsclientset.Interface // used for CRD
-	listers               map[schema.GroupVersionResource]cache.GenericLister
-	informers             map[schema.GroupVersionResource]cache.SharedIndexInformer
-	stoppers              map[schema.GroupVersionResource]chan struct{}
+	extClient apiextensionsclientset.Interface // used for CRD
+
+	listers   util.ConcurrentMap[schema.GroupVersionResource, cache.GenericLister]
+	informers util.ConcurrentMap[schema.GroupVersionResource, cache.SharedIndexInformer]
+	stoppers  util.ConcurrentMap[schema.GroupVersionResource, chan struct{}]
+
 	bindingPolicyResolver BindingPolicyResolver
 	workqueue             workqueue.RateLimitingInterface
 	initializedTs         time.Time
@@ -205,9 +207,9 @@ func makeController(logger logr.Logger,
 		dynamicClient:         dynamicClient,
 		kubernetesClient:      kubernetesClient,
 		extClient:             extClient,
-		listers:               make(map[schema.GroupVersionResource]cache.GenericLister),
-		informers:             make(map[schema.GroupVersionResource]cache.SharedIndexInformer),
-		stoppers:              make(map[schema.GroupVersionResource]chan struct{}),
+		listers:               util.NewConcurrentMap[schema.GroupVersionResource, cache.GenericLister](),
+		informers:             util.NewConcurrentMap[schema.GroupVersionResource, cache.SharedIndexInformer](),
+		stoppers:              util.NewConcurrentMap[schema.GroupVersionResource, chan struct{}](),
 		bindingPolicyResolver: NewBindingPolicyResolver(),
 		workqueue:             workqueue.NewRateLimitingQueue(ratelimiter),
 		allowedGroupsSet:      allowedGroupsSet,
@@ -283,7 +285,7 @@ func (c *Controller) run(ctx context.Context, workers int, cListers chan interfa
 			if informable {
 				gvr := gv.WithResource(resource.Name)
 				informer := informerFactory.ForResource(gvr).Informer()
-				c.informers[gvr] = informer
+				c.informers.Set(gvr, informer)
 
 				// add the event handler functions
 				informer.AddEventHandler(cache.ResourceEventHandlerFuncs{
@@ -303,7 +305,7 @@ func (c *Controller) run(ctx context.Context, workers int, cListers chan interfa
 				})
 
 				// create and index the lister
-				c.listers[gvr] = cache.NewGenericLister(informer.GetIndexer(), gvr.GroupResource())
+				c.listers.Set(gvr, cache.NewGenericLister(informer.GetIndexer(), gvr.GroupResource()))
 
 				// run the informer
 				// we need to be able to stop informers for APIs (CRDs) that are removed
@@ -311,7 +313,7 @@ func (c *Controller) run(ctx context.Context, workers int, cListers chan interfa
 				// instead than informerFactory.Start(ctx.Done())
 				stopper := make(chan struct{})
 				defer close(stopper)
-				c.stoppers[gvr] = stopper
+				c.stoppers.Set(gvr, stopper)
 				go informer.Run(stopper)
 			}
 		}
@@ -319,11 +321,17 @@ func (c *Controller) run(ctx context.Context, workers int, cListers chan interfa
 
 	// wait for all informers caches to be synced
 	// then send listers for the status controller to use
-	for _, informer := range c.informers {
+	for key := range c.informers.Keys() {
+		informer, found := c.informers.Get(key)
+		if !found {
+			// key was removed from the map, skip
+			continue
+		}
 		if ok := cache.WaitForCacheSync(ctx.Done(), informer.HasSynced); !ok {
 			return fmt.Errorf("failed to wait for caches to sync")
 		}
 	}
+
 	c.logger.Info("All caches synced")
 	cListers <- c.listers
 	c.logger.Info("Sent listers")
@@ -550,8 +558,8 @@ func (c *Controller) reconcile(ctx context.Context, objIdentifier util.ObjectIde
 }
 
 func (c *Controller) getObjectFromIdentifier(objIdentifier util.ObjectIdentifier) (runtime.Object, error) {
-	lister := c.listers[objIdentifier.GVR()]
-	if lister == nil {
+	lister, found := c.listers.Get(objIdentifier.GVR())
+	if !found {
 		return nil, fmt.Errorf("could not get lister for gvr: %s", objIdentifier.GVR())
 	}
 
@@ -570,11 +578,11 @@ func isBeingDeleted(obj runtime.Object) bool {
 	return mObj.GetDeletionTimestamp() != nil
 }
 
-func (c *Controller) GetListers() map[schema.GroupVersionResource]cache.GenericLister {
+func (c *Controller) GetListers() util.ConcurrentMap[schema.GroupVersionResource, cache.GenericLister] {
 	return c.listers
 }
 
-func (c *Controller) GetInformers() map[schema.GroupVersionResource]cache.SharedIndexInformer {
+func (c *Controller) GetInformers() util.ConcurrentMap[schema.GroupVersionResource, cache.SharedIndexInformer] {
 	return c.informers
 }
 

--- a/pkg/util/concurrent-map.go
+++ b/pkg/util/concurrent-map.go
@@ -1,8 +1,25 @@
+/*
+Copyright 2024 The KubeStellar Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package util
 
 import (
-	"k8s.io/apimachinery/pkg/util/sets"
 	"sync"
+
+	"k8s.io/apimachinery/pkg/util/sets"
 )
 
 // ConcurrentMap is a thread-safe map.

--- a/pkg/util/concurrent-map.go
+++ b/pkg/util/concurrent-map.go
@@ -84,7 +84,6 @@ func (mm *rwMutexMap[K, V]) Get(key K) (V, bool) {
 
 // Iterator iterates over the map and calls the given function for each
 // key/value pair sequentially.
-// If the given function returns false, the iteration is stopped.
 // If the given function returns an error, the iteration is stopped and
 // the error is returned.
 // During the iteration, the map must not be mutated by the given function.

--- a/pkg/util/concurrent-map.go
+++ b/pkg/util/concurrent-map.go
@@ -33,12 +33,11 @@ type ConcurrentMap[K comparable, V any] interface {
 	Get(key K) (V, bool)
 	// Iterator iterates over the map and calls the given function for each
 	// key/value pair sequentially.
-	// If the given function returns false, the iteration is stopped.
 	// If the given function returns an error, the iteration is stopped and
 	// the error is returned.
 	// During the iteration, the map must not be mutated by the given function.
 	// If the map is mutated during the iteration, the behavior is undefined.
-	Iterator(yield func(K, V) (bool, error)) error
+	Iterator(yield func(K, V) error) error
 	// Len returns the number of items in the map.
 	Len() int
 }
@@ -90,12 +89,12 @@ func (mm *rwMutexMap[K, V]) Get(key K) (V, bool) {
 // the error is returned.
 // During the iteration, the map must not be mutated by the given function.
 // If the map is mutated during the iteration, the behavior is undefined.
-func (mm *rwMutexMap[K, V]) Iterator(yield func(K, V) (bool, error)) error {
+func (mm *rwMutexMap[K, V]) Iterator(yield func(K, V) error) error {
 	mm.RLock()
 	defer mm.RUnlock()
 
 	for k, v := range mm.m {
-		if ok, err := yield(k, v); !ok || err != nil {
+		if err := yield(k, v); err != nil {
 			return err
 		}
 	}

--- a/pkg/util/concurrent-map.go
+++ b/pkg/util/concurrent-map.go
@@ -1,0 +1,79 @@
+package util
+
+import (
+	"k8s.io/apimachinery/pkg/util/sets"
+	"sync"
+)
+
+// ConcurrentMap is a thread-safe map.
+type ConcurrentMap[K comparable, V any] interface {
+	// Set sets the value for the given key.
+	Set(key K, value V)
+	// Remove removes the value for the given key.
+	Remove(key K)
+	// Get gets the value for the given key.
+	// The second return value is true if the key exists in the map, otherwise false.
+	// Getting a key does not guarantee that no other goroutine will also work with it.
+	Get(key K) (V, bool)
+	// Keys returns a copy of all keys in the map at the time of the call.
+	// Nothing guarantees that when used, these keys are still in the map.
+	Keys() sets.Set[K]
+	// Len returns the number of items in the map.
+	Len() int
+}
+
+// NewConcurrentMap creates a new ConcurrentMap.
+func NewConcurrentMap[K comparable, V any]() ConcurrentMap[K, V] {
+	return &rwMutexMap[K, V]{
+		m: make(map[K]V),
+	}
+}
+
+type rwMutexMap[K comparable, V any] struct {
+	sync.RWMutex
+	m map[K]V
+}
+
+// Set sets the value for the given key.
+func (mm *rwMutexMap[K, V]) Set(key K, value V) {
+	mm.Lock()
+	defer mm.Unlock()
+
+	mm.m[key] = value
+}
+
+// Remove removes the value for the given key.
+func (mm *rwMutexMap[K, V]) Remove(key K) {
+	mm.Lock()
+	defer mm.Unlock()
+
+	delete(mm.m, key)
+}
+
+// Get gets the value for the given key.
+// The second return value is true if the key exists in the map, otherwise false.
+// Getting a key does not guarantee that no other goroutine will also work with it.
+func (mm *rwMutexMap[K, V]) Get(key K) (V, bool) {
+	mm.RLock()
+	defer mm.RUnlock()
+
+	value, ok := mm.m[key]
+	return value, ok
+}
+
+// Keys returns a copy of all keys in the map at the time of the call.
+// Nothing guarantees that when used, these keys are still in the map.
+func (mm *rwMutexMap[K, V]) Keys() sets.Set[K] {
+	mm.RLock()
+	defer mm.RUnlock()
+
+	return sets.KeySet(mm.m)
+}
+
+// Len returns the number of items in the map.
+func (mm *rwMutexMap[K, V]) Len() int {
+	mm.RLock()
+	defer mm.RUnlock()
+
+	return len(mm.m)
+}

--- a/test/integration/controller-manager/crd-handling_test.go
+++ b/test/integration/controller-manager/crd-handling_test.go
@@ -99,8 +99,8 @@ func TestCRDHandling(t *testing.T) {
 	}
 	time.Sleep(5 * time.Second)
 
-	initNumInformers := len(ctlr.GetInformers())
-	initNumListers := len(ctlr.GetListers())
+	initNumInformers := ctlr.GetInformers().Len()
+	initNumListers := ctlr.GetListers().Len()
 	logger.Info("Check controller's initial watch", "initNumInformers", initNumInformers, "initNumListers", initNumListers)
 	if initNumInformers != initNumListers {
 		t.Fatalf("Mismatch, initNumInformers=%d, initNumListers=%d", initNumInformers, initNumListers)
@@ -112,7 +112,7 @@ func TestCRDHandling(t *testing.T) {
 
 	err = wait.PollUntilContextTimeout(ctx, 2*time.Second, time.Minute, false, func(ctx context.Context) (done bool, err error) {
 		informers, listers := ctlr.GetInformers(), ctlr.GetListers()
-		numInformers, numListers := len(informers), len(listers)
+		numInformers, numListers := informers.Len(), listers.Len()
 		if numInformers != initNumInformers+2 {
 			logger.Info("Doesn't increase", "numInformers", numInformers, "initNumInformers", initNumInformers)
 			return false, nil
@@ -125,19 +125,19 @@ func TestCRDHandling(t *testing.T) {
 			logger.Info("Mismatch", "numInformers", numInformers, "numListers", numListers)
 			return false, nil
 		}
-		if _, ok := informers[watched]; !ok {
+		if _, found := informers.Get(watched); !found {
 			logger.Info("Informer is missing", "gvk", watched)
 			return false, nil
 		}
-		if _, ok := listers[watched]; !ok {
+		if _, found := listers.Get(watched); !found {
 			logger.Info("Lister is missing", "gvk", watched)
 			return false, nil
 		}
-		if _, ok := informers[notWatched]; ok {
+		if _, found := informers.Get(notWatched); found {
 			logger.Info("Informer unexpectedly appears", "gvk", notWatched)
 			return false, nil
 		}
-		if _, ok := listers[notWatched]; ok {
+		if _, found := listers.Get(notWatched); found {
 			logger.Info("Lister unexpectedly appears", "gvk", notWatched)
 			return false, nil
 		}
@@ -151,7 +151,7 @@ func TestCRDHandling(t *testing.T) {
 
 	err = wait.PollUntilContextTimeout(ctx, 2*time.Second, time.Minute, false, func(ctx context.Context) (done bool, err error) {
 		informers, listers := ctlr.GetInformers(), ctlr.GetListers()
-		numInformers, numListers := len(informers), len(listers)
+		numInformers, numListers := informers.Len(), listers.Len()
 		if numInformers != initNumInformers {
 			logger.Info("Doesn't reset", "numInformers", numInformers, "initNumInformers", initNumInformers)
 			return false, nil
@@ -164,19 +164,19 @@ func TestCRDHandling(t *testing.T) {
 			logger.Info("Mismatch", "numInformers", numInformers, "numListers", numListers)
 			return false, nil
 		}
-		if _, ok := informers[watched]; ok {
+		if _, found := informers.Get(watched); found {
 			logger.Info("Informer still exists", "gvk", watched)
 			return false, nil
 		}
-		if _, ok := listers[watched]; ok {
+		if _, found := listers.Get(watched); found {
 			logger.Info("Lister still exists", "gvk", watched)
 			return false, nil
 		}
-		if _, ok := informers[notWatched]; ok {
+		if _, found := informers.Get(notWatched); found {
 			logger.Info("Informer still unexpectedly appears", "gvk", notWatched)
 			return false, nil
 		}
-		if _, ok := listers[notWatched]; ok {
+		if _, found := listers.Get(notWatched); found {
 			logger.Info("Lister still unexpectedly appears", "gvk", notWatched)
 			return false, nil
 		}


### PR DESCRIPTION
## Summary
This PR fixes race conditions over controller field maps that may occur due to concurrent read/writes across goroutines.

The maps are:
```
listers               map[schema.GroupVersionResource]cache.GenericLister
informers             map[schema.GroupVersionResource]cache.SharedIndexInformer
stoppers              map[schema.GroupVersionResource]chan struct{}
```

When a CRD is being handled by a worker, the following call may be made:
```
if len(toStartList) > 0 {
	go c.startInformersForNewAPIResources(ctx, toStartList)
}
```

Where `c.startInformersForNewAPIResources` contains writes to these maps. 
Which means that there are 2 levels of concurrency here: different workers may handle different CRD objects, and each handling may contain executions of the above inner block.

Therefore, this PR introduces a new thread-safe interface `ConcurrentMap` which is implemented with a RWLock protected map.

### Notes 
- This change alone is sufficient since the now proper use of the controller/workqueue pattern makes sure that no two goroutines will work on the same keys in these maps.
- While these race conditions were not observed in practice (due to the lack of high-concurrency tests over CRD objects), they are apparent in the code.

## Related issue(s)

Fixes #1860 
