### PR TITLE
✨ Add crawl for all broken links

### DIFF
--- a/.github/workflows/full-broken-links-crawler.yml
+++ b/.github/workflows/full-broken-links-crawler.yml
@@ -1,0 +1,64 @@
+name: Full Broken Links Crawler
+run-name: Full Broken Links Crawler - ${{ github.ref_name }}
+
+on:
+  # So we can trigger manually if needed
+  workflow_dispatch:
+
+  schedule:
+    - cron: "0 9 * * 5"
+
+permissions:
+  contents: write
+
+jobs:
+  debug-event:
+    name: debug-event-contents
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "event name is:" ${{ github.event_name }}
+      - run: echo "event type is:" ${{ github.event.action }}
+      - run: echo "repository is:" ${{ github.repository }}
+      - run: echo "GITHUB_REF=<$GITHUB_REF>"
+      - run: echo "GITHUB_REPOSITORY=<$GITHUB_REPOSITORY>"
+
+  broken-links-crawler:
+    name: broken-links-crawler
+    runs-on: ubuntu-latest
+    steps:
+      - name: get workflow_dispatch branch name
+        shell: bash
+        run: |
+            branch="${GITHUB_REF##*/}"
+            echo "branch=$branch" >> $GITHUB_OUTPUT
+            if [ "$branch" == main ]
+            then version=unreleased-development
+            else version="$branch"
+            fi
+            echo "version=$version" >> $GITHUB_OUTPUT
+            if [ "$GITHUB_REPOSITORY_OWNER" == kubestellar ]
+            then site=docs.kubestellar.io
+            else site=${GITHUB_REPOSITORY/\//.github.io/}
+            fi
+            site="${site,,}"
+            echo "site=$site" >>$GITHUB_OUTPUT
+
+        id: extract_branch
+
+      - name: echo workflow_dispatch branch name
+        run: |
+            echo workflow_dispatch - runhing on site ${{ steps.extract_branch.outputs.site }}
+            echo workflow_dispatch - running on branch ${{ steps.extract_branch.outputs.branch }}
+            echo workflow_dispatch - running on version ${{ steps.extract_branch.outputs.version }}
+
+      - uses: ScholliYT/Broken-Links-Crawler-Action@fix-http-redirects
+        with:
+          website_url: https://${{ steps.extract_branch.outputs.site }}/${{ steps.extract_branch.outputs.version }}
+          include_url_prefix: "https:"
+          exclude_url_prefix: 'mailto:,https://drive.google.com'
+          exclude_url_contained: '#__,/.,.svg'
+          resolve_before_filtering: 'true'
+          verbose: 'true'
+          max_retry_time: 30
+          max_retries: 5
+          max_depth: 4


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
This PR adds a workflow that reports all broken links to HTTPS URLs. This workflow is not triggered by pushes or PRs because it always finds a lot of stuff. Instead, it is triggered once a week (09:00 on Friday) and manually.

## Related issue(s)

Fixes #
