### PR TITLE
📖 Rename quickstart to Getting Started, other doc brush up

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,7 +18,7 @@ We can't wait to collaborate with you!
     - In go.mod it is indicated by the "go" directive.
     - In the .github/workflows yaml files it is indicated by "go-version"
 
-Check out our [QuickStart Guide](https://docs.kubestellar.io/stable/Getting-Started/quickstart/)
+Check out [Getting Started](https://docs.kubestellar.io/latest/direct/get-started/)
 
 ### Issues
 Prioritization for pull requests is given to those that address and resolve existing GitHub issues. Utilize the available issue labels to identify meaningful and relevant issues to work on.

--- a/docs/README.md
+++ b/docs/README.md
@@ -99,7 +99,7 @@ We have a few shortcut urls that come in handy when referring others to our proj
 - [https://kubestellar.io/infomercial](https://kubestellar.io/infomercial) - our infomercial that premieres on June 12th at 9am
 
 and.. the very important…
-- [https://kubestellar.io/quickstart](https://kubestellar.io/quickstart) - our 'stable' quickstart
+- [https://kubestellar.io/quickstart](https://kubestellar.io/quickstart) - our 'stable' Getting Started recipe
 
 ## Jinja templating
 

--- a/docs/content/direct/acquire-hosting-cluster.md
+++ b/docs/content/direct/acquire-hosting-cluster.md
@@ -20,7 +20,7 @@ TODO: finish writing this subsection for real. Following are some clues.
 
 When everything runs on one machine, the defaults just work. When core and some WECs are on different machines, it gets more challenging. When the KubeFlex hosting cluster is an OpenShift cluster with a public domain name, the defaults just work.
 
-After the quickstart setup, I looked at an OCM Agent (klusterlet-agent, to be specific) and did not find a clear passing of kubeconfig. I found adjacent Secrets holding kubeconfigs in which `cluster[0].cluster.server` was `https://kubeflex-control-plane:31048`. Note that `kubeflex-control-plane` is the name of the Docker container running `kind` cluster serving as KubeFlex hosting cluster. I could not find an explanation for the port number 31048; that Docker container maps port 443 inside to 9443 on the outside.
+After the Getting Started setup, I looked at an OCM Agent (klusterlet-agent, to be specific) and did not find a clear passing of kubeconfig. I found adjacent Secrets holding kubeconfigs in which `cluster[0].cluster.server` was `https://kubeflex-control-plane:31048`. Note that `kubeflex-control-plane` is the name of the Docker container running `kind` cluster serving as KubeFlex hosting cluster. I could not find an explanation for the port number 31048; that Docker container maps port 443 inside to 9443 on the outside.
 
 `kflex init` takes a command line flag `--domain string` described as `domain for FQDN (default "localtest.me")`.
 

--- a/docs/content/direct/core-chart.md
+++ b/docs/content/direct/core-chart.md
@@ -2,8 +2,7 @@
 
 This documents explains how to use KubeStellar Core chart to do three
 of the 11 installation and usage steps; please see [the
-outline](user-guide-intro.md) for generalities and [the
-quickstart](get-started.md) for an example of usage.
+full outline](user-guide-intro.md#the-full-story) for generalities and [Getting Started](get-started.md) for an example of usage.
 
 This Helm chart can do any subset of the following things.
 
@@ -41,7 +40,7 @@ If a host port number different from the expected 9443 is used for the Kind clus
 By default the KubeStellar Core chart uses a test domain `localtest.me`, which is OK for testing on a single host machine. However, scenarios that span more than one machine, it is necessary to set `--set "kubeflex-controller.domain=<domain>"` to a more appropriate `<domain>` that can be reached from Workload Execution CLusters (WECs).
 
 For convenience, a new local **Kind** cluster that satisfies the requirements for KubeStellar setup
-(e.g., as in [the quickstart](get-started.md)) can be created with the following command:
+(e.g., as in [Getting Started](get-started.md)) can be created with the following command:
 
 ```shell
 bash <(curl -s https://raw.githubusercontent.com/kubestellar/kubestellar/v{{ config.ks_latest_release }}/scripts/create-kind-cluster-with-SSL-passthrough.sh) --name kubeflex --port 9443
@@ -145,7 +144,7 @@ User defined control planes can be added using additional value files of `--set`
 - add two ITSes named its1 and its2 of of type vcluster and host, respectively: `--set-json='ITSes=[{"name":"its1"},{"name":"its2","type":"host"}]'`
 - add a single WDS named wds1 of default k8s type connected to the one and only ITS: `--set-json='WDSes=[{"name":"wds1"}]'`
 
-A KubeStellar Core installation that is consistent with [the quickstart](get-started.md) and and supports [the example scenarios](./example-scenarios.md) could be achieved with the following command:
+A KubeStellar Core installation that is consistent with [Getting Started](get-started.md) and and supports [the example scenarios](./example-scenarios.md) could be achieved with the following command:
 
 ```shell
 helm upgrade --install ks-core oci://ghcr.io/kubestellar/kubestellar/core-chart --version $KUBESTELLAR_VERSION \

--- a/docs/content/direct/example-scenarios.md
+++ b/docs/content/direct/example-scenarios.md
@@ -1,8 +1,10 @@
 # KubeStellar Example Scenarios
 
-This document shows some simple examples of using the release that contains this version of this document. These scenarios can be used to test a KubeStellar installation for proper functionality. General setup instructions are outlined in [the Overview](user-guide-intro.md); a simple example setup is in [the quickstart](get-started.md).
+This document shows some simple examples of using the release that contains this version of this document. These scenarios can be used to test a KubeStellar installation for proper functionality. These scenarios suppose that you have done "setup". General setup instructions are outlined in [the User Guide Overview](user-guide-intro.md#the-full-story); a simple example setup is in [the Setup section of Getting Started](get-started.md#setup).
 
-Each scenario supposes that one ITS and one WDS have been created and two WECs have been created and registered. These scenarios are written as shell commands (bash or zsh). These commands assume that you have defined the following shell variables to convey the needed information about that ITS and WDS and those WECs.
+## Assumptions and variables
+
+Each scenario supposes that one ITS and one WDS have been created, and that two WECs have been created and registered and also labeled for selection by KubeStellar control objects. These scenarios are written as shell commands (bash or zsh). These commands assume that you have defined the following shell variables to convey the needed information about that ITS and WDS and those WECs. For a concrete example of settings of these variables, see [the end of Getting Started](get-started.md#exercise-kubestellar).
 
 - `host_context`: the name of the kubeconfig context to use when accessing the KubeFlex hosting cluster.
 - `its_cp`: the name of the KubeFlex control plane that is playing the role of ITS.

--- a/docs/content/direct/get-started.md
+++ b/docs/content/direct/get-started.md
@@ -1,30 +1,34 @@
-# KubeStellar Quickstart Setup
+# Getting Started with KubeStellar
 
-This Quick Start outlines step 1, shows a concrete example of steps 2--7 in the [Installation and Usage outline](user-guide-intro.md), and forwards you to one example of the remaining steps. In this example you will create three new `kind` clusters to serve as your KubeFlex hosting cluster and two WECs.
+This pages shows one concrete example of steps 2--7 from the [full Installation and Usage outline](user-guide-intro.md#the-full-story). This example produces a simple single-host system suitable for kicking the tires, using [kind](https://kind.sigs.k8s.io/) to create three new clusters to serve as your KubeFlex hosting cluster and two WECs. This page concludes with forwarding you to one example of the remaining steps.
 
-  1. Install software prerequisites
-  1. Cleanup from previous runs
-  1. Create the KubeFlex hosting cluster and Kubestellar core components
-  1. Create and register two WECs.
+  1. Setup
+    1. Install software prerequisites
+    1. Cleanup from previous runs
+    1. Create the KubeFlex hosting cluster and Kubestellar core components
+    1. Create and register two WECs.
   1. Exercise KubeStellar
 
----
-## Install software prerequisites
+## Setup
 
-The following command will check for the prerequisites that you will need for this quickstart. See [the prerequisites doc](pre-reqs.md) for more details.
+This is one way to produce a very simple system, suitable for study but not production usage. For general setup information, see [the full story](user-guide-intro.md#the-full-story).
+
+### Install software prerequisites
+
+The following command will check for the prerequisites that you will need for the later steps. See [the prerequisites doc](pre-reqs.md) for more details.
 
 ```shell
 bash <(curl https://raw.githubusercontent.com/kubestellar/kubestellar/v{{ config.ks_latest_regular_release }}/hack/check_pre_req.sh) kflex ocm helm kubectl docker kind
 ```
 
-This quickstart uses [kind](https://kind.sigs.k8s.io/) to create three Kubernetes clusters on your machine.
+This setup recipe uses [kind](https://kind.sigs.k8s.io/) to create three Kubernetes clusters on your machine.
 Note that `kind` does not support three or more concurrent clusters unless you raise some limits as described in this `kind` "known issue": [Pod errors due to “too many open files”](https://kind.sigs.k8s.io/docs/user/known-issues/#pod-errors-due-to-too-many-open-files).
 
-## Cleanup from previous runs
+### Cleanup from previous runs
 
-If you have run this quickstart or any related recipe previously then
+If you have run this recipe or any related recipe previously then
 you will first want to remove any related debris. The following
-commands tear down the state established by this quickstart.
+commands tear down the state established by this recipe.
 
 ```shell
 kind delete cluster --name kubeflex
@@ -35,21 +39,21 @@ kubectl config delete-context cluster1
 kubectl config delete-context cluster2
 ```
 
-## Set the Version appropriately as an environment variable
+### Set the Version appropriately as an environment variable
 
 ```shell
 export KUBESTELLAR_VERSION={{ config.ks_latest_release }}
 ```
 
-## Create a kind cluster to host KubeFlex
+### Create a kind cluster to host KubeFlex
 
-For convenience, a new local **Kind** cluster that satisfies the requirements for KubeStellar setup and that can be used to commission the quickstart workload can be created with the following command:
+For convenience, a new local **Kind** cluster that satisfies the requirements for playing the role of KubeFlex hosting cluster can be created with the following command:
 
 ```shell
 bash <(curl -s https://raw.githubusercontent.com/kubestellar/kubestellar/v0.23.0/scripts/create-kind-cluster-with-SSL-passthrough.sh) --name kubeflex --port 9443
 ```
 
-## Use Core Helm chart to initialize KubeFlex and create ITS and WDS
+### Use Core Helm chart to initialize KubeFlex and create ITS and WDS
 
 ```shell
 helm upgrade --install ks-core oci://ghcr.io/kubestellar/kubestellar/core-chart \
@@ -58,7 +62,7 @@ helm upgrade --install ks-core oci://ghcr.io/kubestellar/kubestellar/core-chart 
     --set-json='WDSes=[{"name":"wds1"}]'
 ```
 
-## Create and register two workload execution cluster(s)
+### Create and register two workload execution cluster(s)
 
  {%
     include-markdown "example-wecs.md"
@@ -67,7 +71,7 @@ helm upgrade --install ks-core oci://ghcr.io/kubestellar/kubestellar/core-chart 
 
 ## Exercise KubeStellar
 
-Proceed to Scenario 1 (multi-cluster workload deployment with kubectl) in [the example scenarios](example-scenarios.md) after defining the shell variables that characterize the setup done above. Following are setting for those variables, whose meanings are defined at the start of the example scenarios document.
+Proceed to [Scenario 1 (multi-cluster workload deployment with kubectl) in the example scenarios](example-scenarios.md#scenario-1-multi-cluster-workload-deployment-with-kubectl) after defining the shell variables that characterize the setup done above. Following are setting for those variables, whose meanings are defined [at the start of the example scenarios document](example-scenarios.md#assumptions-and-variables).
 
 ```shell
 host_context=kind-kubeflex

--- a/docs/content/direct/init-hosting-cluster.md
+++ b/docs/content/direct/init-hosting-cluster.md
@@ -21,7 +21,7 @@ kflex init
 
 ### Using an existing OpenShift cluster as the hosting cluster
 
-When the hosting cluster is an OpenShift cluster, the recipe for registering a WEC with the ITS ([to be written](wec.md)) needs to be modified. In the `clusteradm` command, omit the `--force-internal-endpoint-lookup` flag. If following [the quickstart commands](get-started.md#create-and-register-two-workload-execution-clusters) literally, this means to define `flags=""` rather than `flags="--force-internal-endpoint-lookup"`.
+When the hosting cluster is an OpenShift cluster, the recipe for registering a WEC with the ITS ([to be written](wec.md)) needs to be modified. In the `clusteradm` command, omit the `--force-internal-endpoint-lookup` flag. If following [Getting Started](get-started.md#create-and-register-two-workload-execution-clusters) literally, this means to define `flags=""` rather than `flags="--force-internal-endpoint-lookup"`.
 
 ## KubeStellar core Helm chart
 

--- a/docs/content/direct/packaging.md
+++ b/docs/content/direct/packaging.md
@@ -298,11 +298,11 @@ One uses [the Helm CLI image](#helm-cli-container-image) to instantiate [the Kub
 
 ### Scripts and instructions
 
-There are instructions for using a release (the [quickstart](get-started.md) document) and a setup script for end-to-end testing(`test/e2e/common/setup-kubestellar.sh`). The end-to-end testing can either test the local copy/version of the kubestellar repo or test a release. So there are three cases to consider.
+There are instructions for using a release ([Getting Started](get-started.md) document) and a setup script for end-to-end testing(`test/e2e/common/setup-kubestellar.sh`). The end-to-end testing can either test the local copy/version of the kubestellar repo or test a release. So there are three cases to consider.
 
 #### Example setup instructions
 
-There were two variants of the setup instructions for the examples: an older one --- which is out of service at the moment, is called "step-by-step", and uses the `ocm` and `kubestellar` PostCreateHooks --- and [the quickstart](get-started.md), which uses the [core Helm chart](#kubestellar-core-helm-chart). The latter is the preferred method, and is the only one described here.
+There were two variants of the setup instructions for the examples: an older one --- which is out of service at the moment, is called "step-by-step", and uses the `ocm` and `kubestellar` PostCreateHooks --- and [Getting Started](get-started.md), which uses the [core Helm chart](#kubestellar-core-helm-chart). The latter is the preferred method, and is the only one described here.
 
 The instructions are a Markdown file that displays commands for a user to execute. These start with commands that define environment variables that hold the release of ks/kubestellar and of ks/ocm-transport-plugin to use.
 

--- a/docs/content/direct/pre-reqs.md
+++ b/docs/content/direct/pre-reqs.md
@@ -46,7 +46,7 @@ follow [these instructions](https://github.com/kubestellar/kubeflex/blob/main/do
 - **helm** - to deploy the kubestellar and kubeflex charts
 - **kubectl** - to access the kubernetes clusters
 
-## Additional Software for the Quickstart setup
+## Additional Software for the Getting Started setup
 
 - [**kind**](https://kind.sigs.k8s.io/)
 - **docker** (or compatible docker engine that works with kind)

--- a/docs/content/direct/release.md
+++ b/docs/content/direct/release.md
@@ -124,7 +124,7 @@ We will maintain a document that lists releases that pass our quality bar. The l
 
 We used to maintain a statement of what is the latest stable release in `docs/content/direct/README.md`.
 
-We maintain a [quickstart](get-started.md) that tells users how to exercise the release that the document appears in. This requires a self-reference that is updated as part of the release process.
+We maintain a [Getting Started](get-started.md) document that tells users how to exercise the release that the document appears in. This requires a self-reference that is updated as part of the release process.
 
 ## Policy
 

--- a/docs/content/direct/setup-overview.md
+++ b/docs/content/direct/setup-overview.md
@@ -1,6 +1,6 @@
 # Setting up KubeStellar
 
-"Setup" is a porous grouping of some of the steps in [the full outline](user-guide-intro.md#the-full-story), and comprises the following. Also, bear in mind the [Setup limitations](direct/setup-limitations.md).
+"Setup" is a porous grouping of some of the steps in [the full outline](user-guide-intro.md#the-full-story), and comprises the following. Also, bear in mind the [Setup limitations](setup-limitations.md).
 
 - Install software prerequisites. See [prerequisites](pre-reqs.md).
 - KubeFlex Hosting cluster
@@ -9,7 +9,7 @@
 - Core Spaces
     - Create an [Inventory and Transport Space](its.md) (ITS).
     - Create a [Workload Description Space](wds.md) (WDS).
-- [Core Helm Chart](direct/core-chart.md) (covering three of the above topics).
+- [Core Helm Chart](core-chart.md) (covering three of the above topics).
 - Workload Execution Clusters
     - Create a [Workload Execution Cluster](wec.md) (WEC).
     - [Register the WEC in the ITS](wec-registration.md).

--- a/docs/content/direct/user-guide-intro.md
+++ b/docs/content/direct/user-guide-intro.md
@@ -5,15 +5,15 @@ See the KubeStellar [overview](../readme.md) for architecture and other informat
 
 This user guide is an ongoing project. If you find errors, please point them out in our [Slack channel](https://kubernetes.slack.com/archives/C058SUSL5AA/) or open an issue in our [github repository](https://github.com/kubestellar/kubestellar)!
 
-## Quickstart
+## Simple Example
 
-If you want to try a simplified installation process and example, you can try our [Quickstart](get-started.md), which uses [kind](https://kind.sigs.k8s.io/) and a helm chart. The [helm chart](core-chart.md) supports many options; the instructions on the Quickstart page show only the chart's usage in that recipe.
+If you want to try a simple installation process and example then you can try out [Getting Started](get-started.md), which uses [kind](https://kind.sigs.k8s.io/) and a helm chart. The [helm chart](core-chart.md) supports many options; the instructions on the Getting Started page show only the chart's usage in that recipe.
 
 ## In Brief
 
 If you want a simple rough grouping, you can divide the concepts here into:
 
-- "setup" (steps 1--7 below), exemplified by [the quickstart](get-started.md), and
+- "setup" (steps 1--7 below), exemplified in [the Setup section of Getting Started](get-started.md#setup), and
 - "usage" (the remaining steps), illustrated by [the example scenarios document](example-scenarios.md).
 
 However, you do not need to follow that dichotomy. As noted below, the relevant components can be organized more flexibly.
@@ -49,4 +49,4 @@ Besides "Start", the other green items in that graph are entry points for extend
 
 KubeStellar's [Core Helm chart](core-chart.md) combines initializing the KubeFlex hosting cluster, creating some ITSes, and creating some WDSes.
 
-You can find an example run through of steps 2--7 in [the quickstart](get-started.md). This dovetails with [the example scenarios document](example-scenarios.md), which shows examples of the later steps.
+You can find an example run through of steps 2--7 in [Getting Started](get-started.md). This dovetails with [the example scenarios document](example-scenarios.md), which shows examples of the later steps.

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -33,11 +33,10 @@ nav:
         - KubeFlex: direct/kubeflex-intro.md
         - KubeStellar Galaxy: direct/galaxy-intro.md
       - Release-notes: direct/release-notes.md
-  - Quick Start: direct/get-started.md
+  - Getting Started: direct/get-started.md
   - User Guide:
       - Overview: direct/user-guide-intro.md
-      - Quickstart: direct/get-started.md
-      - Setup:
+      - General Setup:
           - Overview: direct/setup-overview.md
           - Setup limitations: direct/setup-limitations.md
           - Prerequisites: direct/pre-reqs.md


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
This PR makes some improvements to the website for navigation and clarity. These include the following.

- Rename "quickstart" to "Getting Started".
- Made "Getting Started" disjoint from "User Guide", because they are both listed across the top section of the website (if your browser is open wide enough) and I was told that some readers assume this means that they are disjoint.
- Rename the navigation DAG node "Setup" to "General Setup", which contrasts with "the Setup section in Getting Started".
- Made the references from the end of Getting Started to example scenario 1 use actual hyperlinks.
- Added a reference (with hyperlink) from the definitions of the relevant shell variables at the start of the example scenarios document to the concrete example in Getting Started.
- Increased the mentions of cluster labeling at the start of the example scenarios document.
- Fixed a couple of broken links.

Preview at https://mikespreitzer.github.io/kcp-edge-mc/doc-twist-710/

## Related issue(s)

Fixes #
