### PR TITLE
:bug: undo the assumption of individual delta events in binding controller

### DIFF
--- a/pkg/binding/controller.go
+++ b/pkg/binding/controller.go
@@ -388,10 +388,7 @@ func shouldSkipUpdate(old, new interface{}) bool {
 	if newMObj.GetResourceVersion() == oldMObj.GetResourceVersion() {
 		return true
 	}
-	// avoid enqueing events when adding finalizers to bindingpolicy
-	if util.IsBindingPolicy(new) && (len(newMObj.GetFinalizers()) > len(oldMObj.GetFinalizers())) {
-		return true
-	}
+
 	return false
 }
 


### PR DESCRIPTION
## Summary
In `shouldSkipUpdate` which is called in informers update events handling, the code was assuming that individual deltas get individual events. Then based on this assumption, a binding-policy would get skipped if the update involved increasing the size of the object finalizers list.

This can cause the skipping of the handling of binding-policies that satisfy the latter, while containing other changes.


## Related issue(s)
This issue was found and opened by @MikeSpreitzer 

Fixes #1841
