### PR TITLE
🌱 Improvements to ginkgo E2E test suite

### DIFF
--- a/pkg/binding/controller.go
+++ b/pkg/binding/controller.go
@@ -459,6 +459,7 @@ func (c *Controller) setupManagedClustersInformer(ctx context.Context) error {
 			oldLabels := oldM.GetLabels()
 			newLabels := newM.GetLabels()
 			if !reflect.DeepEqual(oldLabels, newLabels) {
+				c.logger.V(4).Info("Handling labels change", "old", old, "new", new)
 				c.evaluateBindingPoliciesForUpdate(ctx, newM.GetName(), oldLabels, newLabels)
 			}
 		},

--- a/pkg/binding/selectors.go
+++ b/pkg/binding/selectors.go
@@ -76,8 +76,8 @@ func (c *Controller) updateResolutions(ctx context.Context, objIdentifier util.O
 					"objectIdentifier", objIdentifier)
 				c.enqueueBinding(bindingPolicy.GetName())
 			} else {
-				logger.V(4).Info("Not enqueuing Binding for syncing due to the removal of an "+
-					"object from its resolution", "binding", bindingPolicy.GetName(),
+				logger.V(4).Info("Not enqueuing Binding for syncing, because its resolution continues "+
+					"to not include workload object", "binding", bindingPolicy.GetName(),
 					"objectIdentifier", objIdentifier)
 			}
 			continue

--- a/pkg/status/combinedstatus-resolver.go
+++ b/pkg/status/combinedstatus-resolver.go
@@ -306,7 +306,7 @@ func (c *combinedStatusResolver) NoteWorkStatus(workStatus *workStatus) sets.Set
 
 	// update resolutions sensitive to the workstatus
 	for _, resolutions := range c.bindingNameToResolutions {
-		resolution, exists := resolutions[workStatus.sourceObjectIdentifier]
+		resolution, exists := resolutions[workStatus.SourceObjectIdentifier]
 		if !exists {
 			continue
 		}
@@ -314,9 +314,9 @@ func (c *combinedStatusResolver) NoteWorkStatus(workStatus *workStatus) sets.Set
 		content := c.getCombinedContentMap(workStatus, resolution)
 
 		// this call logs errors, but does not return them for now
-		if resolution.evaluateWorkStatus(c.celEvaluator, workStatus.wecName, content) {
+		if resolution.evaluateWorkStatus(c.celEvaluator, workStatus.WECName, content) {
 			combinedStatusIdentifiersToQueue.Insert(util.IdentifierForCombinedStatus(resolution.getName(),
-				workStatus.sourceObjectIdentifier.ObjectName.Namespace))
+				workStatus.SourceObjectIdentifier.ObjectName.Namespace))
 		}
 	}
 
@@ -456,11 +456,11 @@ func (c *combinedStatusResolver) evaluateWorkStatusesPerBindingReadLocked(bindin
 				continue
 			}
 
-			csResolution := c.bindingNameToResolutions[bindingName][workStatus.sourceObjectIdentifier]
+			csResolution := c.bindingNameToResolutions[bindingName][workStatus.SourceObjectIdentifier]
 			content := c.getCombinedContentMap(workStatus, csResolution)
 
 			// evaluate workstatus
-			if csResolution.evaluateWorkStatus(c.celEvaluator, workStatus.wecName, content) {
+			if csResolution.evaluateWorkStatus(c.celEvaluator, workStatus.WECName, content) {
 				combinedStatusesToQueue.Insert(util.IdentifierForCombinedStatus(csResolution.getName(),
 					workloadObjIdentifier.ObjectName.Namespace))
 			}
@@ -479,10 +479,10 @@ func (c *combinedStatusResolver) getCombinedContentMap(workStatus *workStatus,
 	}
 
 	if resolution.requiresSourceObjectMetaOrSpec() {
-		objMap, err := c.getObjectMetaAndSpec(workStatus.sourceObjectIdentifier)
+		objMap, err := c.getObjectMetaAndSpec(workStatus.SourceObjectIdentifier)
 		if err != nil {
 			runtime2.HandleError(fmt.Errorf("failed to get meta & spec for source object %s: %w",
-				workStatus.sourceObjectIdentifier, err))
+				workStatus.SourceObjectIdentifier, err))
 		}
 
 		content[sourceObjectKey] = objMap
