### PR TITLE
✨ Make the status controller handle the deletion of workstatuses

### DIFF
--- a/pkg/status/controller.go
+++ b/pkg/status/controller.go
@@ -170,7 +170,7 @@ func (c *Controller) runWorkStatusInformer(ctx context.Context) {
 			if shouldSkipDelete(obj) {
 				return
 			}
-			c.handleObject(obj)
+			c.handleObjectDeletion(obj)
 		},
 	})
 
@@ -204,6 +204,14 @@ func (c *Controller) handleObject(obj any) {
 	c.enqueueObject(obj)
 }
 
+// handleObjectDeletion is like handleObject except that handleObjectDeletion calls
+// enqueueObjectDeletion instead of enqueueObject
+func (c *Controller) handleObjectDeletion(obj any) {
+	rObj := obj.(runtime.Object)
+	c.logger.V(4).Info("Got object deletion event", "obj", util.RefToRuntimeObj(rObj))
+	c.enqueueObjectDeletion(obj)
+}
+
 // enqueueObject generates key and put it onto the work queue.
 func (c *Controller) enqueueObject(obj interface{}) {
 	ref, err := cache.ObjectToName(obj)
@@ -212,6 +220,12 @@ func (c *Controller) enqueueObject(obj interface{}) {
 		return
 	}
 	c.workqueue.Add(ref)
+}
+
+// enqueueObjectDeletion is like enqueueObject except that enqueueObjectDeletion
+// puts the full object instead of its reference into the work queue.
+func (c *Controller) enqueueObjectDeletion(obj interface{}) {
+	c.workqueue.Add(obj)
 }
 
 // runWorker is a long-running function that will continually call the
