### PR TITLE
:sparkles: More combined status testing

### DIFF
--- a/docs/content/direct/combined-status.md
+++ b/docs/content/direct/combined-status.md
@@ -176,7 +176,7 @@ combinedFields:
 ### List of WECs where the Deployment is not as available as desired
 
 ```yaml
-filter: "obj.spec.replicas != reported.status.availableReplicas"
+filter: "obj.spec.replicas != returned.status.availableReplicas"
 select:
    - name: wec
      def: inventory.name
@@ -191,7 +191,7 @@ select:
    - name: wec
      def: inventory.name
    - name: status
-     def: reported.status
+     def: returned.status
 ```
 
 ## Special case for 1 WEC

--- a/test/e2e/ginkgo/multiple_cluster_deployment_test.go
+++ b/test/e2e/ginkgo/multiple_cluster_deployment_test.go
@@ -563,9 +563,9 @@ var _ = ginkgo.Describe("end to end testing", func() {
 			gomega.Expect(*cs.Results[0].Rows[0].Columns[0].Number).To(gomega.Equal("2"))
 		})
 
-		ginkgo.It("list of WECs with available nginx deployment", func(ctx context.Context) {
+		ginkgo.It("can list all the WECs where the reported number of availableReplicas equals the desired number of replicas", func(ctx context.Context) {
 
-			availableNginxCEL := ksapi.Expression("obj.spec.replicas == returned.status.availableReplicas && obj.metadata.labels['app.kubernetes.io/name'] == 'nginx'")
+			availableNginxCEL := ksapi.Expression("obj.spec.replicas == returned.status.availableReplicas")
 			util.CreateStatusCollector(ctx, ksWds, listNginxWecsStatusCollectorName,
 				ksapi.StatusCollectorSpec{
 					Filter: &availableNginxCEL,
@@ -591,6 +591,16 @@ var _ = ginkgo.Describe("end to end testing", func() {
 			gomega.Expect(cs.Results[0].ColumnNames[0]).To(gomega.Equal("wecName"))
 
 			gomega.ExpectWithOffset(1, len(cs.Results[0].Rows)).To(gomega.Equal(2))
+
+			// we don't know which row will hold data for which WEC
+			row0expectedWec := "cluster1"
+			row1expectedWec := "cluster2"
+			if *cs.Results[0].Rows[0].Columns[0].String != row0expectedWec {
+				row0expectedWec = "cluster2"
+				row1expectedWec = "cluster1"
+			}
+			gomega.Expect(*cs.Results[0].Rows[0].Columns[0].String).To(gomega.Equal(row0expectedWec))
+			gomega.Expect(*cs.Results[0].Rows[1].Columns[0].String).To(gomega.Equal(row1expectedWec))
 		})
 
 		ginkgo.It("can support multiple StatusCollectors", func(ctx context.Context) {

--- a/test/e2e/ginkgo/multiple_cluster_deployment_test.go
+++ b/test/e2e/ginkgo/multiple_cluster_deployment_test.go
@@ -474,6 +474,7 @@ var _ = ginkgo.Describe("end to end testing", func() {
 		sumAvailableReplicasStatusCollectorName := "sum-available-replicas"
 		selectAvailableStatusCollectorName := "select-available-replicas"
 		selectReplicasStatusCollectorName := "replicas"
+		listNginxWecsStatusCollectorName := "nginx-wecs"
 
 		clusterSelector := []metav1.LabelSelector{
 			{MatchLabels: map[string]string{"location-group": "edge"}},
@@ -560,6 +561,36 @@ var _ = ginkgo.Describe("end to end testing", func() {
 			gomega.Expect(len(cs.Results[0].Rows)).To(gomega.Equal(1))
 			gomega.Expect(len(cs.Results[0].Rows[0].Columns)).To(gomega.Equal(1))
 			gomega.Expect(*cs.Results[0].Rows[0].Columns[0].Number).To(gomega.Equal("2"))
+		})
+
+		ginkgo.It("list of WECs with available nginx deployment", func(ctx context.Context) {
+
+			availableNginxCEL := ksapi.Expression("obj.spec.replicas == returned.status.availableReplicas && obj.metadata.labels['app.kubernetes.io/name'] == 'nginx'")
+			util.CreateStatusCollector(ctx, ksWds, listNginxWecsStatusCollectorName,
+				ksapi.StatusCollectorSpec{
+					Filter: &availableNginxCEL,
+					Select: []ksapi.NamedExpression{
+						{
+							Name: "wecName",
+							Def:  "inventory.name",
+						},
+					},
+					Limit: 10,
+				})
+
+			testAndStatusCollection[0].StatusCollectors = []string{listNginxWecsStatusCollectorName}
+			util.CreateBindingPolicy(ctx, ksWds, bpName, clusterSelector, testAndStatusCollection)
+
+			cs := util.GetCombinedStatus(ctx, ksWds, wds, ns, workloadName, bpName)
+
+			// Validate CombinedStatus results
+			gomega.Expect(len(cs.Results)).To(gomega.Equal(1))
+			gomega.Expect(cs.Results[0].Name).To(gomega.Equal(listNginxWecsStatusCollectorName))
+
+			gomega.ExpectWithOffset(1, len(cs.Results[0].ColumnNames)).To(gomega.Equal(1))
+			gomega.Expect(cs.Results[0].ColumnNames[0]).To(gomega.Equal("wecName"))
+
+			gomega.ExpectWithOffset(1, len(cs.Results[0].Rows)).To(gomega.Equal(2))
 		})
 
 		ginkgo.It("can support multiple StatusCollectors", func(ctx context.Context) {


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
1. Additional combined status e2e test for the `obj` identifier in CEL expression.
2. Small fix to the combined status doc.

## Related issue(s)

Fixes #
