### PR TITLE
🐛 Make broken-links-crawler.yml a "reusable" workflow

### DIFF
--- a/.github/workflows/broken-links-crawler.yml
+++ b/.github/workflows/broken-links-crawler.yml
@@ -1,14 +1,25 @@
 name: Broken Links Crawler
 run-name: Broken Links Crawler - ${{ github.ref_name }}
 
+env:
+  PASSED_BRANCH: ${{ inputs.branch }}
+
 on:
   # So we can trigger manually if needed
   workflow_dispatch:
-  # To confirm any changes to docs build successfully, without deploying them
-  workflow_run:
-    workflows: ["Generate and push docs"]
-    types:
-      - completed
+    inputs:
+      branch:
+        required: true
+        type: string
+        description: the branch to be translated to the version to check
+
+  # Normal use is being called on a particular branch
+  workflow_call:
+    inputs:
+      branch:
+        required: true
+        type: string
+        description: the branch to be translated to the version to check
 
 permissions:
   contents: write
@@ -23,16 +34,17 @@ jobs:
       - run: echo "repository is:" ${{ github.repository }}
       - run: echo "GITHUB_REF=<$GITHUB_REF>"
       - run: echo "GITHUB_REPOSITORY=<$GITHUB_REPOSITORY>"
+      - run: echo "PASSED_BRANCH=<$PASSED_BRANCH>"
 
   broken-links-crawler:
     name: broken-links-crawler
     runs-on: ubuntu-latest
     if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
     steps:
-      - name: get workflow_dispatch branch name
+      - name: set variables and check timing
         shell: bash
         run: |
-            branch="${GITHUB_REF##*/}"
+            branch="$PASSED_BRANCH"
             echo "branch=$branch" >> $GITHUB_OUTPUT
             if [ "$branch" == main ]
             then version=unreleased-development
@@ -45,12 +57,25 @@ jobs:
             fi
             site="${site,,}"
             echo "site=$site" >>$GITHUB_OUTPUT
+            echo "site=<$site> version=<$version>"
+            sleep 30
+            cat <<EOF
+            Because the website does not actually get updated until after the
+            completion of an asynchronous workflow named
+            'pages build and deployment', you should check that the website was
+            updated after that workflow started.
+            BTW, the time is now $(date).
+            Following is the last run of 'pages build and deployment';
+            note created_at and updated_at.
+            EOF
+            curl -L -H "Accept: application/vnd.github+json" -H "X-GitHub-Api-Version: 2022-11-28" "https://api.github.com/repos/${GITHUB_REPOSITORY}/actions/runs?per_page=10" | jq '[ .workflow_runs[] | select(.name == "pages build and deployment") ] | .[0]'
+            echo "HEAD of https://${site}/${version}/ (compare last-modified):"
+            curl -IL "https://${site}/${version}/"
 
         id: extract_branch
         if: github.event_name != 'pull_request' && github.event_name != 'push'
-#         run: echo workflow_dispatch - running on branch ${GITHUB_REF##*/}
 
-      - name: echo workflow_dispatch branch name
+      - name: echo workflow_dispatch branch name et cetera
         run: |
             echo workflow_dispatch - runhing on site ${{ steps.extract_branch.outputs.site }}
             echo workflow_dispatch - running on branch ${{ steps.extract_branch.outputs.branch }}

--- a/.github/workflows/docs-gen-and-push.yml
+++ b/.github/workflows/docs-gen-and-push.yml
@@ -55,3 +55,9 @@ jobs:
           cache: 'pip'
 
       - run: make deploy-docs
+
+  call-crawl:
+    needs: generate-and-push
+    uses: ./.github/workflows/broken-links-crawler.yml
+    with:
+      branch: ${{ github.ref_name }}


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
This PR changes the way that the "Generate and push docs" workflow is linked to the "Broken Links Crawler" workflow, so that the latter acts on the same GitHub "ref" as the former.

## Related issue(s)

Fixes #2203
