### PR TITLE
🌱 Simplify test of eventual consistency of singleton status

### DIFF
--- a/pkg/binding/bindingpolicy.go
+++ b/pkg/binding/bindingpolicy.go
@@ -172,8 +172,8 @@ func (c *Controller) evaluateBindingPoliciesForUpdate(ctx context.Context, clust
 			utilruntime.HandleError(err)
 			return
 		}
-		if match1 || match2 {
-			logger.V(4).Info("Enqueuing reference to bindingPolicy because of changing match with cluster", "clusterId", clusterId, "bindingPolicyName", bindingPolicy.Name)
+		if match1 != match2 {
+			logger.V(4).Info("Enqueuing reference to bindingPolicy because of changing match with cluster", "clusterId", clusterId, "bindingPolicyName", bindingPolicy.Name, "oldMatch", match1, "newMatch", match2, "oldLabels", oldLabels, "newLabels", newLabels)
 			c.workqueue.Add(bindingPolicyRef(bindingPolicy.Name))
 		}
 	}
@@ -331,7 +331,7 @@ func (c *Controller) testObject(ctx context.Context, objIdentifier util.ObjectId
 			}
 		}
 
-		klog.FromContext(ctx).Info("Workload object matched test", "objIdentifier", objIdentifier, "objLabels", objLabels, "test", test)
+		klog.FromContext(ctx).V(4).Info("Workload object matched test", "objIdentifier", objIdentifier, "objLabels", objLabels, "test", test)
 		// test is a match
 		matchedStatusCollectors.Insert(test.StatusCollectors...)
 		matched = true

--- a/pkg/binding/controller.go
+++ b/pkg/binding/controller.go
@@ -459,6 +459,7 @@ func (c *Controller) setupManagedClustersInformer(ctx context.Context) error {
 			oldLabels := oldM.GetLabels()
 			newLabels := newM.GetLabels()
 			if !reflect.DeepEqual(oldLabels, newLabels) {
+				c.logger.V(4).Info("Handling labels change", "old", old, "new", new)
 				c.evaluateBindingPoliciesForUpdate(ctx, newM.GetName(), oldLabels, newLabels)
 			}
 		},

