### PR TITLE
:sparkles: Set the singleton status label value to be true or false

### DIFF
--- a/pkg/binding/selectors.go
+++ b/pkg/binding/selectors.go
@@ -130,12 +130,12 @@ func (c *Controller) updateResolutions(ctx context.Context, objIdentifier util.O
 	}
 
 	// if the binding-policies matching cycles end and the object is not selected by a singleton binding,
-	// we need to remove the singleton label from the object if it exists.
+	// we need to update the singleton label value for the object.
 	// NOTE that this takes care of the case where the object was previously selected by a singleton binding
 	// and is no longer selected by any binding.
 	if !objBeingDeleted && !isSelectedBySingletonBinding {
 		if err := c.handleSingletonLabel(ctx, obj, objGVR, util.BindingPolicyLabelSingletonStatusValueUnset); err != nil {
-			return fmt.Errorf("failed to remove singleton label from object: %w", err)
+			return fmt.Errorf("failed to update singleton label for object: %w", err)
 		}
 	}
 

--- a/pkg/util/labels.go
+++ b/pkg/util/labels.go
@@ -28,9 +28,12 @@ import (
 )
 
 const (
-	// BindingPolicyLabelSingletonStatusKey is the key for the singleton status reporting
-	// requirement. The value should be the bindingpolicy that is selecting the labeled object.
+	// BindingPolicyLabelSingletonStatusKey is the key for the singleton status reporting requirement.
 	BindingPolicyLabelSingletonStatusKey = "managed-by.kubestellar.io/singletonstatus"
+	// BindingPolicyLabelSingletonStatusValueSet is the value when the status reporting is required.
+	BindingPolicyLabelSingletonStatusValueSet = "true"
+	// BindingPolicyLabelSingletonStatusValueUnset is the value when the status reporting is not required.
+	BindingPolicyLabelSingletonStatusValueUnset = "false"
 )
 
 func GetBindingPolicyGVR() schema.GroupVersionResource {


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
Today the singleton status label value is set to the `BindingPolicy` name and this value is unused. This PR propose to set it to true/false and then the status controller will remove the status from the workload object when singleton status label value is set to `false` in the `WorkStatus`, and will add the status if it's `true`.

## Related issue(s)
https://github.com/kubestellar/kubestellar/issues/1838
https://github.com/kubestellar/kubestellar/issues/1856

Fixes #
Together with https://github.com/kubestellar/ocm-status-addon/pull/42, should fix https://github.com/kubestellar/kubestellar/issues/1838