### PR TITLE
:book: Add additional emphasis to website left navigation to reduce confusion

### DIFF
--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -36,6 +36,7 @@ nav:
   - Getting Started: direct/get-started.md
   - User Guide:
       - Overview: direct/user-guide-intro.md
+      - Getting Started: direct/get-started.md
       - General Setup:
           - Overview: direct/setup-overview.md
           - Setup limitations: direct/setup-limitations.md

--- a/docs/overrides/home.html
+++ b/docs/overrides/home.html
@@ -10,7 +10,7 @@
     <div class="px-1 ctx-header-text conteiner">
       
        <span class="shortcut-bar Space-Bd-BT"> 
-        <a class="shortcut-bar-text" href="direct/get-started/" >START</a>&nbsp;&nbsp;&nbsp;
+        <a class="shortcut-bar-text" href="direct/get-started/">START</a>&nbsp;&nbsp;&nbsp;
         <a class="shortcut-bar-text" href="readme/">ABOUT</a>&nbsp;&nbsp;&nbsp;
         <a class="shortcut-bar-text" href="direct/user-guide-intro/">USE</a>&nbsp;&nbsp;&nbsp;
         <a class="shortcut-bar-text" href="direct/contribute/">CONTRIBUTE</a>&nbsp;&nbsp;&nbsp;&nbsp;

--- a/docs/overrides/home.html
+++ b/docs/overrides/home.html
@@ -10,7 +10,7 @@
     <div class="px-1 ctx-header-text conteiner">
       
        <span class="shortcut-bar Space-Bd-BT"> 
-        <a class="shortcut-bar-text" href="direct/get-started/" tooltiptext="Jump to the Getting Started section of the User Guide ">START</a>&nbsp;&nbsp;&nbsp;
+        <a class="shortcut-bar-text" href="direct/get-started/" >START</a>&nbsp;&nbsp;&nbsp;
         <a class="shortcut-bar-text" href="readme/">ABOUT</a>&nbsp;&nbsp;&nbsp;
         <a class="shortcut-bar-text" href="direct/user-guide-intro/">USE</a>&nbsp;&nbsp;&nbsp;
         <a class="shortcut-bar-text" href="direct/contribute/">CONTRIBUTE</a>&nbsp;&nbsp;&nbsp;&nbsp;

--- a/docs/overrides/home.html
+++ b/docs/overrides/home.html
@@ -10,7 +10,7 @@
     <div class="px-1 ctx-header-text conteiner">
       
        <span class="shortcut-bar Space-Bd-BT"> 
-        <a class="shortcut-bar-text" href="direct/get-started/">START</a>&nbsp;&nbsp;&nbsp;
+        <a class="shortcut-bar-text" href="direct/get-started/" tooltiptext="Jump to the Getting Started section of the User Guide ">START</a>&nbsp;&nbsp;&nbsp;
         <a class="shortcut-bar-text" href="readme/">ABOUT</a>&nbsp;&nbsp;&nbsp;
         <a class="shortcut-bar-text" href="direct/user-guide-intro/">USE</a>&nbsp;&nbsp;&nbsp;
         <a class="shortcut-bar-text" href="direct/contribute/">CONTRIBUTE</a>&nbsp;&nbsp;&nbsp;&nbsp;

--- a/docs/overrides/stylesheets/kubestellar.css
+++ b/docs/overrides/stylesheets/kubestellar.css
@@ -172,3 +172,21 @@ dl.crd-meta {
     }
 
 }
+
+.md-nav__link--active {
+    background-color: var(--md-code-bg-color);
+    border-radius: 0.2em;
+    padding: 0.2em;
+    outline: 0.1em solid;
+  }
+  
+  /* Additional styling to fix glitches */
+  
+  .md-sidebar__inner {
+    padding-top: 0.1em;
+  }
+  
+  .md-nav--lifted > .md-nav__list > .md-nav__item--active > .md-nav__link {
+    box-shadow: initial;
+  }
+  


### PR DESCRIPTION
## Summary
The rendering of the left menu tree in our existing rendered website only uses a color change to indicate the currently active page in the tree. This makes it less obvious to the user how they are traveling through the website.

This PR is a simple change to the css styling to make it much more obvious where a visitor is in the tree.
It also by way of example restores the previous behavior of having the getting started link in the masthead jump you to that as a page in the user guide tree

[The site may be previewed at https://kproche.github.io/kubestellar/doc-nav-emphasis/](https://kproche.github.io/kubestellar/doc-nav-emphasis/)

## How it looks before this PR
![image](https://github.com/kubestellar/kubestellar/assets/25445603/ea7bd782-a8a0-47b4-80c5-fb86f341f9bf)

## How it looks after this PR

![image](https://github.com/kubestellar/kubestellar/assets/25445603/25d4157f-196a-4329-a9a5-cabef60ccf4e)

