### PR TITLE
📖 Update version warning banner in release-0.22.0

### DIFF
--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -129,7 +129,7 @@ extra:
   #     link: mailto:kubestellar-dev@google.groups.com
   #     name: Email us
   version:
-    default: stable
+    default: latest
     # Enable mike for multi-version selection
     provider: mike
   analytics:

--- a/docs/overrides/main.html
+++ b/docs/overrides/main.html
@@ -60,13 +60,9 @@
 {% endblock %}
 
 {% block outdated %}
-  You're not viewing the latest stable release.
-  <a href="{{ '../' ~ base_url ~ '/stable' }}">
-    <strong>Click here to go to the latest stable release</strong>
-  </a>
-  Also, FYI, 
-  <a href="{{ '../' ~ base_url ~ '/latest' }}">
-    <strong>Click here to go to the latest release</strong>
+  You are not viewing the latest release.
+  <a href="{{ '../' ~ base_url }}">
+    <strong>Click here to go to the latest release.</strong>
   </a>
 {% endblock %}
 


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
This PR changes the version warning banner behavior in branch `release-0.22.0` to match the changes made to branch `main` in #2111 .
This PR only changes enough to get the needed behavior fix; the older automation in the new state gives the right result (e.g., the `latest` alias has already been set to point to `release-0.22.0`, no need to change it).

## Related issue(s)

This is part of addressing #2019 .
