### PR TITLE
📖 Remove use of `watch` command in example-wecs.md

### DIFF
--- a/docs/content/direct/example-wecs.md
+++ b/docs/content/direct/example-wecs.md
@@ -20,14 +20,13 @@ register them with the hub as descibed in the
    The `clusteradm` command grabs a token from the hub (`imbs1` context), and constructs the command to apply the new cluster
    to be registered as a managed cluster on the OCM hub.
 
-2. Issue the command:
+2. Repeatedly issue the command:
 
    ```shell
-   watch kubectl --context imbs1 get csr
+   kubectl --context imbs1 get csr
    ```
 
-   and wait until the certificate signing requests (CSR) for both cluster1 and cluster2 are created, then
-   ctrl+C.
+   until you see that the certificate signing requests (CSR) for both cluster1 and cluster2 exist.
    Note that the CSRs condition is supposed to be `Pending` until you approve them in step 4.
 
 3. Once the CSRs are created approve the csrs to complete the cluster registration with the command:


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
This PR modifies one step in example-wecs.md to replace the use of the `watch` command with English language saying to repeat the `kubectl` command.  This is good because `watch` is not built into all OSes (for example, it is not in MacOS Sonoma) and is not listed among the prerequisites for using KubeStellar. This is the only place that the `watch` command is used in KubeStellar instructions. We _could_ instead add `watch` as a prerequisite, but I think that is more heavyweight approach.

## Related issue(s)

Fixes #
