### PR TITLE
🌱 Stop rendering Helm chart into local-chart directory

### DIFF
--- a/test/e2e/common/setup-kubestellar.sh
+++ b/test/e2e/common/setup-kubestellar.sh
@@ -99,7 +99,6 @@ if [ "$use_release" != true ]; then
   cd "${SRC_DIR}/../../.."
   pwd
   make ko-build-local
-  rm -rf local-chart
   make install-local-chart KUBE_CONTEXT=kind-kubeflex "KUBESTELLAR_CONTROLLER_MANAGER_VERBOSITY=$KUBESTELLAR_CONTROLLER_MANAGER_VERBOSITY"
   cd -
 fi


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
This PR changes the scripting/makery to stop rendering the Helm chart into a directory named `local-chart/`; instead, it is just kept in `chart/`. This is good because it makes everything simpler.

## Related issue(s)
