### PR TITLE
📖 Add prereq section for quickstart install

### DIFF
--- a/docs/content/direct/pre-reqs.md
+++ b/docs/content/direct/pre-reqs.md
@@ -45,6 +45,10 @@ follow [these instructions](https://github.com/kubestellar/kubeflex/blob/main/do
 
 - **helm** - to deploy the kubestellar and kubeflex charts
 - **kubectl** - to access the kubernetes clusters
+
+## Additional Software for the Quickstart setup
+
+- [**kind**](https://kind.sigs.k8s.io/)
 - **docker** (or compatible docker engine that works with kind)
 
 ## Additional Software For Running the Examples


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
This PR adds a section to the pre-reqs doc to cover what else the quickstart needs in its setup phase (i.e., kind) and moves the mention of docker to where it belongs.

Preview at https://mikespreitzer.github.io/kcp-edge-mc/doc-quickstart-prereq/direct/pre-reqs/

## Related issue(s)

