### PR TITLE
✨ Parameterize deploy docs

### DIFF
--- a/.github/workflows/docs-gen-and-push.yml
+++ b/.github/workflows/docs-gen-and-push.yml
@@ -33,11 +33,6 @@ jobs:
   
       - run: git fetch origin gh-pages
 
-      - uses: actions/setup-go@v5
-        with:
-          go-version: v1.19
-          cache: true
-
       - uses: actions/setup-python@v5
         with:
           python-version: '3.10'

--- a/.github/workflows/docs-gen-and-push.yml
+++ b/.github/workflows/docs-gen-and-push.yml
@@ -4,6 +4,23 @@ run-name: Generate and push docs - ${{ github.ref_name }}
 on:
   # So we can trigger manually if needed
   workflow_dispatch:
+    inputs:
+      aliasLatest:
+        description: 'Alias to latest'
+        required: false
+        default: ''
+        type: choice
+        options:
+        - ''
+        - '--alias-to=latest'
+      aliasStable:
+        description: 'Alias to stable'
+        required: false
+        default: ''
+        type: choice
+        options:
+        - ''
+        - '--alias-to=stable'
   # To confirm any changes to docs build successfully, without deploying them
   push:
     branches:
@@ -38,4 +55,8 @@ jobs:
           python-version: '3.10'
           cache: 'pip'
 
-      - run: make deploy-docs
+      - name: make deploy-docs
+        env:
+          ALIAS_LATEST: ${{ github.event.inputs.aliasLatest }}
+          ALIAS_STABLE: ${{ github.event.inputs.aliasStable }}
+        run: make deploy-docs DEPLOY_DOCS_EXTRA="$ALIAS_LATEST $ALIAS_STABLE"

--- a/Makefile
+++ b/Makefile
@@ -294,7 +294,7 @@ serve-docs: venv
 .PHONY: deploy-docs
 deploy-docs: venv
 	. $(VENV)/activate; \
-	REMOTE=$(REMOTE) BRANCH=$(BRANCH) docs/scripts/deploy-docs.sh
+	REMOTE=$(REMOTE) BRANCH=$(BRANCH) docs/scripts/deploy-docs.sh $(DEPLOY_DOCS_EXTRA)
 
 .PHONY: verify-go-versions
 verify-go-versions:

