### PR TITLE
✨ Remove spec.suspend when cleaning a Job

### DIFF
--- a/pkg/transport/filtering/job.go
+++ b/pkg/transport/filtering/job.go
@@ -44,6 +44,10 @@ func cleanJob(object *unstructured.Unstructured) {
 		unstructured.RemoveNestedField(objectU, "spec", "selector")
 		changed = true
 	}
+	if _, found, _ := unstructured.NestedFieldNoCopy(objectU, "spec", "suspend"); found {
+		unstructured.RemoveNestedField(objectU, "spec", "suspend")
+		changed = true
+	}
 	podLabels, foundlabels, _ := unstructured.NestedMap(objectU, "spec", "template", "metadata", "labels")
 	if foundlabels {
 		if cleanJobLabels(podLabels) {


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
This PR continues the campaign for cleaning Job objects, by removing `spec.suspend` if it exists.

This is unsatisfying to me. This change **assumes** that `suspend: true` is present (when it is found) because the scenario is one where the WDS is _not_ denatured wrt Job execution. That is not the only possible scenario. It is also possible that the WDS _is_ denatured wrt Job execution and the user is trying to exert remote control over when the job is executed in the WEC.

## Related issue(s)

This addresses part of #1936 
