### PR TITLE
📖 [release-0.23.0] Fix broken cross-ref to CONTRIBUTING doc

### DIFF
--- a/docs/content/readme.md
+++ b/docs/content/readme.md
@@ -40,7 +40,7 @@ KubeStellar simplifies this process by allowing developers to define a binding p
 
 ## Contributing
 
-We ❤️ our contributors! If you're interested in helping us out, please head over to our [Contributing]({{ config.docs_url }}/{{ config.ks_branch }}/Contribution%20guidelines/CONTRIBUTING/) guide.
+We ❤️ our contributors! If you're interested in helping us out, please head over to our [Contributing](Contribution%20guidelines/CONTRIBUTING.md) guide.
 
 ## Getting in touch
 


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
This PR replaces a broken absolute link to a document with a working relative link.

Preview at https://mikespreitzer.github.io/kcp-edge-mc/doc-unmain/readme/#contributing

## Related issue(s)

This should fix #2232 in the branch named `release-0.23.0`, which is the one that is currently the source of the default version of the website.
