### PR TITLE
✨ Update PCHs to include ocm status-addon and transport-plugin

### DIFF
--- a/config/postcreate-hooks/kubestellar.yaml
+++ b/config/postcreate-hooks/kubestellar.yaml
@@ -74,8 +74,8 @@ spec:
       verbs:
       - get
       - list
-      - watch      
-  - apiVersion: rbac.authorization.k8s.io/v1  
+      - watch
+  - apiVersion: rbac.authorization.k8s.io/v1
     kind: ClusterRoleBinding
     metadata:
       name: "{{.Namespace}}-{{.HookName}}"
@@ -86,7 +86,7 @@ spec:
     subjects:
     - kind: ServiceAccount
       name: default
-      namespace: "{{.Namespace}}"       
+      namespace: "{{.Namespace}}"
   - apiVersion: rbac.authorization.k8s.io/v1
     kind: Role
     metadata:
@@ -138,7 +138,7 @@ spec:
       resources:
       - services
       verbs:
-      - get      
+      - get
     - apiGroups:
       - apps
       resources:
@@ -152,8 +152,8 @@ spec:
       - roles
       - rolebindings
       verbs:
-      - create                
-  - apiVersion: rbac.authorization.k8s.io/v1  
+      - create
+  - apiVersion: rbac.authorization.k8s.io/v1
     kind: RoleBinding
     metadata:
       name: "{{.HookName}}"
@@ -164,7 +164,7 @@ spec:
     subjects:
     - kind: ServiceAccount
       name: default
-      namespace: "{{.Namespace}}"   
+      namespace: "{{.Namespace}}"
   - apiVersion: batch/v1
     kind: Job
     metadata:
@@ -179,7 +179,7 @@ spec:
             args:
               - upgrade
               - --install
-              - -n
+              - --namespace
               - "{{.Namespace}}"
               - kubestellar
               - oci://ghcr.io/kubestellar/kubestellar/controller-manager-chart
@@ -189,6 +189,23 @@ spec:
               - "ControlPlaneName={{.ControlPlaneName}}"
             env:
             - name: XDG_CACHE_HOME
-              value: /tmp/helm/.cache  
+              value: /tmp/helm/.cache
+          - name: "{{.HookName}}-otp"
+            image: quay.io/kubestellar/helm:3.14.0
+            imagePullPolicy: IfNotPresent
+            args:
+              - upgrade
+              - --install
+              - --namespace
+              - "{{.Namespace}}"
+              - ocm-transport-plugin
+              - oci://ghcr.io/kubestellar/ocm-transport-plugin/chart/ocm-transport-plugin
+              - --version
+              - "0.1.7"
+              - --set
+              - "wds_cp_name={{.ControlPlaneName}}"
+            env:
+            - name: XDG_CACHE_HOME
+              value: /tmp/helm/.cache
           restartPolicy: Never
       backoffLimit: 1

--- a/config/postcreate-hooks/ocm.yaml
+++ b/config/postcreate-hooks/ocm.yaml
@@ -14,17 +14,40 @@ spec:
       template:
         spec:
           containers:
-          - name: "{{.HookName}}"
+          - name: "{{.HookName}}-ocm"
             image: quay.io/kubestellar/clusteradm:0.7.2
             args:
             - init
             env:
             - name: KUBECONFIG
-              value: "/etc/kube/config-incluster"    
+              value: "/etc/kube/config-incluster"
             volumeMounts:
             - name: kubeconfig
               mountPath: "/etc/kube"
-              readOnly: true  
+              readOnly: true
+          - name: "{{.HookName}}-statusaddon"
+            image: quay.io/kubestellar/helm:3.14.0
+            args:
+              - upgrade
+              - --install
+              - status-addon
+              - oci://ghcr.io/kubestellar/ocm-status-addon-chart
+              - --version
+              - v0.2.0-rc8
+              - --namespace
+              - open-cluster-management
+              - --create-namespace
+            env:
+            - name: HELM_CONFIG_HOME
+              value: "/tmp"
+            - name: HELM_CACHE_HOME
+              value: "/tmp"
+            - name: KUBECONFIG
+              value: "/etc/kube/config-incluster"
+            volumeMounts:
+            - name: kubeconfig
+              mountPath: "/etc/kube"
+              readOnly: true
           volumes:
           - name: kubeconfig
             secret:

