### PR TITLE
📖 Add grouping and extension points in usage outline graph

### DIFF
--- a/docs/content/direct/usage-basics.md
+++ b/docs/content/direct/usage-basics.md
@@ -23,9 +23,6 @@ By "maintain" we mean create, read, update, delete, list, and watch as you like,
 There is some flexibility in the ordering of those stage. The following flowchart shows the dependencies.
 
 ```mermaid
----
-KubeStellar activity ordering
----
 flowchart LR
     step0[SW prereqs]
     step1[Acquire host cluster]
@@ -56,5 +53,57 @@ flowchart LR
 You can have multiple ITSes, WDSes, and WECs, created and deleted over time as you like.
 
 KubeStellar's [Core Helm chart](core-chart.md) combines initializing the KubeFlex hosting cluster, creating some ITSes, and creating some WDSes.
+
+The following variant of that graph shows what the Core Helm chart covers and shows all the entry points for extending usage.
+
+```mermaid
+flowchart LR
+    start((Start))
+    extend1((Extend))
+    extend2((Extend))
+    extend3((Extend))
+    extend4((Extend))
+    extend5((Extend))
+    style start stroke:#00B000,fill:#C0FFC0,stroke-width:2pt
+    style extend1 stroke:#006000,fill:#E0FFE0,stroke-width:2pt,stroke-dasharray: 5 5
+    style extend2 stroke:#006000,fill:#E0FFE0,stroke-width:2pt,stroke-dasharray: 5 5
+    style extend3 stroke:#006000,fill:#E0FFE0,stroke-width:2pt,stroke-dasharray: 5 5
+    style extend4 stroke:#006000,fill:#E0FFE0,stroke-width:2pt,stroke-dasharray: 5 5
+    style extend5 stroke:#006000,fill:#E0FFE0,stroke-width:2pt,stroke-dasharray: 5 5
+    step0[SW prereqs]
+    step1[Acquire host cluster]
+    subgraph core_chart[Core Chart]
+    step2[Initialize host cluster]
+    step3i[Create ITS]
+    step3w[Create WDS]
+    end
+    style core_chart fill:#F0F0F0,stroke-dasharray: 5 5
+    step4[Create WEC]
+    step5[Register WEC]
+    step6[Create workload]
+    step7[Create control objects]
+    step8[Enjoy]
+    step9[Consume reported state]
+    start -.-> step0
+    start -.-> step1
+    extend1 -.-> step3i
+    extend2 -.-> step3w
+    extend3 -.-> step4
+    extend4 -.-> step6
+    extend5 -.-> step7
+    step0 --> step2
+    step1 --> step2
+    step2 --> step3i
+    step2 --> step3w
+    step4 --> step5
+    step3i --> step5
+    step3i --> step3w
+    step3w --> step6
+    step3w --> step7
+    step5 --> step8
+    step6 --> step8
+    step7 --> step8
+    step8 --> step9
+```
 
 You can find an example run through of steps 2--7 in [the quickstart](get-started.md). This dovetails with [the example scenarios document](example-scenarios.md), which shows examples of the later steps.


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
This PR updates the usage outline doc to include a second graph that adds to the first graph two things: (1) a box showing what the Core Helm chart covers, to emphasize that real usage does not require the user to go through all the steps individually, and (2) explicit call-outs of all the entry points for extending usage, to make it clear that the user has all these choices and why the graph is so articulated.

The base and enhanced graphs are drawn with Mermaid, whose results are not greatly satisfactory to me. I am particular not fond of all the unnecessary line-crossing, because it makes the graph unnecessarily complex visually.

Preview at https://mikespreitzer.github.io/kcp-edge-mc/doc-group-outline/direct/usage-basics/

## Related issue(s)

Fixes #
