### PR TITLE
🐛 Fix triggering problems in doc workflows

### DIFF
--- a/.github/workflows/broken-links-crawler.yml
+++ b/.github/workflows/broken-links-crawler.yml
@@ -14,10 +14,17 @@ permissions:
   contents: write
 
 jobs:
+  debug-event:
+    name: debug-event-contents
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "event name is:" ${{ github.event_name }} 
+      - run: echo "event type is:" ${{ github.event.action }} 
+
   broken-links-crawler:
     name: broken-links-crawler
     runs-on: ubuntu-latest
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
     steps:
       - name: get workflow_dispatch branch name
         shell: bash

--- a/.github/workflows/docs-gen-and-push.yml
+++ b/.github/workflows/docs-gen-and-push.yml
@@ -5,14 +5,6 @@ on:
   # So we can trigger manually if needed
   workflow_dispatch:
   # To confirm any changes to docs build successfully, without deploying them
-  pull_request_target:
-    branches:
-      - main
-      - "release-*"
-    paths:
-      - "docs/**"
-      - "*.md"
-      - ".github/workflows/docs-gen-and-push.yaml"
   push:
     branches:
       - main


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
This PR makes the broken links crawler do something when invoked manually. This PR also stops the docs-gen-and-push workflow from being triggered by mere PR activity.

I have tested the former using `main` in my fork. I am unable to test the latter because it has a condition that restricts it to only running on the shared repo.

## Related issue(s)

Fixes #1986 
Fixes #1987 
