### PR TITLE
:bug: fix Binding cluster selection implementation

### DIFF
--- a/test/e2e/multi-cluster-deployment/use-kubestellar.sh
+++ b/test/e2e/multi-cluster-deployment/use-kubestellar.sh
@@ -28,7 +28,9 @@ metadata:
   name: nginx-bindingpolicy
 spec:
   clusterSelectors:
-  - matchLabels: {"location-group":"edge"}
+  - matchLabels: {"name":"cluster1"}
+  - matchExpressions:
+    - { key: name, operator: In, values: [cluster2, cluster3] }
   downsync:
   - objectSelectors:
     - matchLabels: {"app.kubernetes.io/name":"nginx"}

--- a/test/e2e/multi-cluster-deployment/use-kubestellar.sh
+++ b/test/e2e/multi-cluster-deployment/use-kubestellar.sh
@@ -30,7 +30,7 @@ spec:
   clusterSelectors:
   - matchLabels: {"name":"cluster1"}
   - matchExpressions:
-    - { key: name, operator: In, values: [cluster2, cluster3] }
+    - { key: name, operator: In, values: [cluster2] }
   downsync:
   - objectSelectors:
     - matchLabels: {"app.kubernetes.io/name":"nginx"}

--- a/test/e2e/multi-cluster-deployment/use-kubestellar.sh
+++ b/test/e2e/multi-cluster-deployment/use-kubestellar.sh
@@ -28,9 +28,7 @@ metadata:
   name: nginx-bindingpolicy
 spec:
   clusterSelectors:
-  - matchLabels: {"name":"cluster1"}
-  - matchExpressions:
-    - { key: name, operator: In, values: [cluster2] }
+  - matchLabels: {"location-group":"edge"}
   downsync:
   - objectSelectors:
     - matchLabels: {"app.kubernetes.io/name":"nginx"}


### PR DESCRIPTION
## Summary
This PR fixes the implementation of ocm::FindClustersBySelectors to support OR in BindingPolicy spec's `clusterSelectors`, as well as support complex label selectors such as [set-based selectors](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#set-based-requirement).

## Related issue(s)

Fixes #1699
Fixes #1655 
