### PR TITLE
📖 Make examples.md use OTP helm chart

### DIFF
--- a/docs/content/direct/examples.md
+++ b/docs/content/direct/examples.md
@@ -26,57 +26,57 @@ The following steps establish an initial state used in the examples below.
 
 1. Create a Kind hosting cluster with nginx ingress controller and KubeFlex controller-manager installed:
 
-   ```shell
-   kflex init --create-kind
-   ```
+    ```shell
+    kflex init --create-kind
+    ```
    If you are installing KubeStellar on an existing Kubernetes or OpenShift cluster, just use the command `kflex init`.
 
 1. Update the post-create-hooks in KubeFlex to install kubestellar with the desired images:
 
-   ```shell
-   kubectl apply -f https://raw.githubusercontent.com/kubestellar/kubestellar/v${KUBESTELLAR_VERSION}/config/postcreate-hooks/kubestellar.yaml
-   kubectl apply -f https://raw.githubusercontent.com/kubestellar/kubestellar/v${KUBESTELLAR_VERSION}/config/postcreate-hooks/ocm.yaml
-   ```
+    ```shell
+    kubectl apply -f https://raw.githubusercontent.com/kubestellar/kubestellar/v${KUBESTELLAR_VERSION}/config/postcreate-hooks/kubestellar.yaml
+    kubectl apply -f https://raw.githubusercontent.com/kubestellar/kubestellar/v${KUBESTELLAR_VERSION}/config/postcreate-hooks/ocm.yaml
+    ```
 
 1. Create an inventory & mailbox space of type `vcluster` running *OCM* (Open Cluster Management)
 in KubeFlex. Note that `-p ocm` runs a post-create hook on the *vcluster* control plane
 which installs OCM on it.
 
-   ```shell
-   kflex create imbs1 --type vcluster -p ocm
-   ```
+    ```shell
+    kflex create imbs1 --type vcluster -p ocm
+    ```
 
 1. Install status add-on on imbs1:
 
-   Wait until the `managedclusteraddons` resource shows up on `imbs1`. You can check on that with the command:
+    Wait until the `managedclusteraddons` resource shows up on `imbs1`. You can check on that with the command:
 
-   ```shell
-   kubectl --context imbs1 api-resources | grep managedclusteraddons
-   ```
+    ```shell
+    kubectl --context imbs1 api-resources | grep managedclusteraddons
+    ```
 
-   and then install the status add-on:
+    and then install the status add-on:
 
-   ```shell
-   helm --kube-context imbs1 upgrade --install status-addon -n open-cluster-management oci://ghcr.io/kubestellar/ocm-status-addon-chart --version v${OCM_STATUS_ADDON_VERSION}
-   ```
+    ```shell
+    helm --kube-context imbs1 upgrade --install status-addon -n open-cluster-management oci://ghcr.io/kubestellar/ocm-status-addon-chart --version v${OCM_STATUS_ADDON_VERSION}
+    ```
 
-   see [here](./architecture.md#ocm-status-add-on-agent) for more details on the add-on.
+    see [here](./architecture.md#ocm-status-add-on-agent) for more details on the add-on.
 
 1. Create a Workload Description Space `wds1` in KubeFlex. Similarly to before, `-p kubestellar`
 runs a post-create hook on the *k8s* control plane that starts an instance of a KubeStellar controller
 manager which connects to the `wds1` front-end and the `imbs1` OCM control plane back-end.
 
-   ```shell
-   kflex create wds1 -p kubestellar
-   ```
+    ```shell
+    kflex create wds1 -p kubestellar
+    ```
 
 1. Deploy the OCM based transport controller
 
-   ```shell
-   helm --kube-context kind-kubeflex upgrade --install ocm-transport-plugin oci://ghcr.io/kubestellar/ocm-transport-plugin/chart/ocm-transport-plugin --version ${OCM_TRANSPORT_PLUGIN} \
-    --set transport_cp_name=imbs1 \
-    --set wds_cp_name=wds1
-   ```
+    ```shell
+    helm --kube-context kind-kubeflex upgrade --install ocm-transport-plugin oci://ghcr.io/kubestellar/ocm-transport-plugin/chart/ocm-transport-plugin --version ${OCM_TRANSPORT_PLUGIN} \
+     --set transport_cp_name=imbs1 \
+     --set wds_cp_name=wds1
+    ```
 
 1. Follow the steps to [create and register two clusters with OCM](example-wecs.md).
 
@@ -84,26 +84,26 @@ manager which connects to the `wds1` front-end and the `imbs1` OCM control plane
 see the `kubestellar-controller-manager` in the `wds1-system` namespace and the
 statefulset `vcluster` in the `imbs1-system` namespace, both fully ready.
 
-   ```shell
-   kubectl --context kind-kubeflex get deployments,statefulsets --all-namespaces
-   ```
+    ```shell
+    kubectl --context kind-kubeflex get deployments,statefulsets --all-namespaces
+    ```
    The output should look something like the following:
 
-   ```shell
-   NAMESPACE            NAME                                             READY   UP-TO-DATE   AVAILABLE   AGE
-   ingress-nginx        deployment.apps/ingress-nginx-controller         1/1     1            1           22h
-   kube-system          deployment.apps/coredns                          2/2     2            2           22h
-   kubeflex-system      deployment.apps/kubeflex-controller-manager      1/1     1            1           22h
-   local-path-storage   deployment.apps/local-path-provisioner           1/1     1            1           22h
-   wds1-system          deployment.apps/kube-apiserver                   1/1     1            1           22m
-   wds1-system          deployment.apps/kube-controller-manager          1/1     1            1           22m
-   wds1-system          deployment.apps/kubestellar-controller-manager   1/1     1            1           21m
-   wds1-system          deployment.apps/transport-controller             1/1     1            1           21m
+    ```shell
+    NAMESPACE            NAME                                             READY   UP-TO-DATE   AVAILABLE   AGE
+    ingress-nginx        deployment.apps/ingress-nginx-controller         1/1     1            1           22h
+    kube-system          deployment.apps/coredns                          2/2     2            2           22h
+    kubeflex-system      deployment.apps/kubeflex-controller-manager      1/1     1            1           22h
+    local-path-storage   deployment.apps/local-path-provisioner           1/1     1            1           22h
+    wds1-system          deployment.apps/kube-apiserver                   1/1     1            1           22m
+    wds1-system          deployment.apps/kube-controller-manager          1/1     1            1           22m
+    wds1-system          deployment.apps/kubestellar-controller-manager   1/1     1            1           21m
+    wds1-system          deployment.apps/transport-controller             1/1     1            1           21m
 
-   NAMESPACE         NAME                                   READY   AGE
-   imbs1-system      statefulset.apps/vcluster              1/1     11h
-   kubeflex-system   statefulset.apps/postgres-postgresql   1/1     22h
-   ```
+    NAMESPACE         NAME                                   READY   AGE
+    imbs1-system      statefulset.apps/vcluster              1/1     11h
+    kubeflex-system   statefulset.apps/postgres-postgresql   1/1     22h
+    ```
 
 ## Scenario 1 - multi-cluster workload deployment with kubectl
 


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
This is @francostellari 's work from PR #1985, changing examples.md to use the OTP helm chart to install the transport controller. I rebased it to remove the merges of `main` into the PR branch.

I have added a commit that restores the indentation that is needed to make the list numbering render properly for the GitHub pages (the website).

## Related issue(s)

Fixes #1866
