### PR TITLE
📖 Stable is release-0.21.1

### DIFF
--- a/docs/overrides/main.html
+++ b/docs/overrides/main.html
@@ -60,9 +60,13 @@
 {% endblock %}
 
 {% block outdated %}
-  You're not viewing the stable release.
+  You're not viewing the latest release.
   <a href="{{ '../latest/' ~ base_url }}">
-    <strong>Click here to go to the stable release</strong>
+    <strong>Click here to go to the latest release</strong>
+  </a>
+  Also, FYI, 
+  <a href="{{ '../stable/' ~ base_url }}">
+    <strong>Click here to go to the latest stable release</strong>
   </a>
 {% endblock %}
 

--- a/docs/scripts/deploy-docs.sh
+++ b/docs/scripts/deploy-docs.sh
@@ -22,6 +22,8 @@ set -o xtrace
 REPO_ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)
 cd "$REPO_ROOT/docs"
 
+STABLE_RELEASE=release-0.21.1
+
 if [[ "${GITHUB_EVENT_NAME:-}" == "pull_request" || "${GITHUB_EVENT_NAME:-}" == "pull_request_target" ]]; then
   # For PRs, we don't want to use GITHUB_REF_NAME, which will be something like merge/1234; instead, we want to use
   # the branch the PR is targeting, such as main or release-0.11
@@ -60,7 +62,7 @@ if [[ -n "${CI:-}" ]]; then
     if [ $VERSION == "main" ]; then
       ALIAS_OPTIONS+=(--update-aliases "$VERSION" "unstable")
       ALIAS_OPTIONS_LATEST+=(--update-aliases "$VERSION" "latest")
-    elif [ $VERSION == "release-0.3" ]; then
+    elif [ $VERSION == "$STABLE_RELEASE" ]; then
       ALIAS_OPTIONS+=(--update-aliases "$VERSION" "stable")
     else
       ALIAS_OPTIONS+=(--update-aliases "$VERSION")
@@ -74,7 +76,7 @@ if [[ -n "${CI:-}" ]]; then
     if [ $VERSION == "main" ]; then
       ALIAS_OPTIONS+=(--update-aliases "$VERSION" "unstable")
       ALIAS_OPTIONS_LATEST+=(--update-aliases "$VERSION" "latest")
-    elif [ $VERSION == "release-0.3" ]; then
+    elif [ $VERSION == "$STABLE_RELEASE" ]; then
       ALIAS_OPTIONS+=(--update-aliases "$VERSION" "stable")
     else
       ALIAS_OPTIONS+=(--update-aliases "$VERSION")


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
This PR updates deploy-docs.sh to consider release-0.21.1 to be the stable release, instead of 0.3.

BTW, a better fix would take the stable number from the VERSION file.

This PR is based in #1948. We can ether just merge this one, or merge that one first and then I will rebase this one.

## Related issue(s)

Fixes #
