### PR TITLE
:bug: Do not watch workstatuses in binding controller

### DIFF
--- a/pkg/binding/controller.go
+++ b/pkg/binding/controller.go
@@ -73,6 +73,7 @@ var excludedResourceNames = map[string]bool{
 	"csistoragecapacities": true,
 	"csinodes":             true,
 	"endpoints":            true,
+	"workstatuses":         true,
 }
 
 const (


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
The binding controller does not need to reconcile workstatuses and in some setups this can cause a race condition with the status addon. For details see https://github.com/kubestellar/kubestellar/issues/1913

## Related issue(s)

Fixes https://github.com/kubestellar/kubestellar/issues/1913
