### PR TITLE
🐛 Clean metadata.generateName in workload objects before wrapping

### DIFF
--- a/pkg/transport/generic_transport_controller.go
+++ b/pkg/transport/generic_transport_controller.go
@@ -604,6 +604,7 @@ func cleanObject(object *unstructured.Unstructured) *unstructured.Unstructured {
 	objectCopy.SetSelfLink("")
 	objectCopy.SetResourceVersion("")
 	objectCopy.SetUID("")
+	objectCopy.SetGenerateName("")
 
 	annotations := objectCopy.GetAnnotations()
 	delete(annotations, "kubectl.kubernetes.io/last-applied-configuration")

--- a/test/e2e/ginkgo/multiple_cluster_deployment_test.go
+++ b/test/e2e/ginkgo/multiple_cluster_deployment_test.go
@@ -251,6 +251,18 @@ var _ = ginkgo.Describe("end to end testing", func() {
 					}}})
 			util.ValidateNumServices(ctx, wec1, ns, 1)
 		})
+		ginkgo.It("properly starts a job with metadata.generateName", func() {
+			util.CreateJob(ctx, wds, ns, "hello-job", "hello-job")
+			util.CreateBindingPolicy(ctx, ksWds, "hello-job",
+				[]metav1.LabelSelector{
+					{MatchLabels: map[string]string{"name": "cluster1"}},
+				},
+				[]ksapi.DownsyncObjectTest{
+					{ObjectSelectors: []metav1.LabelSelector{
+						{MatchLabels: map[string]string{"app.kubernetes.io/name": "hello-job"}},
+					}}})
+			util.ValidateNumJobs(ctx, wec1, ns, 1)
+		})
 	})
 
 	ginkgo.Context("resiliency testing", func() {


### PR DESCRIPTION
## Summary
The background of this PR is documented in #1852. In the discussions of #1852, we agreed with an approach to (a) let the names be generated in WDSes, (b) clean the `.metadata.generateName` field in workload objects; (3) wrap the objects with name already generated for transport.

This PR implements the approach.

## Related issue(s)
Fixes #1852 
