### PR TITLE
🐛 Allow a 'singleton' bindingpolicy to select no clusters

### DIFF
--- a/pkg/binding/bindingpolicy.go
+++ b/pkg/binding/bindingpolicy.go
@@ -403,7 +403,8 @@ func SliceContains[Elt comparable](slice []Elt, seek Elt) bool {
 	return false
 }
 
-// sort by name and pick first cluster so that the choice is deterministic based on names
+// pickSingleDestination sorts clusters by name and picks first cluster so that the choice is deterministic based on names
+// pickSingleDestination expects a non-empty clusterSet
 func pickSingleDestination(clusterSet sets.Set[string]) sets.Set[string] {
 	return sets.New(sets.List(clusterSet)[0])
 }

--- a/pkg/binding/bindingpolicy.go
+++ b/pkg/binding/bindingpolicy.go
@@ -86,12 +86,17 @@ func (c *Controller) handleBindingPolicy(ctx context.Context, objIdentifier util
 		if err != nil {
 			return fmt.Errorf("failed to ocm.FindClustersBySelectors: %w", err)
 		}
+		if len(clusterSet) == 0 {
+			logger.Info("No clusters are selected by BindingPolicy", "name", bindingPolicy.Name)
+		}
 
 		if bindingPolicy.Spec.WantSingletonReportedState {
 			// if the bindingpolicy requires a singleton status, then we should only
 			// have one destination
 			// TODO: this should be removed once we have proper enforcement or error reporting for this
-			clusterSet = pickSingleDestination(clusterSet)
+			if len(clusterSet) > 1 {
+				clusterSet = pickSingleDestination(clusterSet)
+			}
 		}
 
 		// set destinations and enqueue binding for syncing

--- a/test/e2e/ginkgo/multiple_cluster_deployment_test.go
+++ b/test/e2e/ginkgo/multiple_cluster_deployment_test.go
@@ -214,6 +214,29 @@ var _ = ginkgo.Describe("end to end testing", func() {
 	})
 
 	ginkgo.Context("singleton status testing", func() {
+		ginkgo.It("no singleton status when a singleton bindingpolicy/deployment is created but no matching WEC(s)", func() {
+			util.DeleteDeployment(ctx, wds, ns, "nginx")
+			util.CreateDeployment(ctx, wds, ns, "nginx-singleton",
+				map[string]string{
+					"app.kubernetes.io/name": "nginx-singleton",
+				})
+			util.CreateBindingPolicy(ctx, ksWds, "nginx-singleton",
+				[]metav1.LabelSelector{
+					{MatchLabels: map[string]string{"name": "CelestialNexus"}},
+				},
+				[]ksapi.DownsyncObjectTest{
+					{ObjectSelectors: []metav1.LabelSelector{
+						{MatchLabels: map[string]string{"app.kubernetes.io/name": "nginx-singleton"}},
+					}}})
+			patch := []byte(`{"spec":{"wantSingletonReportedState": true}}`)
+			_, err := ksWds.ControlV1alpha1().BindingPolicies().Patch(
+				ctx, "nginx-singleton", types.MergePatchType, patch, metav1.PatchOptions{})
+			gomega.ExpectWithOffset(1, err).NotTo(gomega.HaveOccurred())
+			util.ValidateNumDeployments(ctx, wec1, ns, 0)
+			util.ValidateNumDeployments(ctx, wec2, ns, 0)
+			util.ValidateSingletonStatusZeroValue(ctx, wds, ns, "nginx-singleton")
+		})
+
 		ginkgo.It("sets singleton status when a singleton bindingpolicy/deployment is created", func() {
 			util.DeleteDeployment(ctx, wds, ns, "nginx") // we don't have to delete nginx
 			util.CreateDeployment(ctx, wds, ns, "nginx-singleton",

--- a/test/util/util.go
+++ b/test/util/util.go
@@ -310,6 +310,14 @@ func ValidateNumJobs(ctx context.Context, wec *kubernetes.Clientset, ns string, 
 	}, timeout).Should(gomega.Equal(num))
 }
 
+func ValidateSingletonStatusZeroValue(ctx context.Context, wds *kubernetes.Clientset, ns string, name string) {
+	gomega.Eventually(func() []appsv1.DeploymentCondition {
+		deployment, err := wds.AppsV1().Deployments(ns).Get(ctx, name, metav1.GetOptions{})
+		gomega.ExpectWithOffset(1, err).NotTo(gomega.HaveOccurred())
+		return deployment.Status.Conditions
+	}, timeout).Should(gomega.BeNil())
+}
+
 func ValidateSingletonStatus(ctx context.Context, wds *kubernetes.Clientset, ns string, name string) {
 	gomega.Eventually(func() int {
 		deployment, err := wds.AppsV1().Deployments(ns).Get(ctx, name, metav1.GetOptions{})


### PR DESCRIPTION
## Summary
This PR fixes #1945. More details are documented at https://github.com/kubestellar/kubestellar/issues/1945#issuecomment-2034897896.

Fixes #1945 
