### PR TITLE
✨ Enable kubestellar-controller-manager to be told ITS name

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -246,7 +246,7 @@ CONTROLLER_TOOLS_VERSION ?= v0.13.0
 .PHONY: kustomize
 kustomize: $(KUSTOMIZE) ## Download kustomize locally if necessary.
 $(KUSTOMIZE): $(LOCALBIN)
-	test -s $(LOCALBIN)/kustomize || GOBIN=$(LOCALBIN) go install sigs.k8s.io/kustomize/kustomize/v5@latest
+	test -s $(LOCALBIN)/kustomize || GOBIN=$(LOCALBIN) go install sigs.k8s.io/kustomize/kustomize/v5@v5.3.0
 
 .PHONY: controller-gen
 controller-gen: $(CONTROLLER_GEN) ## Download controller-gen locally if necessary. If wrong version is installed, it will be overwritten.

--- a/chart/templates/controller-manager.yaml
+++ b/chart/templates/controller-manager.yaml
@@ -200,6 +200,7 @@ spec:
         - --health-probe-bind-address=:8081
         - --metrics-bind-address=127.0.0.1:8080
         - --leader-elect
+        - --its-name={{.Values.ITSName}}
         - --wds-name={{.Values.ControlPlaneName}}
         - --api-groups={{.Values.APIGroups}}
         - -v=2

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -11,3 +11,7 @@ ControlPlaneName: wds1
 # "<group1>\,<group2>\,<groupN>" with "" and escaped \,
 APIGroups:
 
+# The name of the Inventory and Transport Space to use.
+# Empty string means that there must be only one and that
+# is the one to use.
+ITSName: ""

--- a/cmd/controller-manager/main.go
+++ b/cmd/controller-manager/main.go
@@ -58,11 +58,13 @@ func main() {
 	var metricsAddr string
 	var enableLeaderElection bool
 	var probeAddr string
+	var itsName string
 	var wdsName string
 	var wdsLabel string
 	var allowedGroupsString string
 	flag.StringVar(&metricsAddr, "metrics-bind-address", ":8080", "The address the metric endpoint binds to.")
 	flag.StringVar(&probeAddr, "health-probe-bind-address", ":8081", "The address the probe endpoint binds to.")
+	flag.StringVar(&itsName, "its-name", "", "name of the Inventory and Transport Space to connect to (empty string means to use the only one)")
 	flag.StringVar(&wdsName, "wds-name", "", "name of the workload description space to connect to")
 	flag.StringVar(&wdsLabel, "wds-label", "", "label of the workload description space to connect to")
 	flag.StringVar(&allowedGroupsString, "api-groups", "", "list of allowed api groups, comma separated. Empty string means all API groups are allowed")
@@ -129,7 +131,7 @@ func main() {
 
 	// get the config for IMBS
 	setupLog.Info("Getting config for IMBS")
-	imbsRestConfig, imbsName, err := util.GetIMBSKubeconfig(setupLog)
+	imbsRestConfig, imbsName, err := util.GetIMBSKubeconfig(setupLog, itsName)
 	if err != nil {
 		setupLog.Error(err, "unable to get IMBS kubeconfig")
 		os.Exit(1)

--- a/pkg/util/kubeconfig.go
+++ b/pkg/util/kubeconfig.go
@@ -65,8 +65,8 @@ func GetWDSKubeconfig(logger logr.Logger, wdsName, wdsLabel string) (*rest.Confi
 	return getRestConfig(logger, wdsName, label.Key, label.Value)
 }
 
-func GetIMBSKubeconfig(logger logr.Logger) (*rest.Config, string, error) {
-	return getRestConfig(logger, "", ControlPlaneTypeLabel, ControlPlaneTypeIMBS)
+func GetIMBSKubeconfig(logger logr.Logger, imbsName string) (*rest.Config, string, error) {
+	return getRestConfig(logger, imbsName, ControlPlaneTypeLabel, ControlPlaneTypeIMBS)
 }
 
 // get the rest config for a control plane based on labels and name


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
This PR generalizes the kubestellar controller-manager so that it can be told which ITS to use. This enables more than one ITS in the system!

## Related issue(s)

This addresses part of #2025 . Fully addressing it would involve adding testing and making any needed doc updates.
