### PR TITLE
✨ Enable website previews

### DIFF
--- a/.github/workflows/docs-gen-and-push.yml
+++ b/.github/workflows/docs-gen-and-push.yml
@@ -8,6 +8,7 @@ on:
   push:
     branches:
       - "release-*"
+      - "doc-*"
     paths:
       - "docs/**"
       - "*.md"
@@ -20,14 +21,29 @@ concurrency:
   group: ${{ github.workflow }}
 
 jobs:
+  debug:
+    name: print relevant info
+    runs-on: ubuntu-latest
+    steps:
+      - run: |
+          echo "github.actor=${{ github.actor }}"
+          echo "github.action_ref=${{ github.action_ref }}"
+          echo "github.event_name=${{ github.event_name }}"
+          echo "github.head_ref=${{ github.head_ref }}"
+          echo "github.ref=${{ github.ref }}"
+          echo "github.ref_name=${{ github.ref_name }}"
+          echo "github.repository_owner=${{ github.repository_owner }}"
+          echo "github.triggering_actor=${{ github.triggering_actor }}"
+          echo "GITHUB_ACTION_REF=$GITHUB_ACTION_REF"
+
   generate-and-push:
-    if: github.repository_owner == 'kubestellar'
+    if: github.repository_owner == 'kubestellar' || github.repository_owner == github.actor
     name: Generate and push docs
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4.1.1
         with:
-          token: ${{ secrets.GH_ALL_PROJECT_TOKEN }}
+          token: ${{ github.repository_owner == 'kubestellar' && secrets.GH_ALL_PROJECT_TOKEN || github.token }}
           persist-credentials: 'true'
   
       - run: git fetch origin gh-pages

--- a/docs/README.md
+++ b/docs/README.md
@@ -8,6 +8,8 @@ We have two web sites, as follows.
 - `https://kubestellar.io`. This is hosted by GoDaddy and administered by [Andy Anderson](mailto://andy@clubanderson.com). It contains a few redirects. The most important is that `https://kubestellar.io/` redirects to `https://docs.kubestellar.io/`.
 - `https://docs.kubestellar.io`. This is a GitHub pages website based on the `github.com/kubestellar/kubestellar/` repository.
 
+Also, a contributor has their own copy of the website, at `https://${repo_owner}.github.io/${fork_name}`.
+
 ### GitHub pages
 
 Our documentation is powered by [mike](https://github.com/jimporter/mike) and [MkDocs](https://www.mkdocs.org/). MkDocs is powered by [Python-Markdown](https://pypi.org/project/Markdown/). These are immensely configurable and extensible. You can see our MkDocs configuration in `docs/mkdocs.yml`. Following are some of the choices we have made.
@@ -425,9 +427,13 @@ git add .;git commit -m "add index, home, and CNAME files";git push -u origin gh
 
 - if the above did not work, then you might have an issue with the GoDaddy domain (expired, files missing, etc.)
 
+### How to delete a rendering of a branch
+
+Use `mike delete $branch_name`, either acting locally on your checked out `gh-pages` branch (after pull and before git commit and push) or acting more directly on the remote repo using `--remote` and `--push`. See [the mike delete command doc](https://github.com/jimporter/mike?tab=readme-ov-file#deleting-docs).
+
 ## Publishing Workflow
 
 All documentation building and publishing is done using GitHub Actions in
-`.github/workflows/docs-gen-and-push.yml`. This workflow is triggered either manually or by a push to a branch named `main` or `release-<something>`. This workflow will build and publish a website _version_ whose name is the same as the name of the branch that it is working on. This workflow will also update the relevant `mike` alias, if necessary.
+`.github/workflows/docs-gen-and-push.yml`. This workflow is triggered either manually or by a push to a branch named `main` or `release-<something>` or `doc-<something>`. This workflow will actually do something _ONLY_ if either (a) it is acting on the shared GitHub repository at `github.com/kubestellar/kubestellar` and on behalf of the repository owner or (b) it is acting on a contributor's fork of that repo and on behalf of that same contributor. The published site appears at `https://pages.github.io/kubestellar/${branch}` in case (a) and at `https://${repo_owner}.github.io/${fork_name}/${branch}` in case (b). This workflow will build and publish a website _version_ whose name is the same as the name of the branch that it is working on. This workflow will also update the relevant `mike` alias, if necessary.
 
 <!--readme-for-documentation-end-->

--- a/docs/scripts/deploy-docs.sh
+++ b/docs/scripts/deploy-docs.sh
@@ -65,7 +65,7 @@ fi
 mike deploy "${MIKE_OPTIONS[@]}" "$VERSION"
 
 if [[ -n "${CI:-}" ]] && [[ "${GITHUB_EVENT_NAME}" =~ ^push|workflow_dispatch$ ]]; then
-  if [[ "$VERSION" =~ ^release- ]]; then
+  if [[ "$VERSION" =~ ^release- ]] || [[ "$VERSION" =~ ^doc- ]] ; then
     latest=$(mike list | awk '{ print $1 }' | grep '^release-[0-9.]*$' | head -1)
     if [ "$VERSION" == "$latest" ]; then
       desired_alias=latest


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
This PR modifies the website update workflow to also render in the case of a contributor working on a branch whose name starts with "doc-". The rendering is only done if the actor involved in the github action is the repository owner. The rendering goes to the contributor's own github pages site. For example, this PR caused publication to https://mikespreitzer.github.io/kcp-edge-mc/doc-preview-enable/ .

## Related issue(s)

Fixes #