--- a/docs/content/direct/examples.md
+++ b/docs/content/direct/examples.md
@@ -22,8 +22,6 @@ The following steps establish an initial state used in the examples below.
 
     ```shell
     export KUBESTELLAR_VERSION=0.22.0
-    export OCM_STATUS_ADDON_VERSION=0.2.0-rc8
-    export OCM_TRANSPORT_PLUGIN=0.1.7
     ```
 
 1. Create a Kind hosting cluster with nginx ingress controller and KubeFlex controller-manager installed:
@@ -42,43 +40,19 @@ The following steps establish an initial state used in the examples below.
 
 1. Create an inventory & mailbox space of type `vcluster` running *OCM* (Open Cluster Management)
 in KubeFlex. Note that `-p ocm` runs a post-create hook on the *vcluster* control plane
-which installs OCM on it.
+which installs OCM on it. This step includes the status add-on described [here](./architecture.md#ocm-status-add-on-agent) for more details on the add-on.
 
     ```shell
     kflex create its1 --type vcluster -p ocm
     ```
 
-1. Install status add-on on its1:
-
-    Wait until the `managedclusteraddons` resource shows up on `its1`. You can check on that with the command:
-
-    ```shell
-    kubectl --context its1 api-resources | grep managedclusteraddons || true
-    ```
-
-    and then install the status add-on:
-
-    ```shell
-    helm --kube-context its1 upgrade --install status-addon -n open-cluster-management oci://ghcr.io/kubestellar/ocm-status-addon-chart --version v${OCM_STATUS_ADDON_VERSION}
-    ```
-
-    see [here](./architecture.md#ocm-status-add-on-agent) for more details on the add-on.
-
 1. Create a Workload Description Space `wds1` in KubeFlex. Similarly to before, `-p kubestellar`
 runs a post-create hook on the *k8s* control plane that starts an instance of a KubeStellar controller
 manager which connects to the `wds1` front-end and the `its1` OCM control plane back-end.
+Additionally the OCM based transport controller will be deployed.
 
     ```shell
     kflex create wds1 -p kubestellar
-    ```
-
-1. Deploy the OCM based transport controller
-
-    ```shell
-    helm --kube-context kind-kubeflex upgrade --install ocm-transport-plugin oci://ghcr.io/kubestellar/ocm-transport-plugin/chart/ocm-transport-plugin --version ${OCM_TRANSPORT_PLUGIN} \
-     --set transport_cp_name=its1 \
-     --set wds_cp_name=wds1 \
-     -n wds1-system
     ```
 
 1. Follow the steps to [create and register two clusters with OCM](example-wecs.md).

--- a/docs/content/direct/examples.md
+++ b/docs/content/direct/examples.md
@@ -40,7 +40,9 @@ The following steps establish an initial state used in the examples below.
 
 1. Create an inventory & mailbox space of type `vcluster` running *OCM* (Open Cluster Management)
 in KubeFlex. Note that `-p ocm` runs a post-create hook on the *vcluster* control plane
-which installs OCM on it. This step includes the status add-on described [here](./architecture.md#ocm-status-add-on-agent) for more details on the add-on.
+which installs OCM on it.
+This step includes the installation of the status add-on controller.
+See [here](./architecture.md#ocm-status-add-on-agent) for more details on the add-on.
 
     ```shell
     kflex create its1 --type vcluster -p ocm


### PR DESCRIPTION
## Summary

Update PCHs to include ocm status-addon and transport-plugin:

1. update ocm.yaml PCH to include a second container installing the OCM status-addon along OCM
2. update kubestellar.yaml PCH to include a second container installing the OCM transport-plugin along with the KubeStellar plugin
3. update the example.md to remove the corresponding 2 steps

## Related issue(s)

Fixes #
