### PR TITLE
📖 Remove all-macros.md

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -150,7 +150,6 @@ bash <(curl -s \{\{ config.repo_raw_url \}\}/\{\{ config.ks_branch \}\}/bootstra
 
 
 <b>note:</b><br /> 
-&nbsp;&nbsp;&nbsp;&nbsp;- A more extensive and detailed list is located at [mkdocs information](./content/Contribution%20guidelines/operations/all-macros.md) <br />
 &nbsp;&nbsp;&nbsp;&nbsp;- We also check for broken links as part of our PR pipeline.  For more information check out our <a href="{{ config.repo_url }}/actions/workflows/broken-links-crawler.yml">Broken Links Crawler</a><br />
 
 ### Navigation (website menu)

--- a/docs/content/Contribution guidelines/operations/all-macros.md
+++ b/docs/content/Contribution guidelines/operations/all-macros.md
@@ -1,3 +1,0 @@
-All variables supported by this documentation implementation:
-
-{{ macros_info() }}

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -71,7 +71,6 @@ nav:
       - Website:
           - Overview: Contribution guidelines/operations/document-management.md
           - Testing website PRs: Contribution guidelines/operations/testing-doc-prs.md
-          - Listing of variables: Contribution guidelines/operations/all-macros.md
       - Security:
           - Policy: Contribution guidelines/security/security.md
           - Contacts: Contribution guidelines/security/security_contacts.md


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
This PR removes the file `docs/content/Contribution guidelines/operations/all-macros.md` because it was only useful to hacky document authors and deemed too confusing when it turns up in search results.

Preview at https://mikespreitzer.github.io/kcp-edge-mc/doc-trim-710/

## Related issue(s)

Fixes #
