### PR TITLE
🌱 Make unit tests not require envtest

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -160,8 +160,8 @@ vet: ## Run go vet against code.
 	go vet ./...
 
 .PHONY: test
-test: manifests generate fmt vet envtest ## Run tests.
-	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(LOCALBIN) -p path)" go test ./api/... ./cmd/... ./pkg/... -coverprofile cover.out
+test: manifests generate fmt vet ## Run tests.
+	go test ./api/... ./cmd/... ./pkg/... -coverprofile cover.out
 
 ##@ Build
 


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
This test removes the dependency of our _unit_ tests on `envtest`. This is good because our unit tests are not relying on `envtest` and because `envtest` is (a) designed to support integration tests rather than unit tests and (b) made for working with controller-runtime based controllers but our controllers are not full-fledged controller-runtime based controllers and our trend is to make them less so rather than more.

## Related issue(s)

Fixes #
