### PR TITLE
🌱 Make broken links crawler work on forks

### DIFF
--- a/.github/workflows/broken-links-crawler.yml
+++ b/.github/workflows/broken-links-crawler.yml
@@ -18,8 +18,11 @@ jobs:
     name: debug-event-contents
     runs-on: ubuntu-latest
     steps:
-      - run: echo "event name is:" ${{ github.event_name }} 
-      - run: echo "event type is:" ${{ github.event.action }} 
+      - run: echo "event name is:" ${{ github.event_name }}
+      - run: echo "event type is:" ${{ github.event.action }}
+      - run: echo "repository is:" ${{ github.repository }}
+      - run: echo "GITHUB_REF=<$GITHUB_REF>"
+      - run: echo "GITHUB_REPOSITORY=<$GITHUB_REPOSITORY>"
 
   broken-links-crawler:
     name: broken-links-crawler
@@ -29,22 +32,35 @@ jobs:
       - name: get workflow_dispatch branch name
         shell: bash
         run: |
-            echo "branch=${GITHUB_REF##*/}" >> $GITHUB_OUTPUT
-            echo "version=$(sed 's/^main$/unreleased-development/' <<<"${GITHUB_REF##*/}")" >> $GITHUB_OUTPUT
+            branch="${GITHUB_REF##*/}"
+            echo "branch=$branch" >> $GITHUB_OUTPUT
+            if [ "$branch" == main ]
+            then version=unreleased-development
+            else version="$branch"
+            fi
+            echo "version=$version" >> $GITHUB_OUTPUT
+            if [ "$GITHUB_REPOSITORY_OWNER" == kubestellar ]
+            then site=docs.kubestellar.io
+            else site=${GITHUB_REPOSITORY/\//.github.io/}
+            fi
+            site="${site,,}"
+            echo "site=$site" >>$GITHUB_OUTPUT
+
         id: extract_branch
         if: github.event_name != 'pull_request' && github.event_name != 'push'
 #         run: echo workflow_dispatch - running on branch ${GITHUB_REF##*/}
 
       - name: echo workflow_dispatch branch name
         run: |
+            echo workflow_dispatch - runhing on site ${{ steps.extract_branch.outputs.site }}
             echo workflow_dispatch - running on branch ${{ steps.extract_branch.outputs.branch }}
             echo workflow_dispatch - running on version ${{ steps.extract_branch.outputs.version }}
         if: github.event_name != 'pull_request' && github.event_name != 'push'
 
       - uses: ScholliYT/Broken-Links-Crawler-Action@fix-http-redirects
         with:
-          website_url: https://docs.kubestellar.io/${{ steps.extract_branch.outputs.version }}
-          include_url_prefix: https://docs.kubestellar.io/${{ steps.extract_branch.outputs.vesion }}
+          website_url: https://${{ steps.extract_branch.outputs.site }}/${{ steps.extract_branch.outputs.version }}
+          include_url_prefix: https://${{ steps.extract_branch.outputs.site }}/${{ steps.extract_branch.outputs.version }}
           exclude_url_prefix: 'mailto:,https://drive.google.com'
           exclude_url_contained: '#__,/.,.svg'
           resolve_before_filtering: 'true'


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
This PR generalizes the broken links crawler workflow so that it works on forks; previously it only worked on the shared repo.

Tested by pushing to the `main` branch on my fork; see https://github.com/MikeSpreitzer/kcp-edge-mc/actions/runs/9721013863

I briefly goofed up on testing, creating commit 09feb2cdd07d31764176329f8a3f8a22874d5ffa in the shared repo; commit be284b14f76b8c147ec4b853ee359d9b742f2404 undoes that.

## Related issue(s)

In combination with #2275 (now merged),

Fixes #2203
