### PR TITLE
✨ Improve testability by allowing controllers to run independently

### DIFF
--- a/pkg/binding/binding.go
+++ b/pkg/binding/binding.go
@@ -97,11 +97,11 @@ func (c *Controller) updateOrCreateBinding(ctx context.Context, bdg *v1alpha1.Bi
 	bdg.SetOwnerReferences([]metav1.OwnerReference{ownerReference})
 
 	logger := klog.FromContext(ctx)
-	bdgEcho, err := c.controlClient.Bindings().Update(ctx, bdg, metav1.UpdateOptions{FieldManager: controllerName})
+	bdgEcho, err := c.controlClient.Bindings().Update(ctx, bdg, metav1.UpdateOptions{FieldManager: ControllerName})
 
 	if err != nil {
 		if errors.IsNotFound(err) {
-			bdgEcho, err = c.controlClient.Bindings().Create(ctx, bdg, metav1.CreateOptions{FieldManager: controllerName})
+			bdgEcho, err = c.controlClient.Bindings().Create(ctx, bdg, metav1.CreateOptions{FieldManager: ControllerName})
 			if err != nil {
 				return fmt.Errorf("failed to create binding (name=%s): %w", bdg.Name, err)
 			}

--- a/pkg/binding/bindingpolicy.go
+++ b/pkg/binding/bindingpolicy.go
@@ -247,7 +247,7 @@ func (c *Controller) handleBindingPolicyFinalizer(ctx context.Context, bindingPo
 		if controllerutil.ContainsFinalizer(bindingPolicy, KSFinalizer) {
 			bindingPolicy = bindingPolicy.DeepCopy()
 			controllerutil.RemoveFinalizer(bindingPolicy, KSFinalizer)
-			_, err := c.controlClient.BindingPolicies().Update(ctx, bindingPolicy, metav1.UpdateOptions{FieldManager: controllerName})
+			_, err := c.controlClient.BindingPolicies().Update(ctx, bindingPolicy, metav1.UpdateOptions{FieldManager: ControllerName})
 			if err != nil {
 				if errors.IsNotFound(err) {
 					// object was deleted after getting into this function. This is not an error.
@@ -263,7 +263,7 @@ func (c *Controller) handleBindingPolicyFinalizer(ctx context.Context, bindingPo
 	if !controllerutil.ContainsFinalizer(bindingPolicy, KSFinalizer) {
 		bindingPolicy = bindingPolicy.DeepCopy()
 		controllerutil.AddFinalizer(bindingPolicy, KSFinalizer)
-		_, err := c.controlClient.BindingPolicies().Update(ctx, bindingPolicy, metav1.UpdateOptions{FieldManager: controllerName})
+		_, err := c.controlClient.BindingPolicies().Update(ctx, bindingPolicy, metav1.UpdateOptions{FieldManager: ControllerName})
 		if err != nil {
 			return err
 		}

--- a/pkg/binding/controller.go
+++ b/pkg/binding/controller.go
@@ -56,7 +56,7 @@ import (
 )
 
 const (
-	controllerName      = "Binding"
+	ControllerName      = "Binding"
 	defaultResyncPeriod = time.Duration(0)
 )
 
@@ -132,7 +132,7 @@ type bindingRef string
 // Create a new binding controller
 func NewController(parentLogger logr.Logger, wdsRestConfig *rest.Config, itsRestConfig *rest.Config,
 	wdsName string, allowedGroupsSet sets.Set[string]) (*Controller, error) {
-	logger := parentLogger.WithName(controllerName)
+	logger := parentLogger.WithName(ControllerName)
 
 	kubernetesClient, err := kubernetes.NewForConfig(wdsRestConfig)
 	if err != nil {
@@ -274,7 +274,7 @@ func makeController(logger logr.Logger,
 		informers:                   util.NewConcurrentMap[schema.GroupVersionResource, cache.SharedIndexInformer](),
 		stoppers:                    util.NewConcurrentMap[schema.GroupVersionResource, chan struct{}](),
 		bindingPolicyResolver:       NewBindingPolicyResolver(),
-		workqueue:                   workqueue.NewRateLimitingQueueWithConfig(ratelimiter, workqueue.RateLimitingQueueConfig{Name: controllerName + "-" + wdsName}),
+		workqueue:                   workqueue.NewRateLimitingQueueWithConfig(ratelimiter, workqueue.RateLimitingQueueConfig{Name: ControllerName + "-" + wdsName}),
 		allowedGroupsSet:            allowedGroupsSet,
 	}
 
@@ -284,7 +284,7 @@ func makeController(logger logr.Logger,
 // EnsureCRDs will ensure that the CRDs are installed.
 // Call this before Start.
 func (c *Controller) EnsureCRDs(ctx context.Context) error {
-	return crd.ApplyCRDs(ctx, controllerName, c.kubernetesClient, c.extClient, c.logger)
+	return crd.ApplyCRDs(ctx, ControllerName, c.kubernetesClient, c.extClient, c.logger)
 }
 
 // AppendKSResources lets the controller know about the KS resources.
@@ -301,7 +301,7 @@ func (c *Controller) AppendKSResources(ctx context.Context) error {
 
 // Start the controller
 func (c *Controller) Start(parentCtx context.Context, workers int, cListers chan interface{}) error {
-	logger := klog.FromContext(parentCtx).WithName(controllerName)
+	logger := klog.FromContext(parentCtx).WithName(ControllerName)
 	ctx := klog.NewContext(parentCtx, logger)
 
 	// Create informer on managedclusters so we can re-evaluate BindingPolicies.

--- a/pkg/status/combinedstatus.go
+++ b/pkg/status/combinedstatus.go
@@ -81,7 +81,7 @@ func (c *Controller) updateOrCreateCombinedStatus(ctx context.Context,
 
 	if generatedCombinedStatus.ResourceVersion != "" {
 		csEcho, err := c.wdsKsClient.ControlV1alpha1().CombinedStatuses(generatedCombinedStatus.Namespace).Update(ctx,
-			generatedCombinedStatus, metav1.UpdateOptions{FieldManager: controllerName})
+			generatedCombinedStatus, metav1.UpdateOptions{FieldManager: ControllerName})
 		if err != nil {
 			if errors.IsNotFound(err) {
 				logger.Info("CombinedStatus not found (update skipped)",
@@ -99,7 +99,7 @@ func (c *Controller) updateOrCreateCombinedStatus(ctx context.Context,
 	}
 
 	csEcho, err := c.wdsKsClient.ControlV1alpha1().CombinedStatuses(generatedCombinedStatus.Namespace).Create(ctx,
-		generatedCombinedStatus, metav1.CreateOptions{FieldManager: controllerName})
+		generatedCombinedStatus, metav1.CreateOptions{FieldManager: ControllerName})
 	if err != nil {
 		return fmt.Errorf("failed to create CombinedStatus (ns, name = %v, %v): %w",
 			generatedCombinedStatus.Namespace, generatedCombinedStatus.Name, err)

--- a/pkg/status/controller.go
+++ b/pkg/status/controller.go
@@ -49,7 +49,7 @@ import (
 )
 
 const (
-	controllerName      = "Status"
+	ControllerName      = "Status"
 	defaultResyncPeriod = time.Duration(0)
 	queueingDelay       = 5 * time.Second
 	originWdsLabelKey   = "transport.kubestellar.io/originWdsName"
@@ -133,7 +133,7 @@ func NewController(wdsRestConfig *rest.Config, itsRestConfig *rest.Config, wdsNa
 
 	controller := &Controller{
 		wdsName:                 wdsName,
-		logger:                  log.Log.WithName(controllerName),
+		logger:                  log.Log.WithName(ControllerName),
 		wdsDynClient:            wdsDynClient,
 		wdsKsClient:             wdsKsClient,
 		itsDynClient:            itsDynClient,
@@ -146,7 +146,7 @@ func NewController(wdsRestConfig *rest.Config, itsRestConfig *rest.Config, wdsNa
 
 // Start the status controller
 func (c *Controller) Start(parentCtx context.Context, workers int, cListers chan interface{}) error {
-	logger := klog.FromContext(parentCtx).WithName(controllerName)
+	logger := klog.FromContext(parentCtx).WithName(ControllerName)
 	ctx := klog.NewContext(parentCtx, logger)
 	errChan := make(chan error, 1)
 	go func() {
@@ -478,7 +478,7 @@ func (c *Controller) ensureNamespaceExists(ctx context.Context, ns string) error
 				},
 			}
 			_, err = c.wdsDynClient.Resource(namespaceGVR).Create(ctx, namespaceObj,
-				metav1.CreateOptions{FieldManager: controllerName})
+				metav1.CreateOptions{FieldManager: ControllerName})
 			if err != nil && !errors.IsAlreadyExists(err) {
 				return fmt.Errorf("failed to create namespace: %w", err)
 			}

--- a/pkg/status/statuscollector.go
+++ b/pkg/status/statuscollector.go
@@ -143,7 +143,7 @@ func (c *Controller) updateStatusCollectorErrors(ctx context.Context, statusColl
 	})
 
 	scEcho, err := c.wdsKsClient.ControlV1alpha1().StatusCollectors().UpdateStatus(ctx,
-		statusCollector, metav1.UpdateOptions{FieldManager: controllerName})
+		statusCollector, metav1.UpdateOptions{FieldManager: ControllerName})
 
 	if err != nil {
 		if errors.IsNotFound(err) {

--- a/pkg/util/resources.go
+++ b/pkg/util/resources.go
@@ -40,6 +40,14 @@ func ParseAPIGroupsString(apiGroups string) sets.Set[string] {
 	return groupsSet
 }
 
+func ParseControllersString(controllers string) sets.Set[string] {
+	if controllers == "*" {
+		return nil
+	}
+
+	return sets.New(strings.Split(controllers, ",")...)
+}
+
 // IsResourceGroupAllowed checks if a API group is explicitly allowed by user,
 // an empty or nil allowedResources slice is equivalent to allow all.
 func IsAPIGroupAllowed(apiGroup string, allowedAPIGroups sets.Set[string]) bool {
@@ -47,6 +55,15 @@ func IsAPIGroupAllowed(apiGroup string, allowedAPIGroups sets.Set[string]) bool 
 		return true
 	}
 	return allowedAPIGroups.Has(apiGroup)
+}
+
+// ShouldStartController checks if the given controller should be started,
+// empty of nil controllers is equivalent to start all.
+func ShouldStartController(controller string, controllers sets.Set[string]) bool {
+	if len(controllers) == 0 {
+		return true
+	}
+	return controllers.Has(controller)
 }
 
 // append the minimal set of resources that are required to operate

--- a/pkg/util/resources.go
+++ b/pkg/util/resources.go
@@ -40,14 +40,6 @@ func ParseAPIGroupsString(apiGroups string) sets.Set[string] {
 	return groupsSet
 }
 
-func ParseControllersString(controllers string) sets.Set[string] {
-	if controllers == "*" {
-		return nil
-	}
-
-	return sets.New(strings.Split(controllers, ",")...)
-}
-
 // IsResourceGroupAllowed checks if a API group is explicitly allowed by user,
 // an empty or nil allowedResources slice is equivalent to allow all.
 func IsAPIGroupAllowed(apiGroup string, allowedAPIGroups sets.Set[string]) bool {
@@ -55,15 +47,6 @@ func IsAPIGroupAllowed(apiGroup string, allowedAPIGroups sets.Set[string]) bool 
 		return true
 	}
 	return allowedAPIGroups.Has(apiGroup)
-}
-
-// ShouldStartController checks if the given controller should be started,
-// empty of nil controllers is equivalent to start all.
-func ShouldStartController(controller string, controllers sets.Set[string]) bool {
-	if len(controllers) == 0 {
-		return true
-	}
-	return controllers.Has(controller)
 }
 
 // append the minimal set of resources that are required to operate


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
This PR introduces a `controllers` flag into the controller manager, so we can specify which controller to be started by the controller manager. This feature improves the testability because it allows us to simulate the scenario where some of the controller(s) crush and restart.
