### PR TITLE
✨ Update core chart to use KubeFlex v0.62

### DIFF
--- a/core-chart/Chart.yaml
+++ b/core-chart/Chart.yaml
@@ -29,6 +29,6 @@ icon: https://raw.githubusercontent.com/kubestellar/kubestellar/main/docs/favico
 # List dependencies
 dependencies:
 - name: kubeflex-operator
-  version: v0.6.1
+  version: v0.6.2
   repository: oci://ghcr.io/kubestellar/kubeflex/chart
   condition: kubeflex-operator.install


### PR DESCRIPTION
## Summary

Update core chart to use KubeFlex v0.62

## Related issue(s)

Fixes #
