### PR TITLE
🌱 Remove controller-manager.yaml from Git management

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,9 @@ docs/scripts/generated_script.sh
 # local chart of the controller manager for dev/test
 local-chart/
 
+# KubeStellar controller-manager YAML is dynamically generated when needed
+/chart/templates/controller-manager.yaml
+
 # etc distributions
 /etcd-v*
 

--- a/chart/templates/controller-manager.yaml
+++ b/chart/templates/controller-manager.yaml
@@ -1,1 +1,0 @@
-This file is overwritten by `make chart` (whose results are not kept in Git) and ignored by `make local-chart`.


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
This PR takes `chart/templates/controller-manager.yaml` out of Git control. It is dynamically generated at every use, and already the Git content is only a placeholder (which got little love in review).

Removing it completely from Git management will remove the need to have a distinct "local-chart".

## Related issue(s)

Fixes #
