### PR TITLE
📖 Include apiVersion in exhibited CustomTransform

### DIFF
--- a/docs/content/direct/user-guide.md
+++ b/docs/content/direct/user-guide.md
@@ -63,6 +63,7 @@ Currently the only available transformations are removals of specified content. 
 For example, the following `CustomTransform` object says to remove the `spec` field named `suspend` from `Job` objects (in the API group `batch`).
 
 ```yaml
+apiVersion: control.kubestellar.io/v1alpha1
 kind: CustomTransform
 metadata:
   name: example


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
This PR fixes a copy-and-paste error in the user guide: the `apiVersion` was omitted from the exhibited `CustomTransform` object.

## Related issue(s)

Fixes #2112 
