### PR TITLE
📖 release-0.23.0: Remove misleading empty setup content

### DIFF
--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -31,13 +31,10 @@ nav:
       - Release-notes: direct/release-notes.md
   - Getting Started: 
           - Pre-reqs: direct/pre-reqs.md
-          - Setting up KubeStellar:
-              - Using existing hosting cluster: direct/hosting-cluster.md
-              - KubeStellar on KIND: direct/ks-on-kind.md
-              - KubeStellar on K3D: direct/deploy-on-k3d.md
-              - KubeStellar on OCP: direct/ks-on-ocp.md
-          - Best practices: direct/best-practices.md
           - Examples: direct/examples.md
+          - Using existing hosting cluster: direct/hosting-cluster.md
+          - KubeStellar on K3D: direct/deploy-on-k3d.md
+          - Best practices: direct/best-practices.md
   - Contributing: 
       - Overview of contributing: direct/contributor.md
       - Packaging: direct/packaging.md


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
This PR updates the docs in the `release-0.23.0` branch to remove (from the navigation tree) the dead-ends that people keep getting stuck in: setup on kind and setup on OCP. This also moves the examples ahead of the other setup instructions, because the examples have the setup instructions using three new kind clusters.

Preview at https://mikespreitzer.github.io/kcp-edge-mc/doc-untwist-setup-for-0230/readme/

## Related issue(s)

This fixes #2213 in the branch named `release-0.23.0`. That is the one that drives what people see on the website.
