### PR TITLE
✨ Update create-kind-cluster-with-SSL-passthrough.sh

### DIFF
--- a/scripts/create-kind-cluster-with-SSL-passthrough.sh
+++ b/scripts/create-kind-cluster-with-SSL-passthrough.sh
@@ -85,6 +85,8 @@ else
   echo "Skipping... \"${name}\" kind cluster already exists."
 fi
 
+kubectl config rename-context kind-kubeflex kubeflex
+
 echo "Installing an nginx ingress..."
 kubectl apply -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/main/deploy/static/provider/kind/deploy.yaml
 


### PR DESCRIPTION
kflex does not work with a cluster named "kind-kubeflex" - it is expecting "kubeflex". Without this change, the instructions on the helm install page do not work properly. The problem comes with pulling the contexts using kflex

```
kubectl config delete-context its1 || true
kflex ctx its1
kubectl config delete-context wds1 || true
kflex ctx wds1
kflex ctx # switch back to the initial context
```

fails if "kind-kubeflex" is used

<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

## Related issue(s)

Fixes #
