### PR TITLE
✨ Test for status controller eventual consistency

### DIFF
--- a/test/e2e/ginkgo/multiple_cluster_deployment_test.go
+++ b/test/e2e/ginkgo/multiple_cluster_deployment_test.go
@@ -376,17 +376,17 @@ var _ = ginkgo.Describe("end to end testing", func() {
 						ObjectSelectors: []metav1.LabelSelector{{MatchLabels: map[string]string{"app.kubernetes.io/name": "nginx-singleton"}}},
 					}},
 				},
+				func(bp *ksapi.BindingPolicy) error {
+					bp.Spec.WantSingletonReportedState = true
+					return nil
+				},
 			)
-			patch := []byte(`{"spec":{"wantSingletonReportedState": true}}`)
-			_, err := ksWds.ControlV1alpha1().BindingPolicies().Patch(
-				ctx, "nginx-singleton", types.MergePatchType, patch, metav1.PatchOptions{})
-			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			util.ValidateNumDeployments(ctx, wec1, ns, 1)
 			util.ValidateNumDeployments(ctx, wec2, ns, 0)
 			util.ValidateSingletonStatus(ctx, wds, ns, "nginx-singleton")
-			patchAgain := []byte(`{"spec":{"clusterSelectors":[{"matchLabels":{"name":"CelestialNexus"}}]}}`)
-			_, err = ksWds.ControlV1alpha1().BindingPolicies().Patch(
-				ctx, "nginx-singleton", types.MergePatchType, patchAgain, metav1.PatchOptions{})
+			patch := []byte(`{"spec":{"clusterSelectors":[{"matchLabels":{"name":"CelestialNexus"}}]}}`)
+			_, err := ksWds.ControlV1alpha1().BindingPolicies().Patch(
+				ctx, "nginx-singleton", types.MergePatchType, patch, metav1.PatchOptions{})
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			util.ValidateNumDeployments(ctx, wec1, ns, 0)
 			util.ValidateNumDeployments(ctx, wec2, ns, 0)
@@ -410,11 +410,11 @@ var _ = ginkgo.Describe("end to end testing", func() {
 						ObjectSelectors: []metav1.LabelSelector{{MatchLabels: map[string]string{"app.kubernetes.io/name": "nginx-singleton"}}},
 					}},
 				},
+				func(bp *ksapi.BindingPolicy) error {
+					bp.Spec.WantSingletonReportedState = true
+					return nil
+				},
 			)
-			BPPatch := []byte(`{"spec":{"wantSingletonReportedState": true}}`)
-			_, err := ksWds.ControlV1alpha1().BindingPolicies().Patch(
-				ctx, "nginx-singleton", types.MergePatchType, BPPatch, metav1.PatchOptions{})
-			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			util.ValidateNumDeployments(ctx, wec1, ns, 1)
 			util.ValidateNumDeployments(ctx, wec2, ns, 0)
 			util.ValidateSingletonStatus(ctx, wds, ns, "nginx-singleton")
@@ -436,7 +436,7 @@ var _ = ginkgo.Describe("end to end testing", func() {
 			util.ExpectDepolymentAvailability(ctx, coreCluster, "wds1-system", "kubestellar-controller-manager")
 
 			// At this time, the status controller should not be running, this is a simulation of a crush.
-			BPPatch = []byte(`{"spec":{"clusterSelectors":[{"matchLabels":{"name":"CelestialNexus"}}]}}`)
+			BPPatch := []byte(`{"spec":{"clusterSelectors":[{"matchLabels":{"name":"CelestialNexus"}}]}}`)
 			_, err = ksWds.ControlV1alpha1().BindingPolicies().Patch(
 				ctx, "nginx-singleton", types.MergePatchType, BPPatch, metav1.PatchOptions{})
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())

--- a/test/util/util.go
+++ b/test/util/util.go
@@ -358,7 +358,7 @@ type countAndProblems struct {
 	problems []string
 }
 
-// ValidateNumDeployments waits a limited amount of time for the number of Deployjment objects to equal the given count and
+// ValidateNumDeployments waits a limited amount of time for the number of Deployment objects to equal the given count and
 // all the problemFuncs to return the empty string for every Deployment.
 func ValidateNumDeployments(ctx context.Context, wec *kubernetes.Clientset, ns string, num int, problemFuncs ...func(*appsv1.Deployment) string) {
 	ginkgo.GinkgoHelper()
@@ -403,6 +403,14 @@ func ValidateSingletonStatusZeroValue(ctx context.Context, wds *kubernetes.Clien
 		gomega.ExpectWithOffset(1, err).NotTo(gomega.HaveOccurred())
 		return deployment.Status.Conditions
 	}, timeout).Should(gomega.BeNil())
+}
+
+func ValidateSingletonStatusNonZeroValue(ctx context.Context, wds *kubernetes.Clientset, ns string, name string) {
+	gomega.Eventually(func() []appsv1.DeploymentCondition {
+		deployment, err := wds.AppsV1().Deployments(ns).Get(ctx, name, metav1.GetOptions{})
+		gomega.ExpectWithOffset(1, err).NotTo(gomega.HaveOccurred())
+		return deployment.Status.Conditions
+	}, timeout).Should(gomega.Not(gomega.BeNil()))
 }
 
 func ValidateSingletonStatus(ctx context.Context, wds *kubernetes.Clientset, ns string, name string) {
@@ -597,4 +605,75 @@ func Expect1PodOfEach(ctx context.Context, client *kubernetes.Clientset, ns stri
 		return problems
 	}, timeout).Should(gomega.BeEmpty())
 	ginkgo.By(fmt.Sprintf("Waited for ready pods in namespace %q with name prefixes %v", ns, namePrefixes))
