### PR TITLE
🐛 Improve test/e2e/ginkgo and its README

### DIFF
--- a/.github/workflows/pr-test-e2e.yml
+++ b/.github/workflows/pr-test-e2e.yml
@@ -60,7 +60,7 @@ jobs:
           TEST_FLAGS: ${{ github.event.inputs.testFlags }}
         run: |
           cd test/e2e/ginkgo 
-          KFLEX_DISABLE_CHATTY=true KUBECONFIG=~/.kube/config ginkgo -v $TEST_FLAGS
+          KFLEX_DISABLE_CHATTY=true ginkgo -vv --trace --no-color $TEST_FLAGS
 
       - name: show kubeconfig contexts
         if: always()

--- a/test/e2e/ginkgo/README.md
+++ b/test/e2e/ginkgo/README.md
@@ -19,12 +19,29 @@ The end to end testing includes:
 ## Running the tests
 To install Ginkgo, follow the instructions in [Ginkgo's getting started](https://onsi.github.io/ginkgo/#getting-started).
 
-To execute these tests, issue `ginkgo -v`.  This will make a local image based and run the end to end tests.
+To execute these tests, issue the following command. This will make a local image and run the end to end tests. Omit the `--no-color` if you want pretty terminal output; omit the `KFLEX_DISABLE_CHATTY=true` to get progress logging from kubeflex.
 
-To test the latest release image, issue `ginkgo -v -- -released`
+```shell
+KFLEX_DISABLE_CHATTY=true ginkgo --vv --trace --no-color
+```
 
-To test a specific test use ginkgo's --focus parameter.  For example, `ginkgo -v --focus "survives ITS vcluster coming down"`
+To test the latest release image, pass `--released` to the test. For example:
 
-To skip the cleanup and setup phase use the -skip-setup flag as follows: `ginkgo -v -- -skip-setup`
+```shell
+KFLEX_DISABLE_CHATTY=true ginkgo --vv --trace --no-color -- -released
+```
+
+To test a specific test use ginkgo's `--focus` parameter.  For example:
+
+```shell
+KFLEX_DISABLE_CHATTY=true ginkgo --vv --trace --no-color --focus "survives ITS vcluster coming down"
+```
+
+To skip the cleanup and setup phase, pass `-skip-setup` to the test. For example:
+
+```shell
+KFLEX_DISABLE_CHATTY=true ginkgo --vv --trace --no-color -- -skip-setup
+```
+
 
 

--- a/test/util/util.go
+++ b/test/util/util.go
@@ -20,7 +20,6 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"os"
 	"os/exec"
 	"strings"
 	"time"
@@ -50,7 +49,7 @@ const (
 
 func GetConfig(context string) *rest.Config {
 	config, err := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(
-		&clientcmd.ClientConfigLoadingRules{ExplicitPath: os.Getenv("KUBECONFIG")},
+		clientcmd.NewDefaultClientConfigLoadingRules(),
 		&clientcmd.ConfigOverrides{CurrentContext: context}).ClientConfig()
 	gomega.ExpectWithOffset(1, err).NotTo(gomega.HaveOccurred())
 	return config


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
This PR fixes three problems with test/e2e/ginkgo. This PR removes the strange requirement to set the envar KUBECONFIG to its default value. This PR also makes the workflow that runs the test more verbose, to give contributors a chance to debug problems. This PR also adds helpful clues to the README for the ginkgo tests.

## Related issue(s)

This PR addresses 3 of the 4 problems in #1951
