### PR TITLE
:sparkles: Update OCM clusteradm version to 0.8.2

### DIFF
--- a/config/postcreate-hooks/ocm.yaml
+++ b/config/postcreate-hooks/ocm.yaml
@@ -15,7 +15,7 @@ spec:
         spec:
           containers:
           - name: "{{.HookName}}-ocm"
-            image: quay.io/kubestellar/clusteradm:0.7.2
+            image: quay.io/kubestellar/clusteradm:0.8.2
             args:
             - init
             env:

--- a/docs/content/direct/packaging.md
+++ b/docs/content/direct/packaging.md
@@ -210,7 +210,7 @@ There are two `PostCreateHook` objects defined in the `config/postcreate-hooks/`
 
 #### ocm PostCreateHook
 
-The PostCreateHook defined in `ocm.yaml` gets used on an ITS and adds the hub side of OCM there, using the image `quay.io/kubestellar/clusteradm:0.7.2`. See [above](#clusteradm-container-image) about the source of that. Currently this PostCreateHook is used in the E2E tests but this is a problem because of its fixed reference to container image previously built from sources in this same Git repository.
+The PostCreateHook defined in `ocm.yaml` gets used on an ITS and adds the hub side of OCM there, using the image `quay.io/kubestellar/clusteradm:0.8.2`. This image includes the `clusteradm` CLI release `v0.8.2` which is bundled with the OCM release `v0.13.2`. See [above](#clusteradm-container-image) about the source of that. Currently this PostCreateHook is used in the E2E tests but this is a problem because of its fixed reference to container image previously built from sources in this same Git repository.
 
 #### kubestellar PostCreateHook
 


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
Use a new version of the `clusteradm` image for ocm PostCreateHook in KubeStellar. The `clusteradm` CLI release `v0.8.2` is bundled with the OCM release `v0.13.2` which includes the fix(https://github.com/open-cluster-management-io/ocm/issues/384) for the issue https://github.com/kubestellar/kubestellar/issues/1637

## Related issue(s)

Fixes https://github.com/kubestellar/kubestellar/issues/1637
