### PR TITLE
🐛 Implement usage of ITSName argument by the chart

### DIFF
--- a/config/default/manager_auth_proxy_patch.yaml
+++ b/config/default/manager_auth_proxy_patch.yaml
@@ -53,5 +53,6 @@ spec:
         - "--metrics-bind-address=127.0.0.1:8080"
         - "--leader-elect"
         - "--wds-name={{.Values.ControlPlaneName}}"
+        - "--its-name={{.Values.ITSName}}"
         - "--api-groups={{.Values.APIGroups}}"
         - -v={{.Values.ControllerManager.Verbosity}}


### PR DESCRIPTION
## Summary

KS chart suggests that one could set ITSName: "" to something like its1 and expect the chart to use it and pass it to the controller. However, the value does not seem used in the Helm template.

This PR updates the chart to use it: `--its-name={{.Values.ITSName}}`

## Related issue(s)

Fixes #
