### PR TITLE
📖 release-0.23.0: Remove misleading empty setup content

### DIFF
--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -31,13 +31,10 @@ nav:
       - Release-notes: direct/release-notes.md
   - Getting Started: 
           - Pre-reqs: direct/pre-reqs.md
-          - Setting up KubeStellar:
-              - Using existing hosting cluster: direct/hosting-cluster.md
-              - KubeStellar on KIND: direct/ks-on-kind.md
-              - KubeStellar on K3D: direct/deploy-on-k3d.md
-              - KubeStellar on OCP: direct/ks-on-ocp.md
-          - Best practices: direct/best-practices.md
           - Examples: direct/examples.md
+          - Using existing hosting cluster: direct/hosting-cluster.md
+          - KubeStellar on K3D: direct/deploy-on-k3d.md
+          - Best practices: direct/best-practices.md
   - Contributing: 
       - Overview of contributing: direct/contributor.md
       - Packaging: direct/packaging.md


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
This PR is what #2217 was meant to be: a quick hack to the `release-0.23.0` branch to do a quick fix to the current website.

## Related issue(s)

This fixes https://github.com/kubestellar/kubestellar/issues/2213 in the branch named release-0.23.0. That is the one that drives what people see on the website.
