### PR TITLE
📖 Support multiple transport controllers, doc more staggering

### DIFF
--- a/docs/content/direct/examples.md
+++ b/docs/content/direct/examples.md
@@ -23,7 +23,7 @@ The following steps establish an initial state used in the examples below.
     ```shell
     export KUBESTELLAR_VERSION=0.21.2
     export OCM_STATUS_ADDON_VERSION=0.2.0-rc6
-    export OCM_TRANSPORT_PLUGIN=0.1.2
+    export OCM_TRANSPORT_PLUGIN=0.1.3
     ```
 
 1. Create a Kind hosting cluster with nginx ingress controller and KubeFlex controller-manager installed:
@@ -77,7 +77,8 @@ manager which connects to the `wds1` front-end and the `imbs1` OCM control plane
     ```shell
     helm --kube-context kind-kubeflex upgrade --install ocm-transport-plugin oci://ghcr.io/kubestellar/ocm-transport-plugin/chart/ocm-transport-plugin --version ${OCM_TRANSPORT_PLUGIN} \
      --set transport_cp_name=imbs1 \
-     --set wds_cp_name=wds1
+     --set wds_cp_name=wds1 \
+     -n wds1-system
     ```
 
 1. Follow the steps to [create and register two clusters with OCM](example-wecs.md).
@@ -250,8 +251,9 @@ To create a second WDS based on the hosting cluster, run the commands:
 kflex create wds2 -t host
 
 helm --kube-context kind-kubeflex upgrade --install ocm-transport-plugin oci://ghcr.io/kubestellar/ocm-transport-plugin/chart/ocm-transport-plugin --version ${OCM_TRANSPORT_PLUGIN} \
---set transport_cp_name=imbs1 \
---set wds_cp_name=wds2
+    --set transport_cp_name=imbs1 \
+    --set wds_cp_name=wds2 \
+    -n wds2-system
 ```
 
 where the `-t host` option specifies a control plane of type `host`.

--- a/docs/content/direct/release.md
+++ b/docs/content/direct/release.md
@@ -9,9 +9,19 @@ clues about the problem.
 
 ## Step-by-Step
 
-Making a new release requires a contributor to do the following things. Here `$version` is the semver identifier for the release (e.g., `1.2.3-rc2`).
+### Reacting to a new ocm-transport-plugin release
 
-- Edit the tag in the default transport controller image setting (`export TRANSPORT_CONTROLLER_IMAGE...`) to the latest release of [ks/OTP](https://github.com/kubestellar/ocm-transport-plugin). **NOTE** This step is not really part of making the next ks/ks release, it is part of making that ks/OTP release. As such, the timing is driven by that release, not the ks/ks release.
+Between each release of [ks/OTP](https://github.com/kubestellar/ocm-transport-plugin) and the next release of ks/ks, the following steps should be done in ks/ks.
+
+- Edit `scripts/deploy-transport-controller.sh`: update the tag in the default transport controller image setting (`export TRANSPORT_CONTROLLER_IMAGE...`) to the latest release of ks/OTP.
+
+- Edit `docs/content/direct/examples.md`: update the version in the `export OCM_TRANSPORT_PLUGIN=...` statement to the latest release of ks/OTP.
+
+- Edit `test/e2e/common/setup-kubestellar.sh`: update the setting of `OCM_TRANSPORT_PLUGIN_RELEASE` to the latest.
+
+### Making a new kubestellar release
+
+Making a new kubestellar release requires a contributor to do the following things. Here `$version` is the semver identifier for the release (e.g., `1.2.3-rc2`).
 
 - Edit the source for the KCM PCH (in `config/postcreate-hooks/kubestellar.yaml`) and update the tag in the reference to the KCM container image (it appears in the last object, a `Job`).
 

--- a/scripts/deploy-transport-controller.sh
+++ b/scripts/deploy-transport-controller.sh
@@ -17,7 +17,7 @@
 
 export WDS_NAME="$1" ## first argument is WDS name
 export IMBS_NAME="$2" ## second argument is IMBS name
-export TRANSPORT_CONTROLLER_IMAGE="${3:-ghcr.io/kubestellar/ocm-transport-plugin/transport-controller:0.1.0}" ## third argument is transport controller image
+export TRANSPORT_CONTROLLER_IMAGE="${3:-ghcr.io/kubestellar/ocm-transport-plugin/transport-controller:0.1.3}" ## third argument is transport controller image
 export IMAGE_PULL_POLICY="${IMAGE_PULL_POLICY:=Always}"
 
 # generate from template and env vars and then apply a configmap and a deployment for transport-controller

--- a/test/e2e/common/setup-kubestellar.sh
+++ b/test/e2e/common/setup-kubestellar.sh
@@ -92,7 +92,7 @@ echo "wds1 created."
 :
 cd "${SRC_DIR}/../../.." ## go up to KubeStellar directory
 KUBESTELLAR_DIR="$(pwd)"
-OCM_TRANSPORT_PLUGIN_RELEASE="0.1.0"
+OCM_TRANSPORT_PLUGIN_RELEASE="0.1.3"
 curl -sL https://github.com/kubestellar/ocm-transport-plugin/archive/refs/tags/v${OCM_TRANSPORT_PLUGIN_RELEASE}.tar.gz | tar xz
 cd ocm-transport-plugin-${OCM_TRANSPORT_PLUGIN_RELEASE}
 OCM_TRANSPORT_PLUGIN_DIR="$(pwd)"


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
This PR updates docs and recipes wrt two issues regarding the transport controller. One is to allow multiple WDSes, each with its own transport controller. This required putting the Helm chart instances ("releases") in distinct namespaces. The other issue is overdue updates to track releases of ks/OTP.

## Related issue(s)

Fixes #2047 
