### PR TITLE
✨ Add metrics to transport controller

### DIFF
--- a/.github/workflows/pr-test-e2e.yml
+++ b/.github/workflows/pr-test-e2e.yml
@@ -83,6 +83,10 @@ jobs:
         if: always()
         run: kubectl --context kind-kubeflex get deployments -A
 
+      - name: show Deployment objects in its1
+        if: always()
+        run: kubectl --context its1 get deployments -A
+
       - name: show kubestellar controller manager log
         if: always()
         run: kubectl --context kind-kubeflex logs -n wds1-system $(kubectl --context kind-kubeflex get pod -n wds1-system --selector=control-plane=controller-manager -o jsonpath='{.items[0].metadata.name}')
@@ -118,6 +122,39 @@ jobs:
       - name: show workstatuses
         if: always()
         run: kubectl --context its1 get workstatuses -A -o yaml
+
+      - name: scrape kubestellar controller-manager
+        if: always()
+        run: |
+          kubectl --context kind-kubeflex port-forward -n wds1-system deploy/kubestellar-controller-manager 8080 &
+          sleep 10
+          curl http://localhost:8080/metrics
+          kill %
+
+      - name: scrape transport controller
+        if: always()
+        run: |
+          kubectl --context kind-kubeflex port-forward -n wds1-system deploy/transport-controller 8090 &
+          sleep 10
+          curl http://localhost:8090/metrics
+          kill %
+
+      - name: scrape OCM Status Add-On Controller
+        if: always()
+        run: |
+          kubectl --context its1 port-forward -n open-cluster-management deploy/addon-status-controller 9280 &
+          sleep 10
+          curl http://localhost:9280/metrics
+          kill %
+          sleep 1
+
+      - name: scrape OCM Status Add-On Agent
+        if: always()
+        run: |
+          kubectl --context cluster1 port-forward -n open-cluster-management-agent-addon deploy/status-agent 8080 &
+          sleep 10
+          curl http://localhost:8080/metrics
+          kill %
 
   test-bash:
     name: Test in bash
@@ -166,6 +203,10 @@ jobs:
         if: always()
         run: kubectl --context kind-kubeflex get deployments -A
 
+      - name: show Deployment objects in its1
+        if: always()
+        run: kubectl --context its1 get deployments -A
+
       - name: show kubestellar controller manager log
         if: always()
         run: kubectl --context kind-kubeflex logs -n wds1-system $(kubectl --context kind-kubeflex get pod -n wds1-system --selector=control-plane=controller-manager -o jsonpath='{.items[0].metadata.name}')
@@ -201,3 +242,36 @@ jobs:
       - name: show workstatuses
         if: always()
         run: kubectl --context its1 get workstatuses -A -o yaml
+
+      - name: scrape kubestellar controller-manager
+        if: always()
+        run: |
+          kubectl --context kind-kubeflex port-forward -n wds1-system deploy/kubestellar-controller-manager 8080 &
+          sleep 10
+          curl http://localhost:8080/metrics
+          kill %
+
+      - name: scrape transport controller
+        if: always()
+        run: |
+          kubectl --context kind-kubeflex port-forward -n wds1-system deploy/transport-controller 8090 &
+          sleep 10
+          curl http://localhost:8090/metrics
+          kill %
+
+      - name: scrape OCM Status Add-On Controller
+        if: always()
+        run: |
+          kubectl --context its1 port-forward -n open-cluster-management deploy/addon-status-controller 9280 &
+          sleep 10
+          curl http://localhost:9280/metrics
+          kill %
+          sleep 1
+
+      - name: scrape OCM Status Add-On Agent
+        if: always()
+        run: |
+          kubectl --context cluster1 port-forward -n open-cluster-management-agent-addon deploy/status-agent 8080 &
+          sleep 10
+          curl http://localhost:8080/metrics
+          kill %

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/kubestellar/kubeflex v0.6.1
 	github.com/onsi/ginkgo/v2 v2.13.0
 	github.com/onsi/gomega v1.29.0
