### PR TITLE
✨ Add QPS and Burst flags to core controllers

### DIFF
--- a/pkg/binding/controller.go
+++ b/pkg/binding/controller.go
@@ -148,6 +148,7 @@ func NewController(parentLogger logr.Logger, wdsRestConfig *rest.Config, itsRest
 	disposableConfig := rest.CopyConfig(wdsRestConfig)
 	disposableConfig.Burst = referenceBurstUpperBound
 	disposableConfig.QPS = referenceQPSUpperBound
+	disposableConfig.RateLimiter = nil
 	disposableClient, err := kubernetes.NewForConfig(disposableConfig)
 	if err != nil {
 		return nil, err
@@ -161,6 +162,7 @@ func NewController(parentLogger logr.Logger, wdsRestConfig *rest.Config, itsRest
 	wdsRestConfigTuned := rest.CopyConfig(wdsRestConfig)
 	wdsRestConfigTuned.Burst = computeBurstFromNumGVRs(nGVRs)
 	wdsRestConfigTuned.QPS = computeQPSFromNumGVRs(nGVRs)
+	wdsRestConfigTuned.RateLimiter = nil
 	logger.V(1).Info("Parameters of the tuned client's token bucket rate limiter", "burst", wdsRestConfigTuned.Burst, "qps", wdsRestConfigTuned.QPS)
 
 	// dynamicClient needs higher rate than its default because dynamicClient is repeatedly used by the

--- a/pkg/transport/cmd/options.go
+++ b/pkg/transport/cmd/options.go
@@ -28,8 +28,8 @@ const (
 
 type TransportOptions struct {
 	Concurrency            int
-	WdsClientOptions       *clientopts.ClientOptions
-	TransportClientOptions *clientopts.ClientOptions
+	WdsClientOptions       *clientopts.ClientOptions[*pflag.FlagSet]
+	TransportClientOptions *clientopts.ClientOptions[*pflag.FlagSet]
 	WdsName                string
 	metricsBindAddr        string
 	pprofBindAddr          string
@@ -38,8 +38,8 @@ type TransportOptions struct {
 func NewTransportOptions() *TransportOptions {
 	return &TransportOptions{
 		Concurrency:            defaultConcurrency,
-		WdsClientOptions:       clientopts.NewClientOptions("wds", "access the wds"),
-		TransportClientOptions: clientopts.NewClientOptions("transport", "access the transport space"),
+		WdsClientOptions:       clientopts.NewClientOptions[*pflag.FlagSet]("wds", "accessing the WDS"),
+		TransportClientOptions: clientopts.NewClientOptions[*pflag.FlagSet]("transport", "accessing the ITS"),
 		metricsBindAddr:        ":8090",
 		pprofBindAddr:          ":8092",
 	}


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
This PR adds QPS and Burst command line flags to the kubestellar controller-manager and the generic transport controller code.

## Related issue(s)

This is part of addressing #2159 
