### PR TITLE
🌱 Brush up language and offsets in ginkgo E2E test

### DIFF
--- a/test/e2e/ginkgo/multiple_cluster_deployment_test.go
+++ b/test/e2e/ginkgo/multiple_cluster_deployment_test.go
@@ -72,50 +72,50 @@ var _ = ginkgo.Describe("end to end testing", func() {
 			patch := []byte(`{"spec":{"replicas": 2}}`)
 			_, err := wds.AppsV1().Deployments(ns).Patch(
 				ctx, "nginx", types.MergePatchType, patch, metav1.PatchOptions{})
-			gomega.ExpectWithOffset(1, err).NotTo(gomega.HaveOccurred())
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 			util.ValidateNumDeploymentReplicas(ctx, wec1, ns, 2)
 			util.ValidateNumDeploymentReplicas(ctx, wec2, ns, 2)
 		})
 
 		ginkgo.It("handles changes in bindingpolicy ObjectSelector", func(ctx context.Context) {
-			ginkgo.By("deletes WEC objects when bindingpolicy ObjectSelector stops matching")
+			ginkgo.By("deleting WEC objects when bindingpolicy ObjectSelector stops matching")
 			patch := []byte(`{"spec": {"downsync": [{"objectSelectors": [{"matchLabels": {"app.kubernetes.io/name": "invalid"}}]}]}}`)
 			_, err := ksWds.ControlV1alpha1().BindingPolicies().Patch(
 				ctx, "nginx", types.MergePatchType, patch, metav1.PatchOptions{})
-			gomega.ExpectWithOffset(1, err).NotTo(gomega.HaveOccurred())
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			util.ValidateNumDeployments(ctx, wec1, ns, 0)
 			util.ValidateNumDeployments(ctx, wec2, ns, 0)
 
-			ginkgo.By("creates WEC objects when bindingpolicy ObjectSelector matches")
+			ginkgo.By("creating WEC objects when bindingpolicy ObjectSelector matches")
 			patch = []byte(`{"spec": {"downsync": [{"objectSelectors": [{"matchLabels": {"app.kubernetes.io/name": "nginx"}}]}]}}`)
 			_, err = ksWds.ControlV1alpha1().BindingPolicies().Patch(
 				ctx, "nginx", types.MergePatchType, patch, metav1.PatchOptions{})
-			gomega.ExpectWithOffset(1, err).NotTo(gomega.HaveOccurred())
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			util.ValidateNumDeployments(ctx, wec1, ns, 1)
 			util.ValidateNumDeployments(ctx, wec2, ns, 1)
 		})
 
 		ginkgo.It("handles changes in workload object labels", func(ctx context.Context) {
-			ginkgo.By("deletes WEC objects when workload object labels stop matching")
+			ginkgo.By("deleting WEC objects when workload object labels stop matching")
 			patch := []byte(`{"metadata": {"labels": {"app.kubernetes.io/name": "not-me"}}}`)
 			_, err := wds.AppsV1().Deployments("nginx").Patch(
 				ctx, "nginx", types.MergePatchType, patch, metav1.PatchOptions{})
-			gomega.ExpectWithOffset(1, err).NotTo(gomega.HaveOccurred())
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			util.ValidateNumDeployments(ctx, wec1, ns, 0)
 			util.ValidateNumDeployments(ctx, wec2, ns, 0)
 
-			ginkgo.By("creates WEC objects when workload object labels resume matching")
+			ginkgo.By("creating WEC objects when workload object labels resume matching")
 			patch = []byte(`{"metadata": {"labels": {"app.kubernetes.io/name": "nginx"}}}`)
 			_, err = wds.AppsV1().Deployments("nginx").Patch(
 				ctx, "nginx", types.MergePatchType, patch, metav1.PatchOptions{})
-			gomega.ExpectWithOffset(1, err).NotTo(gomega.HaveOccurred())
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			util.ValidateNumDeployments(ctx, wec1, ns, 1)
 			util.ValidateNumDeployments(ctx, wec2, ns, 1)
 		})
 
 		ginkgo.It("handles multiple bindingpolicies with overlapping matches", func(ctx context.Context) {
-			ginkgo.By("creates a second bindingpolicy with overlapping matches")
+			ginkgo.By("creating a second bindingpolicy with overlapping matches")
 			util.CreateBindingPolicy(ctx, ksWds, "nginx-2",
 				[]metav1.LabelSelector{
 					{MatchLabels: map[string]string{"location-group": "edge"}},
@@ -129,9 +129,9 @@ var _ = ginkgo.Describe("end to end testing", func() {
 			util.ValidateNumDeployments(ctx, wec1, ns, 1)
 			util.ValidateNumDeployments(ctx, wec2, ns, 1)
 
-			ginkgo.By("delete the second bindingpolicy")
+			ginkgo.By("deleting the second bindingpolicy")
 			err := ksWds.ControlV1alpha1().BindingPolicies().Delete(ctx, "nginx-2", metav1.DeleteOptions{})
-			gomega.ExpectWithOffset(1, err).NotTo(gomega.HaveOccurred())
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			util.ValidateNumDeployments(ctx, wec1, ns, 1)
 			util.ValidateNumDeployments(ctx, wec2, ns, 1)
 		})
@@ -144,7 +144,7 @@ var _ = ginkgo.Describe("end to end testing", func() {
 
 		ginkgo.It("deletes WEC objects when BindingPolicy is deleted", func(ctx context.Context) {
 			err := ksWds.ControlV1alpha1().BindingPolicies().Delete(ctx, "nginx", metav1.DeleteOptions{})
-			gomega.ExpectWithOffset(1, err).NotTo(gomega.HaveOccurred())
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			util.ValidateNumDeployments(ctx, wec1, ns, 0)
 			util.ValidateNumDeployments(ctx, wec2, ns, 0)
 		})
@@ -154,12 +154,12 @@ var _ = ginkgo.Describe("end to end testing", func() {
 			ginkgo.DeferCleanup(func(ctx context.Context) {
 				patch := []byte(`{"spec":{"template":{"spec":{"containers":[{"args":["--max-size-wrapped-object=512000","--transport-kubeconfig=/mnt/shared/transport-kubeconfig","--wds-kubeconfig=/mnt/shared/wds-kubeconfig","--wds-name=wds1","-v=4"],"name":"transport-controller"}]}}}}`)
 				_, err := coreCluster.AppsV1().Deployments("wds1-system").Patch(ctx, "transport-controller", types.StrategicMergePatchType, patch, metav1.PatchOptions{})
-				gomega.ExpectWithOffset(1, err).NotTo(gomega.HaveOccurred())
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			})
-			ginkgo.By("set max size of wrapped object to 1000 bytes")
+			ginkgo.By("setting max size of wrapped object to 1000 bytes")
 			patch := []byte(`{"spec":{"template":{"spec":{"containers":[{"args":["--max-size-wrapped-object=1000","--transport-kubeconfig=/mnt/shared/transport-kubeconfig","--wds-kubeconfig=/mnt/shared/wds-kubeconfig","--wds-name=wds1","-v=4"],"name":"transport-controller"}]}}}}`)
 			_, err := coreCluster.AppsV1().Deployments("wds1-system").Patch(ctx, "transport-controller", types.StrategicMergePatchType, patch, metav1.PatchOptions{})
-			gomega.ExpectWithOffset(1, err).NotTo(gomega.HaveOccurred())
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			var names = []string{"1", "2", "3", "4", "5", "6", "7", "8", "9", "10"}
 			for _, i := range names {
 				util.CreateDeployment(ctx, wds, ns, i,
@@ -187,10 +187,10 @@ var _ = ginkgo.Describe("end to end testing", func() {
 			util.ValidateNumDeployments(ctx, wec1, ns, 10)
 			util.ValidateNumDeployments(ctx, wec2, ns, 0)
 
-			ginkgo.By("update to bindingpolicy object with sharded wrapped workloads updates deployments")
+			ginkgo.By("updating the bindingpolicy object with sharded wrapped workloads and expecting updated deployments")
 			patch = []byte(`{"spec": {"clusterSelectors": [{"matchLabels": {"name": "cluster2"}}]}}`)
 			_, err = ksWds.ControlV1alpha1().BindingPolicies().Patch(ctx, "multipledep", types.MergePatchType, patch, metav1.PatchOptions{})
-			gomega.ExpectWithOffset(1, err).NotTo(gomega.HaveOccurred())
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			// Expect addon-addon-status-deploy-0  and nginx-wds1 manifest works on both clusters.
 			// And the 10 manifestworks for the deployment on cluster2.
 			util.ValidateNumManifestworks(ctx, its, "cluster1", 2)
@@ -198,7 +198,7 @@ var _ = ginkgo.Describe("end to end testing", func() {
 			util.ValidateNumDeployments(ctx, wec1, ns, 0)
 			util.ValidateNumDeployments(ctx, wec2, ns, 10)
 
-			ginkgo.By("delete of bindingpolicy with sharded wrapped workloads deletes deployments")
+			ginkgo.By("deleting the bindingpolicy with sharded wrapped workloads and expecting deployments to get deleted")
 			util.DeleteBindingPolicy(ctx, ksWds, "multipledep")
 			// Expect addon-addon-status-deploy-0  and nginx-wds1 manifest works on both clusters.
 			util.ValidateNumManifestworks(ctx, its, "cluster1", 2)
@@ -211,8 +211,8 @@ var _ = ginkgo.Describe("end to end testing", func() {
 		// and a Placement that matches labels A AND B, and verify that only
 		// object 1 matches and is delivered.
 		// 2. Patch the cluster selector and expect objects to be removed and downsynced correctly.
-		ginkgo.It("downsync objects that fully match on object and cluster selector", func(ctx context.Context) {
-			ginkgo.By("create two deployments and a bindingpolicy that matches only one")
+		ginkgo.It("supports multi-factor object and cluster selectors", func(ctx context.Context) {
+			ginkgo.By("creating two deployments and a bindingpolicy that matches only one")
 			util.DeleteDeployment(ctx, wds, ns, "nginx")
 			util.CreateDeployment(ctx, wds, ns, "one",
 				map[string]string{
@@ -237,11 +237,11 @@ var _ = ginkgo.Describe("end to end testing", func() {
 			util.ValidateNumDeployments(ctx, wec1, ns, 1)
 			util.ValidateNumDeployments(ctx, wec2, ns, 0)
 
-			ginkgo.By("patch the cluster selector")
+			ginkgo.By("patching the cluster selector")
 			patch := []byte(`{"spec": {"clusterSelectors": [{"matchLabels": {"name": "cluster2"}}]}}`)
 			_, err := ksWds.ControlV1alpha1().BindingPolicies().Patch(
 				ctx, "both-labels", types.MergePatchType, patch, metav1.PatchOptions{})
-			gomega.ExpectWithOffset(1, err).NotTo(gomega.HaveOccurred())
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			util.ValidateNumDeployments(ctx, wec1, ns, 0)
 			util.ValidateNumDeployments(ctx, wec2, ns, 1)
 		})
@@ -280,7 +280,7 @@ var _ = ginkgo.Describe("end to end testing", func() {
 			util.ValidateNumDeployments(ctx, wec2, ns, 2)
 		})
 
-		ginkgo.It("downsync based on object labels and object name", func(ctx context.Context) {
+		ginkgo.It("selects workload objects based on both labels and name", func(ctx context.Context) {
 			util.DeleteDeployment(ctx, wds, ns, "nginx")
 			util.CreateDeployment(ctx, wds, ns, "one",
 				map[string]string{
@@ -330,14 +330,14 @@ var _ = ginkgo.Describe("end to end testing", func() {
 			patch := []byte(`{"spec":{"wantSingletonReportedState": true}}`)
 			_, err := ksWds.ControlV1alpha1().BindingPolicies().Patch(
 				ctx, "nginx-singleton", types.MergePatchType, patch, metav1.PatchOptions{})
-			gomega.ExpectWithOffset(1, err).NotTo(gomega.HaveOccurred())
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			util.ValidateNumDeployments(ctx, wec1, ns, 1)
 			util.ValidateNumDeployments(ctx, wec2, ns, 0)
 			util.ValidateSingletonStatus(ctx, wds, ns, "nginx-singleton")
 			patch_again := []byte(`{"spec":{"clusterSelectors":[{"matchLabels":{"name":"CelestialNexus"}}]}}`)
 			_, err = ksWds.ControlV1alpha1().BindingPolicies().Patch(
 				ctx, "nginx-singleton", types.MergePatchType, patch_again, metav1.PatchOptions{})
-			gomega.ExpectWithOffset(1, err).NotTo(gomega.HaveOccurred())
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			util.ValidateNumDeployments(ctx, wec1, ns, 0)
 			util.ValidateNumDeployments(ctx, wec2, ns, 0)
 			util.ValidateSingletonStatusZeroValue(ctx, wds, ns, "nginx-singleton")
@@ -398,7 +398,7 @@ var _ = ginkgo.Describe("end to end testing", func() {
 		})
 
 		ginkgo.It("survives everything coming down", func(ctx context.Context) {
-			ginkgo.By("kill as many pods as possible")
+			ginkgo.By("killing as many pods as possible")
 			util.DeletePods(ctx, coreCluster, "wds1-system", "kubestellar")
 			util.DeletePods(ctx, coreCluster, "wds1-system", "transport")
 			util.DeletePods(ctx, coreCluster, "kubeflex-system", "")
@@ -406,7 +406,7 @@ var _ = ginkgo.Describe("end to end testing", func() {
 			util.ValidateNumDeployments(ctx, wec1, ns, 1)
 			util.ValidateNumDeployments(ctx, wec2, ns, 1)
 
-			ginkgo.By("test that a new deployment still gets downsynced")
+			ginkgo.By("testing that a new deployment still gets downsynced")
 			util.CreateDeployment(ctx, wds, ns, "nginx-2",
 				map[string]string{
 					"app.kubernetes.io/name": "nginx",
@@ -438,7 +438,7 @@ var _ = ginkgo.Describe("end to end testing", func() {
 			},
 		}
 
-		ginkgo.It("select full status", func(ctx context.Context) {
+		ginkgo.It("can list the full status from each WEC", func(ctx context.Context) {
 			util.CreateStatusCollector(ctx, ksWds, fullStatusCollectorName,
 				ksapi.StatusCollectorSpec{
 					Select: []ksapi.NamedExpression{
@@ -460,16 +460,16 @@ var _ = ginkgo.Describe("end to end testing", func() {
 			cs := util.GetCombinedStatus(ctx, ksWds, wds, ns, workloadName, bpName)
 
 			// Validate CombinedStatus results
-			gomega.ExpectWithOffset(1, len(cs.Results)).To(gomega.Equal(1))
+			gomega.Expect(len(cs.Results)).To(gomega.Equal(1))
 			gomega.Expect(cs.Results[0].Name).To(gomega.Equal(fullStatusCollectorName))
 
-			gomega.ExpectWithOffset(1, len(cs.Results[0].ColumnNames)).To(gomega.Equal(2))
+			gomega.Expect(len(cs.Results[0].ColumnNames)).To(gomega.Equal(2))
 			gomega.Expect(cs.Results[0].ColumnNames[0]).To(gomega.Equal("wecName"))
 			gomega.Expect(cs.Results[0].ColumnNames[1]).To(gomega.Equal("status"))
 
-			gomega.ExpectWithOffset(1, len(cs.Results[0].Rows)).To(gomega.Equal(2))
-			gomega.ExpectWithOffset(1, len(cs.Results[0].Rows[0].Columns)).To(gomega.Equal(2))
-			gomega.ExpectWithOffset(1, len(cs.Results[0].Rows[1].Columns)).To(gomega.Equal(2))
+			gomega.Expect(len(cs.Results[0].Rows)).To(gomega.Equal(2))
+			gomega.Expect(len(cs.Results[0].Rows[0].Columns)).To(gomega.Equal(2))
+			gomega.Expect(len(cs.Results[0].Rows[1].Columns)).To(gomega.Equal(2))
 
 			// we don't know which row will hold data for which WEC
 			row0expectedWec := "cluster1"
@@ -485,7 +485,7 @@ var _ = ginkgo.Describe("end to end testing", func() {
 			gomega.Expect(cs.Results[0].Rows[1].Columns[1].Object).Should(gomega.Not(gomega.BeNil()))
 		})
 
-		ginkgo.It("available replicas count", func(ctx context.Context) {
+		ginkgo.It("can sum status.availableReplicas across WECs", func(ctx context.Context) {
 			availableReplicasCEL := ksapi.Expression("returned.status.availableReplicas")
 			util.CreateStatusCollector(ctx, ksWds, sumAvailableReplicasStatusCollectorName,
 				ksapi.StatusCollectorSpec{
@@ -506,15 +506,15 @@ var _ = ginkgo.Describe("end to end testing", func() {
 			gomega.Expect(len(cs.Results)).To(gomega.Equal(1))
 			gomega.Expect(cs.Results[0].Name).To(gomega.Equal(sumAvailableReplicasStatusCollectorName))
 
-			gomega.ExpectWithOffset(1, len(cs.Results[0].ColumnNames)).To(gomega.Equal(1))
+			gomega.Expect(len(cs.Results[0].ColumnNames)).To(gomega.Equal(1))
 			gomega.Expect(cs.Results[0].ColumnNames[0]).To(gomega.Equal("sum"))
 
-			gomega.ExpectWithOffset(1, len(cs.Results[0].Rows)).To(gomega.Equal(1))
-			gomega.ExpectWithOffset(1, len(cs.Results[0].Rows[0].Columns)).To(gomega.Equal(1))
+			gomega.Expect(len(cs.Results[0].Rows)).To(gomega.Equal(1))
+			gomega.Expect(len(cs.Results[0].Rows[0].Columns)).To(gomega.Equal(1))
 			gomega.Expect(*cs.Results[0].Rows[0].Columns[0].Number).To(gomega.Equal("2"))
 		})
 
-		ginkgo.It("policy with multiple StatusCollectors", func(ctx context.Context) {
+		ginkgo.It("can support multiple StatusCollectors", func(ctx context.Context) {
 			util.CreateStatusCollector(ctx, ksWds, selectAvailableStatusCollectorName,
 				ksapi.StatusCollectorSpec{
 					Select: []ksapi.NamedExpression{
@@ -550,11 +550,11 @@ var _ = ginkgo.Describe("end to end testing", func() {
 			// Validate CombinedStatus results
 			gomega.Expect(len(cs.Results)).To(gomega.Equal(2))
 
-			gomega.ExpectWithOffset(1, len(cs.Results[0].ColumnNames)).To(gomega.Equal(2))
-			gomega.ExpectWithOffset(1, len(cs.Results[0].Rows)).To(gomega.Equal(2))
+			gomega.Expect(len(cs.Results[0].ColumnNames)).To(gomega.Equal(2))
+			gomega.Expect(len(cs.Results[0].Rows)).To(gomega.Equal(2))
 
-			gomega.ExpectWithOffset(1, len(cs.Results[1].ColumnNames)).To(gomega.Equal(2))
-			gomega.ExpectWithOffset(1, len(cs.Results[1].Rows)).To(gomega.Equal(2))
+			gomega.Expect(len(cs.Results[1].ColumnNames)).To(gomega.Equal(2))
+			gomega.Expect(len(cs.Results[1].Rows)).To(gomega.Equal(2))
 
 		})
 	})


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
This PR fixes up the language in the `It` and `By` calls in the ginkgo-based E2E functional test suite to follow the grammatical norms for those calls.

This PR also fixes incorrect offsets in that test suite.

## Related issue(s)

Fixes #
