### PR TITLE
📖 Fix version warning for release-0.22.0

### DIFF
--- a/docs/overrides/main.html
+++ b/docs/overrides/main.html
@@ -60,13 +60,13 @@
 {% endblock %}
 
 {% block outdated %}
-  You're not viewing the latest release.
-  <a href="{{ '../latest/' ~ base_url }}">
-    <strong>Click here to go to the latest release</strong>
+  You're not viewing the latest stable release.
+  <a href="{{ '../' ~ base_url ~ '/stable' }}">
+    <strong>Click here to go to the latest stable release</strong>
   </a>
   Also, FYI, 
-  <a href="{{ '../stable/' ~ base_url }}">
-    <strong>Click here to go to the latest stable release</strong>
+  <a href="{{ '../' ~ base_url ~ '/latest' }}">
+    <strong>Click here to go to the latest release</strong>
   </a>
 {% endblock %}
 


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
This PR fixes the functionality of the "version warning" banner (see https://squidfunk.github.io/mkdocs-material/setup/setting-up-versioning/?h=#setting-a-default-version), so that the links correctly lead to the "stable" and "latest" aliases.

## Related issue(s)

This addresses the first problem in Issue #2019 --- but only for release-0.22.0 .
