### PR TITLE
✨ sharded manifestwork

### DIFF
--- a/pkg/transport/cmd/generic-main.go
+++ b/pkg/transport/cmd/generic-main.go
@@ -151,7 +151,7 @@ func GenericMain(transportImplementation transport.Transport) {
 		wdsClientset.ControlV1alpha1().Bindings(), wdsControlInformers.Bindings(),
 		wdsControlInformers.CustomTransforms(),
 		transportImplementation, wdsClientset, wdsDynamicClient, transportClientset.CoreV1().Namespaces(), itsK8sInformerFactory.Core().V1().ConfigMaps(),
-		transportClientset, transportDynamicClient, options.WdsName)
+		transportClientset, transportDynamicClient, options.MaxSizeWrappedObject, options.WdsName)
 	if err != nil {
 		logger.Error(err, "failed to construct transport controller")
 		klog.FlushAndExit(klog.ExitFlushTimeout, 1)

--- a/pkg/transport/cmd/options.go
+++ b/pkg/transport/cmd/options.go
@@ -30,6 +30,7 @@ type TransportOptions struct {
 	Concurrency            int
 	WdsClientOptions       *clientopts.ClientOptions[*pflag.FlagSet]
 	TransportClientOptions *clientopts.ClientOptions[*pflag.FlagSet]
+	MaxSizeWrappedObject   int
 	WdsName                string
 	metricsBindAddr        string
 	pprofBindAddr          string
@@ -40,6 +41,7 @@ func NewTransportOptions() *TransportOptions {
 		Concurrency:            defaultConcurrency,
 		WdsClientOptions:       clientopts.NewClientOptions[*pflag.FlagSet]("wds", "accessing the WDS"),
 		TransportClientOptions: clientopts.NewClientOptions[*pflag.FlagSet]("transport", "accessing the ITS"),
+		MaxSizeWrappedObject:   500 * 1024,
 		metricsBindAddr:        ":8090",
 		pprofBindAddr:          ":8092",
 	}
@@ -49,6 +51,7 @@ func (options *TransportOptions) AddFlags(fs *pflag.FlagSet) {
 	fs.IntVar(&options.Concurrency, "concurrency", options.Concurrency, "number of concurrent workers to run in parallel")
 	options.WdsClientOptions.AddFlags(fs)
 	options.TransportClientOptions.AddFlags(fs)
+	fs.IntVar(&options.MaxSizeWrappedObject, "max-size-wrapped-object", options.MaxSizeWrappedObject, "Max size of the wrapped object")
 	fs.StringVar(&options.WdsName, "wds-name", options.WdsName, "name of the wds to connect to. name should be unique")
 	fs.StringVar(&options.metricsBindAddr, "metrics-bind-addr", options.metricsBindAddr, "the [host]:port from which to serve /metrics")
 	fs.StringVar(&options.pprofBindAddr, "pprof-bind-addr", options.pprofBindAddr, "the [host]:port from which to serve /debug/pprof")

--- a/pkg/transport/generic_transport_controller.go
+++ b/pkg/transport/generic_transport_controller.go
@@ -28,7 +28,6 @@ import (
 	clusterlisters "open-cluster-management.io/api/client/cluster/listers/cluster/v1"
 
 	corev1 "k8s.io/api/core/v1"
-	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -93,13 +92,13 @@ func NewTransportController(ctx context.Context,
 	propCfgMapPreInformer corev1informers.ConfigMapInformer,
 	transportClientset kubernetes.Interface,
 	transportDynamicClient dynamic.Interface,
-	wdsName string) (*genericTransportController, error) {
+	maxSizeWrappedObject int, wdsName string) (*genericTransportController, error) {
 	emptyWrappedObject := transport.WrapObjects(make([]*unstructured.Unstructured, 0)) // empty wrapped object to get GVR from it.
 	wrappedObjectGVR, err := getGvrFromWrappedObject(transportClientset, emptyWrappedObject)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get wrapped object GVR - %w", err)
 	}
-	return NewTransportControllerForWrappedObjectGVR(ctx, wdsClientMetrics, itsClientMetrics, inventoryPreInformer, bindingClient, bindingInformer, customTransformInformer, transport, wdsClientset, wdsDynamicClient, itsNSClient, propCfgMapPreInformer, transportDynamicClient, wdsName, wrappedObjectGVR), nil
+	return NewTransportControllerForWrappedObjectGVR(ctx, wdsClientMetrics, itsClientMetrics, inventoryPreInformer, bindingClient, bindingInformer, customTransformInformer, transport, wdsClientset, wdsDynamicClient, itsNSClient, propCfgMapPreInformer, transportDynamicClient, maxSizeWrappedObject, wdsName, wrappedObjectGVR), nil
 }
 
 // NewTransportControllerForWrappedObjectGVR returns a new transport controller.
@@ -116,6 +115,7 @@ func NewTransportControllerForWrappedObjectGVR(ctx context.Context,
 	itsNSClient corev1client.NamespaceInterface,
 	propCfgMapPreInformer corev1informers.ConfigMapInformer,
 	transportDynamicClient dynamic.Interface,
+	maxSizeWrappedObject int,
 	wdsName string, wrappedObjectGVR schema.GroupVersionResource) *genericTransportController {
 	measuredBindingClient := ksmetrics.NewWrappedClusterScopedClient[*v1alpha1.Binding, *v1alpha1.BindingList](wdsClientMetrics, util.GetBindingGVR(), bindingClient)
 	measuredWDSDynamicClient := ksmetrics.NewWrappedDynamicClient(wdsClientMetrics, wdsDynamicClient)
@@ -176,6 +176,7 @@ func NewTransportControllerForWrappedObjectGVR(ctx context.Context,
 		transportClient:              measuredITSDynamicClient,
 		wrappedObjectGVR:             wrappedObjectGVR,
 		wdsDynamicClient:             measuredWDSDynamicClient,
+		MaxSizeWrappedObject:         maxSizeWrappedObject,
 		wdsName:                      wdsName,
 		bindingSensitiveDestinations: make(map[string]sets.Set[v1alpha1.Destination]),
 		destinationProperties:        make(map[v1alpha1.Destination]clusterProperties),
@@ -341,8 +342,9 @@ type genericTransportController struct {
 	transportClient  dynamic.Interface // dynamic client to transport wrapped object. since object kind is unknown during complilation, we use dynamic
 	wrappedObjectGVR schema.GroupVersionResource
 
-	wdsDynamicClient dynamic.Interface
-	wdsName          string
+	wdsDynamicClient     dynamic.Interface
+	MaxSizeWrappedObject int
+	wdsName              string
 
 	customTransformCollection customTransformCollection
 
@@ -618,11 +620,24 @@ func isObjectBeingDeleted(object metav1.Object) bool {
 }
 
 func (c *genericTransportController) deleteWrappedObjectsAndFinalizer(ctx context.Context, binding *v1alpha1.Binding) error {
+	currentWrappedObjectList, err := c.transportClient.Resource(c.wrappedObjectGVR).List(ctx, metav1.ListOptions{
+		LabelSelector: fmt.Sprintf("%s=%s,%s=%s", originOwnerReferenceLabel, binding.GetName(), originWdsLabel, c.wdsName),
+	})
+	if err != nil {
+		return fmt.Errorf("failed to get current wrapped objects that are owned by Binding '%s' - %w", binding.GetName(), err)
+	}
 	c.customTransformCollection.setBindingGroupResources(binding.Name, sets.New[metav1.GroupResource]())
 	for _, destination := range binding.Spec.Destinations {
-		if err := c.deleteWrappedObject(ctx, destination.ClusterId, fmt.Sprintf("%s-%s", binding.GetName(), c.wdsName)); err != nil {
-			// wrapped object name is in the format (Binding.GetName()-WdsName). see updateWrappedObject func for explanation.
-			return fmt.Errorf("failed to delete wrapped object from all destinations' - %w", err)
+		for {
+			currentWrappedObject := c.popWrappedObjectByNamespace(currentWrappedObjectList, destination.ClusterId)
+			if currentWrappedObject != nil {
+				if err := c.deleteWrappedObject(ctx, destination.ClusterId, currentWrappedObject.GetName()); err != nil {
+					// wrapped object name is in the format (Binding.GetName()-WdsName). see updateWrappedObject func for explanation.
+					return fmt.Errorf("failed to delete wrapped object from all destinations' - %w", err)
+				}
+			} else {
+				break
+			}
 		}
 	}
 
@@ -734,7 +749,8 @@ func (c *genericTransportController) getObjectsFromWDS(ctx context.Context, bind
 //     the function has no answer for the given destination.
 //   - the slice of strings describing user errors in the Binding.
 //   - an error if something transient went wrong.
-func (c *genericTransportController) computeDestToWrappedObjects(ctx context.Context, binding *v1alpha1.Binding) (func(v1alpha1.Destination) (*unstructured.Unstructured, bool), []string, sets.Set[metav1.GroupResource], error) {
+func (c *genericTransportController) computeDestToWrappedObjects(ctx context.Context, binding *v1alpha1.Binding) (
+	func(v1alpha1.Destination) ([]*unstructured.Unstructured, bool), []string, sets.Set[metav1.GroupResource], error) {
 	objectsToPropagate, grs, err := c.getObjectsFromWDS(ctx, binding)
 	if err != nil {
 		return nil, nil, grs, fmt.Errorf("failed to get objects to propagate to WECs from Binding object '%s' - %w", binding.GetName(), err)
@@ -747,10 +763,10 @@ func (c *genericTransportController) computeDestToWrappedObjects(ctx context.Con
 	destToCustomizedObjects, bindingErrors := c.computeDestToCustomizedObjects(objectsToPropagate, binding)
 
 	// This will be constant if no object needed customization, otherwise a map's get func
-	var destToWrappedObject func(v1alpha1.Destination) (*unstructured.Unstructured, bool)
+	var destToWrappedObject func(v1alpha1.Destination) ([]*unstructured.Unstructured, bool)
 
 	if destToCustomizedObjects != nil {
-		asMap := map[v1alpha1.Destination]*unstructured.Unstructured{}
+		asMap := map[v1alpha1.Destination][]*unstructured.Unstructured{}
 		for dest, objects := range destToCustomizedObjects {
 			wrappedObject, err := c.wrap(objects, binding)
 			if err != nil {
@@ -764,7 +780,7 @@ func (c *genericTransportController) computeDestToWrappedObjects(ctx context.Con
 		if err != nil {
 			return nil, nil, grs, fmt.Errorf("failed to convert wrapped object to unstructured - %w", err)
 		}
-		destToWrappedObject = func(v1alpha1.Destination) (*unstructured.Unstructured, bool) { return wrappedObject, true }
+		destToWrappedObject = func(v1alpha1.Destination) ([]*unstructured.Unstructured, bool) { return wrappedObject, true }
 	}
 
 	return destToWrappedObject, bindingErrors, grs, nil
@@ -831,20 +847,64 @@ func (c *genericTransportController) computeDestToCustomizedObjects(objectsToPro
 	return destToCustomizedObjects, bindingErrors
 }
 
-func (c *genericTransportController) wrap(objectsToPropagate []*unstructured.Unstructured, binding *v1alpha1.Binding) (*unstructured.Unstructured, error) {
-	wrappedObject, err := convertObjectToUnstructured(c.transport.WrapObjects(objectsToPropagate))
+func (c *genericTransportController) wrapBatch(batchToPropagate []*unstructured.Unstructured, binding *v1alpha1.Binding, numShard int, isSharded bool) (*unstructured.Unstructured, error) {
+	wrappedObject, err := convertObjectToUnstructured(c.transport.WrapObjects(batchToPropagate))
 	if err != nil {
 		return nil, fmt.Errorf("failed to convert wrapped object to unstructured - %w", err)
 	}
-	// wrapped object name is (Binding.GetName()-WdsName).
+	// wrapped object name is (Binding.GetName()-WdsName) or (Binding.GetName()-WdsName-numShard).
 	// pay attention - we cannot use the Binding object name, cause we might have duplicate names coming from different WDS spaces.
 	// we add WdsName to the object name to assure name uniqueness,
 	// in order to easily get the origin Binding object name and wds, we add it as an annotations.
-	wrappedObject.SetName(fmt.Sprintf("%s-%s", binding.GetName(), c.wdsName))
+	if isSharded {
+		wrappedObject.SetName(fmt.Sprintf("%s-%s-%d", binding.GetName(), c.wdsName, numShard))
+	} else {
+		wrappedObject.SetName(fmt.Sprintf("%s-%s", binding.GetName(), c.wdsName))
+	}
 	setLabel(wrappedObject, originOwnerReferenceLabel, binding.GetName())
 	setLabel(wrappedObject, originWdsLabel, c.wdsName)
 	setAnnotation(wrappedObject, originOwnerGenerationAnnotation, binding.GetGeneration())
-	return wrappedObject, nil
+	return wrappedObject, err
+}
+
+func (c *genericTransportController) wrap(objectsToPropagate []*unstructured.Unstructured, binding *v1alpha1.Binding) ([]*unstructured.Unstructured, error) {
+	var wrappedObjects []*unstructured.Unstructured
+	var batchToPropagate []*unstructured.Unstructured = nil
+	maxBatchSize := c.MaxSizeWrappedObject
+	isSharded := false
+	numShard := 0
+	var batchSize int = 0
+	for _, obj := range objectsToPropagate {
+		bytes, err := obj.MarshalJSON()
+		if err != nil {
+			return nil, err
+		}
+		objSize := len(bytes)
+		if objSize > maxBatchSize {
+			return nil, fmt.Errorf("failed to wrap object that is larger than max size")
+		}
+		if objSize+batchSize >= maxBatchSize {
+			isSharded = true
+			wrappedObject, err := c.wrapBatch(batchToPropagate, binding, numShard, isSharded)
+			if err != nil {
+				return nil, err
+			}
+			numShard += 1
+			wrappedObjects = append(wrappedObjects, wrappedObject)
+			batchToPropagate = nil
+			batchSize = 0
+		}
+		batchToPropagate = append(batchToPropagate, obj)
+		batchSize += objSize
+	}
+	if batchToPropagate != nil {
+		wrappedObject, err := c.wrapBatch(batchToPropagate, binding, numShard, isSharded)
+		if err != nil {
+			return nil, err
+		}
+		wrappedObjects = append(wrappedObjects, wrappedObject)
+	}
+	return wrappedObjects, nil
 }
 
 // getPropertiesForDestination returns the properties to use for the given destination and notes
@@ -949,7 +1009,7 @@ func (c *genericTransportController) customizeForDestination(object *unstructure
 	return object, nil, false
 }
 
-func (c *genericTransportController) propagateWrappedObjectToClusters(ctx context.Context, destToDesiredWrappedObject func(v1alpha1.Destination) (*unstructured.Unstructured, bool),
+func (c *genericTransportController) propagateWrappedObjectToClusters(ctx context.Context, destToDesiredWrappedObject func(v1alpha1.Destination) ([]*unstructured.Unstructured, bool),
 	currentWrappedObjectList *unstructured.UnstructuredList, destinations []v1alpha1.Destination, broken bool) error {
 	// if the desired wrapped object is nil, that means we should not propagate this object.
 	// this may happen when the workload section is empty.
@@ -959,18 +1019,40 @@ func (c *genericTransportController) propagateWrappedObjectToClusters(ctx contex
 		return nil // this is not considered an error.
 	}
 
+	c.logger.Info("in propagateWrappedObjectToCluster()")
+
 	for _, destination := range destinations {
-		currentWrappedObject := c.popWrappedObjectByNamespace(currentWrappedObjectList, destination.ClusterId)
-		if broken {
-			continue
-		}
-		desiredWrappedObject, _ := destToDesiredWrappedObject(destination)
-		if currentWrappedObject != nil && apiequality.Semantic.DeepEqual(currentWrappedObject.UnstructuredContent(), desiredWrappedObject.UnstructuredContent()) {
-			continue // current wrapped object is already in the desired state
-		}
-		// othereise, need to create or update the wrapped object
-		if err := c.createOrUpdateWrappedObject(ctx, destination.ClusterId, desiredWrappedObject); err != nil {
-			return fmt.Errorf("failed to propagate wrapped object to cluster mailbox namespace '%s' - %w", destination.ClusterId, err)
+		// Loop until popWrappedObjectByNamespace returns nil, in case the wrapped object is sharded.
+		for {
+			currentWrappedObject := c.popWrappedObjectByNamespace(currentWrappedObjectList, destination.ClusterId)
+			if broken {
+				continue
+			}
+
+			foundMatch := false
+			desiredWrappedObjects, _ := destToDesiredWrappedObject(destination)
+			if currentWrappedObject != nil {
+				for _, desiredWrappedObject := range desiredWrappedObjects {
+					// Can't use apiequality.Semantic.DeepEqual to compare the two objects
+					if currentWrappedObject.GetAnnotations() != nil &&
+						currentWrappedObject.GetAnnotations()[originOwnerGenerationAnnotation] == desiredWrappedObject.GetAnnotations()[originOwnerGenerationAnnotation] {
+						foundMatch = true
+						break
+					}
+				}
+			}
+			if foundMatch {
+				continue
+			}
+			// othereise, need to create or update the wrapped objects
+			for _, desiredWrappedObject := range desiredWrappedObjects {
+				if err := c.createOrUpdateWrappedObject(ctx, destination.ClusterId, desiredWrappedObject); err != nil {
+					return fmt.Errorf("failed to propagate wrapped object to cluster mailbox namespace '%s' - %w", destination.ClusterId, err)
+				}
+			}
+			if currentWrappedObject == nil {
+				break
+			}
 		}
 	}
 

--- a/pkg/transport/generic_transport_controller_test.go
+++ b/pkg/transport/generic_transport_controller_test.go
@@ -388,7 +388,7 @@ func TestGenericController(t *testing.T) {
 		wdsKsClientFake,
 		wdsDynamicClient,
 		itsK8sClientFake.CoreV1().Namespaces(), parmCfgMapPreInformer,
-		itsDynamicClient, "test-wds", wrapperGVR)
+		itsDynamicClient, 500*1024, "test-wds", wrapperGVR)
 	ctlr.RegisterMetrics(legacyregistry.Register)
 	inventoryInformerFactory.Start(ctx.Done())
 	wdsKsInformerFactory.Start(ctx.Done())

--- a/test/e2e/ginkgo/multiple_cluster_deployment_test.go
+++ b/test/e2e/ginkgo/multiple_cluster_deployment_test.go
@@ -129,6 +129,51 @@ var _ = ginkgo.Describe("end to end testing", func() {
 			util.ValidateNumDeployments(ctx, wec2, ns, 0)
 		})
 
+		ginkgo.It("shards a wrapped workload when needed", func() {
+			util.DeleteDeployment(ctx, wds, ns, "nginx")
+			ginkgo.DeferCleanup(func() {
+				patch := []byte(`{"spec":{"template":{"spec":{"containers":[{"args":["--max-size-wrapped-object=512000","--transport-kubeconfig=/mnt/shared/transport-kubeconfig","--wds-kubeconfig=/mnt/shared/wds-kubeconfig","--wds-name=wds1","-v=4"],"name":"transport-controller"}]}}}}`)
+				_, err := coreCluster.AppsV1().Deployments("wds1-system").Patch(ctx, "transport-controller", types.StrategicMergePatchType, patch, metav1.PatchOptions{})
+				gomega.ExpectWithOffset(1, err).NotTo(gomega.HaveOccurred())
+			})
+			ginkgo.By("set max size of wrapped object to 1000 bytes")
+			patch := []byte(`{"spec":{"template":{"spec":{"containers":[{"args":["--max-size-wrapped-object=1000","--transport-kubeconfig=/mnt/shared/transport-kubeconfig","--wds-kubeconfig=/mnt/shared/wds-kubeconfig","--wds-name=wds1","-v=4"],"name":"transport-controller"}]}}}}`)
+			_, err := coreCluster.AppsV1().Deployments("wds1-system").Patch(ctx, "transport-controller", types.StrategicMergePatchType, patch, metav1.PatchOptions{})
+			gomega.ExpectWithOffset(1, err).NotTo(gomega.HaveOccurred())
+			var names = []string{"1", "2", "3", "4", "5", "6", "7", "8", "9", "10"}
+			for _, i := range names {
+				util.CreateDeployment(ctx, wds, ns, i,
+					map[string]string{
+						"label1": "test1",
+					})
+			}
+			util.CreateBindingPolicy(ctx, ksWds, "multipledep",
+				[]metav1.LabelSelector{
+					{MatchLabels: map[string]string{"name": "cluster1"}},
+				},
+				[]ksapi.DownsyncObjectTest{
+					{ObjectSelectors: []metav1.LabelSelector{
+						{MatchLabels: map[string]string{
+							"label1": "test1",
+						}},
+					}}})
+
+			util.ValidateNumDeployments(ctx, wec1, ns, 10)
+			util.ValidateNumDeployments(ctx, wec2, ns, 0)
+
+			ginkgo.By("update to bindingpolicy object with sharded wrapped workloads updates deployments")
+			patch = []byte(`{"spec": {"clusterSelectors": [{"matchLabels": {"name": "cluster2"}}]}}`)
+			_, err = ksWds.ControlV1alpha1().BindingPolicies().Patch(ctx, "multipledep", types.MergePatchType, patch, metav1.PatchOptions{})
+			gomega.ExpectWithOffset(1, err).NotTo(gomega.HaveOccurred())
+			util.ValidateNumDeployments(ctx, wec1, ns, 0)
+			util.ValidateNumDeployments(ctx, wec2, ns, 10)
+
+			ginkgo.By("delete of bindingpolicy with sharded wrapped workloads deletes deployments")
+			util.DeleteBindingPolicy(ctx, ksWds, "multipledep")
+			util.ValidateNumDeployments(ctx, wec1, ns, 0)
+			util.ValidateNumDeployments(ctx, wec2, ns, 0)
+		})
+
 		// 1. Create object 1 with label A and label B, object 2 with label B,
 		// and a Placement that matches labels A AND B, and verify that only
 		// object 1 matches and is delivered.


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
Shard the object containing the wrapped objects to be transported (i.e. the manifestwork) if the object is larger than a max limit which is set by default to 512K.

Marking as a WIP after talking with Nir who suggests we move the max size param into the transport controller rather than have it in the bindingpolicy. 

## Related issue(s)

Fixes #2016