+}
+
+func ScaleDeployment(ctx context.Context, client *kubernetes.Clientset, ns string, name string, target int32) {
+	ginkgo.By(fmt.Sprintf("Scale Deployment %q in namespace %q to %d", name, ns, target))
+	gomega.EventuallyWithOffset(1, func() error {
+		gotSc, err := client.AppsV1().Deployments(ns).GetScale(ctx, name, metav1.GetOptions{})
+		if err != nil {
+			return err
+		}
+		gotSc.Spec.Replicas = target
+		_, err = client.AppsV1().Deployments(ns).UpdateScale(ctx, name, gotSc, metav1.UpdateOptions{})
+		if err != nil {
+			return err
+		}
+		gotDeploy, err := client.AppsV1().Deployments(ns).Get(ctx, name, metav1.GetOptions{})
+		if err != nil {
+			return err
+		}
+		labelSelector := metav1.FormatLabelSelector(gotDeploy.Spec.Selector)
+		podList, err := client.CoreV1().Pods(ns).List(ctx, metav1.ListOptions{
+			LabelSelector: labelSelector,
+		})
+		if err != nil {
+			return err
+		}
+		if len(podList.Items) != int(target) {
+			return fmt.Errorf("pod count not converged yet")
+		}
+		if gotDeploy.Status.ReadyReplicas != target {
+			return fmt.Errorf("ready replicas not converged yet")
+		}
+		return nil
+	}, timeout).Should(gomega.Succeed())
+	ginkgo.GinkgoWriter.Printf("Scaled Deployment %q in namespace %q to %d\n", name, ns, target)
+}
+
+func ExpectDepolymentAvailability(ctx context.Context, client *kubernetes.Clientset, ns string, name string) {
+	gomega.EventuallyWithOffset(1, func() error {
+		deploy, err := client.AppsV1().Deployments(ns).Get(ctx, name, metav1.GetOptions{})
+		if err != nil {
+			return err
+		}
+		if deploy.Status.AvailableReplicas <= 0 {
+			return fmt.Errorf("deployment %q in namespace %q is not available", name, ns)
+		}
+		return nil
+	}, timeout).Should(gomega.Succeed())
+	ginkgo.GinkgoWriter.Printf("Deployment %q in namespace %q is available\n", name, ns)
+}
+
+func ReadContainerArgsInDeployment(ctx context.Context, client *kubernetes.Clientset, ns string, deploymentName string, containerName string) []string {
+	var args []string
+	gomega.EventuallyWithOffset(1, func() error {
+		deploy, err := client.AppsV1().Deployments(ns).Get(ctx, deploymentName, metav1.GetOptions{})
+		if err != nil {
+			return err
+		}
+		foundContainer := false
+		for _, c := range deploy.Spec.Template.Spec.Containers {
+			if c.Name == containerName {
+				foundContainer = true
+				args = c.Args
+				break
+			}
+		}
+		if !foundContainer {
+			return fmt.Errorf("container %q in Deployment %q is not found", containerName, deploymentName)
+		}
+		return nil
+	}, timeout).Should(gomega.Succeed())
+	return args
 }

--- a/test/util/util.go
+++ b/test/util/util.go
@@ -148,7 +148,8 @@ func DeleteBindingPolicy(ctx context.Context, wds *ksClient.Clientset, name stri
 }
 
 func CreateBindingPolicy(ctx context.Context, wds *ksClient.Clientset, name string,
-	clusterSelector []metav1.LabelSelector, testAndStatusCollection []ksapi.DownsyncPolicyClause) {
+	clusterSelector []metav1.LabelSelector, testAndStatusCollection []ksapi.DownsyncPolicyClause,
+	mutators ...func(*ksapi.BindingPolicy) error) {
 	bindingPolicy := ksapi.BindingPolicy{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: name,
@@ -157,6 +158,10 @@ func CreateBindingPolicy(ctx context.Context, wds *ksClient.Clientset, name stri
 			ClusterSelectors: clusterSelector,
 			Downsync:         testAndStatusCollection,
 		},
+	}
+	for _, m := range mutators {
+		err := m(&bindingPolicy)
+		gomega.ExpectWithOffset(1, err).NotTo(gomega.HaveOccurred())
 	}
 	_, err := wds.ControlV1alpha1().BindingPolicies().Create(ctx, &bindingPolicy, metav1.CreateOptions{})
 	gomega.ExpectWithOffset(1, err).NotTo(gomega.HaveOccurred())


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
This PR introduce test on whether status controller achieves eventual consistency w.r.t. the singleton statuses of workload objects in WDS.

The test simulates a scenario where the status controller is absent (e.g. because of a crush) for some time during which there are changes in bindingpolicies. Upon the reappearance of the status controller, it should drive the singleton statuses into their desired state.

## Related
#2285 depends on this PR.
This PR uses #2347 

