### PR TITLE
:sparkles: CombinedStatus Calculation (part 1)

### DIFF
--- a/pkg/binding/bindingpolicy-resolution-broker.go
+++ b/pkg/binding/bindingpolicy-resolution-broker.go
@@ -1,0 +1,129 @@
+/*
+Copyright 2024 The KubeStellar Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package binding
+
+import (
+	"github.com/kubestellar/kubestellar/api/control/v1alpha1"
+	"github.com/kubestellar/kubestellar/pkg/abstract"
+	"github.com/kubestellar/kubestellar/pkg/util"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"sync"
+)
+
+// ResolutionBroker allows for the registration of callback functions that
+// are called when a resolution is updated.
+// It also allows for the retrieval of resolutions for a given bindingPolicyKey.
+type ResolutionBroker interface {
+	// RegisterCallback adds a new callback function that will be called,
+	// on a separate goroutine, when a resolution is updated. The callback
+	// function should accept a bindingPolicyKey.
+	// There is no deduplication of callbacks.
+	RegisterCallback(func(bindingPolicyKey string))
+
+	// GetResolution retrieves the resolution for a given bindingPolicyKey.
+	// If no resolution is associated with the given key, nil is returned.
+	GetResolution(bindingPolicyKey string) *Resolution
+}
+
+// Resolution is a struct that represents the resolution of a binding policy.
+// It contains the destinations and object data for the resolution.
+type Resolution struct {
+	// Destinations is a list of destinations that are the "where" part of the
+	// resolution.
+	Destinations []v1alpha1.Destination
+	// ObjectIdentifierToData is a map of object identifiers to their
+	// corresponding ObjectData.
+	ObjectIdentifierToData map[util.ObjectIdentifier]struct {
+		ResourceVersion  string
+		StatusCollectors []string
+	}
+}
+
+// NewResolutionBroker creates a new ResolutionBroker with the given
+// bindingPolicyResolutionGetter function.
+// The latter function's returned `bindingPolicyResolution` is expected to be
+// thread-safe under the constraint that only its methods are used.
+func NewResolutionBroker(bindingPolicyResolutionGetter func(bindingPolicyKey string) *bindingPolicyResolution) ResolutionBroker {
+	return &resolutionBroker{
+		bindingPolicyResolutionGetter: bindingPolicyResolutionGetter,
+	}
+}
+
+// resolutionBroker implements the ResolutionBroker interface.
+// The broker requires a bindingPolicyResolutionGetter function that retrieves
+// resolutions from a BindingPolicyResolver.
+type resolutionBroker struct {
+	sync.Mutex
+	callbacks []func(bindingPolicyKey string)
+	// bindingPolicyResolutionGetter is a function that retrieves the
+	// resolution for a given bindingPolicyKey. If no resolution is associated
+	// with the given key, nil is returned.
+	// The returned `bindingPolicyResolution` is expected to be thread-safe as
+	// long as only its methods are used.
+	bindingPolicyResolutionGetter func(bindingPolicyKey string) *bindingPolicyResolution
+}
+
+// RegisterCallback adds a new callback function that will be called, on a
+// separate goroutine, when a resolution is updated. The callback function
+// should accept a bindingPolicyKey.
+// There is no deduplication of callbacks.
+func (broker *resolutionBroker) RegisterCallback(callback func(bindingPolicyKey string)) {
+	broker.Lock()
+	defer broker.Unlock()
+
+	broker.callbacks = append(broker.callbacks, callback)
+}
+
+// GetResolution retrieves the resolution for a given bindingPolicyKey.
+// If no resolution is associated with the given key, nil is returned.
+func (broker *resolutionBroker) GetResolution(bindingPolicyKey string) *Resolution {
+	bindingPolicyResolution := broker.bindingPolicyResolutionGetter(bindingPolicyKey)
+
+	if bindingPolicyResolution == nil {
+		return nil
+	}
+
+	return &Resolution{
+		Destinations: bindingPolicyResolution.getDestinationsList(),
+		ObjectIdentifierToData: abstract.PrimitiveMapSafeMap(&bindingPolicyResolution.RWMutex,
+			bindingPolicyResolution.objectIdentifierToData,
+			func(data *objectData) struct {
+				ResourceVersion  string
+				StatusCollectors []string
+			} {
+				return struct {
+					ResourceVersion  string
+					StatusCollectors []string
+				}{
+					ResourceVersion:  data.ResourceVersion,
+					StatusCollectors: sets.List(data.StatusCollectors), // members are string copies
+				}
+			}), // while this function breaks the constraint, it maintains its own concurrency safety
+		// by using the PrimitiveMapSafeMap which transforms a map safely using its read-lock.
+	}
+}
+
+// NotifyCallbacks calls all registered callbacks with the given bindingPolicyKey.
+// The callbacks are called on separate goroutines.
+func (broker *resolutionBroker) NotifyCallbacks(bindingPolicyKey string) {
+	broker.Lock()
+	defer broker.Unlock()
+
+	for _, callback := range broker.callbacks {
+		go callback(bindingPolicyKey)
+	}
+}

--- a/pkg/binding/bindingpolicy-resolution-broker.go
+++ b/pkg/binding/bindingpolicy-resolution-broker.go
@@ -17,11 +17,13 @@ limitations under the License.
 package binding
 
 import (
+	"sync"
+
+	"k8s.io/apimachinery/pkg/util/sets"
+
 	"github.com/kubestellar/kubestellar/api/control/v1alpha1"
 	"github.com/kubestellar/kubestellar/pkg/abstract"
 	"github.com/kubestellar/kubestellar/pkg/util"
-	"k8s.io/apimachinery/pkg/util/sets"
-	"sync"
 )
 
 // ResolutionBroker allows for the registration of callback functions that
@@ -91,7 +93,7 @@ func (broker *resolutionBroker) RegisterCallback(callback func(bindingPolicyKey 
 // GetResolution retrieves the resolution for a given bindingPolicyKey.
 // If no resolution is associated with the given key, nil is returned.
 func (broker *resolutionBroker) GetResolution(bindingPolicyKey string) *Resolution {
-	bindingPolicyResolution := broker.bindingPolicyResolutionGetter(bindingPolicyKey)
+	bindingPolicyResolution := broker.bindingPolicyResolutionGetter(bindingPolicyKey) //thread-safe
 
 	if bindingPolicyResolution == nil {
 		return nil

--- a/pkg/binding/bindingpolicy-resolution.go
+++ b/pkg/binding/bindingpolicy-resolution.go
@@ -199,6 +199,15 @@ func (resolution *bindingPolicyResolution) matchesBindingSpec(bindingSpec *v1alp
 	return true
 }
 
+// getDestinationsList returns a sorted list of v1alpha1.Destination in the
+// resolution.
+func (resolution *bindingPolicyResolution) getDestinationsList() []v1alpha1.Destination {
+	resolution.RLock()
+	defer resolution.RUnlock()
+
+	return destinationsStringSetToSortedDestinations(resolution.destinations)
+}
+
 // destinationsMatch returns true if the destinations in the resolution
 // match the destinations in the binding spec.
 func destinationsMatch(resolvedDestinations sets.Set[string], bindingDestinations []v1alpha1.Destination) bool {


### PR DESCRIPTION
## Summary
This PR is the first in the set that implement #2141. Once the set is completed, Combined-Status would be functional.

In this PR a new binding resolution broker is introduced, which will be used by the to-be-created `CombinedStatusResolver`.

## High-Level Overall Picture
Peek of the overall design and intentions:
- Following this broker, a `WorkStatus` broker will be PR'd. The `WorkStatus` broker will allow callback registering for a finer-granularity notification, where observers will register for changes of a single workload-object (all of its associated work-statuses)
- Using the `binging.ResolutionBroker` and the `status.WorkStatusBroker`, a `CombinedStatusResolver` will maintain:
    - Per (binding) resolution,  and per `StatusCollector`, the information used of every relevant `WorkStatus`
        - When a `WorkStatus` is updated, the `status.WorkStatusBroker` would provide an event to trigger the resolver to fetch the updated information and queue a `CombinedStatus` reference to be updated if necessary. **This provides the necessary benefit of not having to re-evaluate all work-statuses on individual changes


## Related Issues
- #2141 