### PR TITLE
✨ Introduce doc vars for releases

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -101,6 +101,8 @@ There are many global variables defined in the <a href="{{ config.repo_raw_url }
     - edit_uri: {{ config.edit_uri }}
     - ks_branch: {{ config.ks_branch }}
     - ks_tag: {{ config.ks_tag }}
+    - ks_latest_regular_release: {{ config.ks_latest_regular_release }}
+    - ks_latest_release: {{ config.ks_latest_release }}
 
 to use a variables/macro in your documentation reference like this:
 

--- a/docs/content/direct/common-setup-core-chart.md
+++ b/docs/content/direct/common-setup-core-chart.md
@@ -8,7 +8,7 @@ with a choice of user-defined KubeFlex Control Planes (CPs).
 The information provided is specific for the following release:
 
 ```shell
-export KUBESTELLAR_VERSION=0.23.0
+export KUBESTELLAR_VERSION={{ config.ks_latest_release }}
 export OCM_TRANSPORT_PLUGIN=0.1.11
 ```
 

--- a/docs/content/direct/common-setup-step-by-step.md
+++ b/docs/content/direct/common-setup-step-by-step.md
@@ -9,7 +9,7 @@ The following steps create a deployment of KubeStellar Core
 1. Set environment variables to hold KubeStellar and OCM-transport-plugin desired versions:
 
     ```shell
-    export KUBESTELLAR_VERSION=0.23.0
+    export KUBESTELLAR_VERSION={{ config.ks_latest_release }}
     export OCM_TRANSPORT_PLUGIN=0.1.11
     ```
 

--- a/docs/content/direct/core-chart.md
+++ b/docs/content/direct/core-chart.md
@@ -6,7 +6,7 @@ with a choice of user-defined KubeFlex Control Planes (CPs).
 The information provided is specific for the following release:
 
 ```shell
-export KUBESTELLAR_VERSION=0.23.0
+export KUBESTELLAR_VERSION={{ config.ks_latest_release }}
 ```
 
 ## Pre-requisites
@@ -36,14 +36,14 @@ For convenience, a new local **Kind** cluster that satisfies the requirements fo
 and that can be used to exercises the [examples](./examples.md) can be created with the following command:
 
 ```shell
-bash <(curl -s https://raw.githubusercontent.com/kubestellar/kubestellar/v0.23.0/scripts/create-kind-cluster-with-SSL-passthrough.sh) --name kubeflex --port 9443
+bash <(curl -s https://raw.githubusercontent.com/kubestellar/kubestellar/v{{ config.ks_latest_release }}/scripts/create-kind-cluster-with-SSL-passthrough.sh) --name kubeflex --port 9443
 ```
 
 Alternatively, a new local **k3s** cluster that satisfies the requirements for KubeStellar setup
 and that can be used to exercises the [examples](./examples.md) can be created with the following command:
 
 ```shell
-bash <(curl -s https://raw.githubusercontent.com/kubestellar/kubestellar/v0.23.0/scripts/create-k3s-cluster-with-SSL-passthrough.sh) --port 9443
+bash <(curl -s https://raw.githubusercontent.com/kubestellar/kubestellar/v{{ config.ks_latest_release }}/scripts/create-k3s-cluster-with-SSL-passthrough.sh) --port 9443
 ```
 
 3. An **OpenShift** cluster
@@ -118,7 +118,7 @@ WDSes: # all the CPs in this list will execute the wds.yaml PCH
   ...
 ```
 
-where `name` must specify a name unique among all the control planes in that KubeFlex deployment (note that this must be unique among both ITSes and WDSes), the optional `type` can be either k8s (default) or host, see [here](https://github.com/kubestellar/kubeflex/blob/main/docs/users.md) for more information, the optional `APIGroups` provides a list of APIGroups, see [here](https://docs.kubestellar.io/release-0.23.0/direct/examples/#scenario-2-using-the-hosting-cluster-as-wds-to-deploy-a-custom-resource) for more information, and `ITSName` specify the ITS connected to the new WDS being created (this parameter MUST be specified if more that one ITS exists in the cluster, if no value is specified and only one ITS exists in the cluster, then it will be automatically selected).
+where `name` must specify a name unique among all the control planes in that KubeFlex deployment (note that this must be unique among both ITSes and WDSes), the optional `type` can be either k8s (default) or host, see [here](https://github.com/kubestellar/kubeflex/blob/main/docs/users.md) for more information, the optional `APIGroups` provides a list of APIGroups, see [here](https://docs.kubestellar.io/release-{{ config.ks_latest_release }}/direct/examples/#scenario-2-using-the-hosting-cluster-as-wds-to-deploy-a-custom-resource) for more information, and `ITSName` specify the ITS connected to the new WDS being created (this parameter MUST be specified if more that one ITS exists in the cluster, if no value is specified and only one ITS exists in the cluster, then it will be automatically selected).
 
 ## KubeStellar Core Chart usage
 

--- a/docs/content/direct/microshift.md
+++ b/docs/content/direct/microshift.md
@@ -5,7 +5,7 @@ This documents explains how to use KubeStellar Core chart in MicroShift.
 The information provided is specific for the following release:
 
 ```shell
-export KUBESTELLAR_VERSION=0.23.0
+export KUBESTELLAR_VERSION={{ config.ks_latest_release }}
 ```
 
 ## Pre-requisites

--- a/docs/content/direct/release.md
+++ b/docs/content/direct/release.md
@@ -38,15 +38,11 @@ Making a new kubestellar release requires a contributor to do the following thin
 
 - If not already in effect, declare a code freeze. There should be nothing but bug fixes and doc improvements while working towards a regular release.
 
+- Edit `docs/mkdocs.yml` and update the definition of `ks_latest_release` to `$version` (e.g., `'0.23.0-rc42'`). If this is a regular release then also update the definition of `ks_latest_regular_release`.
+
 - Edit the source for the KCM PCH (in `config/postcreate-hooks/kubestellar.yaml`) and update the tag in the reference to the KCM container image (it appears in the last object, a `Job`).
 
-- Edit the examples document(`docs/content/direct/examples.md`) to update the self-references for the coming release. In the interim while we have some content split out into `docs/content/direct/common-setup-core-chart.md` and `docs/content/direct/common-setup-step-by-step.md`, edit in those places.
-
 - Update the version in the core chart defaults, `core-chart/values.yaml`.
-
-- Update the version every place it appears in the core chart instructions, `docs/content/direct/core-chart.md`. Eventually we may settle on a regular release for some curl-to-bash invocations.
-
-- Update the microshift directions, `docs/content/direct/microshift.md`.
 
 - Until we have our first stable release, edit the docs README(`docs/content/direct/README.md`, section "latest-stable-release") where it wishes it could cite a stable release but instead cites the latest release, to rever to the coming release.
 

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -13,6 +13,8 @@ repo_raw_url: https://raw.githubusercontent.com/kubestellar/kubestellar
 edit_uri: edit/main/docs/content
 ks_branch: 'main'
 ks_tag: 'latest'
+ks_latest_regular_release: '0.23.0'
+ks_latest_release: '0.23.0'
 
 ks_kind_port_num: '1119'
 


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
This PR introduces some new documentation variables that align with our current release concepts of "latest regular release" and "latest release". This replaces several self-references with just one (the definition of `ks_latest_release`).

## Related issue(s)

