### PR TITLE
✨ Improve the Status Controller

### DIFF
--- a/cmd/controller-manager/main.go
+++ b/cmd/controller-manager/main.go
@@ -148,22 +148,22 @@ func main() {
 		os.Exit(1)
 	}
 
-	if err := bindingController.Start(ctx, workers); err != nil {
+	cListers := make(chan interface{}, 1)
+
+	if err := bindingController.Start(ctx, workers, cListers); err != nil {
 		setupLog.Error(err, "error starting the binding controller")
 		os.Exit(1)
 	}
 
 	// check if status add-on present and if yes start the status controller
-	if util.CheckWorkStatusIPresent(imbsRestConfig) {
-		listers := bindingController.GetListers()
-		informers := bindingController.GetInformers()
-		statusController, err := status.NewController(wdsRestConfig, imbsRestConfig, wdsName, listers, informers)
+	if util.CheckWorkStatusPresence(imbsRestConfig) {
+		statusController, err := status.NewController(wdsRestConfig, imbsRestConfig, wdsName)
 		if err != nil {
 			setupLog.Error(err, "unable to create status controller")
 			os.Exit(1)
 		}
 
-		if err := statusController.Start(ctx, workers); err != nil {
+		if err := statusController.Start(ctx, workers, cListers); err != nil {
 			setupLog.Error(err, "error starting the status controller")
 			os.Exit(1)
 		}

--- a/pkg/status/controller.go
+++ b/pkg/status/controller.go
@@ -62,16 +62,13 @@ type Controller struct {
 	bindingPolicyInformer cache.SharedIndexInformer
 	bindingPolicyLister   cache.GenericLister
 	workqueue             workqueue.RateLimitingInterface
-	// all wds listers/informers are required to retrieve objects and update status
-	// without having to re-create new caches for this coontroller
-	listers   map[schema.GroupVersionResource]cache.GenericLister
-	informers map[schema.GroupVersionResource]cache.SharedIndexInformer
+	// all wds listers are used to retrieve objects and update status
+	// without having to re-create new caches for this controller
+	listers map[schema.GroupVersionResource]cache.GenericLister
 }
 
 // Create a new  status controller
-func NewController(wdsRestConfig *rest.Config, imbsRestConfig *rest.Config,
-	wdsName string, listers map[schema.GroupVersionResource]cache.GenericLister,
-	informers map[schema.GroupVersionResource]cache.SharedIndexInformer) (*Controller, error) {
+func NewController(wdsRestConfig *rest.Config, imbsRestConfig *rest.Config, wdsName string) (*Controller, error) {
 	ratelimiter := workqueue.NewMaxOfRateLimiter(
 		workqueue.NewItemExponentialFailureRateLimiter(5*time.Millisecond, 1000*time.Second),
 		&workqueue.BucketRateLimiter{Limiter: rate.NewLimiter(rate.Limit(50), 300)},
@@ -108,20 +105,18 @@ func NewController(wdsRestConfig *rest.Config, imbsRestConfig *rest.Config,
 		imbsDynClient:  imbsDynClient,
 		imbsKubeClient: imbsKubeClient,
 		workqueue:      workqueue.NewRateLimitingQueue(ratelimiter),
-		listers:        listers,
-		informers:      informers,
 	}
 
 	return controller, nil
 }
 
 // Start the status controller
-func (c *Controller) Start(parentCtx context.Context, workers int) error {
+func (c *Controller) Start(parentCtx context.Context, workers int, cListers chan interface{}) error {
 	logger := klog.FromContext(parentCtx).WithName(controllerName)
 	ctx := klog.NewContext(parentCtx, logger)
 	errChan := make(chan error, 1)
 	go func() {
-		errChan <- c.run(ctx, workers)
+		errChan <- c.run(ctx, workers, cListers)
 	}()
 
 	// check for errors at startup, after all started we let it continue
@@ -135,29 +130,15 @@ func (c *Controller) Start(parentCtx context.Context, workers int) error {
 }
 
 // Invoked by Start() to run the translator
-func (c *Controller) run(ctx context.Context, workers int) error {
+func (c *Controller) run(ctx context.Context, workers int, cListers chan interface{}) error {
 	defer c.workqueue.ShutDown()
 
 	// start informers
 	go c.runBindingPolicyInformer(ctx)
 	go c.runWorkStatusInformer(ctx)
 
-	// wait for all informers caches to be synced
-	c.logger.Info("waiting for caches to sync")
-
-	// we can't use cache.WaitForCacheSync here because informers are started by the binding controller
-	// and may not be started yet, thus WaitForCacheSync throws an exception. PollUntilContextCancel is
-	// a safer approach here.
-	for _, informer := range c.informers {
-		wait.PollUntilContextCancel(ctx, time.Second, true, func(ctx context.Context) (bool, error) {
-			if informer != nil && informer.HasSynced() {
-				return true, nil
-			}
-			return false, nil
-		})
-	}
-
-	c.logger.Info("All caches synced")
+	c.listers = (<-cListers).(map[schema.GroupVersionResource]cache.GenericLister)
+	c.logger.Info("Received listers")
 
 	c.logger.Info("Starting workers", "count", workers)
 	for i := 0; i < workers; i++ {

--- a/pkg/util/unstructured.go
+++ b/pkg/util/unstructured.go
@@ -153,7 +153,7 @@ func GetWorkStatusStatus(workStatus runtime.Object) (map[string]interface{}, err
 	return status, nil
 }
 
-func CheckWorkStatusIPresent(config *rest.Config) bool {
+func CheckWorkStatusPresence(config *rest.Config) bool {
 	discoveryClient, err := discovery.NewDiscoveryClientForConfig(config)
 	if err != nil {
 		return false

--- a/test/integration/controller-manager/crd-handling_test.go
+++ b/test/integration/controller-manager/crd-handling_test.go
@@ -93,7 +93,7 @@ func TestCRDHandling(t *testing.T) {
 		t.Fatal(err)
 	}
 	t.Log("CRDs ensured")
-	err = ctlr.Start(ctx, 4)
+	err = ctlr.Start(ctx, 4, make(chan interface{}, 1))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/test/integration/controller-manager/matching_test.go
+++ b/test/integration/controller-manager/matching_test.go
@@ -150,7 +150,7 @@ func TestMatching(t *testing.T) {
 		t.Fatal(err)
 	}
 	t.Log("CRDs ensured")
-	err = ctlr.Start(ctx, 4)
+	err = ctlr.Start(ctx, 4, make(chan interface{}, 1))
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
## Summary
This PR improves the status controller in two aspects.
1. Idiomatic synchronization between the status controller and the binding controller using a channel. So that the status controller doesn't need to check everyone of the per-resource informers for cache sync. Instead it proceeds immediately when the binding controller knows that all caches are synced.
2. Removal of watch to bindingpolicies.

## Related issue(s)
Closes #1862 
