### PR TITLE
📖 Replace broken absolute URL with working relative one

### DIFF
--- a/docs/content/readme.md
+++ b/docs/content/readme.md
@@ -40,7 +40,7 @@ KubeStellar simplifies this process by allowing developers to define a binding p
 
 ## Contributing
 
-We ❤️ our contributors! If you're interested in helping us out, please head over to our [Contributing]({{ config.docs_url }}/{{ config.ks_branch }}/Contribution%20guidelines/CONTRIBUTING/) guide.
+We ❤️ our contributors! If you're interested in helping us out, please head over to our [Contributing](Contribution%20guidelines/CONTRIBUTING.md) guide.
 
 ## Getting in touch
 


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
This PR fixes a broken link in the doc, in the `main` branch, replacing an erroneous absolute URL with a working relative URL.

Preview at https://mikespreitzer.github.io/kcp-edge-mc/doc-fixrel-main/readme/#contributing

## Related issue(s)

This should fix #2232 in `main`. PR #2234 fixed it in `release-0.23.0`.
