### PR TITLE
📖 Remove confusion between "latest" and "stable"

### DIFF
--- a/docs/overrides/main.html
+++ b/docs/overrides/main.html
@@ -60,9 +60,13 @@
 {% endblock %}
 
 {% block outdated %}
-  You're not viewing the stable release.
+  You're not viewing the latest release.
   <a href="{{ '../latest/' ~ base_url }}">
-    <strong>Click here to go to the stable release</strong>
+    <strong>Click here to go to the latest release</strong>
+  </a>
+  Also, FYI, 
+  <a href="{{ '../stable/' ~ base_url }}">
+    <strong>Click here to go to the latest stable release</strong>
   </a>
 {% endblock %}
 


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
This PR changes the warning message that appears on the website in certain circumstances, to not confuse "latest" with "stable".

## Related issue(s)

Fixes #
