### PR TITLE
📖 Finish doc updates wrt E2E test on OCP

### DIFF
--- a/docs/content/direct/release.md
+++ b/docs/content/direct/release.md
@@ -21,15 +21,11 @@ Between each release of [ks/OTP](https://github.com/kubestellar/ocm-transport-pl
 
 - Edit `test/e2e/common/setup-kubestellar.sh`: update the setting of `OCM_TRANSPORT_PLUGIN_RELEASE` to the latest.
 
-- Edit `test/e2e/multi-cluster-deployment/README.md`: update the setting of `OCM_TRANSPORT_PLUGIN_RELEASE` to the latest.
-
-
 ### Reacting to a new ocm-status-addon release
 
 Update the references to the ocm-status-addon release in the following files.
 
 - `docs/content/direct/examples.md`
-- `test/e2e/multi-cluster-deployment/README.md`
 - `test/e2e/common/setup-kubestellar.sh`
 
 ### Making a new kubestellar release
@@ -41,8 +37,6 @@ Making a new kubestellar release requires a contributor to do the following thin
 - Edit the source for the KCM PCH (in `config/postcreate-hooks/kubestellar.yaml`) and update the tag in the reference to the KCM container image (it appears in the last object, a `Job`).
 
 - Edit [the examples document](examples.md) to update the self-references for the coming release.
-
-- Update the kubestellar self-reference in `test/e2e/multi-cluster-deployment/README.md`.
 
 - Until we have our first stable release, edit [the README](README.md#latest-stable-release) where it wishes it could cite a stable release but instead cites the latest release, to rever to the coming release.
 

--- a/test/e2e/multi-cluster-deployment/README.md
+++ b/test/e2e/multi-cluster-deployment/README.md
@@ -17,8 +17,9 @@ cd test/e2e/multi-cluster-deployment
 
 ## Running the test in three existing OCP clusters
 
+**NOTE**: at present this _only_ works with `--released`.
 
-1. Create a kubeconfig with contexts for the `kscore`, `cluster1` and `cluster2`. The following shows what the result should look like.
+1. Create a kubeconfig with contexts named `kscore` (for the kubeflex hosting cluster), `cluster1` and `cluster2`. The following shows what the result should look like.
 
 ```bash
 $ kubectl config get-contexts
@@ -37,8 +38,6 @@ $ kubectl config rename-context <default-wec1-context-name> kscore
 2. Run e2e test in your ocp cluster:
 
 ```
- export KUBESTELLAR_VERSION=0.23.0-alpha.1
- export OCM_STATUS_ADDON_VERSION=0.2.0-rc8
- export OCM_TRANSPORT_PLUGIN=0.1.7
- bash <(curl -s https://raw.githubusercontent.com/kubestellar/kubestellar/release-$KUBESTELLAR_VERSION/test/e2e/multi-cluster-deployment/run-test.sh) --env ocp
+cd test/e2e/multi-cluster-deployment
+./run-test.sh --env ocp --released
 ```


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
This PR makes two updates to documentation, which should have been done in #2137.

- Update `test/e2e/multi-cluster-deployment/README.md` on how to invoke the test.
- Update `docs/content/direct/release.md`, removing updates to the self-references removed here.

## Related issue(s)

Fixes #