@@ -602,6 +602,6 @@ func expressionPtrsEqual(e1, e2 *v1alpha1.Expression) bool {
 // inventoryForWorkStatus returns an inventory map for the given workstatus.
 func inventoryForWorkStatus(ws *workStatus) map[string]interface{} {
 	return map[string]interface{}{
-		"name": ws.wecName,
+		"name": ws.WECName,
 	}
 }

--- a/pkg/status/controller.go
+++ b/pkg/status/controller.go
@@ -87,12 +87,12 @@ type bindingRef string
 
 // workStatusRef is a workqueue item that references a WorkStatus
 type workStatusRef struct {
-	// name is the name of the WorkStatus object
-	name string
-	// wecName is the WorkStatus namespace
-	wecName string
-	// sourceObjectIdentifier is the identifier of the source object
-	sourceObjectIdentifier util.ObjectIdentifier
+	// Name is the Name of the WorkStatus object
+	Name string
+	// WECName is the WorkStatus namespace
+	WECName string
+	// SourceObjectIdentifier is the identifier of the source object
+	SourceObjectIdentifier util.ObjectIdentifier
 }
 
 // combinedStatusRef is a workqueue item that references a CombinedStatus
@@ -388,8 +388,8 @@ func (c *Controller) handleWorkStatus(obj any) {
 	}
 
 	c.logger.V(5).Info("Enqueuing reference to WorkStatus because of informer event",
-		"sourceObjectName", wsRef.sourceObjectIdentifier.ObjectName,
-		"sourceObjectGVK", wsRef.sourceObjectIdentifier.GVK, "wecName", wsRef.wecName)
+		"sourceObjectName", wsRef.SourceObjectIdentifier.ObjectName,
+		"sourceObjectGVK", wsRef.SourceObjectIdentifier.GVK, "wecName", wsRef.WECName)
 }
 
 // runWorker is a long-running function that will continually call the
@@ -427,7 +427,7 @@ func (c *Controller) processNextWorkItem(ctx context.Context) bool {
 		// Finally, if no error occurs we Forget this item so it does not
 		// get queued again until another change happens.
 		c.workqueue.Forget(item)
-		c.logger.V(2).Info("Successfully synced", "object", item)
+		c.logger.V(2).Info("Successfully synced", "object", item, "type", fmt.Sprintf("%T", item))
 		return nil
 	}(item)
 

--- a/pkg/status/workstatus.go
+++ b/pkg/status/workstatus.go
@@ -53,7 +53,7 @@ func (c *Controller) syncWorkStatus(ctx context.Context, ref workStatusRef) erro
 		status:        nil,
 	}
 
