### PR TITLE
🌱 Remove irrelevant hostAliases for transport-controller pod

### DIFF
--- a/scripts/deploy-transport-controller.sh
+++ b/scripts/deploy-transport-controller.sh
@@ -18,7 +18,6 @@
 export WDS_NAME="$1" ## first argument is WDS name
 export IMBS_NAME="$2" ## second argument is IMBS name
 export TRANSPORT_CONTROLLER_IMAGE="${3:-ghcr.io/kubestellar/ocm-transport-plugin/transport-controller:0.1.0-rc4}" ## third argument is transport controller image
-export HOST_IP=$(ifconfig | grep -w inet | awk '{ print $2 }' | grep -v 127.0.0.1 | head -1)
 export IMAGE_PULL_POLICY="${IMAGE_PULL_POLICY:=Always}"
 
 # generate from template and env vars and then apply a configmap and a deployment for transport-controller
@@ -103,9 +102,6 @@ spec:
           - name: shared-volume
             mountPath: /mnt/shared
             readOnly: true
-      hostAliases:
-      - ip: ${HOST_IP}
-        hostnames: [ "${WDS_NAME}.localtest.me", "${IMBS_NAME}.localtest.me" ]
       volumes:
       - name: shared-volume
         emptyDir: {}


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
This PR simplifies `scripts/deploy-transport-controller.sh` by removing the provision of hostAliases for `wds1.localtest.me` and `imbs1.localtest.me`. These host aliases are not needed. The init containers in the transport-controller Deployment extract the _in-cluster_ kubeconfigs for wds1 and imbs1, and these use Kubernetes Service domain names to reach the relevant apiserver. It is the _external_ kubeconfigs that use `<something>.localtest.me`. But the transport-controller belongs in the kubeflex hosting cluster (as long as we are using kubeflex at all, and those init containers are specific to using kubeflex), so the external kubeconfigs are irrelevant.

## Related issue(s)

Fixes #
