### PR TITLE
🐛 change a reconcile log message text and level

### DIFF
--- a/pkg/binding/controller.go
+++ b/pkg/binding/controller.go
@@ -512,12 +512,12 @@ func (c *Controller) processNextWorkItem(ctx context.Context) bool {
 		if err := c.reconcile(ctx, objIdentifier); err != nil {
 			// Put the item back on the workqueue to handle any transient errors.
 			c.workqueue.AddRateLimited(objIdentifier)
-			return fmt.Errorf("error syncing object (identifier: %#v): %s, requeuing", objIdentifier, err.Error())
+			return fmt.Errorf("error reconciling object (identifier: %#v): %s, requeuing", objIdentifier, err.Error())
 		}
 		// Finally, if no error occurs we Forget this item so it does not
 		// get queued again until another change happens.
 		c.workqueue.Forget(objIdentifier)
-		logger.V(2).Info("Successfully synced", "objectIdentifier", objIdentifier)
+		logger.V(4).Info("Successfully reconciled", "objectIdentifier", objIdentifier)
 		return nil
 	}(item)
 


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
When we call reconcile in the binding controller we log messages that use the term sync.  I changed these to reconcile as well as lowered the logging level from 2 to 4.

## Related issue(s)

Fixes #1932 
