### PR TITLE
🌱 Fix goreleaser.yml and prep for release 0.24.0-alpha.2

### DIFF
--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -26,7 +26,7 @@ jobs:
 
     - uses: actions/setup-go@v5
       with:
-        go-version: v1.19
+        go-version: v1.21
 
     - name: Delete non-semver tags
       run: 'git tag -d $(git tag -l | grep -v "^v")'

--- a/config/postcreate-hooks/kubestellar.yaml
+++ b/config/postcreate-hooks/kubestellar.yaml
@@ -184,7 +184,7 @@ spec:
               - kubestellar
               - oci://ghcr.io/kubestellar/kubestellar/controller-manager-chart
               - --version
-              - "0.24.0-alpha.1"
+              - "0.24.0-alpha.2"
               - --set
               - "ControlPlaneName={{.ControlPlaneName}}"
             env:

--- a/core-chart/values.yaml
+++ b/core-chart/values.yaml
@@ -7,7 +7,7 @@
 # please do not change them unless you know what your are doing.
 HELM_VERSION: "3.15.0"
 KUBECTL_VERSION: "1.30.1"
-KUBESTELLAR_VERSION: "0.24.0-alpha.1"
+KUBESTELLAR_VERSION: "0.24.0-alpha.2"
 CLUSTERADM_VERSION: "0.8.2"
 OCM_STATUS_ADDON_VERSION: "0.2.0-rc10"
 OCM_TRANSPORT_PLUGIN_VERSION: "0.1.11"

--- a/docs/content/direct/release-notes.md
+++ b/docs/content/direct/release-notes.md
@@ -6,7 +6,7 @@ The following sections list the known issues for each release. The issue list is
 
 The main change from 0.23.X is the completion of the status combination and introduction of the create-only feature. There is also further work on the organization of the website.
 
-### 0.24.0-alpha.1
+### 0.24.0-alpha.2
 
 The first of several releases required to get the create-only feature implemented in both the ks/ks and ks/OTP repositories. The API for this feature is present but the implementation is incomplete: the `Binding` objects are correctly derived from the `BindingPolicy` objects but the transport controller does not implement the feature.
 

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -14,7 +14,7 @@ edit_uri: edit/main/docs/content
 ks_branch: 'main'
 ks_tag: 'latest'
 ks_latest_regular_release: '0.23.1'
-ks_latest_release: '0.24.0-alpha.1'
+ks_latest_release: '0.24.0-alpha.2'
 
 ks_kind_port_num: '1119'
 


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
This PR does two things. First is fix an oversight in the release workflow, it needed to be updated to say to use version 1.21 of go. The other thing is update the self-references in preparation for release 0.24.0-alpha.2.

Doc preview at https://mikespreitzer.github.io/kcp-edge-mc/release-prep-0240a2/readme/

## Related issue(s)

Fixes #
