### PR TITLE
📖 Add multi-version warning to the header 

### DIFF
--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -111,6 +111,8 @@ theme:
   # Common files such as images, stylesheets, theme overrides
   custom_dir: 'overrides'
   features:
+    # enable the ability to dismiss the announcement bar
+    - announce.dismiss
     - content.action.edit
     - content.action.view
     # Enable navigation section index pages, so we don't see Concepts > Concepts

--- a/docs/overrides/main.html
+++ b/docs/overrides/main.html
@@ -58,7 +58,7 @@
 </a>
 
 <p> 
-    <strong>KubeStellar has multiple documentation versions to match its multiple releases. Please ensure you are viewing the docs version corresponding to the version of the code you are using!</strong>
+    KubeStellar has multiple documentation versions to match its multiple releases. Please make sure you are viewing the docs version corresponding to the release version of the code you are using!
 </p>
 {% endblock %}
 
@@ -66,6 +66,6 @@
   You are not viewing the latest regular release.
   <a href="{{ '../' ~ base_url }}">
     <strong>Click here to go to the latest regular release.</strong>
-  </a>
+  </a> The <em>unreleased-development</em> release corresponds to the <em>main</em> branch of the repository.
 {% endblock %}
 

--- a/docs/overrides/main.html
+++ b/docs/overrides/main.html
@@ -56,10 +56,6 @@
     <strong style="color: white">LinkedIn</strong>
   </p>
 </a>
-
-<p> 
-    KubeStellar has multiple documentation versions to match its multiple releases. Please make sure you are viewing the docs version corresponding to the release version of the code you are using!
-</p>
 {% endblock %}
 
 {% block outdated %}
@@ -69,3 +65,15 @@
   </a> The <em>unreleased-development</em> release corresponds to the <em>main</em> branch of the repository.
 {% endblock %}
 
+{% block header %}
+       {{ super() }}
+       <header class='md-header' data-md-component='header'>
+	       <div class='md-header__inner md-grid' data-md-component='container'>
+	       <p class='md_container' style="font-size:larger"> 
+	       KubeStellar has multiple documentation versions to match its multiple releases.<br />
+	       Please make sure you are viewing the docs version which matches the release version of the code you are using!
+	       </p>
+	       </div>
+       </header>
+
+{% endblock %}

--- a/docs/overrides/main.html
+++ b/docs/overrides/main.html
@@ -57,6 +57,9 @@
   </p>
 </a>
 
+<p> 
+    <strong>KubeStellar has multiple documentation versions to match its multiple releases. Please ensure you are viewing the docs version corresponding to the version of the code you are using!</strong>
+</p>
 {% endblock %}
 
 {% block outdated %}

--- a/docs/overrides/main.html
+++ b/docs/overrides/main.html
@@ -67,7 +67,7 @@
 
 {% block header %}
        {{ super() }}
-       <header class='md-header' data-md-component='header'>
+       <header class='md-header' data-md-component='header' style="z-index:-10;">
 	       <div class='md-header__inner md-grid' data-md-component='container'>
 	       <p class='md_container' style="font-size:larger"> 
 	       KubeStellar has multiple documentation versions to match its multiple releases.<br />


### PR DESCRIPTION
Previewable at https://kproche.github.io/kubestellar/doc-announce/

This PR is intended to clarify and remind website visitors to compare the website version they are reading with the release version of KubeStellar they are using.

It adds a notice to that effect to the upper "announce" bar on the masthead of the site.
It also makes that bar dismissible for visitors who wish to regain the real estate on their browser screen.

Finally, an explanation about the un-released development "release" is added to the yellow "outdated" warning banner.

New banner:
![image](https://github.com/user-attachments/assets/a1a23ac9-2fff-4f97-97b8-1ad8375c5167)

Old banner:
![image](https://github.com/user-attachments/assets/9b9cef1d-0908-4e22-bf08-ef53c60ebc9b)


Note: before merging, the assorted commits and tweaks should be squashed. I anticipate some wording tweaks, so that has not been done yet.

