### PR TITLE
✨ remove make test from make ko-build-local

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -170,7 +170,7 @@ run: manifests generate fmt vet ## Run a controller from your host.
 	go run ./cmd/controller-manager/main.go $(ARGS)
 
 .PHONY: ko-build-local
-ko-build-local: test ## Build local container image with ko
+ko-build-local: ## Build local container image with ko 
 	$(shell (docker version | { ! grep -qi podman; } ) || echo "DOCKER_HOST=unix://$$HOME/.local/share/containers/podman/machine/qemu/podman.sock ") KO_DOCKER_REPO=ko.local ko build -B ./cmd/${CMD_NAME} -t ${IMAGE_TAG} --platform linux/${ARCH}
 	docker tag ko.local/${CMD_NAME}:${IMAGE_TAG} ${IMAGE_REPO}:${IMAGE_TAG}
 


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
Currently make ko-build-local also make test which takes up to 4 minutes on CICD.  I am removing the make test part of ko-build-local.

## Related issue(s)

Fixes #1893 
