### PR TITLE
📖 Track fixes to version warning banner

### DIFF
--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -122,7 +122,7 @@ extra:
   #     link: mailto:kubestellar-dev@google.groups.com
   #     name: Email us
   version:
-    default: stable
+    default: latest
     # Enable mike for multi-version selection
     provider: mike
   analytics:

--- a/docs/overrides/main.html
+++ b/docs/overrides/main.html
@@ -60,9 +60,9 @@
 {% endblock %}
 
 {% block outdated %}
-  You're not viewing the stable release.
-  <a href="{{ '../latest/' ~ base_url }}">
-    <strong>Click here to go to the stable release</strong>
+  You are not viewing the latest release.
+  <a href="{{ '../' ~ base_url }}">
+    <strong>Click here to go to the latest release.</strong>
   </a>
 {% endblock %}
 


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
This PR fixes the version warning banner in the branch named release-0.21.2, following the pattern set in https://github.com/kubestellar/kubestellar/pull/2111 .

## Related issue(s)

This is part of addressing part of #2019 .