--- a/docs/README.md
+++ b/docs/README.md
@@ -129,13 +129,14 @@ In the document you want to include, add the start and end tags you configured i
 for more information on the 'include-markdown' plugin for mkdocs look [here](https://github.com/mondeja/mkdocs-include-markdown-plugin)
 
 ### Supported aliases for our documentation
-We currently support 3 aliases for our documentation:
 
-    - from the release major.minor branch:
-        - [{{ config.docs_url }}/stable]({{ config.docs_url }}/stable)
-    - from the main branch:
-        - [{{ config.docs_url }}/unstable]({{ config.docs_url }}/unstable)
-        - [{{ config.docs_url }}/latest]({{ config.docs_url }}/latest)
+`mike` has a concept of aliases. We currently maintain the following three aliases.
+
+- `unstable` ([{{config.docs_url}}/unstable](https://docs.kubestellar.io/unstable)), which always is an alias for the version named "main";
+- `stable` ([{{config.docs_url}}/stable](https://docs.kubestellar.io/stable)), for the latest of the releases that are considered "stable";
+- `latest` ([{{config.docs_url}}/latest](https://docs.kubestellar.io/latest)), for the latest release.
+
+Advancing the "latest" alias is a normal part of the release process (see the release process document). We advance the "stable" alias when a newer release is deemed "stable". Setting either alias is done by manually triggering the publishing workflow (see below) in [the GitHub web UI](https://github.com/kubestellar/kubestellar/actions/workflows/docs-gen-and-push.yml).
 
 ### Shortcut URLs
 We have a few shortcut urls that come in handy when referring others to our project:
@@ -425,5 +426,9 @@ git add .;git commit -m "add index, home, and CNAME files";git push -u origin gh
 ## Publishing Workflow
 
 All documentation building and publishing is done using GitHub Actions in
-[docs-gen-and-push.yaml](../.github/workflows/docs-gen-and-push.yaml). The overall sequence is:
+`.github/workflows/docs-gen-and-push.yml`. This workflow is triggered either manually or by a push to a branch named `main` or `release-<something>`. This workflow will build and publish a website _version_ whose name is the same as the name of the branch that it is working on.
+
+This workflow has a couple of optional parameters that can tell it to also set the "latest" and/or "stable" aliases to refer to the version that the workflow is publishing. These appear in GitHub's web UI for manually dispatching a workflow.
+
+
 <!--readme-for-documentation-end-->

--- a/docs/content/direct/release.md
+++ b/docs/content/direct/release.md
@@ -36,6 +36,8 @@ Update the references to the ocm-status-addon release in the following files.
 
 Making a new kubestellar release requires a contributor to do the following things. Here `$version` is the semver identifier for the release (e.g., `1.2.3-rc2`).
 
+- If not already in effect, declare a code freeze. There should be nothing but bug fixes and doc improvements while working towards a regular release.
+
 - Edit the source for the KCM PCH (in `config/postcreate-hooks/kubestellar.yaml`) and update the tag in the reference to the KCM container image (it appears in the last object, a `Job`).
 
 - Edit [the examples document](examples.md) to update the self-references for the coming release.
@@ -48,6 +50,8 @@ Making a new kubestellar release requires a contributor to do the following thin
 
 - Make a new Git commit with those changes and get it into the right branch in the shared repo (through the regular PR process if not authorized to cheat).
 
+- Wait for successful completion of the testing after that merge.
+
 - Apply the Git tag `v$version` to that new commit in the shared repo.
 
 - After that, the "goreleaser" GitHub workflow then creates and publishes the artifacts for that release (as discussed [above](#technology)) and then the "Test latest release" workflow will run the E2E tests using those artifacts. 
@@ -58,7 +62,13 @@ Making a new kubestellar release requires a contributor to do the following thin
 
 - Follow the procedure in [OCP testing](release-testing.md#e2e-release-tests-on-ocp), to verify that the release is functional on OCP.
 
+- If the test results are good and the release is regular (not an RC) then declare the code freeze over.
+
+- If the test results are good and the release is regular (not an RC) then advance the website's alias for "latest" to refer to this release.
+
 - If the testing results are good, update [ks/OTP](https://github.com/kubestellar/ocm-transport-plugin) to refer to the new ks/ks release and [make a new release of ks/OTP](https://github.com/kubestellar/ocm-transport-plugin/blob/main/docs/release.md).
+
+- When enough good experience is in, advance the website's alias for "stable" to this release.
 
 ## Goals and limitations
 


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
This PR changes `.github/workflows/docs-gen-and-push.yml` from fixed aliasing to parameterized aliasing. Before this change, there was a fixed policy:

- version "main" gets aliased to "latest" and "unstable";
- version "release-0.21.1" (as defined by a line in `docs/scripts/deploy-docs.sh`) gets aliased to "stable".

With this change: there is still a fixed policy of aliasing "main" to "unstable", but the aliases "latest" and "stable" are not automatically applied. Instead the workflow takes inputs that tell it whether to apply the "latest" alias and whether to apply the "stable" alias. When project maintainers decide to advance the "latest" and/or "stable" aliases, they explicitly run the workflow with appropriate parameter values. Here is an example of what that looked like when I was testing:

<img width="985" alt="Screenshot 2024-05-03 at 1 18 15 AM" src="https://github.com/kubestellar/kubestellar/assets/14296719/ec607e98-f71c-45e3-a70b-e9889074ad1c">

Note also that `mike` gives control over where a visitor to the site initially lands. In `mike` jargon this is called the "default" version. Our website currently has that set to "stable". We could change it to "latest" or "unstable" if we wanted to. See https://github.com/jimporter/mike?tab=readme-ov-file#setting-the-default-version .

`mike` has a `list` command that lists all the website versions and their aliases. Here is the current list for our website:

```
release-0.22.0 [latest]
release-0.22.0-rc3
release-0.22.0-rc2
release-0.22.0-rc1
release-0.21.2 [stable]
release-0.21.2-rc1
release-0.21.1
release-0.21.0
release-0.15
release-0.14
release-0.13
release-0.12
release-0.11
release-0.10
release-0.9
release-0.8
release-0.7
release-0.6
release-0.5
release-0.4
release-0.3
release-0.2
main [unstable]
```

This PR also removes an unnecessary step from the workflow: setup for Go. The doc tools are written in Python.

## Related issue(s)

This addresses part of #2019 .
