### PR TITLE
🐛 Updates for the controller manager to watch everything

### DIFF
--- a/chart/templates/controller-manager.yaml
+++ b/chart/templates/controller-manager.yaml
@@ -221,7 +221,7 @@ spec:
         resources:
           limits:
             cpu: 500m
-            memory: 512Mi
+            memory: 1Gi
           requests:
             cpu: 10m
             memory: 64Mi

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -50,7 +50,7 @@ spec:
         resources:
           limits:
             cpu: 500m
-            memory: 512Mi
+            memory: 1Gi
           requests:
             cpu: 10m
             memory: 64Mi

--- a/pkg/binding/controller.go
+++ b/pkg/binding/controller.go
@@ -455,7 +455,7 @@ func (c *Controller) handleObject(obj any, resource string, eventType string) {
 		obj = typed.Obj
 		wasDeletedFinalStateUnknown = true
 	}
-	c.logger.Info("Got object event", "eventType", eventType,
+	c.logger.V(4).Info("Got object event", "eventType", eventType,
 		"wasDeletedFinalStateUnknown", wasDeletedFinalStateUnknown, "obj", util.RefToRuntimeObj(obj.(runtime.Object)),
 		"resource", resource)
 

--- a/pkg/status/controller.go
+++ b/pkg/status/controller.go
@@ -200,7 +200,7 @@ func shouldSkipDelete(_ interface{}) bool {
 // At this time it is very simple, more complex processing might be required here
 func (c *Controller) handleObject(obj any) {
 	rObj := obj.(runtime.Object)
-	c.logger.V(2).Info("Got object event", "obj", util.RefToRuntimeObj(rObj))
+	c.logger.V(4).Info("Got object event", "obj", util.RefToRuntimeObj(rObj))
 	c.enqueueObject(obj)
 }
 


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
This PR increases the memory limit of the controller manager, and adjusts the verbosity levels for the logging messages from the event handlers.

Changes in this PR are built into quay.io/junatibm/controller-manager:1711835357. I tested the image, with the increased memory limit, in the same environment as #1990. The controller ran for minutes without `OOMKilled`:
```
👉 Downloads $ oc cluster-info
Kubernetes control plane is running at https://c115-e.us-south.containers.cloud.ibm.com:30829

To further debug and diagnose cluster problems, use 'kubectl cluster-info dump'.
👉 Downloads $ oc -n wds2-system get deploy,po
NAME                                             READY   UP-TO-DATE   AVAILABLE   AGE
deployment.apps/kubestellar-controller-manager   1/1     1            1           8d
deployment.apps/transport-controller             1/1     1            1           8d

NAME                                                 READY   STATUS    RESTARTS   AGE
pod/kubestellar-controller-manager-56ccb5d76-4l5fz   2/2     Running   0          6m40s
pod/transport-controller-656fcff866-26mgt            1/1     Running   0          8d
👉 Downloads $ oc -n wds2-system get po kubestellar-controller-manager-56ccb5d76-4l5fz -oyaml | yq .spec.containers[1]
args:
  - --health-probe-bind-address=:8081
  - --metrics-bind-address=127.0.0.1:8080
  - --leader-elect
  - --wds-name=wds2
  - -v=2
image: quay.io/junatibm/controller-manager:1711835357
imagePullPolicy: IfNotPresent
livenessProbe:
  failureThreshold: 3
  httpGet:
    path: /healthz
    port: 8081
    scheme: HTTP
  initialDelaySeconds: 15
  periodSeconds: 20
  successThreshold: 1
  timeoutSeconds: 1
name: manager
readinessProbe:
  failureThreshold: 3
  httpGet:
    path: /readyz
    port: 8081
    scheme: HTTP
  initialDelaySeconds: 5
  periodSeconds: 10
  successThreshold: 1
  timeoutSeconds: 1
resources:
  limits:
    cpu: 500m
    memory: 1Gi
  requests:
    cpu: 10m
    memory: 64Mi
securityContext:
  allowPrivilegeEscalation: false
  capabilities:
    drop:
      - ALL
  runAsUser: 1001110000
terminationMessagePath: /dev/termination-log
terminationMessagePolicy: File
volumeMounts:
  - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
    name: kube-api-access-5zch7
    readOnly: true
👉 Downloads $ 
```

Also trying to hit #2000 by this PR.

## Related issue(s)
Fixes #1990 
