### PR TITLE
🐛 Replace include statement with sylink, so fragment refs work

### DIFF
--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -1,4 +1,3 @@
-<!--governance-start-->
 # KubeStellar Project Governance
 
 The KubeStellar project is dedicated to solving challenges stemming from
@@ -162,4 +161,3 @@ Governance require a 2/3 vote of all Maintainers.
 
 Changes to this Governance and its supporting documents may be approved by a 
 2/3 vote of the Maintainers.
-<!--governance-end-->

--- a/docs/content/Contribution guidelines/governance.md
+++ b/docs/content/Contribution guidelines/governance.md
@@ -1,5 +1,1 @@
-{%
-   include-markdown "../../../GOVERNANCE.md"
-   start="<!--governance-start-->"
-   end="<!--governance-end-->"
-%}
+../../../GOVERNANCE.md


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
This PR replaces the use of `include-markdown` in `docs/content/Contribution guidelines/governance.md` with making that file into a symlink. Apparently mkdocs was not rendering the fragment references correctly.

## Related issue(s)

Fixes #1929
