### PR TITLE
📖 [release-0.23.0] Strengthen warning in k3d report

### DIFF
--- a/docs/content/direct/deploy-on-k3d.md
+++ b/docs/content/direct/deploy-on-k3d.md
@@ -1,8 +1,8 @@
 # Deploy KubeStellar on K3D
 
-This document shows how to deploy kubestellar on K3D hub and wec clusters.
+This document shows how KubeStellar release 0.22.0 was set up using feshly created k3d clusters for the hosting cluster and two WECs.
 
-This is a point-in-time statement that worked with KubeStellar release v0.22.0.
+**NOTE WELL:** This is a report of a something was done in the past with an older release of KubeStellar; 0.22.0 is NOT the latest release.
 
 ## Prereqs
 


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
This PR updates the introductory material of the report of how KubeStellar was deployed using k3d, to emphasize that it is a blast from the past and not referencing the latest regular release.

Preview at https://mikespreitzer.github.io/kcp-edge-mc/doc-warn-harder/direct/deploy-on-k3d/

## Related issue(s)

I hope this will fix issue #2230 in branch `release-0.23.0`, which is the source of the default version of the website currently.

I hope that the greater re-organization work being done in `main` will dissolve the problematic file and put the important pieces elsewhere.
