### PR TITLE
✨ Optimizations against client-side throttling

### DIFF
--- a/cmd/controller-manager/main.go
+++ b/cmd/controller-manager/main.go
@@ -148,6 +148,11 @@ func main() {
 		os.Exit(1)
 	}
 
+	if err := bindingController.AppendKSResources(ctx); err != nil {
+		setupLog.Error(err, "error appending KubeStellar resources to discovered lists")
+		os.Exit(1)
+	}
+
 	cListers := make(chan interface{}, 1)
 
 	if err := bindingController.Start(ctx, workers, cListers); err != nil {

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -21,9 +21,7 @@ import (
 	"os"
 
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
 
 	tenancyv1alpha1 "github.com/kubestellar/kubeflex/api/v1alpha1"
@@ -35,16 +33,6 @@ func GetClient() *client.Client {
 	config := config.GetConfigOrDie()
 	scheme := runtime.NewScheme()
 
-	httpClient, err := rest.HTTPClientFor(config)
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "Error creating HTTPClient: %v\n", err)
-		os.Exit(1)
-	}
-	mapper, err := apiutil.NewDiscoveryRESTMapper(config, httpClient)
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "Error creating NewDiscoveryRESTMapper: %v\n", err)
-		os.Exit(1)
-	}
 	if err := controlv1alpha1.AddToScheme(scheme); err != nil {
 		fmt.Fprintf(os.Stderr, "Error adding to schema: %v\n", err)
 		os.Exit(1)
@@ -53,7 +41,7 @@ func GetClient() *client.Client {
 		fmt.Fprintf(os.Stderr, "Error adding to schema: %v\n", err)
 		os.Exit(1)
 	}
-	c, err := client.New(config, client.Options{Scheme: scheme, Mapper: mapper})
+	c, err := client.New(config, client.Options{Scheme: scheme})
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Error creating client: %v\n", err)
 		os.Exit(1)

--- a/pkg/crd/crds.go
+++ b/pkg/crd/crds.go
@@ -57,7 +57,7 @@ const (
 )
 
 func ApplyCRDs(ctx context.Context, dynamicClient dynamic.Interface, clientset kubernetes.Interface, clientsetExt apiextensionsclientset.Interface, logger logr.Logger) error {
-	ctxLimited, cancel := context.WithTimeout(ctx, 30*time.Second)
+	ctxLimited, cancel := context.WithTimeout(ctx, time.Minute)
 	defer cancel()
 
 	crds, err := readCRDs()

--- a/pkg/crd/crds.go
+++ b/pkg/crd/crds.go
@@ -91,16 +91,15 @@ func ApplyCRDs(ctx context.Context, dynamicClient dynamic.Interface, clientset k
 
 // Convert GroupVersionKind to GroupVersionResource
 func groupVersionKindToResource(clientset kubernetes.Interface, gvk schema.GroupVersionKind, logger logr.Logger) (*schema.GroupVersionResource, error) {
-	resourceList, err := clientset.Discovery().ServerPreferredResources()
+	gv := gvk.GroupVersion().String()
+	list, err := clientset.Discovery().ServerResourcesForGroupVersion(gv)
 	if err != nil {
-		logger.Info("Did not get all preferred resources", "error", err.Error())
+		logger.Info("Error getting APIResourceList", "gv", gv, "error", err.Error())
 	}
 
-	for _, resource := range resourceList {
-		for _, apiResource := range resource.APIResources {
-			if apiResource.Kind == gvk.Kind && resource.GroupVersion == gvk.GroupVersion().String() {
-				return &schema.GroupVersionResource{Group: gvk.Group, Version: gvk.Version, Resource: apiResource.Name}, nil
-			}
+	for _, apiResource := range list.APIResources {
+		if apiResource.Kind == gvk.Kind {
+			return &schema.GroupVersionResource{Group: gvk.Group, Version: gvk.Version, Resource: apiResource.Name}, nil
 		}
 	}
 

--- a/pkg/util/unstructured.go
+++ b/pkg/util/unstructured.go
@@ -28,20 +28,19 @@ import (
 )
 
 const (
-	CRDKind                              = "CustomResourceDefinition"
-	AnyVersion                           = "*"
-	ServiceVersion                       = "v1"
-	ServiceKind                          = "Service"
-	BindingPolicyKind                    = "BindingPolicy"
-	BindingPolicyResource                = "bindingpolicies"
-	BindingKind                          = "Binding"
-	BindingResource                      = "bindings"
-	WorkStatusGroup                      = "control.kubestellar.io"
-	WorkStatusVersion                    = "v1alpha1"
-	WorkStatusResource                   = "workstatuses"
-	AnnotationToPreserveValuesKey        = "annotations.kubestellar.io/preserve"
-	PreserveNodePortValue                = "nodeport"
-	UnableToRetrieveCompleteAPIListError = "unable to retrieve the complete list of server APIs"
+	CRDKind                       = "CustomResourceDefinition"
+	AnyVersion                    = "*"
+	ServiceVersion                = "v1"
+	ServiceKind                   = "Service"
+	BindingPolicyKind             = "BindingPolicy"
+	BindingPolicyResource         = "bindingpolicies"
+	BindingKind                   = "Binding"
+	BindingResource               = "bindings"
+	WorkStatusGroup               = "control.kubestellar.io"
+	WorkStatusVersion             = "v1alpha1"
+	WorkStatusResource            = "workstatuses"
+	AnnotationToPreserveValuesKey = "annotations.kubestellar.io/preserve"
+	PreserveNodePortValue         = "nodeport"
 )
 
 // this type is used in status-addon, which we cannot import due to conflicting versions

--- a/test/integration/controller-manager/crd-handling_test.go
+++ b/test/integration/controller-manager/crd-handling_test.go
@@ -93,6 +93,11 @@ func TestCRDHandling(t *testing.T) {
 		t.Fatal(err)
 	}
 	t.Log("CRDs ensured")
+	err = ctlr.AppendKSResources(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Log("Appended KS resources to discovered lists")
 	err = ctlr.Start(ctx, 4, make(chan interface{}, 1))
 	if err != nil {
 		t.Fatal(err)

--- a/test/integration/controller-manager/matching_test.go
+++ b/test/integration/controller-manager/matching_test.go
@@ -150,6 +150,11 @@ func TestMatching(t *testing.T) {
 		t.Fatal(err)
 	}
 	t.Log("CRDs ensured")
+	err = ctlr.AppendKSResources(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Log("Appended KS resources to discovered lists")
 	err = ctlr.Start(ctx, 4, make(chan interface{}, 1))
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
This PR introduces a few optimizations to address the client-side throttling.

From the binding controller's [log](https://github.com/kubestellar/kubestellar/files/14652779/cm.log), I identified two sources which independently trigger client-side throttling.
1. The API discovery of the WDS apiserver when the binding controller ensures the two KS CRDs (bindingpolicise, bindings). This source is tracked by #1916. This kind of client-side throttling is so severe that the binding controller just failed to start because of context timeout (for applying CRDs).  
1. The API discovery of the WDS apiserver when the binding controller retrieves the kubeconfigs of the WDS and the IMBS. This source is tracked by #1953.

This PR handles both sources, as follows.
1. For source 1, this PR replaces the full API discovery (call `ServerPreferredResources()`) with bare minimum discovery within a GroupVersion. Also, just for robustness, the context timeout for applying CRDs is extended.
1. For source 2, this PR kills the discoveries when the binding controller retrieves the kubeconfigs.

_In addition_ to the changes above, this PR also introduces another optimization to the extreme, which is reduce the full discovery to exactly once during the lifecycle of a binding controller.

All the changes of this PR are baked into quay.io/junatibm/controller-manager:1711133606. @cwiklik kindly helped me to test this image in his same environment as #1916. In the test, we were happy to see that the binding controller now starts successfully in seconds and all the throttling went away:
```
👉 Downloads $ oc cluster-info
Kubernetes control plane is running at https://c115-e.us-south.containers.cloud.ibm.com:30829

To further debug and diagnose cluster problems, use 'kubectl cluster-info dump'.
👉 Downloads $ oc -n wds2-system logs kubestellar-controller-manager-856c5ff888-w8rjn | head -n 100
I0323 16:34:38.681752       1 main.go:81] "Command line flag" logger="setup" name="add_dir_header" value="false"
I0323 16:34:38.681840       1 main.go:81] "Command line flag" logger="setup" name="alsologtostderr" value="false"
I0323 16:34:38.681849       1 main.go:81] "Command line flag" logger="setup" name="api-groups" value="workload.codeflare.dev,workloads.kueue.x-k8s.io,batch"
I0323 16:34:38.681857       1 main.go:81] "Command line flag" logger="setup" name="health-probe-bind-address" value=":8081"
I0323 16:34:38.681863       1 main.go:81] "Command line flag" logger="setup" name="kubeconfig" value=""
I0323 16:34:38.681869       1 main.go:81] "Command line flag" logger="setup" name="leader-elect" value="true"
I0323 16:34:38.681876       1 main.go:81] "Command line flag" logger="setup" name="log_backtrace_at" value=":0"
I0323 16:34:38.681882       1 main.go:81] "Command line flag" logger="setup" name="log_dir" value=""
I0323 16:34:38.681895       1 main.go:81] "Command line flag" logger="setup" name="log_file" value=""
I0323 16:34:38.681902       1 main.go:81] "Command line flag" logger="setup" name="log_file_max_size" value="1800"
I0323 16:34:38.681907       1 main.go:81] "Command line flag" logger="setup" name="logtostderr" value="true"
I0323 16:34:38.681913       1 main.go:81] "Command line flag" logger="setup" name="metrics-bind-address" value="127.0.0.1:8080"
I0323 16:34:38.681918       1 main.go:81] "Command line flag" logger="setup" name="one_output" value="false"
I0323 16:34:38.681923       1 main.go:81] "Command line flag" logger="setup" name="skip_headers" value="false"
I0323 16:34:38.681929       1 main.go:81] "Command line flag" logger="setup" name="skip_log_headers" value="false"
I0323 16:34:38.681935       1 main.go:81] "Command line flag" logger="setup" name="stderrthreshold" value="2"
I0323 16:34:38.681941       1 main.go:81] "Command line flag" logger="setup" name="v" value="2"
I0323 16:34:38.681948       1 main.go:81] "Command line flag" logger="setup" name="vmodule" value=""
I0323 16:34:38.681953       1 main.go:81] "Command line flag" logger="setup" name="wds-label" value=""
I0323 16:34:38.681959       1 main.go:81] "Command line flag" logger="setup" name="wds-name" value="wds2"
I0323 16:34:38.682581       1 listener.go:44] "Metrics server is starting to listen" logger="controller-runtime.metrics" addr="127.0.0.1:8080"
I0323 16:34:38.683009       1 main.go:122] "Getting config for WDS" logger="setup" name="wds2"
I0323 16:34:38.683030       1 kubeconfig.go:64] "using label" logger="setup" key="kflex.kubestellar.io/cptype" value="wds"
I0323 16:34:38.683438       1 kubeconfig.go:84] "waiting for cp with label" logger="setup" key="kflex.kubestellar.io/cptype" value="wds"
I0323 16:34:38.751916       1 main.go:128] "Got config for WDS" logger="setup" name="wds2"
I0323 16:34:38.751939       1 main.go:131] "Getting config for IMBS" logger="setup"
I0323 16:34:38.753961       1 kubeconfig.go:84] "waiting for cp with label" logger="setup" key="kflex.kubestellar.io/cptype" value="imbs"
I0323 16:34:38.812203       1 main.go:137] "Got config for IMBS" logger="setup" name="imbs1"
I0323 16:34:38.928888       1 controller.go:173] "Discovery" logger="Binding" numAPIResourceLists=149 err=null
I0323 16:34:38.928933       1 controller.go:141] "Parameters of the tuned client's token bucket rate limiter" logger="Binding" burst=300 qps=50
I0323 16:34:38.986814       1 crds.go:76] "applying crd" logger="Binding" name="bindingpolicies.control.kubestellar.io"
I0323 16:34:39.046510       1 crds.go:87] "crd established" logger="Binding" name="bindingpolicies.control.kubestellar.io"
I0323 16:34:39.052039       1 crds.go:76] "applying crd" logger="Binding" name="bindings.control.kubestellar.io"
I0323 16:34:39.108375       1 crds.go:87] "crd established" logger="Binding" name="bindings.control.kubestellar.io"
I0323 16:34:39.108414       1 controller.go:287] "No need to watch per user input" logger="Binding" groupVersion="v1"
I0323 16:34:39.108422       1 controller.go:283] "Ignoring APIResourceList" logger="Binding" groupVersion="apiregistration.k8s.io/v1"
I0323 16:34:39.108446       1 controller.go:287] "No need to watch per user input" logger="Binding" groupVersion="apps/v1"
I0323 16:34:39.108452       1 controller.go:287] "No need to watch per user input" logger="Binding" groupVersion="events.k8s.io/v1"
I0323 16:34:39.108460       1 controller.go:287] "No need to watch per user input" logger="Binding" groupVersion="authentication.k8s.io/v1"
I0323 16:34:39.108467       1 controller.go:287] "No need to watch per user input" logger="Binding" groupVersion="authorization.k8s.io/v1"
I0323 16:34:39.108474       1 controller.go:287] "No need to watch per user input" logger="Binding" groupVersion="autoscaling/v2"
I0323 16:34:39.108482       1 controller.go:287] "No need to watch per user input" logger="Binding" groupVersion="autoscaling/v1"
I0323 16:34:39.108492       1 controller.go:290] "Working on APIResourceList" logger="Binding" groupVersion="batch/v1" numResources=2
I0323 16:34:39.108800       1 controller.go:287] "No need to watch per user input" logger="Binding" groupVersion="certificates.k8s.io/v1"
I0323 16:34:39.108820       1 controller.go:287] "No need to watch per user input" logger="Binding" groupVersion="networking.k8s.io/v1"
I0323 16:34:39.108828       1 controller.go:287] "No need to watch per user input" logger="Binding" groupVersion="policy/v1"
I0323 16:34:39.108837       1 controller.go:287] "No need to watch per user input" logger="Binding" groupVersion="rbac.authorization.k8s.io/v1"
I0323 16:34:39.108844       1 controller.go:287] "No need to watch per user input" logger="Binding" groupVersion="storage.k8s.io/v1"
I0323 16:34:39.108852       1 controller.go:287] "No need to watch per user input" logger="Binding" groupVersion="storage.k8s.io/v1beta1"
I0323 16:34:39.108879       1 controller.go:287] "No need to watch per user input" logger="Binding" groupVersion="admissionregistration.k8s.io/v1"
I0323 16:34:39.108897       1 controller.go:290] "Working on APIResourceList" logger="Binding" groupVersion="apiextensions.k8s.io/v1" numResources=1
I0323 16:34:39.109329       1 controller.go:283] "Ignoring APIResourceList" logger="Binding" groupVersion="scheduling.k8s.io/v1"
I0323 16:34:39.109369       1 controller.go:283] "Ignoring APIResourceList" logger="Binding" groupVersion="coordination.k8s.io/v1"
I0323 16:34:39.109384       1 controller.go:287] "No need to watch per user input" logger="Binding" groupVersion="node.k8s.io/v1"
I0323 16:34:39.109393       1 controller.go:283] "Ignoring APIResourceList" logger="Binding" groupVersion="discovery.k8s.io/v1"
I0323 16:34:39.109405       1 controller.go:283] "Ignoring APIResourceList" logger="Binding" groupVersion="flowcontrol.apiserver.k8s.io/v1beta3"
I0323 16:34:39.109416       1 controller.go:283] "Ignoring APIResourceList" logger="Binding" groupVersion="flowcontrol.apiserver.k8s.io/v1beta2"
I0323 16:34:39.109450       1 controller.go:287] "No need to watch per user input" logger="Binding" groupVersion="proxy.open-cluster-management.io/v1alpha1"
I0323 16:34:39.109464       1 controller.go:287] "No need to watch per user input" logger="Binding" groupVersion="proxy.open-cluster-management.io/v1beta1"
I0323 16:34:39.109473       1 controller.go:287] "No need to watch per user input" logger="Binding" groupVersion="apps.openshift.io/v1"
I0323 16:34:39.109482       1 controller.go:287] "No need to watch per user input" logger="Binding" groupVersion="authorization.openshift.io/v1"
I0323 16:34:39.109491       1 controller.go:287] "No need to watch per user input" logger="Binding" groupVersion="build.openshift.io/v1"
I0323 16:34:39.109500       1 controller.go:287] "No need to watch per user input" logger="Binding" groupVersion="image.openshift.io/v1"
I0323 16:34:39.109508       1 controller.go:287] "No need to watch per user input" logger="Binding" groupVersion="oauth.openshift.io/v1"
I0323 16:34:39.109517       1 controller.go:287] "No need to watch per user input" logger="Binding" groupVersion="project.openshift.io/v1"
I0323 16:34:39.109578       1 controller.go:287] "No need to watch per user input" logger="Binding" groupVersion="quota.openshift.io/v1"
I0323 16:34:39.109588       1 controller.go:287] "No need to watch per user input" logger="Binding" groupVersion="route.openshift.io/v1"
I0323 16:34:39.109632       1 controller.go:287] "No need to watch per user input" logger="Binding" groupVersion="security.openshift.io/v1"
I0323 16:34:39.110027       1 controller.go:287] "No need to watch per user input" logger="Binding" groupVersion="template.openshift.io/v1"
I0323 16:34:39.110042       1 controller.go:287] "No need to watch per user input" logger="Binding" groupVersion="user.openshift.io/v1"
I0323 16:34:39.110051       1 controller.go:287] "No need to watch per user input" logger="Binding" groupVersion="packages.operators.coreos.com/v1"
I0323 16:34:39.110060       1 controller.go:287] "No need to watch per user input" logger="Binding" groupVersion="config.openshift.io/v1"
I0323 16:34:39.110069       1 controller.go:287] "No need to watch per user input" logger="Binding" groupVersion="operator.openshift.io/v1"
I0323 16:34:39.110077       1 controller.go:287] "No need to watch per user input" logger="Binding" groupVersion="operator.openshift.io/v1alpha1"
I0323 16:34:39.110085       1 controller.go:287] "No need to watch per user input" logger="Binding" groupVersion="acme.cert-manager.io/v1"
I0323 16:34:39.110093       1 controller.go:287] "No need to watch per user input" logger="Binding" groupVersion="admission.hive.openshift.io/v1"
I0323 16:34:39.110103       1 controller.go:287] "No need to watch per user input" logger="Binding" groupVersion="agent.open-cluster-management.io/v1"
I0323 16:34:39.110110       1 controller.go:287] "No need to watch per user input" logger="Binding" groupVersion="apiserver.openshift.io/v1"
I0323 16:34:39.110119       1 controller.go:287] "No need to watch per user input" logger="Binding" groupVersion="apps.open-cluster-management.io/v1"
I0323 16:34:39.110127       1 controller.go:287] "No need to watch per user input" logger="Binding" groupVersion="apps.open-cluster-management.io/v1beta1"
I0323 16:34:39.110135       1 controller.go:287] "No need to watch per user input" logger="Binding" groupVersion="apps.open-cluster-management.io/v1alpha1"
I0323 16:34:39.110143       1 controller.go:287] "No need to watch per user input" logger="Binding" groupVersion="cert-manager.io/v1"
I0323 16:34:39.110152       1 controller.go:287] "No need to watch per user input" logger="Binding" groupVersion="cloudcredential.openshift.io/v1"
I0323 16:34:39.110161       1 controller.go:287] "No need to watch per user input" logger="Binding" groupVersion="cluster.open-cluster-management.io/v1"
I0323 16:34:39.110169       1 controller.go:287] "No need to watch per user input" logger="Binding" groupVersion="cluster.open-cluster-management.io/v1beta2"
I0323 16:34:39.110177       1 controller.go:287] "No need to watch per user input" logger="Binding" groupVersion="cluster.open-cluster-management.io/v1beta1"
I0323 16:34:39.110185       1 controller.go:287] "No need to watch per user input" logger="Binding" groupVersion="cluster.open-cluster-management.io/v1alpha1"
I0323 16:34:39.110193       1 controller.go:287] "No need to watch per user input" logger="Binding" groupVersion="console.open-cluster-management.io/v1"
I0323 16:34:39.110201       1 controller.go:287] "No need to watch per user input" logger="Binding" groupVersion="console.openshift.io/v1"
I0323 16:34:39.110209       1 controller.go:287] "No need to watch per user input" logger="Binding" groupVersion="console.openshift.io/v1alpha1"
I0323 16:34:39.110217       1 controller.go:287] "No need to watch per user input" logger="Binding" groupVersion="crd.projectcalico.org/v1"
I0323 16:34:39.110225       1 controller.go:287] "No need to watch per user input" logger="Binding" groupVersion="dashboard.opendatahub.io/v1"
I0323 16:34:39.110234       1 controller.go:287] "No need to watch per user input" logger="Binding" groupVersion="dashboard.opendatahub.io/v1alpha"
I0323 16:34:39.110242       1 controller.go:287] "No need to watch per user input" logger="Binding" groupVersion="discovery.open-cluster-management.io/v1"
I0323 16:34:39.110251       1 controller.go:287] "No need to watch per user input" logger="Binding" groupVersion="discovery.open-cluster-management.io/v1alpha1"
I0323 16:34:39.110258       1 controller.go:287] "No need to watch per user input" logger="Binding" groupVersion="hive.openshift.io/v1"
I0323 16:34:39.110265       1 controller.go:287] "No need to watch per user input" logger="Binding" groupVersion="ibm.com/v1"
I0323 16:34:39.110274       1 controller.go:287] "No need to watch per user input" logger="Binding" groupVersion="ibm.com/v1alpha1"
I0323 16:34:39.110293       1 controller.go:287] "No need to watch per user input" logger="Binding" groupVersion="imageregistry.operator.openshift.io/v1"
I0323 16:34:39.110301       1 controller.go:287] "No need to watch per user input" logger="Binding" groupVersion="ingress.operator.openshift.io/v1"
```

## Related issue(s)
Fixes #1916 
Fixes #1953 
