### PR TITLE
:bug: Filter and update status if not subresource

### DIFF
--- a/pkg/status/controller.go
+++ b/pkg/status/controller.go
@@ -328,8 +328,16 @@ func updateObjectStatus(ctx context.Context, objRef *util.SourceRef, status map[
 
 	if objRef.Namespace == "" {
 		_, err = wdsDynClient.Resource(gvr).UpdateStatus(ctx, unstrObj, metav1.UpdateOptions{})
+		// if resource not found it may mean no status subresource - try to update the whole resource
+		if errors.IsNotFound(err) {
+			_, err = wdsDynClient.Resource(gvr).Update(ctx, unstrObj, metav1.UpdateOptions{})
+		}
 	} else {
 		_, err = wdsDynClient.Resource(gvr).Namespace(objRef.Namespace).UpdateStatus(ctx, unstrObj, metav1.UpdateOptions{})
+		// if resource not found it may mean no status subresource - try to update the whole resource
+		if errors.IsNotFound(err) {
+			_, err = wdsDynClient.Resource(gvr).Namespace(objRef.Namespace).Update(ctx, unstrObj, metav1.UpdateOptions{})
+		}
 	}
 	if err != nil {
 		return fmt.Errorf("failed to update status: %w", err)

--- a/pkg/status/controller.go
+++ b/pkg/status/controller.go
@@ -328,18 +328,14 @@ func updateObjectStatus(ctx context.Context, objRef *util.SourceRef, status map[
 
 	if objRef.Namespace == "" {
 		_, err = wdsDynClient.Resource(gvr).UpdateStatus(ctx, unstrObj, metav1.UpdateOptions{})
-		// if resource not found it may mean no status subresource - try to update the whole resource
-		if errors.IsNotFound(err) {
-			_, err = wdsDynClient.Resource(gvr).Update(ctx, unstrObj, metav1.UpdateOptions{})
-		}
 	} else {
 		_, err = wdsDynClient.Resource(gvr).Namespace(objRef.Namespace).UpdateStatus(ctx, unstrObj, metav1.UpdateOptions{})
-		// if resource not found it may mean no status subresource - try to update the whole resource
-		if errors.IsNotFound(err) {
-			_, err = wdsDynClient.Resource(gvr).Namespace(objRef.Namespace).Update(ctx, unstrObj, metav1.UpdateOptions{})
-		}
 	}
 	if err != nil {
+		// if resource not found it may mean no status subresource - try to patch the status
+		if errors.IsNotFound(err) {
+			return util.PatchStatus(ctx, unstrObj, status, objRef.Namespace, gvr, wdsDynClient)
+		}
 		return fmt.Errorf("failed to update status: %w", err)
 	}
 

--- a/pkg/transport/generic_transport_controller.go
+++ b/pkg/transport/generic_transport_controller.go
@@ -610,6 +610,9 @@ func cleanObject(object *unstructured.Unstructured) *unstructured.Unstructured {
 	delete(annotations, "kubectl.kubernetes.io/last-applied-configuration")
 	objectCopy.SetAnnotations(annotations)
 
+	// OCM removes the status only if subresource. We remove it in all cases.
+	unstructured.RemoveNestedField(objectCopy.Object, "status")
+
 	// clean fields specific to the concrete object.
 	objectsFilter.CleanObjectSpecifics(objectCopy)
 

--- a/pkg/transport/generic_transport_controller.go
+++ b/pkg/transport/generic_transport_controller.go
@@ -610,7 +610,7 @@ func cleanObject(object *unstructured.Unstructured) *unstructured.Unstructured {
 	delete(annotations, "kubectl.kubernetes.io/last-applied-configuration")
 	objectCopy.SetAnnotations(annotations)
 
-	// OCM removes the status only if subresource. We remove it in all cases.
+	// remove the status field.
 	unstructured.RemoveNestedField(objectCopy.Object, "status")
 
 	// clean fields specific to the concrete object.


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
1. Filter out the status when down syncing a resource. The OCM transport does not filter out the status which is not a subresource(for example Argo Workflow resource).

2. The status controller should update the status regardless to subresource or not.

## Related issue(s)

Fixes https://github.com/kubestellar/kubestellar/issues/1894
