### PR TITLE
🐛 Make ginkgo setup interruptable

### DIFF
--- a/test/e2e/ginkgo/ginkgo_suite_test.go
+++ b/test/e2e/ginkgo/ginkgo_suite_test.go
@@ -39,7 +39,6 @@ func TestGinkgo(t *testing.T) {
 }
 
 var (
-	ctx                context.Context
 	coreCluster        *kubernetes.Clientset
 	wds                *kubernetes.Clientset
 	ksWds              *ksClient.Clientset
@@ -65,13 +64,12 @@ func init() {
 	flag.StringVar(&wec2CtxFlag, "wec2-context", "cluster2", "context for wec2 cluster")
 }
 
-var _ = ginkgo.BeforeSuite(func() {
+var _ = ginkgo.BeforeSuite(func(ctx context.Context) {
 	if !skipSetupFlag {
-		util.Cleanup()
-		util.SetupKubestellar(releasedFlag)
+		util.Cleanup(ctx)
+		util.SetupKubestellar(ctx, releasedFlag)
 	}
 
-	ctx = context.Background()
 	configCore := util.GetConfig(hostClusterCtxFlag)
 	configWds := util.GetConfig(wds1CtxFlag)
 	configITS := util.GetConfig(its1CtxFlag)

--- a/test/e2e/ginkgo/multiple_cluster_deployment_test.go
+++ b/test/e2e/ginkgo/multiple_cluster_deployment_test.go
@@ -17,6 +17,8 @@ limitations under the License.
 package e2e
 
 import (
+	"context"
+
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
 
@@ -33,7 +35,7 @@ const (
 )
 
 var _ = ginkgo.Describe("end to end testing", func() {
-	ginkgo.BeforeEach(func() {
+	ginkgo.BeforeEach(func(ctx context.Context) {
 		// Cleanup the WDS, create 1 deployment and 1 binding policy.
 		util.CleanupWDS(ctx, wds, ksWds, ns)
 		util.CreateDeployment(ctx, wds, ns, "nginx",
@@ -50,6 +52,8 @@ var _ = ginkgo.Describe("end to end testing", func() {
 					{MatchLabels: map[string]string{"app.kubernetes.io/name": "nginx"}},
 				}}})
 	})
+
+	ctx := context.Background()
 
 	ginkgo.Context("multiple WECs", func() {
 		ginkgo.It("propagates deployment to the WECs while applying CustomTransform", func() {

--- a/test/util/util.go
+++ b/test/util/util.go
@@ -102,9 +102,9 @@ func CreateNS(ctx context.Context, client *kubernetes.Clientset, name string) {
 	}, timeout).Should(gomega.Succeed())
 }
 
-func Cleanup() {
+func Cleanup(ctx context.Context) {
 	var e, o bytes.Buffer
-	cmd := exec.Command("../common/cleanup.sh")
+	cmd := exec.CommandContext(ctx, "../common/cleanup.sh")
 	cmd.Stderr = &e
 	cmd.Stdout = &o
 	err := cmd.Run()
@@ -115,8 +115,7 @@ func Cleanup() {
 	gomega.Expect(err).To(gomega.Succeed())
 }
 
-func SetupKubestellar(releasedFlag bool) {
-	var cmd *exec.Cmd
+func SetupKubestellar(ctx context.Context, releasedFlag bool) {
 	var e, o bytes.Buffer
 	var args []string
 	if releasedFlag {
@@ -124,7 +123,7 @@ func SetupKubestellar(releasedFlag bool) {
 	}
 	commandName := "../common/setup-kubestellar.sh"
 	ginkgo.By(fmt.Sprintf("Execing command %v", append([]string{commandName}, args...)))
-	cmd = exec.Command(commandName, args...)
+	cmd := exec.CommandContext(ctx, commandName, args...)
 	cmd.Stderr = &e
 	cmd.Stdout = &o
 	err := cmd.Run()


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
This PR attempts to connect ginkgo timeout to interrupting the `exec.Cmd` that runs `setup-kubestellar.sh`, so that a timeout during that script will cause the logging in SetupKubestellar to take effect. This should give a way to understand what went wrong during `setup-kubestellar.sh` when that suffers a timeout.

## Related issue(s)

This is intended to partially address #2200 .
