### PR TITLE
:bug: Do not exclude scheduling.k8s.io group

### DIFF
--- a/pkg/binding/controller.go
+++ b/pkg/binding/controller.go
@@ -58,7 +58,6 @@ const (
 // Resource groups to exclude for watchers as they should not be delivered to other clusters
 var excludedGroups = map[string]bool{
 	"flowcontrol.apiserver.k8s.io": true,
-	"scheduling.k8s.io":            true,
 	"discovery.k8s.io":             true,
 	"apiregistration.k8s.io":       true,
 	"coordination.k8s.io":          true,


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
The resource group `scheduling.k8s.io` is currently include 1 resource called `PriorityClass` that allow users to set scheduling priority for deployments/pods. We should allow down syncing for `PriorityClass`.

## Related issue(s)

Fixes #