--- a/pkg/binding/selectors.go
+++ b/pkg/binding/selectors.go
@@ -76,8 +76,8 @@ func (c *Controller) updateResolutions(ctx context.Context, objIdentifier util.O
 					"objectIdentifier", objIdentifier)
 				c.enqueueBinding(bindingPolicy.GetName())
 			} else {
-				logger.V(4).Info("Not enqueuing Binding for syncing due to the removal of an "+
-					"object from its resolution", "binding", bindingPolicy.GetName(),
+				logger.V(4).Info("Not enqueuing Binding for syncing, because its resolution continues "+
+					"to not include object", "binding", bindingPolicy.GetName(),
 					"objectIdentifier", objIdentifier)
 			}
 			continue

--- a/test/e2e/ginkgo/README.md
+++ b/test/e2e/ginkgo/README.md
@@ -29,11 +29,18 @@ To execute these tests, issue the following command. This will make a local imag
 KFLEX_DISABLE_CHATTY=true ginkgo --vv --trace --no-color
 ```
 
-To test the latest release image, pass `--released` to the test. For example:
+To pass additional command line flags/args to the embedded usage of the [setup-kubestellar.sh script](../common/setup-kubestellar.sh), pass one additional flag to the test suite, where this outer flag's name is `kubestellar-setup-flags` and the outer flag's value is the space-separated concatenation of all the additional setup-kubestellar flags/args. Remember that test suite args/flags must be preceeded on the `ginkgo` command line by `--`. Following is an example.
+
+```shell
+KFLEX_DISABLE_CHATTY=true ginkgo --vv --trace --no-color -- -kubestellar-setup-flags="--kubestellar-controller-manager-verbosity 5" 
+```
+
+To test the latest release image, either (a) pass the `--released` flag to setup-kubestellar using the technique above or (b) pass `--released` to the test suite. For example:
 
 ```shell
 KFLEX_DISABLE_CHATTY=true ginkgo --vv --trace --no-color -- -released
 ```
+
 
 To test a specific test use ginkgo's `--focus` parameter.  For example:
 

--- a/test/e2e/ginkgo/ginkgo_suite_test.go
+++ b/test/e2e/ginkgo/ginkgo_suite_test.go
@@ -19,6 +19,7 @@ package e2e
 import (
 	"context"
 	"flag"
+	"strings"
 	"testing"
 	"time"
 
@@ -46,6 +47,7 @@ var (
 	wec2               *kubernetes.Clientset
 	its                *ocmWorkClient.Clientset
 	releasedFlag       bool
+	ksSetupFlags       string
 	skipSetupFlag      bool
 	hostClusterCtxFlag string
 	wds1CtxFlag        string
@@ -57,6 +59,7 @@ var (
 func init() {
 	flag.BoolVar(&releasedFlag, "released", false, "released controls whether we use a release image")
 	flag.BoolVar(&skipSetupFlag, "skip-setup", false, "skip kubestellar cleanup and setup")
+	flag.StringVar(&ksSetupFlags, "kubestellar-setup-flags", ksSetupFlags, "additional command line flags for setup-kubestellar.sh, space separated")
 	flag.StringVar(&hostClusterCtxFlag, "host-cluster-context", "kind-kubeflex", "context for kubeflex hosting cluster")
 	flag.StringVar(&wds1CtxFlag, "wds1-context", "wds1", "context for KS wds1 space")
 	flag.StringVar(&its1CtxFlag, "its1-context", "its1", "context for KS its1 space")
@@ -66,8 +69,9 @@ func init() {
 
 var _ = ginkgo.BeforeSuite(func(ctx context.Context) {
 	if !skipSetupFlag {
+		separatedFlags := strings.Split(ksSetupFlags, " ")
 		util.Cleanup(ctx)
-		util.SetupKubestellar(ctx, releasedFlag)
+		util.SetupKubestellar(ctx, releasedFlag, separatedFlags...)
 	}
 
 	configCore := util.GetConfig(hostClusterCtxFlag)

--- a/test/e2e/ginkgo/multiple_cluster_deployment_test.go
+++ b/test/e2e/ginkgo/multiple_cluster_deployment_test.go
@@ -405,6 +405,7 @@ var _ = ginkgo.Describe("end to end testing", func() {
 
 	ginkgo.Context("singleton status eventual consistency", func() {
 		ginkgo.It("cleans up previously synced but currently invalid singleton status", func(ctx context.Context) {
+			ginkgo.By("creating nginx-singleton Deployment and BindingPolicy and expecting singleton status")
 			util.DeleteDeployment(ctx, wds, ns, "nginx")
 			util.CreateDeployment(ctx, wds, ns, "nginx-singleton",
 				map[string]string{
@@ -427,6 +428,7 @@ var _ = ginkgo.Describe("end to end testing", func() {
 			util.ValidateNumDeployments(ctx, wec1, ns, 1)
 			util.ValidateNumDeployments(ctx, wec2, ns, 0)
 			util.ValidateSingletonStatus(ctx, wds, ns, "nginx-singleton")
+			util.ValidateSingletonStatusNonZeroValue(ctx, wds, ns, "nginx-singleton")
 			ginkgo.GinkgoWriter.Println("Singleton status synced")
 
 			originalArgs := util.ReadContainerArgsInDeployment(ctx, coreCluster, "wds1-system", "kubestellar-controller-manager", "manager")
@@ -453,6 +455,7 @@ var _ = ginkgo.Describe("end to end testing", func() {
 			err = util.ScaleDeployment(ctx, coreCluster, "wds1-system", "kubestellar-controller-manager", 0)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			util.WaitForDepolymentAvailability(ctx, coreCluster, "wds1-system", "kubestellar-controller-manager")
+			ginkgo.By("reconfiguring the kubestellar controller-manager to not run the status controller")
 			changedArgsPatch := []byte(fmt.Sprintf(`{"spec":{"template":{"spec":{"containers":[{"args":%s,"name":"manager"}]}}}}`, string(changedArgsBytes)))
 			semiCrashed = true
 			_, err = coreCluster.AppsV1().Deployments("wds1-system").Patch(ctx, "kubestellar-controller-manager", types.StrategicMergePatchType, changedArgsPatch, metav1.PatchOptions{})
@@ -461,20 +464,24 @@ var _ = ginkgo.Describe("end to end testing", func() {
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			scaledDown = false
 			util.WaitForDepolymentAvailability(ctx, coreCluster, "wds1-system", "kubestellar-controller-manager")
+			util.ValidateSingletonStatusNonZeroValue(ctx, wds, ns, "nginx-singleton")
 
 			// At this time, the status controller should not be running, this is a simulation of a crush.
+			ginkgo.By("patching the nginx-singleton BindingPolicy to not match the nginx-singleton Deployment")
 			BPPatch := []byte(`{"spec":{"clusterSelectors":[{"matchLabels":{"name":"CelestialNexus"}}]}}`)
 			_, err = ksWds.ControlV1alpha1().BindingPolicies().Patch(
 				ctx, "nginx-singleton", types.MergePatchType, BPPatch, metav1.PatchOptions{})
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			util.ValidateNumDeployments(ctx, wec1, ns, 0)
 			util.ValidateNumDeployments(ctx, wec2, ns, 0)
+			util.ValidateSingletonStatusNonZeroValue(ctx, wds, ns, "nginx-singleton")
 
 			scaledDown = true
 			// Restart the controller manager normally.
 			err = util.ScaleDeployment(ctx, coreCluster, "wds1-system", "kubestellar-controller-manager", 0)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			util.WaitForDepolymentAvailability(ctx, coreCluster, "wds1-system", "kubestellar-controller-manager")
+			ginkgo.By("restoring normal configuration of the kubestellar controller-manager")
 			_, err = coreCluster.AppsV1().Deployments("wds1-system").Patch(ctx, "kubestellar-controller-manager", types.StrategicMergePatchType, originalArgsPatch, metav1.PatchOptions{})
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			semiCrashed = false


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
This PR simplifies the "cleans up previously synced but currently invalid singleton status" test spec, removing unnecessary scale down and up of the controller around its reconfiguration. This should be valid now that the test uses a proper wait for the reported state of the controller-manager Deployment to match its desired state.

## Related issue(s)

Fixes #
