### PR TITLE
📖 Fix typo in nav tree that made broken link to troubleshooting

### DIFF
--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -62,7 +62,7 @@ nav:
           - Example Scenarios: direct/example-scenarios.md
           - Third-party integrations:
               - ArgoCD to WDS: direct/argo-to-wds1.md
-          - Troubleshooting: troubleshooting.md
+          - Troubleshooting: direct/troubleshooting.md
   - Contributing: 
       - How to join in: direct/contribute.md
       - Code of Conduct: Contribution guidelines/coc.md


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
This PR fixes a typo in the nav tree in `docs/mkdocs.yml`.

Preview at https://mikespreitzer.github.io/kcp-edge-mc/doc-fixlink-720/direct/user-guide-intro/

## Related issue(s)

