### PR TITLE
📖 [release-0.23.0] Replace another wrong absolute link with correct relative one

### DIFF
--- a/docs/content/direct/common-setup-core-chart.md
+++ b/docs/content/direct/common-setup-core-chart.md
@@ -28,7 +28,7 @@ bash <(curl -s https://raw.githubusercontent.com/kubestellar/kubestellar/v${KUBE
 
 ## Install KubeStellar Core chart
 
-A KubeStellar Core installation compatible with the common setup suitable for Common Setup described in the [examples](https://docs.kubestellar.io/release-0.22.0/direct/examples/) could be achieved with the following command:
+A KubeStellar Core installation compatible with the common setup suitable for Common Setup described in the [examples](examples.md) could be achieved with the following command:
 
 ```shell
 helm upgrade --install ks-core oci://ghcr.io/kubestellar/kubestellar/core-chart --version $KUBESTELLAR_VERSION \


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
This fixes another wrong link.

Preview at https://mikespreitzer.github.io/kcp-edge-mc/doc-fixrel2-r0230/direct/common-setup-core-chart/#install-kubestellar-core-chart

## Related issue(s)

This fixes #2235 in `release-0.23.0`, which is the branch that drives the current default version of the website.
