### PR TITLE
✨ Track OTP release 0.1.5 and prep for KS release 0.22.0-rc2

### DIFF
--- a/config/postcreate-hooks/kubestellar.yaml
+++ b/config/postcreate-hooks/kubestellar.yaml
@@ -184,7 +184,7 @@ spec:
               - kubestellar
               - oci://ghcr.io/kubestellar/kubestellar/controller-manager-chart
               - --version
-              - "0.22.0-rc1"
+              - "0.22.0-rc2"
               - --set
               - "ControlPlaneName={{.ControlPlaneName}}"
             env:

--- a/docs/content/direct/README.md
+++ b/docs/content/direct/README.md
@@ -37,7 +37,7 @@ We do not have one that is proven very good yet.
 The first release using the new architecture is 0.20.0; it is feture-incomplete.
 Release 0.21.0 works but is not well documented on the website; [view the missing information directly at GitHub](https://github.com/kubestellar/kubestellar/tree/release-0.21.0/docs/content/direct).
 Release 0.21.2 mostly works but references an outdated version (0.1.0) of the OCM transport plugin.
-The latest release is 0.22.0-rc1.
+The latest release is 0.22.0-rc2.
 See also [the release notes](release-notes.md).
 
 ## Architecture

--- a/docs/content/direct/examples.md
+++ b/docs/content/direct/examples.md
@@ -21,9 +21,9 @@ The following steps establish an initial state used in the examples below.
 1. Set environment variables to hold KubeStellar and OCM-status-addon desired versions:
 
     ```shell
-    export KUBESTELLAR_VERSION=0.22.0-rc1
+    export KUBESTELLAR_VERSION=0.22.0-rc2
     export OCM_STATUS_ADDON_VERSION=0.2.0-rc8
-    export OCM_TRANSPORT_PLUGIN=0.1.3
+    export OCM_TRANSPORT_PLUGIN=0.1.5
     ```
 
 1. Create a Kind hosting cluster with nginx ingress controller and KubeFlex controller-manager installed:

--- a/docs/content/direct/release-notes.md
+++ b/docs/content/direct/release-notes.md
@@ -11,6 +11,7 @@ The changes include adding the following features.
 - `PriorityClass` objects (from API group `scheduling.k8s.io`) propagate now.
 - Support multiple WDSes.
 - Allow multiple ITSes.
+- Use the new Helm chart from kubestellar/ocm-transport-plugin for deploying the transport controller.
 
 Prominent bug fixes include more discerning cleaning of workload objects on their way from WDS to WEC. This includes keeping a "headless" `Service` headless and removing the `spec.suspend` field from a `Job`.
 

--- a/scripts/deploy-transport-controller.sh
+++ b/scripts/deploy-transport-controller.sh
@@ -16,7 +16,7 @@
 # Transport deployment script assumes it runs using the kubeflex hosting cluster context.
 
 
-DEFAULT_TRANSPORT_CONTROLLER_IMAGE=ghcr.io/kubestellar/ocm-transport-plugin/transport-controller:0.1.3
+DEFAULT_TRANSPORT_CONTROLLER_IMAGE=ghcr.io/kubestellar/ocm-transport-plugin/transport-controller:0.1.5
 
 args=()
 

--- a/test/e2e/common/setup-kubestellar.sh
+++ b/test/e2e/common/setup-kubestellar.sh
@@ -118,7 +118,7 @@ echo "wds1 created."
 :
 cd "${SRC_DIR}/../../.." ## go up to KubeStellar directory
 KUBESTELLAR_DIR="$(pwd)"
-OCM_TRANSPORT_PLUGIN_RELEASE="0.1.3"
+OCM_TRANSPORT_PLUGIN_RELEASE="0.1.5"
 curl -sL https://github.com/kubestellar/ocm-transport-plugin/archive/refs/tags/v${OCM_TRANSPORT_PLUGIN_RELEASE}.tar.gz | tar xz
 cd ocm-transport-plugin-${OCM_TRANSPORT_PLUGIN_RELEASE}
 OCM_TRANSPORT_PLUGIN_DIR="$(pwd)"


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
This PR (a) tracks the 0.1.5 release of ks/OTP and (b) updates the ks/ks self-references in preparation for its 0.22.0-rc2.

## Related issue(s)

Fixes #