+	github.com/prometheus/client_golang v1.16.0
 	github.com/spf13/pflag v1.0.5
 	golang.org/x/exp v0.0.0-20220722155223-a9213eeb770e
 	golang.org/x/time v0.3.0
@@ -97,7 +98,6 @@ require (
 	github.com/opencontainers/selinux v1.10.0 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pquerna/cachecontrol v0.1.0 // indirect
-	github.com/prometheus/client_golang v1.16.0 // indirect
 	github.com/prometheus/client_model v0.4.0 // indirect
 	github.com/prometheus/common v0.44.0 // indirect
 	github.com/prometheus/procfs v0.10.1 // indirect

--- a/pkg/metrics/client.go
+++ b/pkg/metrics/client.go
@@ -76,6 +76,12 @@ func MustRegister(reg RegisterFn, registerable ...interface{ Register(RegisterFn
 	}
 }
 
+func MustRegisterAbles(reg RegisterFn, registerable ...k8smetrics.Registerable) {
+	for _, ra := range registerable {
+		Must(reg(ra))
+	}
+}
+
 type multiSpaceClientMetrics struct {
 	// CallLatency measures round-trip seconds.
 	// Labels are:

--- a/pkg/metrics/client.go
+++ b/pkg/metrics/client.go
@@ -1,0 +1,167 @@
+/*
+Copyright 2024 The KubeStellar Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metrics
+
+import (
+	"fmt"
+	"io"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	k8smetrics "k8s.io/component-base/metrics"
+)
+
+// MultiSpaceClientMetrics maintains apiserver call metrics for a collection of spaces.
+// A space is the service provided by a collection of equivalent apiservers.
+type MultiSpaceClientMetrics interface {
+	Register(RegisterFn) error
+
+	// MetricsForSpace returns the metrics interface for a given space
+	MetricsForSpace(string) ClientMetrics
+
+	// SpaceRecord observes one round-trip latency.
+	// resource is a value returned from GVRString
+	SpaceRecord(space, resource, method string, err error, latency time.Duration)
+}
+
+// ClientMetrics is the client-of-apiserver metrics for various kinds of object
+type ClientMetrics interface {
+	// ResourceMetrics returns the metrics interface specialized to the given resource
+	ResourceMetrics(schema.GroupVersionResource) ClientResourceMetrics
+
+	// Record observes one round-trip latency.
+	// resource is a value returned from GVRString
+	Record(resource string, method string, err error, latency time.Duration)
+}
+
+type ClientResourceMetrics interface {
+	// ResourceRecord observes one round-trip latency.
+	// resource is a value returned from GVRString
+	ResourceRecord(method string, err error, latency time.Duration)
+}
+
+// GVRString renders a GroupVersionResource as a domain name in a simple, regular way
+func GVRString(gvr schema.GroupVersionResource) string {
+	return gvr.Resource + "." + gvr.Version + "." + gvr.Group
+}
+
+type RegisterFn = func(k8smetrics.Registerable) error
+
+func Must(err error) {
+	if err != nil {
+		panic(err)
+	}
+}
+
+func MustRegister(reg RegisterFn, registerable ...interface{ Register(RegisterFn) error }) {
+	for _, ra := range registerable {
+		Must(ra.Register(reg))
+	}
+}
+
+type multiSpaceClientMetrics struct {
+	// CallLatency measures round-trip seconds.
+	// Labels are:
+	// - space
+	// - resource
+	// - method
+	// - error
+	CallLatency *k8smetrics.HistogramVec
+}
+
+type clientMetrics struct {
+	// CallLatency measures round-trip seconds.
+	// Labels are:
+	// - resource
+	// - method
+	// - error
+	CallLatency prometheus.ObserverVec
+}
+
+type clientResourceMetrics struct {
+	Resource string
+	Base     clientMetrics
+}
+
+var _ MultiSpaceClientMetrics = &multiSpaceClientMetrics{}
+
+func NewMultiSpaceClientMetrics() *multiSpaceClientMetrics {
+	return &multiSpaceClientMetrics{
+		CallLatency: k8smetrics.NewHistogramVec(&k8smetrics.HistogramOpts{
+			Namespace:      "kubestellar",
+			Subsystem:      "apiserver_call",
+			Name:           "latency_seconds",
+			Help:           "apiserver call latency in seconds",
+			Buckets:        []float64{0.01, 0.1, 0.2, 0.5, 1, 2, 5, 10, 20, 50, 100},
+			StabilityLevel: k8smetrics.ALPHA,
+		},
+			[]string{"space", "resource", "method", "error"}),
+	}
+}
+
+func (msc *multiSpaceClientMetrics) Register(reg RegisterFn) error {
+	return reg(msc.CallLatency)
+}
+
+func (msc *multiSpaceClientMetrics) MetricsForSpace(space string) ClientMetrics {
+	sub := msc.CallLatency.MustCurryWith(map[string]string{"space": space})
+	return &clientMetrics{sub}
+}
+
+func (msc *multiSpaceClientMetrics) SpaceRecord(space, resource, method string, err error, latency time.Duration) {
+	errStr := ErrorShort(err)
+	msc.CallLatency.WithLabelValues(space, resource, method, errStr).Observe(latency.Seconds())
+}
+
+func (cm *clientMetrics) ResourceMetrics(gvr schema.GroupVersionResource) ClientResourceMetrics {
+	return &clientResourceMetrics{
+		Resource: GVRString(gvr),
+		Base:     *cm,
+	}
+}
+func (cm *clientMetrics) Record(resource, method string, err error, latency time.Duration) {
+	errStr := ErrorShort(err)
+	cm.CallLatency.WithLabelValues(resource, method, errStr).Observe(latency.Seconds())
+}
+
+func (crm *clientResourceMetrics) ResourceRecord(method string, err error, latency time.Duration) {
+	crm.Base.Record(crm.Resource, method, err, latency)
+}
+
+func ErrorShort(err error) string {
+	if err == nil {
+		return ""
+	}
+	if apiStatus, is := err.(k8serrors.APIStatus); is {
+		status := apiStatus.Status()
+		return "apiStatus:" + string(status.Reason)
+	}
+	switch err {
+	case errPanic:
+		return "panic"
+	case io.EOF:
+		return "io.EOF"
+	case io.ErrClosedPipe:
+		return "io.ErrClosedPipe"
+	case io.ErrUnexpectedEOF:
+		return "io.ErrUnexpectedEOF"
+	}
+	return fmt.Sprintf("%T", err)
+}

--- a/pkg/metrics/client_test.go
+++ b/pkg/metrics/client_test.go
@@ -1,0 +1,39 @@
+/*
+Copyright 2024 The KubeStellar Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metrics
+
+import (
+	"testing"
+	"time"
+
+	k8smetrics "k8s.io/component-base/metrics"
+)
+
+func TestClientMetrics(t *testing.T) {
+	reg := k8smetrics.NewKubeRegistry()
+	msc := NewMultiSpaceClientMetrics()
+	MustRegister(reg.Register, msc)
+	cm := msc.MetricsForSpace("outer")
+	cm.Record("widgets", "frob", nil, 42*time.Millisecond)
+	gathered, err := reg.Gather()
+	if err != nil {
+		t.Error(err)
+	}
+	if len(gathered) != 1 {
+		t.Fatalf("Got wrong number of MetricFamily: expected 1, got %d", len(gathered))
+	}
+}

--- a/pkg/metrics/sampler.go
+++ b/pkg/metrics/sampler.go
@@ -1,0 +1,74 @@
+/*
+Copyright 2024 The KubeStellar Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metrics
+
+import (
+	"sync"
+	"time"
+
+	k8smetrics "k8s.io/component-base/metrics"
+)
+
+// Sampler is something that can be prodded to act,
+// and every prod will eventually be followed by an act.
+// Quick successive prods may lead to only one act.
+type Sampler interface {
+	Prod()
+	Register(RegisterFn) error
+}
+
+func NewSampler(read func() float64, opts *k8smetrics.KubeOpts) Sampler {
+	return &sampler{
+		Read:  read,
+		Gauge: k8smetrics.NewGauge((*k8smetrics.GaugeOpts)(opts)),
+	}
+}
+
+func NewListLenSampler[Elt any](getList func() []Elt, opts *k8smetrics.KubeOpts) Sampler {
+	return NewSampler(func() float64 { return float64(len(getList())) }, opts)
+}
+
+type sampler struct {
+	Read      func() float64
+	Gauge     *k8smetrics.Gauge
+	mutex     sync.Mutex
+	EvalTimer *time.Timer
+}
+
+const samplerDelay = 5 * time.Second
+
+func (sr *sampler) Register(reg RegisterFn) error {
+	return reg(sr.Gauge)
+}
+
+func (sr *sampler) Prod() {
+	sr.mutex.Lock()
+	defer sr.mutex.Unlock()
+	if sr.EvalTimer != nil {
+		sr.EvalTimer.Reset(samplerDelay)
+	} else {
+		sr.EvalTimer = time.AfterFunc(samplerDelay, sr.sample)
+	}
+}
+
+func (sr *sampler) sample() {
+	val := sr.Read()
+	sr.Gauge.Set(val)
+	sr.mutex.Lock()
+	defer sr.mutex.Unlock()
+	sr.EvalTimer = nil
+}

--- a/pkg/metrics/wrap_client.go
+++ b/pkg/metrics/wrap_client.go
@@ -1,0 +1,180 @@
+/*
+Copyright 2024 The KubeStellar Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metrics
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	types "k8s.io/apimachinery/pkg/types"
+	watch "k8s.io/apimachinery/pkg/watch"
+)
+
+type MRObject interface {
+	metav1.Object
+	runtime.Object
+}
+
+// ClientModNamespace is the commonly used methods of the typed stubs for a given object type.
+// These are the methods that a cluster-scoped kind of object has,
+// and the methods that a namespace-scoped kind of object has after specializing to a namespace.
+type ClientModNamespace[Single MRObject, List runtime.Object] interface {
+	Create(ctx context.Context, object Single, opts metav1.CreateOptions) (Single, error)
+	Update(ctx context.Context, object Single, opts metav1.UpdateOptions) (Single, error)
+	UpdateStatus(ctx context.Context, object Single, opts metav1.UpdateOptions) (Single, error)
+	Delete(ctx context.Context, name string, opts metav1.DeleteOptions) error
+	Get(ctx context.Context, name string, opts metav1.GetOptions) (Single, error)
+	List(ctx context.Context, opts metav1.ListOptions) (List, error)
+	Watch(ctx context.Context, opts metav1.ListOptions) (watch.Interface, error)
+	Patch(ctx context.Context, name string, pt types.PatchType, data []byte, opts metav1.PatchOptions, subresources ...string) (result Single, err error)
+}
+
+// NamespacedClient is similar to the interface of the typed stubs for a namespace-scoped kind of object,
+// but uses a fixed name for the method that specializes to a namespace.
+type NamespacedClient[Single MRObject, List runtime.Object] interface {
+	Namespace(string) ClientModNamespace[Single, List]
+}
+
+type namespacedClient[Single MRObject, List runtime.Object] struct {
+	namespaceFn func(string) ClientModNamespace[Single, List]
+}
+
+var _ NamespacedClient[MRObject, MRObject] = &namespacedClient[MRObject, MRObject]{}
+
+func (nsc *namespacedClient[Single, List]) Namespace(namespace string) ClientModNamespace[Single, List] {
+	return nsc.namespaceFn(namespace)
+}
+
+type MeasuredClientModNamespace[Single MRObject, List runtime.Object] interface {
+	ClientModNamespace[Single, List]
+	ClientResourceMetrics
+}
+
+type MeasuredNamespacedClient[Single MRObject, List runtime.Object] interface {
+	NamespacedClient[Single, List]
+	ClientResourceMetrics
+}
+
+type wrappedClientMetrics[Single MRObject, List runtime.Object] struct {
+	ClientResourceMetrics
+	Inner ClientModNamespace[Single, List]
+}
+
+var _ MeasuredClientModNamespace[MRObject, MRObject] = &wrappedClientMetrics[MRObject, MRObject]{}
+
+func NewWrappedClusterScopedClient[Single MRObject, List runtime.Object](cm ClientMetrics, gvr schema.GroupVersionResource, inner ClientModNamespace[Single, List]) MeasuredClientModNamespace[Single, List] {
+	return &wrappedClientMetrics[Single, List]{
+		Inner:                 inner,
+		ClientResourceMetrics: cm.ResourceMetrics(gvr),
+	}
+}
+
+func NewWrappedNamespacedClient[Single MRObject, List runtime.Object](cm ClientMetrics, gvr schema.GroupVersionResource, namespaceFn func(string) ClientModNamespace[Single, List]) MeasuredNamespacedClient[Single, List] {
+	return &wrappedNamespacingMetrics[Single, List]{
+		namespaceFn:           namespaceFn,
+		ClientResourceMetrics: cm.ResourceMetrics(gvr),
+	}
+}
+
+type wrappedNamespacingMetrics[Single MRObject, List runtime.Object] struct {
+	ClientResourceMetrics
+	namespaceFn func(string) ClientModNamespace[Single, List]
+}
+
+func (wnm *wrappedNamespacingMetrics[Single, List]) Namespace(namespace string) ClientModNamespace[Single, List] {
+	inner := wnm.namespaceFn(namespace)
+	return &wrappedClientMetrics[Single, List]{
+		Inner:                 inner,
+		ClientResourceMetrics: wnm.ClientResourceMetrics}
+}
+
+var errPanic = errors.New("panic")
+
+func (wcm *wrappedClientMetrics[Single, List]) Create(ctx context.Context, object Single, opts metav1.CreateOptions) (Single, error) {
+	var ans Single
+	err := errPanic
+	start := time.Now()
+	defer func() { wcm.ResourceRecord("create", err, time.Since(start)) }()
+	ans, err = wcm.Inner.Create(ctx, object, opts)
+	return ans, err
+}
+
+func (wcm *wrappedClientMetrics[Single, List]) Update(ctx context.Context, object Single, opts metav1.UpdateOptions) (Single, error) {
+	var ans Single
+	err := errPanic
+	start := time.Now()
+	defer func() { wcm.ResourceRecord("update", err, time.Since(start)) }()
+	ans, err = wcm.Inner.Update(ctx, object, opts)
+	return ans, err
+}
+
+func (wcm *wrappedClientMetrics[Single, List]) UpdateStatus(ctx context.Context, object Single, opts metav1.UpdateOptions) (Single, error) {
+	var ans Single
+	err := errPanic
+	start := time.Now()
+	defer func() { wcm.ResourceRecord("update_status", err, time.Since(start)) }()
+	ans, err = wcm.Inner.UpdateStatus(ctx, object, opts)
+	return ans, err
+}
+
+func (wcm *wrappedClientMetrics[Single, List]) Delete(ctx context.Context, name string, opts metav1.DeleteOptions) error {
+	err := errPanic
+	start := time.Now()
+	defer func() { wcm.ResourceRecord("delete", err, time.Since(start)) }()
+	err = wcm.Inner.Delete(ctx, name, opts)
+	return err
+}
+
+func (wcm *wrappedClientMetrics[Single, List]) Get(ctx context.Context, name string, opts metav1.GetOptions) (Single, error) {
+	var ans Single
+	err := errPanic
+	start := time.Now()
+	defer func() { wcm.ResourceRecord("get", err, time.Since(start)) }()
+	ans, err = wcm.Inner.Get(ctx, name, opts)
+	return ans, err
+}
+
+func (wcm *wrappedClientMetrics[Single, List]) List(ctx context.Context, opts metav1.ListOptions) (List, error) {
+	var ans List
+	err := errPanic
+	start := time.Now()
+	defer func() { wcm.ResourceRecord("list", err, time.Since(start)) }()
+	ans, err = wcm.Inner.List(ctx, opts)
+	return ans, err
+}
+
+func (wcm *wrappedClientMetrics[Single, List]) Watch(ctx context.Context, opts metav1.ListOptions) (watch.Interface, error) {
+	var ans watch.Interface
+	err := errPanic
+	start := time.Now()
+	defer func() { wcm.ResourceRecord("watch", err, time.Since(start)) }()
+	ans, err = wcm.Inner.Watch(ctx, opts)
+	return ans, err
+}
+
+func (wcm *wrappedClientMetrics[Single, List]) Patch(ctx context.Context, name string, pt types.PatchType, data []byte, opts metav1.PatchOptions, subresources ...string) (Single, error) {
+	var ans Single
+	err := errPanic
+	start := time.Now()
+	defer func() { wcm.ResourceRecord("patch", err, time.Since(start)) }()
+	ans, err = wcm.Inner.Patch(ctx, name, pt, data, opts, subresources...)
+	return ans, err
+}

--- a/pkg/metrics/wrap_dynamic.go
+++ b/pkg/metrics/wrap_dynamic.go
@@ -1,0 +1,173 @@
+/*
+Copyright 2024 The KubeStellar Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metrics
+
+import (
+	"context"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	types "k8s.io/apimachinery/pkg/types"
+	watch "k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/dynamic"
+)
+
+type MeasuredDynamicClient interface {
+	dynamic.Interface
+	ClientMetrics
+}
+
+type wrappedDynamicClient struct {
+	ClientMetrics
+	Inner dynamic.Interface
+}
+
+type wrappedDynamicResourceInteface struct {
+	wrappedDynamicModNamespace
+	Inner dynamic.NamespaceableResourceInterface
+}
+
+type wrappedDynamicModNamespace struct {
+	ClientResourceMetrics
+	Inner dynamic.ResourceInterface
+}
+
+func NewWrappedDynamicClient(clientMetrics ClientMetrics, inner dynamic.Interface) MeasuredDynamicClient {
+	return &wrappedDynamicClient{
+		Inner:         inner,
+		ClientMetrics: clientMetrics,
+	}
+}
+
+func (wdc *wrappedDynamicClient) Resource(gvr schema.GroupVersionResource) dynamic.NamespaceableResourceInterface {
+	inner := wdc.Inner.Resource(gvr)
+	return &wrappedDynamicResourceInteface{
+		wrappedDynamicModNamespace: wrappedDynamicModNamespace{
+			ClientResourceMetrics: wdc.ClientMetrics.ResourceMetrics(gvr),
+			Inner:                 inner,
+		},
+		Inner: inner,
+	}
+}
+
+func (wdr *wrappedDynamicResourceInteface) Namespace(namespace string) dynamic.ResourceInterface {
+	return &wrappedDynamicModNamespace{
+		ClientResourceMetrics: wdr.ClientResourceMetrics,
+		Inner:                 wdr.Inner.Namespace(namespace),
+	}
+}
+
+func (wdn *wrappedDynamicModNamespace) Apply(ctx context.Context, name string, object *unstructured.Unstructured, options metav1.ApplyOptions, subresources ...string) (*unstructured.Unstructured, error) {
+	var ans *unstructured.Unstructured
+	err := errPanic
+	start := time.Now()
+	defer func() { wdn.ResourceRecord("apply", err, time.Since(start)) }()
+	ans, err = wdn.Inner.Apply(ctx, name, object, options, subresources...)
+	return ans, err
+
+}
+
+func (wdn *wrappedDynamicModNamespace) ApplyStatus(ctx context.Context, name string, object *unstructured.Unstructured, options metav1.ApplyOptions) (*unstructured.Unstructured, error) {
+	var ans *unstructured.Unstructured
+	err := errPanic
+	start := time.Now()
+	defer func() { wdn.ResourceRecord("apply_status", err, time.Since(start)) }()
+	ans, err = wdn.Inner.Apply(ctx, name, object, options)
+	return ans, err
+
+}
+
+func (wdn *wrappedDynamicModNamespace) Create(ctx context.Context, object *unstructured.Unstructured, opts metav1.CreateOptions, subresources ...string) (*unstructured.Unstructured, error) {
+	var ans *unstructured.Unstructured
+	err := errPanic
+	start := time.Now()
+	defer func() { wdn.ResourceRecord("create", err, time.Since(start)) }()
+	ans, err = wdn.Inner.Create(ctx, object, opts, subresources...)
+	return ans, err
+}
+
+func (wdn *wrappedDynamicModNamespace) Update(ctx context.Context, object *unstructured.Unstructured, opts metav1.UpdateOptions, subresources ...string) (*unstructured.Unstructured, error) {
+	var ans *unstructured.Unstructured
+	err := errPanic
+	start := time.Now()
+	defer func() { wdn.ResourceRecord("update", err, time.Since(start)) }()
+	ans, err = wdn.Inner.Update(ctx, object, opts, subresources...)
+	return ans, err
+}
+
+func (wdn *wrappedDynamicModNamespace) UpdateStatus(ctx context.Context, object *unstructured.Unstructured, opts metav1.UpdateOptions) (*unstructured.Unstructured, error) {
+	var ans *unstructured.Unstructured
+	err := errPanic
+	start := time.Now()
+	defer func() { wdn.ResourceRecord("update_status", err, time.Since(start)) }()
+	ans, err = wdn.Inner.UpdateStatus(ctx, object, opts)
+	return ans, err
+}
+
+func (wdn *wrappedDynamicModNamespace) Delete(ctx context.Context, name string, opts metav1.DeleteOptions, subresources ...string) error {
+	err := errPanic
+	start := time.Now()
+	defer func() { wdn.ResourceRecord("delete", err, time.Since(start)) }()
+	err = wdn.Inner.Delete(ctx, name, opts, subresources...)
+	return err
+}
+
+func (wdn *wrappedDynamicModNamespace) DeleteCollection(ctx context.Context, options metav1.DeleteOptions, listOptions metav1.ListOptions) error {
+	err := errPanic
+	start := time.Now()
+	defer func() { wdn.ResourceRecord("delete_collection", err, time.Since(start)) }()
+	err = wdn.Inner.DeleteCollection(ctx, options, listOptions)
+	return err
+}
+
+func (wdn *wrappedDynamicModNamespace) Get(ctx context.Context, name string, opts metav1.GetOptions, subresources ...string) (*unstructured.Unstructured, error) {
+	var ans *unstructured.Unstructured
+	err := errPanic
+	start := time.Now()
+	defer func() { wdn.ResourceRecord("get", err, time.Since(start)) }()
+	ans, err = wdn.Inner.Get(ctx, name, opts, subresources...)
+	return ans, err
+}
+
+func (wdn *wrappedDynamicModNamespace) List(ctx context.Context, opts metav1.ListOptions) (*unstructured.UnstructuredList, error) {
+	var ans *unstructured.UnstructuredList
+	err := errPanic
+	start := time.Now()
+	defer func() { wdn.ResourceRecord("list", err, time.Since(start)) }()
+	ans, err = wdn.Inner.List(ctx, opts)
+	return ans, err
+}
+
+func (wdn *wrappedDynamicModNamespace) Watch(ctx context.Context, opts metav1.ListOptions) (watch.Interface, error) {
+	var ans watch.Interface
+	err := errPanic
+	start := time.Now()
+	defer func() { wdn.ResourceRecord("watch", err, time.Since(start)) }()
+	ans, err = wdn.Inner.Watch(ctx, opts)
+	return ans, err
+}
+
+func (wdn *wrappedDynamicModNamespace) Patch(ctx context.Context, name string, pt types.PatchType, data []byte, opts metav1.PatchOptions, subresources ...string) (*unstructured.Unstructured, error) {
+	var ans *unstructured.Unstructured
+	err := errPanic
+	start := time.Now()
+	defer func() { wdn.ResourceRecord("patch", err, time.Since(start)) }()
+	ans, err = wdn.Inner.Patch(ctx, name, pt, data, opts, subresources...)
+	return ans, err
+}

--- a/pkg/transport/cmd/generic-main.go
+++ b/pkg/transport/cmd/generic-main.go
@@ -156,6 +156,7 @@ func GenericMain(transportImplementation transport.Transport) {
 		logger.Error(err, "failed to construct transport controller")
 		klog.FlushAndExit(klog.ExitFlushTimeout, 1)
 	}
+	transportController.RegisterMetrics(legacyregistry.Register)
 
 	// notice that there is no need to run Start method in a separate goroutine.
 	// Start method is non-blocking and runs each of the factory's informers in its own dedicated goroutine.

--- a/pkg/transport/custom_transform_collection.go
+++ b/pkg/transport/custom_transform_collection.go
@@ -27,8 +27,8 @@ import (
 
 	"github.com/kubestellar/kubestellar/api/control/v1alpha1"
 	"github.com/kubestellar/kubestellar/pkg/abstract"
-	controlclient "github.com/kubestellar/kubestellar/pkg/generated/clientset/versioned/typed/control/v1alpha1"
 	"github.com/kubestellar/kubestellar/pkg/jsonpath"
+	ksmetrics "github.com/kubestellar/kubestellar/pkg/metrics"
 )
 
 // customTransformCollection digests CustomTransform objects and caches the results.
@@ -52,7 +52,7 @@ type customTransformChanges struct {
 // customTransformCollectionImpl implements customTransformCollection
 type customTransformCollectionImpl struct {
 	// client is here for updating the status of a CustomTransform
-	client controlclient.CustomTransformInterface
+	client ksmetrics.ClientModNamespace[*v1alpha1.CustomTransform, *v1alpha1.CustomTransformList]
 
 	// getTransformObjects is the part of the CustomTransform informer's cache.Indexer behavior
 	// that is needed here, for using the index named in `customTransformDomainIndexName`.
@@ -93,7 +93,7 @@ type groupResourceTransformData struct {
 	changes          customTransformChanges
 }
 
-func newCustomTransformCollection(client controlclient.CustomTransformInterface, getTransformObjects func(indexName, indexedValue string) ([]any, error), enqueue func(any)) customTransformCollection {
+func newCustomTransformCollection(client ksmetrics.ClientModNamespace[*v1alpha1.CustomTransform, *v1alpha1.CustomTransformList], getTransformObjects func(indexName, indexedValue string) ([]any, error), enqueue func(any)) customTransformCollection {
 	return &customTransformCollectionImpl{
 		client:                      client,
 		getTransformObjects:         getTransformObjects,

--- a/pkg/transport/generic_transport_controller_test.go
+++ b/pkg/transport/generic_transport_controller_test.go
@@ -389,6 +389,7 @@ func TestGenericController(t *testing.T) {
 		wdsDynamicClient,
 		itsK8sClientFake.CoreV1().Namespaces(), parmCfgMapPreInformer,
 		itsDynamicClient, "test-wds", wrapperGVR)
+	ctlr.RegisterMetrics(legacyregistry.Register)
 	inventoryInformerFactory.Start(ctx.Done())
 	wdsKsInformerFactory.Start(ctx.Done())
 	itsK8sInformerFactory.Start(ctx.Done())


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
This PR adds metrics to the generic transport controller. These added metrics are as follows.

- kubestellar_apiserver_call_latency_seconds: histogram of round trip times for calls on apiservers, broken down by: space, resource, method, and shortened error.
- kubestellar_transport_controller_binding_whats: histogram of the number of workload objects referenced in a Binding, observed whenever a Binding is sync'd.
- kubestellar_transport_controller_binding_wheres: histogram of the number of WECs referenced by a Binding, observed whenever a Binding is sync'd.
- kubestellar_transport_controller_binding_areas: histogram of the product of number of workload objects referenced and number of WECs referenced by a Binding, observed whenever a Binding is sync'd.
- kubestellar_transport_controller_bindings: gauge of the number of Binding objects in the ITS.
- kubestellar_transport_controller_prop_maps: gauge of the number of property ConfigMap objects in the WDS.
- kubestellar_transport_controller_transforms: gauge of the number of CustomTransform objects in the WDS.
- kubestellar_transport_controller_wecs: gauge of the number of inventory objects in the ITS.
- kubestellar_transport_controller_wrapped_objects: gauge of the number of wrapped objects (envelopes, ManifestWork objects) in the ITS.

This PR also adds metrics scrapes at the end of the E2E testing workflow.

## Related issue(s)

This addresses part of #2158 
