### PR TITLE
✨  Single script that activates e2e tests for bash and ginkgo tests

### DIFF
--- a/test/e2e/common/cleanup.sh
+++ b/test/e2e/common/cleanup.sh
@@ -41,7 +41,7 @@ elif [ $env == "ocp" ];then
         cluster=$1
 
         kubectl --context $cluster delete ns nginx --ignore-not-found
-        clusteradm unjoin --cluster-name $cluster
+        clusteradm unjoin --cluster-name $cluster  2> /dev/null
         kubectl --context $cluster delete ns open-cluster-management open-cluster-management-agent open-cluster-management-agent-addon --ignore-not-found
     }
 

--- a/test/e2e/multi-cluster-deployment/README.md
+++ b/test/e2e/multi-cluster-deployment/README.md
@@ -10,9 +10,16 @@ The transport controller will be invoked with `-v=4` unless othewise specified o
 
 Starting from a local directory containing the git repo, do the following.
 
-```
+a) Bash tests:
+```bash
 cd test/e2e/multi-cluster-deployment
 ./run-test.sh
+```
+
+b) Ginkgo tests:
+```bash
+cd test/e2e/multi-cluster-deployment
+./run-test.sh --test-type ginkgo
 ```
 
 ## Running the test in three existing OCP clusters
@@ -32,12 +39,19 @@ CURRENT   NAME          CLUSTER                   AUTHINFO               NAMESPA
 Use the following command to rename the default context name for `cluster1` workload execution cluster:
 
 ```bash 
-$ kubectl config rename-context <default-wec1-context-name> kscore
+$ kubectl config rename-context <default-wec1-context-name> cluster1
 ```
 
 2. Run e2e test in your ocp cluster:
 
-```
+a) Bash tests:
+```bash
 cd test/e2e/multi-cluster-deployment
 ./run-test.sh --env ocp --released
+```
+
+b) Ginkgo tests:
+```bash
+cd test/e2e/multi-cluster-deployment
+./run-test.sh --env ocp --released --test-type ginkgo
 ```


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

This PR improves the current e2e tests with a single script that activates both bash and ginkgo tests for kind and ocp clusters

## Related issue(s)

https://github.com/kubestellar/kubestellar/issues/2104


Fixes #
