### PR TITLE
🌱 Wait properly for intended Deployment availability

### DIFF
--- a/test/e2e/ginkgo/multiple_cluster_deployment_test.go
+++ b/test/e2e/ginkgo/multiple_cluster_deployment_test.go
@@ -209,19 +209,33 @@ var _ = ginkgo.Describe("end to end testing", func() {
 			changedArgsBytes, err := json.Marshal(changedArgs)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			changedArgsPatch := []byte(fmt.Sprintf(`{"spec":{"template":{"spec":{"containers":[{"args":%s,"name":"transport-controller"}]}}}}`, string(changedArgsBytes)))
-			var patched bool
+			var scaledDown, mwLimited bool
 			ginkgo.DeferCleanup(func(ctx context.Context) {
-				if patched {
+				if mwLimited {
 					_, err = coreCluster.AppsV1().Deployments("wds1-system").Patch(ctx, "transport-controller", types.StrategicMergePatchType, originalArgsPatch, metav1.PatchOptions{})
+					gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				}
+				if scaledDown {
+					err = util.ScaleDeployment(ctx, coreCluster, "wds1-system", "transport-controller", 1)
 					gomega.Expect(err).NotTo(gomega.HaveOccurred())
 				}
 			})
 
-			ginkgo.By("setting max size of wrapped object to 1000 bytes")
-			patched = true
-			_, err = coreCluster.AppsV1().Deployments("wds1-system").Patch(ctx, "transport-controller", types.StrategicMergePatchType, changedArgsPatch, metav1.PatchOptions{})
+			ginkgo.By("stopping the transport controller")
+			scaledDown = true
+			err = util.ScaleDeployment(ctx, coreCluster, "wds1-system", "transport-controller", 0)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			util.WaitForDepolymentAvailability(ctx, coreCluster, "wds1-system", "transport-controller")
+
+			ginkgo.By("setting max size of wrapped object to 1000 bytes")
+			mwLimited = true
+			_, err = coreCluster.AppsV1().Deployments("wds1-system").Patch(ctx, "transport-controller", types.StrategicMergePatchType, changedArgsPatch, metav1.PatchOptions{})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			ginkgo.By("restarting the transport controller")
+			err = util.ScaleDeployment(ctx, coreCluster, "wds1-system", "transport-controller", 1)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			util.WaitForDepolymentAvailability(ctx, coreCluster, "wds1-system", "transport-controller")
+
 			var names = []string{"1", "2", "3", "4", "5", "6", "7", "8", "9", "10"}
 			for _, i := range names {
 				util.CreateDeployment(ctx, wds, ns, i,

--- a/test/util/util.go
+++ b/test/util/util.go
@@ -642,6 +642,9 @@ func WaitForDepolymentAvailability(ctx context.Context, client kubernetes.Interf
 		if gotDeploy.Status.AvailableReplicas != *gotDeploy.Spec.Replicas {
 			return fmt.Errorf("got Status.AvailableReplicas=%d but Spec.Replicas=%d", gotDeploy.Status.AvailableReplicas, *gotDeploy.Spec.Replicas)
 		}
+		if gotDeploy.Status.UnavailableReplicas != 0 {
+			return fmt.Errorf("got UnavailableReplicas=%d", gotDeploy.Status.UnavailableReplicas)
+		}
 		return nil
 	}, timeout).Should(gomega.Succeed())
 	ginkgo.GinkgoWriter.Printf("Deployment %q in namespace %q has desired AvailableReplicas=%d\n", name, ns, target)


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
This PR makes some improvements in the ginkgo E2E tests, primarily around waiting for a Deployment to have the desired number of "available replicas".

This PR also improves the `ginkgo.DeferCleanup` func for two test cases, one testing sharding of ManifestWork objects and one testing eventual consistency vs singleton status.

This PR also improves the test of ManifestWork sharding by making it read the existing args of the transport-controller container.

## Related issue(s)

Fixes #
