### PR TITLE
📖 Streamline release categorization

### DIFF
--- a/.github/workflows/docs-gen-and-push.yml
+++ b/.github/workflows/docs-gen-and-push.yml
@@ -4,23 +4,6 @@ run-name: Generate and push docs - ${{ github.ref_name }}
 on:
   # So we can trigger manually if needed
   workflow_dispatch:
-    inputs:
-      aliasLatest:
-        description: 'Alias to latest'
-        required: false
-        default: ''
-        type: choice
-        options:
-        - ''
-        - '--alias-to=latest'
-      aliasStable:
-        description: 'Alias to stable'
-        required: false
-        default: ''
-        type: choice
-        options:
-        - ''
-        - '--alias-to=stable'
   # To confirm any changes to docs build successfully, without deploying them
   push:
     branches:
@@ -55,8 +38,4 @@ jobs:
           python-version: '3.10'
           cache: 'pip'
 
-      - name: make deploy-docs
-        env:
-          ALIAS_LATEST: ${{ github.event.inputs.aliasLatest }}
-          ALIAS_STABLE: ${{ github.event.inputs.aliasStable }}
-        run: make deploy-docs DEPLOY_DOCS_EXTRA="$ALIAS_LATEST $ALIAS_STABLE"
+      - run: make deploy-docs

--- a/Makefile
+++ b/Makefile
@@ -294,7 +294,7 @@ serve-docs: venv
 .PHONY: deploy-docs
 deploy-docs: venv
 	. $(VENV)/activate; \
-	REMOTE=$(REMOTE) BRANCH=$(BRANCH) docs/scripts/deploy-docs.sh $(DEPLOY_DOCS_EXTRA)
+	REMOTE=$(REMOTE) BRANCH=$(BRANCH) docs/scripts/deploy-docs.sh
 
 .PHONY: verify-go-versions
 verify-go-versions:

--- a/docs/README.md
+++ b/docs/README.md
@@ -130,13 +130,12 @@ for more information on the 'include-markdown' plugin for mkdocs look [here](htt
 
 ### Supported aliases for our documentation
 
-`mike` has a concept of aliases. We currently maintain the following three aliases.
+`mike` has a concept of aliases. We currently maintain the following two aliases.
 
 - `unstable` ([{{config.docs_url}}/unstable](https://docs.kubestellar.io/unstable)), which always is an alias for the version named "main";
-- `stable` ([{{config.docs_url}}/stable](https://docs.kubestellar.io/stable)), for the latest of the releases that are considered "stable";
-- `latest` ([{{config.docs_url}}/latest](https://docs.kubestellar.io/latest)), for the latest release.
+- `latest` ([{{config.docs_url}}/latest](https://docs.kubestellar.io/latest)), for the latest regular release.
 
-Advancing the "latest" alias is a normal part of the release process (see the release process document). We advance the "stable" alias when a newer release is deemed "stable". Setting either alias is done by manually triggering the publishing workflow (see below) in [the GitHub web UI](https://github.com/kubestellar/kubestellar/actions/workflows/docs-gen-and-push.yml).
+The publishing workflow updates these aliases. The latest regular release is determined by picking the first version listed by `mike list` that matches the regexp `release-[0-9.]*`.
 
 ### Shortcut URLs
 We have a few shortcut urls that come in handy when referring others to our project:
@@ -426,9 +425,6 @@ git add .;git commit -m "add index, home, and CNAME files";git push -u origin gh
 ## Publishing Workflow
 
 All documentation building and publishing is done using GitHub Actions in
-`.github/workflows/docs-gen-and-push.yml`. This workflow is triggered either manually or by a push to a branch named `main` or `release-<something>`. This workflow will build and publish a website _version_ whose name is the same as the name of the branch that it is working on.
-
-This workflow has a couple of optional parameters that can tell it to also set the "latest" and/or "stable" aliases to refer to the version that the workflow is publishing. These appear in GitHub's web UI for manually dispatching a workflow.
-
+`.github/workflows/docs-gen-and-push.yml`. This workflow is triggered either manually or by a push to a branch named `main` or `release-<something>`. This workflow will build and publish a website _version_ whose name is the same as the name of the branch that it is working on. This workflow will also update the relevant `mike` alias, if necessary.
 
 <!--readme-for-documentation-end-->

--- a/docs/content/direct/release.md
+++ b/docs/content/direct/release.md
@@ -64,11 +64,7 @@ Making a new kubestellar release requires a contributor to do the following thin
 
 - If the test results are good and the release is regular (not an RC) then declare the code freeze over.
 
-- If the test results are good and the release is regular (not an RC) then advance the website's alias for "latest" to refer to this release.
-
 - If the testing results are good, update [ks/OTP](https://github.com/kubestellar/ocm-transport-plugin) to refer to the new ks/ks release and [make a new release of ks/OTP](https://github.com/kubestellar/ocm-transport-plugin/blob/main/docs/release.md).
-
-- When enough good experience is in, advance the website's alias for "stable" to this release.
 
 ## Goals and limitations
 

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -129,7 +129,7 @@ extra:
   #     link: mailto:kubestellar-dev@google.groups.com
   #     name: Email us
   version:
-    default: stable
+    default: latest
     # Enable mike for multi-version selection
     provider: mike
   analytics:

--- a/docs/overrides/main.html
+++ b/docs/overrides/main.html
@@ -60,13 +60,9 @@
 {% endblock %}
 
 {% block outdated %}
-  You're not viewing the latest release.
-  <a href="{{ '../latest/' ~ base_url }}">
-    <strong>Click here to go to the latest release</strong>
-  </a>
-  Also, FYI, 
-  <a href="{{ '../stable/' ~ base_url }}">
-    <strong>Click here to go to the latest stable release</strong>
+  You are not viewing the latest release.
+  <a href="{{ '../' ~ base_url }}">
+    <strong>Click here to go to the latest release.</strong>
   </a>
 {% endblock %}
 


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
This PR updates the policy docs and website behavior to eliminate the concept of a "stable" release and equate "latest" with the highest semver regular release.

If accepted, this PR will need to be followed up with corresponding PRs to the existing release branches so that their version warning banner will behave as intended.

## Related issue(s)

This partly resolves #2019