-	obj, err := c.workStatusLister.ByNamespace(ref.wecName).Get(ref.name)
+	obj, err := c.workStatusLister.ByNamespace(ref.WECName).Get(ref.Name)
 	if err != nil {
 		if !errors.IsNotFound(err) {
 			return fmt.Errorf("failed to get workstatus (%v): %w", ref, err)
@@ -78,7 +78,7 @@ func (c *Controller) syncWorkStatus(ctx context.Context, ref workStatusRef) erro
 func (c *Controller) syncSingletonWorkStatus(ctx context.Context, ref singletonWorkStatusRef) error {
 	logger := klog.FromContext(ctx)
 
-	workStatusObj, err := c.workStatusLister.ByNamespace(ref.wecName).Get(ref.name)
+	workStatusObj, err := c.workStatusLister.ByNamespace(ref.WECName).Get(ref.Name)
 	if err != nil {
 		if !errors.IsNotFound(err) {
 			return fmt.Errorf("failed to get workstatus (%v): %w", ref, err)
@@ -87,7 +87,7 @@ func (c *Controller) syncSingletonWorkStatus(ctx context.Context, ref singletonW
 
 	if workStatusObj == nil { // make sure status of source obj is deleted
 		emptyStatus := make(map[string]interface{})
-		if err = updateObjectStatus(ctx, &ref.sourceObjectIdentifier, emptyStatus,
+		if err = updateObjectStatus(ctx, &ref.SourceObjectIdentifier, emptyStatus,
 			c.listers, c.wdsDynClient); err != nil {
 			return err
 		}
@@ -104,7 +104,7 @@ func (c *Controller) syncSingletonWorkStatus(ctx context.Context, ref singletonW
 	// remove the status if singleton status label value is unset
 	if statusLabelVal == util.BindingPolicyLabelSingletonStatusValueUnset {
 		emptyStatus := make(map[string]interface{})
-		return updateObjectStatus(ctx, &ref.sourceObjectIdentifier, emptyStatus,
+		return updateObjectStatus(ctx, &ref.SourceObjectIdentifier, emptyStatus,
 			c.listers, c.wdsDynClient)
 	}
 
@@ -118,8 +118,8 @@ func (c *Controller) syncSingletonWorkStatus(ctx context.Context, ref singletonW
 		return nil
 	}
 
-	logger.Info("Updating singleton status", "objectIdentifier", ref.sourceObjectIdentifier)
-	if err = updateObjectStatus(ctx, &ref.sourceObjectIdentifier, status, c.listers, c.wdsDynClient); err != nil {
+	logger.Info("Updating singleton status", "objectIdentifier", ref.SourceObjectIdentifier)
+	if err = updateObjectStatus(ctx, &ref.SourceObjectIdentifier, status, c.listers, c.wdsDynClient); err != nil {
 		return err
 	}
 
@@ -206,8 +206,8 @@ func runtimeObjectToWorkStatusRef(obj runtime.Object) (*workStatusRef, error) {
 	}
 
 	return &workStatusRef{
-		name:                   name,
-		wecName:                wecName,
-		sourceObjectIdentifier: objIdentifier,
+		Name:                   name,
+		WECName:                wecName,
+		SourceObjectIdentifier: objIdentifier,
 	}, nil
 }

--- a/test/e2e/ginkgo/README.md
+++ b/test/e2e/ginkgo/README.md
@@ -29,11 +29,18 @@ To execute these tests, issue the following command. This will make a local imag
 KFLEX_DISABLE_CHATTY=true ginkgo --vv --trace --no-color
 ```
 
-To test the latest release image, pass `--released` to the test. For example:
+To pass additional command line flags/args to the embedded usage of the [setup-kubestellar.sh script](../common/setup-kubestellar.sh), pass one additional flag to the test suite, where this outer flag's name is `kubestellar-setup-flags` and the outer flag's value is the space-separated concatenation of all the additional setup-kubestellar flags/args. Remember that test suite args/flags must be preceeded on the `ginkgo` command line by `--`. Following is an example.
+
+```shell
+KFLEX_DISABLE_CHATTY=true ginkgo --vv --trace --no-color -- -kubestellar-setup-flags="--kubestellar-controller-manager-verbosity 5" 
+```
+
+To test the latest release image, either (a) pass the `--released` flag to setup-kubestellar using the technique above or (b) pass `--released` to the test suite. For example:
 
 ```shell
 KFLEX_DISABLE_CHATTY=true ginkgo --vv --trace --no-color -- -released
 ```
+
 
 To test a specific test use ginkgo's `--focus` parameter.  For example:
 

--- a/test/e2e/ginkgo/README.md
+++ b/test/e2e/ginkgo/README.md
@@ -41,7 +41,6 @@ To test the latest release image, either (a) pass the `--released` flag to setup
 KFLEX_DISABLE_CHATTY=true ginkgo --vv --trace --no-color -- -released
 ```
 
-
 To test a specific test use ginkgo's `--focus` parameter.  For example:
 
 ```shell

--- a/test/e2e/ginkgo/ginkgo_suite_test.go
+++ b/test/e2e/ginkgo/ginkgo_suite_test.go
@@ -70,6 +70,9 @@ func init() {
 var _ = ginkgo.BeforeSuite(func(ctx context.Context) {
 	if !skipSetupFlag {
 		separatedFlags := strings.Split(ksSetupFlags, " ")
+		if len(ksSetupFlags) == 0 {
+			separatedFlags = separatedFlags[:0]
+		}
 		util.Cleanup(ctx)
 		util.SetupKubestellar(ctx, releasedFlag, separatedFlags...)
 	}

--- a/test/e2e/ginkgo/ginkgo_suite_test.go
+++ b/test/e2e/ginkgo/ginkgo_suite_test.go
@@ -19,6 +19,7 @@ package e2e
 import (
 	"context"
 	"flag"
+	"strings"
 	"testing"
 	"time"
 
@@ -46,6 +47,7 @@ var (
 	wec2               *kubernetes.Clientset
 	its                *ocmWorkClient.Clientset
 	releasedFlag       bool
+	ksSetupFlags       string
 	skipSetupFlag      bool
 	hostClusterCtxFlag string
 	wds1CtxFlag        string
@@ -57,6 +59,7 @@ var (
 func init() {
 	flag.BoolVar(&releasedFlag, "released", false, "released controls whether we use a release image")
 	flag.BoolVar(&skipSetupFlag, "skip-setup", false, "skip kubestellar cleanup and setup")
+	flag.StringVar(&ksSetupFlags, "kubestellar-setup-flags", ksSetupFlags, "additional command line flags for setup-kubestellar.sh, space separated")
 	flag.StringVar(&hostClusterCtxFlag, "host-cluster-context", "kind-kubeflex", "context for kubeflex hosting cluster")
 	flag.StringVar(&wds1CtxFlag, "wds1-context", "wds1", "context for KS wds1 space")
 	flag.StringVar(&its1CtxFlag, "its1-context", "its1", "context for KS its1 space")
@@ -66,8 +69,9 @@ func init() {
 
 var _ = ginkgo.BeforeSuite(func(ctx context.Context) {
 	if !skipSetupFlag {
+		separatedFlags := strings.Split(ksSetupFlags, " ")
 		util.Cleanup(ctx)
-		util.SetupKubestellar(ctx, releasedFlag)
+		util.SetupKubestellar(ctx, releasedFlag, separatedFlags...)
 	}
 
 	configCore := util.GetConfig(hostClusterCtxFlag)

--- a/test/e2e/ginkgo/multiple_cluster_deployment_test.go
+++ b/test/e2e/ginkgo/multiple_cluster_deployment_test.go
@@ -405,6 +405,7 @@ var _ = ginkgo.Describe("end to end testing", func() {
 
 	ginkgo.Context("singleton status eventual consistency", func() {
 		ginkgo.It("cleans up previously synced but currently invalid singleton status", func(ctx context.Context) {
+			ginkgo.By("creating nginx-singleton Deployment and BindingPolicy and expecting singleton status")
 			util.DeleteDeployment(ctx, wds, ns, "nginx")
 			util.CreateDeployment(ctx, wds, ns, "nginx-singleton",
 				map[string]string{
@@ -427,6 +428,7 @@ var _ = ginkgo.Describe("end to end testing", func() {
 			util.ValidateNumDeployments(ctx, wec1, ns, 1)
 			util.ValidateNumDeployments(ctx, wec2, ns, 0)
 			util.ValidateSingletonStatus(ctx, wds, ns, "nginx-singleton")
+			util.ValidateSingletonStatusNonZeroValue(ctx, wds, ns, "nginx-singleton")
 			ginkgo.GinkgoWriter.Println("Singleton status synced")
 
 			originalArgs := util.ReadContainerArgsInDeployment(ctx, coreCluster, "wds1-system", "kubestellar-controller-manager", "manager")
@@ -450,9 +452,16 @@ var _ = ginkgo.Describe("end to end testing", func() {
 
 			scaledDown = true
 			// Restart the controller manager without starting the status controller.
+
+			// Mike on 24-08-01: I do not understand why, but experimentation shows that
+			// making this configuration change, even though calling WaitForDepolymentAvailability,
+			// without surrounding by scaling down and then up the CM Deployment
+			// leads to the later patch to the nginx-singleton BindingPolicy
+			// triggering the nginx-singleton Deployment's Status being zeroed.
 			err = util.ScaleDeployment(ctx, coreCluster, "wds1-system", "kubestellar-controller-manager", 0)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			util.WaitForDepolymentAvailability(ctx, coreCluster, "wds1-system", "kubestellar-controller-manager")
+			ginkgo.By("reconfiguring the kubestellar controller-manager to not run the status controller")
 			changedArgsPatch := []byte(fmt.Sprintf(`{"spec":{"template":{"spec":{"containers":[{"args":%s,"name":"manager"}]}}}}`, string(changedArgsBytes)))
 			semiCrashed = true
 			_, err = coreCluster.AppsV1().Deployments("wds1-system").Patch(ctx, "kubestellar-controller-manager", types.StrategicMergePatchType, changedArgsPatch, metav1.PatchOptions{})
@@ -461,20 +470,24 @@ var _ = ginkgo.Describe("end to end testing", func() {
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			scaledDown = false
 			util.WaitForDepolymentAvailability(ctx, coreCluster, "wds1-system", "kubestellar-controller-manager")
+			util.ValidateSingletonStatusNonZeroValue(ctx, wds, ns, "nginx-singleton")
 
 			// At this time, the status controller should not be running, this is a simulation of a crush.
+			ginkgo.By("patching the nginx-singleton BindingPolicy to not match any cluster")
 			BPPatch := []byte(`{"spec":{"clusterSelectors":[{"matchLabels":{"name":"CelestialNexus"}}]}}`)
 			_, err = ksWds.ControlV1alpha1().BindingPolicies().Patch(
 				ctx, "nginx-singleton", types.MergePatchType, BPPatch, metav1.PatchOptions{})
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			util.ValidateNumDeployments(ctx, wec1, ns, 0)
 			util.ValidateNumDeployments(ctx, wec2, ns, 0)
+			util.ValidateSingletonStatusNonZeroValue(ctx, wds, ns, "nginx-singleton")
 
 			scaledDown = true
 			// Restart the controller manager normally.
 			err = util.ScaleDeployment(ctx, coreCluster, "wds1-system", "kubestellar-controller-manager", 0)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			util.WaitForDepolymentAvailability(ctx, coreCluster, "wds1-system", "kubestellar-controller-manager")
+			ginkgo.By("restoring normal configuration of the kubestellar controller-manager")
 			_, err = coreCluster.AppsV1().Deployments("wds1-system").Patch(ctx, "kubestellar-controller-manager", types.StrategicMergePatchType, originalArgsPatch, metav1.PatchOptions{})
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			semiCrashed = false

--- a/test/e2e/ginkgo/multiple_cluster_deployment_test.go
+++ b/test/e2e/ginkgo/multiple_cluster_deployment_test.go
@@ -445,8 +445,7 @@ var _ = ginkgo.Describe("end to end testing", func() {
 					gomega.Expect(err).NotTo(gomega.HaveOccurred())
 				}
 				if scaledDown {
-					err = util.ScaleDeployment(ctx, coreCluster, "wds1-system", "kubestellar-controller-manager", 1)
-					gomega.Expect(err).NotTo(gomega.HaveOccurred())
+					util.ScaleDeployment(ctx, coreCluster, "wds1-system", "kubestellar-controller-manager", 1)
 				}
 			})
 
@@ -458,16 +457,14 @@ var _ = ginkgo.Describe("end to end testing", func() {
 			// without surrounding by scaling down and then up the CM Deployment
 			// leads to the later patch to the nginx-singleton BindingPolicy
 			// triggering the nginx-singleton Deployment's Status being zeroed.
-			err = util.ScaleDeployment(ctx, coreCluster, "wds1-system", "kubestellar-controller-manager", 0)
-			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			util.ScaleDeployment(ctx, coreCluster, "wds1-system", "kubestellar-controller-manager", 0)
 			util.WaitForDepolymentAvailability(ctx, coreCluster, "wds1-system", "kubestellar-controller-manager")
 			ginkgo.By("reconfiguring the kubestellar controller-manager to not run the status controller")
 			changedArgsPatch := []byte(fmt.Sprintf(`{"spec":{"template":{"spec":{"containers":[{"args":%s,"name":"manager"}]}}}}`, string(changedArgsBytes)))
 			semiCrashed = true
 			_, err = coreCluster.AppsV1().Deployments("wds1-system").Patch(ctx, "kubestellar-controller-manager", types.StrategicMergePatchType, changedArgsPatch, metav1.PatchOptions{})
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
-			err = util.ScaleDeployment(ctx, coreCluster, "wds1-system", "kubestellar-controller-manager", 1)
-			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			util.ScaleDeployment(ctx, coreCluster, "wds1-system", "kubestellar-controller-manager", 1)
 			scaledDown = false
 			util.WaitForDepolymentAvailability(ctx, coreCluster, "wds1-system", "kubestellar-controller-manager")
 			util.ValidateSingletonStatusNonZeroValue(ctx, wds, ns, "nginx-singleton")
@@ -484,15 +481,13 @@ var _ = ginkgo.Describe("end to end testing", func() {
 
 			scaledDown = true
 			// Restart the controller manager normally.
-			err = util.ScaleDeployment(ctx, coreCluster, "wds1-system", "kubestellar-controller-manager", 0)
-			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			util.ScaleDeployment(ctx, coreCluster, "wds1-system", "kubestellar-controller-manager", 0)
 			util.WaitForDepolymentAvailability(ctx, coreCluster, "wds1-system", "kubestellar-controller-manager")
 			ginkgo.By("restoring normal configuration of the kubestellar controller-manager")
 			_, err = coreCluster.AppsV1().Deployments("wds1-system").Patch(ctx, "kubestellar-controller-manager", types.StrategicMergePatchType, originalArgsPatch, metav1.PatchOptions{})
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			semiCrashed = false
-			err = util.ScaleDeployment(ctx, coreCluster, "wds1-system", "kubestellar-controller-manager", 1)
-			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			util.ScaleDeployment(ctx, coreCluster, "wds1-system", "kubestellar-controller-manager", 1)
 			scaledDown = false
 			util.WaitForDepolymentAvailability(ctx, coreCluster, "wds1-system", "kubestellar-controller-manager")
 

--- a/test/e2e/ginkgo/multiple_cluster_deployment_test.go
+++ b/test/e2e/ginkgo/multiple_cluster_deployment_test.go
@@ -429,7 +429,7 @@ var _ = ginkgo.Describe("end to end testing", func() {
 			util.ValidateNumDeployments(ctx, wec2, ns, 0)
 			util.ValidateSingletonStatus(ctx, wds, ns, "nginx-singleton")
 			util.ValidateSingletonStatusNonZeroValue(ctx, wds, ns, "nginx-singleton")
-			ginkgo.GinkgoWriter.Println("Singleton status synced")
+			ginkgo.GinkgoLogr.Info("Singleton status synced")
 
 			originalArgs := util.ReadContainerArgsInDeployment(ctx, coreCluster, "wds1-system", "kubestellar-controller-manager", "manager")
 			originalArgsBytes, err := json.Marshal(originalArgs)

--- a/test/util/util.go
+++ b/test/util/util.go
@@ -132,7 +132,7 @@ func SetupKubestellar(ctx context.Context, releasedFlag bool, otherFlags ...stri
 	}
 	args = append(args, otherFlags...)
 	commandName := "../common/setup-kubestellar.sh"
-	ginkgo.By(fmt.Sprintf("Execing command %v", append([]string{commandName}, args...)))
+	ginkgo.By(fmt.Sprintf("Execing command %#v", append([]string{commandName}, args...)))
 	cmd := exec.CommandContext(ctx, commandName, args...)
 	cmd.Stderr = &e
 	cmd.Stdout = &o
@@ -401,7 +401,7 @@ func ValidateNumServices(ctx context.Context, wec *kubernetes.Clientset, ns stri
 	ginkgo.GinkgoHelper()
 	gomega.Eventually(func() int {
 		services, err := wec.CoreV1().Services(ns).List(ctx, metav1.ListOptions{})
-		gomega.ExpectWithOffset(1, err).NotTo(gomega.HaveOccurred())
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		return len(services.Items)
 	}, timeout).Should(gomega.Equal(num))
 }
@@ -410,7 +410,7 @@ func ValidateNumJobs(ctx context.Context, wec *kubernetes.Clientset, ns string, 
 	ginkgo.GinkgoHelper()
 	gomega.Eventually(func() int {
 		jobs, err := wec.BatchV1().Jobs(ns).List(ctx, metav1.ListOptions{})
-		gomega.ExpectWithOffset(1, err).NotTo(gomega.HaveOccurred())
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		return len(jobs.Items)
 	}, timeout).Should(gomega.Equal(num))
 }
@@ -419,7 +419,7 @@ func ValidateSingletonStatusZeroValue(ctx context.Context, wds *kubernetes.Clien
 	ginkgo.GinkgoHelper()
 	gomega.Eventually(func() []appsv1.DeploymentCondition {
 		deployment, err := wds.AppsV1().Deployments(ns).Get(ctx, name, metav1.GetOptions{})
-		gomega.ExpectWithOffset(1, err).NotTo(gomega.HaveOccurred())
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		return deployment.Status.Conditions
 	}, timeout).Should(gomega.BeNil())
 }
@@ -428,7 +428,7 @@ func ValidateSingletonStatusNonZeroValue(ctx context.Context, wds *kubernetes.Cl
 	ginkgo.GinkgoHelper()
 	gomega.Eventually(func() []appsv1.DeploymentCondition {
 		deployment, err := wds.AppsV1().Deployments(ns).Get(ctx, name, metav1.GetOptions{})
-		gomega.ExpectWithOffset(1, err).NotTo(gomega.HaveOccurred())
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		return deployment.Status.Conditions
 	}, timeout).Should(gomega.Not(gomega.BeNil()))
 }
@@ -437,7 +437,7 @@ func ValidateSingletonStatus(ctx context.Context, wds *kubernetes.Clientset, ns 
 	ginkgo.GinkgoHelper()
 	gomega.Eventually(func() int {
 		deployment, err := wds.AppsV1().Deployments(ns).Get(ctx, name, metav1.GetOptions{})
-		gomega.ExpectWithOffset(1, err).NotTo(gomega.HaveOccurred())
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		return int(deployment.Status.AvailableReplicas)
 	}, timeout).Should(gomega.Equal(1))
 }
@@ -459,7 +459,7 @@ func ValidateNumManifestworks(ctx context.Context, ocmWorkIts *ocmWorkClient.Cli
 	ginkgo.GinkgoHelper()
 	gomega.Eventually(func() int {
 		list, err := ocmWorkIts.WorkV1().ManifestWorks(ns).List(ctx, metav1.ListOptions{})
-		gomega.ExpectWithOffset(1, err).NotTo(gomega.HaveOccurred())
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		return len(list.Items)
 	}, timeout).Should(gomega.Equal(num))
 }
@@ -468,7 +468,7 @@ func ValidateNumDeploymentReplicas(ctx context.Context, wec *kubernetes.Clientse
 	ginkgo.GinkgoHelper()
 	gomega.Eventually(func() int {
 		deployments, err := wec.AppsV1().Deployments(ns).List(ctx, metav1.ListOptions{})
-		gomega.ExpectWithOffset(1, err).NotTo(gomega.HaveOccurred())
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		if len(deployments.Items) != 1 {
 			return 0
 		}

--- a/test/util/util.go
+++ b/test/util/util.go
@@ -32,7 +32,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -99,7 +99,7 @@ func CreateNS(ctx context.Context, client *kubernetes.Clientset, name string) {
 		},
 	}
 	_, err := client.CoreV1().Namespaces().Create(ctx, nsObj, metav1.CreateOptions{})
-	if errors.IsAlreadyExists(err) {
+	if k8serrors.IsAlreadyExists(err) {
 		err = nil
 	}
 	gomega.Expect(err).NotTo(gomega.HaveOccurred())
@@ -584,7 +584,7 @@ func DeletePods(ctx context.Context, client *kubernetes.Clientset, ns string, na
 		problems := map[string]error{}
 		for podName := range stillNeedsDelete {
 			err := client.CoreV1().Pods(ns).Delete(ctx, podName, metav1.DeleteOptions{})
-			if err == nil || errors.IsNotFound(err) {
+			if err == nil || k8serrors.IsNotFound(err) {
 				delete(stillNeedsDelete, podName)
 			} else {
 				problems[podName] = err
@@ -597,7 +597,7 @@ func DeletePods(ctx context.Context, client *kubernetes.Clientset, ns string, na
 		remaining := map[string]types.UID{}
 		for podName, podUID := range goners {
 			pod, err := client.CoreV1().Pods(ns).Get(ctx, podName, metav1.GetOptions{})
-			if err == nil && pod.UID == podUID || err != nil && !errors.IsNotFound(err) {
+			if err == nil && pod.UID == podUID || err != nil && !k8serrors.IsNotFound(err) {
 				remaining[pod.Name] = pod.UID
 			}
 		}


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
This PR makes various improvements to the binding controller and the ginkgo E2E test suite.

There is a bug fix regarding excessive enqueuing.

This PR adds missing calls to `ginkgo.GinkgoHelper`. This PR also replaces use of offset with use of `ginkgo.GinkgoHelper`.

This PR adds the ability to pass all allowed `setup-kubestellar.sh` flags/args through the `ginkgo` command.

The are improvements to debug logging.

## Related issue(s)

Fixes #
