### PR TITLE
✨ update shard test to check number of manifestworks

### DIFF
--- a/test/e2e/ginkgo/multiple_cluster_deployment_test.go
+++ b/test/e2e/ginkgo/multiple_cluster_deployment_test.go
@@ -180,6 +180,10 @@ var _ = ginkgo.Describe("end to end testing", func() {
 				},
 			)
 
+			// Expect addon-addon-status-deploy-0  and nginx-wds1 manifest works on both clusters.
+			// And the 10 manifestworks for the deployment on cluster1.
+			util.ValidateNumManifestworks(ctx, its, "cluster1", 12)
+			util.ValidateNumManifestworks(ctx, its, "cluster2", 2)
 			util.ValidateNumDeployments(ctx, wec1, ns, 10)
 			util.ValidateNumDeployments(ctx, wec2, ns, 0)
 
@@ -187,11 +191,18 @@ var _ = ginkgo.Describe("end to end testing", func() {
 			patch = []byte(`{"spec": {"clusterSelectors": [{"matchLabels": {"name": "cluster2"}}]}}`)
 			_, err = ksWds.ControlV1alpha1().BindingPolicies().Patch(ctx, "multipledep", types.MergePatchType, patch, metav1.PatchOptions{})
 			gomega.ExpectWithOffset(1, err).NotTo(gomega.HaveOccurred())
+			// Expect addon-addon-status-deploy-0  and nginx-wds1 manifest works on both clusters.
+			// And the 10 manifestworks for the deployment on cluster2.
+			util.ValidateNumManifestworks(ctx, its, "cluster1", 2)
+			util.ValidateNumManifestworks(ctx, its, "cluster2", 12)
 			util.ValidateNumDeployments(ctx, wec1, ns, 0)
 			util.ValidateNumDeployments(ctx, wec2, ns, 10)
 
 			ginkgo.By("delete of bindingpolicy with sharded wrapped workloads deletes deployments")
 			util.DeleteBindingPolicy(ctx, ksWds, "multipledep")
+			// Expect addon-addon-status-deploy-0  and nginx-wds1 manifest works on both clusters.
+			util.ValidateNumManifestworks(ctx, its, "cluster1", 2)
+			util.ValidateNumManifestworks(ctx, its, "cluster2", 2)
 			util.ValidateNumDeployments(ctx, wec1, ns, 0)
 			util.ValidateNumDeployments(ctx, wec2, ns, 0)
 		})


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
We have an existing test case for sharding wrapped objects (i.e. manifestwork objects) but it's end to end test case and does not test the manifestworks themselves.  On second thought it should.  

## Related issue(s)

Fixes #