@@ -243,25 +257,35 @@ func (c *Controller) processNextWorkItem(ctx context.Context) bool {
 		// We expect a cache.ObjectName to come off the workqueue. We do this as the delayed
 		// nature of the workqueue means the items in the informer cache may actually be
 		// more up to date that when the item was initially put onto the
-		// workqueue.
-		ref, ok := obj.(cache.ObjectName)
-		if !ok {
-			// if the item in the workqueue is invalid, we call
-			// Forget here to avoid process a work item that is invalid.
+		// workqueue. With the exception that the object is being deleted.
+		if ref, ok := obj.(cache.ObjectName); ok {
+			if err := c.reconcile(ctx, ref); err != nil {
+				// Put the item back on the workqueue to handle any transient errors.
+				c.workqueue.AddRateLimited(obj)
+				return fmt.Errorf("error syncing key '%s': %s, requeuing", obj, err.Error())
+			}
+			// If no error occurs we Forget this item so it does not
+			// get queued again until another change happens.
 			c.workqueue.Forget(obj)
-			utilruntime.HandleError(fmt.Errorf("expected a string key in the workqueue but got %#v", obj))
+			c.logger.V(2).Info("Successfully synced", "obj", obj)
 			return nil
 		}
-		// Run the reconciler, passing it the full key or the metav1 Object
-		if err := c.reconcile(ctx, ref); err != nil {
-			// Put the item back on the workqueue to handle any transient errors.
-			c.workqueue.AddRateLimited(obj)
-			return fmt.Errorf("error syncing key '%s': %s, requeuing", obj, err.Error())
+
+		// Object is being deleted.
+		if full, ok := obj.(runtime.Object); ok {
+			if err := c.reconcileDeletion(ctx, full); err != nil {
+				c.workqueue.AddRateLimited(obj)
+				return fmt.Errorf("error syncing deletion of %s: %s, requeuing", util.RefToRuntimeObj(full), err.Error())
+			}
+			c.workqueue.Forget(obj)
+			c.logger.V(2).Info("Successfully synced deletion", "obj", util.RefToRuntimeObj(full))
+			return nil
 		}
-		// Finally, if no error occurs we Forget this item so it does not
-		// get queued again until another change happens.
+
+		// If the item in the workqueue is invalid, we call
+		// Forget here to avoid processing a work item that is invalid.
 		c.workqueue.Forget(obj)
-		c.logger.V(2).Info("Successfully synced", "object", obj)
+		utilruntime.HandleError(fmt.Errorf("got unexpected item from workqueue %#v", obj))
 		return nil
 	}(obj)
 
@@ -309,6 +333,28 @@ func (c *Controller) reconcile(ctx context.Context, ref cache.ObjectName) error 
 
 	c.logger.Info("updating singleton status", "kind", sourceRef.Kind, "name", sourceRef.Name, "namespace", sourceRef.Namespace)
 	return updateObjectStatus(ctx, sourceRef, status, c.listers, c.wdsDynClient)
+}
+
+// reconcileDeletion needs a full WorkStatus object instead of cache.ObjectName, because
+// (a) on WorkStatus object deletion, the controller may need to cleanup the status
+// of the corresponding workload object in WDS; and
+// (b) the corresponding workload object is tracked in the spec of the WorkStatus object.
+func (c *Controller) reconcileDeletion(ctx context.Context, full runtime.Object) error {
+	sourceRef, err := util.GetWorkStatusSourceRef(full)
+	if err != nil {
+		return err
+	}
+
+	statusLabelVal, ok := full.(metav1.Object).GetLabels()[util.BindingPolicyLabelSingletonStatusKey]
+	if !ok {
+		return nil
+	}
+
+	if statusLabelVal == util.BindingPolicyLabelSingletonStatusValueSet {
+		emptyStatus := make(map[string]interface{})
+		return updateObjectStatus(ctx, sourceRef, emptyStatus, c.listers, c.wdsDynClient)
+	}
+	return nil
 }
 
 func updateObjectStatus(ctx context.Context, objRef *util.SourceRef, status map[string]interface{},

--- a/test/e2e/ginkgo/multiple_cluster_deployment_test.go
+++ b/test/e2e/ginkgo/multiple_cluster_deployment_test.go
@@ -214,6 +214,29 @@ var _ = ginkgo.Describe("end to end testing", func() {
 	})
 
 	ginkgo.Context("singleton status testing", func() {
+		ginkgo.It("no singleton status when a singleton bindingpolicy/deployment is created but no matching WEC(s)", func() {
+			util.DeleteDeployment(ctx, wds, ns, "nginx")
+			util.CreateDeployment(ctx, wds, ns, "nginx-singleton",
+				map[string]string{
+					"app.kubernetes.io/name": "nginx-singleton",
+				})
+			util.CreateBindingPolicy(ctx, ksWds, "nginx-singleton",
+				[]metav1.LabelSelector{
+					{MatchLabels: map[string]string{"name": "CelestialNexus"}},
+				},
+				[]ksapi.DownsyncObjectTest{
+					{ObjectSelectors: []metav1.LabelSelector{
+						{MatchLabels: map[string]string{"app.kubernetes.io/name": "nginx-singleton"}},
+					}}})
+			patch := []byte(`{"spec":{"wantSingletonReportedState": true}}`)
+			_, err := ksWds.ControlV1alpha1().BindingPolicies().Patch(
+				ctx, "nginx-singleton", types.MergePatchType, patch, metav1.PatchOptions{})
+			gomega.ExpectWithOffset(1, err).NotTo(gomega.HaveOccurred())
+			util.ValidateNumDeployments(ctx, wec1, ns, 0)
+			util.ValidateNumDeployments(ctx, wec2, ns, 0)
+			util.ValidateSingletonStatusZeroValue(ctx, wds, ns, "nginx-singleton")
+		})
+
 		ginkgo.It("sets singleton status when a singleton bindingpolicy/deployment is created", func() {
 			util.DeleteDeployment(ctx, wds, ns, "nginx") // we don't have to delete nginx
 			util.CreateDeployment(ctx, wds, ns, "nginx-singleton",

--- a/test/e2e/ginkgo/multiple_cluster_deployment_test.go
+++ b/test/e2e/ginkgo/multiple_cluster_deployment_test.go
@@ -214,30 +214,7 @@ var _ = ginkgo.Describe("end to end testing", func() {
 	})
 
 	ginkgo.Context("singleton status testing", func() {
-		ginkgo.It("no singleton status when a singleton bindingpolicy/deployment is created but no matching WEC(s)", func() {
-			util.DeleteDeployment(ctx, wds, ns, "nginx")
-			util.CreateDeployment(ctx, wds, ns, "nginx-singleton",
-				map[string]string{
-					"app.kubernetes.io/name": "nginx-singleton",
-				})
-			util.CreateBindingPolicy(ctx, ksWds, "nginx-singleton",
-				[]metav1.LabelSelector{
-					{MatchLabels: map[string]string{"name": "CelestialNexus"}},
-				},
-				[]ksapi.DownsyncObjectTest{
-					{ObjectSelectors: []metav1.LabelSelector{
-						{MatchLabels: map[string]string{"app.kubernetes.io/name": "nginx-singleton"}},
-					}}})
-			patch := []byte(`{"spec":{"wantSingletonReportedState": true}}`)
-			_, err := ksWds.ControlV1alpha1().BindingPolicies().Patch(
-				ctx, "nginx-singleton", types.MergePatchType, patch, metav1.PatchOptions{})
-			gomega.ExpectWithOffset(1, err).NotTo(gomega.HaveOccurred())
-			util.ValidateNumDeployments(ctx, wec1, ns, 0)
-			util.ValidateNumDeployments(ctx, wec2, ns, 0)
-			util.ValidateSingletonStatusZeroValue(ctx, wds, ns, "nginx-singleton")
-		})
-
-		ginkgo.It("sets singleton status when a singleton bindingpolicy/deployment is created", func() {
+		ginkgo.It("sets (or deletes) singleton status when a singleton bindingpolicy/deployment is created (or deleted)", func() {
 			util.DeleteDeployment(ctx, wds, ns, "nginx") // we don't have to delete nginx
 			util.CreateDeployment(ctx, wds, ns, "nginx-singleton",
 				map[string]string{
@@ -258,35 +235,9 @@ var _ = ginkgo.Describe("end to end testing", func() {
 			util.ValidateNumDeployments(ctx, wec1, ns, 1)
 			util.ValidateNumDeployments(ctx, wec2, ns, 0)
 			util.ValidateSingletonStatus(ctx, wds, ns, "nginx-singleton")
-		})
-
-		// This ginkgo subject node is currently written in an 'incorrect' way, in the sense that
-		// the Deployment's status always begins with zero value no matter there are matching WEC(s) or not, so
-		// this node doesn't test any behaviors of KubeStellar.
-		// The correct way to test is to merge this node with the previous node, to show that the Deployment's status:
-		// (1) is updated (with non-zero value) when there are matching WEC(s); then
-		// (2) is deleted (ends up with zero value) when there are no matching WEC(s) any more, due to changes of the bindingpolicy's ClusterSelectors or WEC(s)'s labels.
-		//
-		// But today there is a bug which prevents such a merged node from succeeding.
-		// We will complete the tests here by merging the two nodes after fixing that bug.
-		// We track this by https://github.com/kubestellar/kubestellar/issues/2020#issuecomment-2037539110
-		ginkgo.It("zeros singleton status when there is a singleton bindingpolicy/deployment but WEC(s) are not selected any more", func() {
-			util.DeleteDeployment(ctx, wds, ns, "nginx")
-			util.CreateDeployment(ctx, wds, ns, "nginx-singleton",
-				map[string]string{
-					"app.kubernetes.io/name": "nginx-singleton",
-				})
-			util.CreateBindingPolicy(ctx, ksWds, "nginx-singleton",
-				[]metav1.LabelSelector{
-					{MatchLabels: map[string]string{"name": "CelestialNexus"}},
-				},
-				[]ksapi.DownsyncObjectTest{
-					{ObjectSelectors: []metav1.LabelSelector{
-						{MatchLabels: map[string]string{"app.kubernetes.io/name": "nginx-singleton"}},
-					}}})
-			patch := []byte(`{"spec":{"wantSingletonReportedState": true}}`)
-			_, err := ksWds.ControlV1alpha1().BindingPolicies().Patch(
-				ctx, "nginx-singleton", types.MergePatchType, patch, metav1.PatchOptions{})
+			patch_again := []byte(`{"spec":{"clusterSelectors":[{"matchLabels":{"name":"CelestialNexus"}}]}}`)
+			_, err = ksWds.ControlV1alpha1().BindingPolicies().Patch(
+				ctx, "nginx-singleton", types.MergePatchType, patch_again, metav1.PatchOptions{})
 			gomega.ExpectWithOffset(1, err).NotTo(gomega.HaveOccurred())
 			util.ValidateNumDeployments(ctx, wec1, ns, 0)
 			util.ValidateNumDeployments(ctx, wec2, ns, 0)


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
This PR adds logic to the status controller so that it handles the deletion of WorkStatus objects.

This PR also completes a pending e2e test, tracked by [this comment](https://github.com/kubestellar/kubestellar/issues/2020#issuecomment-2037539110). The test was blocked by #2020, and it's now unblocked by this PR.

## Related issue(s)

Closes #2020 
