### PR TITLE
✨ Shard based on number of wrapped objects in a single manifestwork

### DIFF
--- a/pkg/transport/cmd/generic-main.go
+++ b/pkg/transport/cmd/generic-main.go
@@ -151,7 +151,7 @@ func GenericMain(transportImplementation transport.Transport) {
 		wdsClientset.ControlV1alpha1().Bindings(), wdsControlInformers.Bindings(),
 		wdsControlInformers.CustomTransforms(),
 		transportImplementation, wdsClientset, wdsDynamicClient, transportClientset.CoreV1().Namespaces(), itsK8sInformerFactory.Core().V1().ConfigMaps(),
-		transportClientset, transportDynamicClient, options.MaxSizeWrappedObject, options.WdsName)
+		transportClientset, transportDynamicClient, options.MaxSizeWrapped, options.MaxNumWrapped, options.WdsName)
 	if err != nil {
 		logger.Error(err, "failed to construct transport controller")
 		klog.FlushAndExit(klog.ExitFlushTimeout, 1)

--- a/pkg/transport/cmd/options.go
+++ b/pkg/transport/cmd/options.go
@@ -17,6 +17,8 @@ limitations under the License.
 package cmd
 
 import (
+	"math"
+
 	"github.com/spf13/pflag"
 
 	clientopts "github.com/kubestellar/kubestellar/options"
@@ -30,7 +32,8 @@ type TransportOptions struct {
 	Concurrency            int
 	WdsClientOptions       *clientopts.ClientOptions[*pflag.FlagSet]
 	TransportClientOptions *clientopts.ClientOptions[*pflag.FlagSet]
-	MaxSizeWrappedObject   int
+	MaxSizeWrapped         int
+	MaxNumWrapped          int
 	WdsName                string
 	metricsBindAddr        string
 	pprofBindAddr          string
@@ -41,7 +44,8 @@ func NewTransportOptions() *TransportOptions {
 		Concurrency:            defaultConcurrency,
 		WdsClientOptions:       clientopts.NewClientOptions[*pflag.FlagSet]("wds", "accessing the WDS"),
 		TransportClientOptions: clientopts.NewClientOptions[*pflag.FlagSet]("transport", "accessing the ITS"),
-		MaxSizeWrappedObject:   500 * 1024,
+		MaxNumWrapped:          math.MaxInt,
+		MaxSizeWrapped:         500 * 1024,
 		metricsBindAddr:        ":8090",
 		pprofBindAddr:          ":8092",
 	}
@@ -51,7 +55,8 @@ func (options *TransportOptions) AddFlags(fs *pflag.FlagSet) {
 	fs.IntVar(&options.Concurrency, "concurrency", options.Concurrency, "number of concurrent workers to run in parallel")
 	options.WdsClientOptions.AddFlags(fs)
 	options.TransportClientOptions.AddFlags(fs)
-	fs.IntVar(&options.MaxSizeWrappedObject, "max-size-wrapped-object", options.MaxSizeWrappedObject, "Max size of the wrapped object")
+	fs.IntVar(&options.MaxSizeWrapped, "max-size-wrapped", options.MaxSizeWrapped, "Max size of the wrapped object in bytes")
+	fs.IntVar(&options.MaxNumWrapped, "max-num-wrapped", options.MaxNumWrapped, "Max number of objects inside the wrapped object")
 	fs.StringVar(&options.WdsName, "wds-name", options.WdsName, "name of the wds to connect to. name should be unique")
 	fs.StringVar(&options.metricsBindAddr, "metrics-bind-addr", options.metricsBindAddr, "the [host]:port from which to serve /metrics")
 	fs.StringVar(&options.pprofBindAddr, "pprof-bind-addr", options.pprofBindAddr, "the [host]:port from which to serve /debug/pprof")

--- a/pkg/transport/generic_transport_controller_test.go
+++ b/pkg/transport/generic_transport_controller_test.go
@@ -406,7 +406,7 @@ func TestGenericController(t *testing.T) {
 		wdsKsClientFake,
 		wdsDynamicClient,
 		itsK8sClientFake.CoreV1().Namespaces(), parmCfgMapPreInformer,
-		itsDynamicClient, 500*1024, "test-wds", wrapperGVR)
+		itsDynamicClient, 500*1024, 500*1024, "test-wds", wrapperGVR)
 	ctlr.RegisterMetrics(legacyregistry.Register)
 	inventoryInformerFactory.Start(ctx.Done())
 	wdsKsInformerFactory.Start(ctx.Done())

--- a/test/e2e/ginkgo/multiple_cluster_deployment_test.go
+++ b/test/e2e/ginkgo/multiple_cluster_deployment_test.go
@@ -205,7 +205,7 @@ var _ = ginkgo.Describe("end to end testing", func() {
 			originalArgsBytes, err := json.Marshal(originalArgs)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			originalArgsPatch := []byte(fmt.Sprintf(`{"spec":{"template":{"spec":{"containers":[{"args":%s,"name":"transport-controller"}]}}}}`, string(originalArgsBytes)))
-			changedArgs := append(originalArgs, "--max-num-wrapped=1000")
+			changedArgs := append(originalArgs, "--max-num-wrapped=2")
 			changedArgsBytes, err := json.Marshal(changedArgs)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			changedArgsPatch := []byte(fmt.Sprintf(`{"spec":{"template":{"spec":{"containers":[{"args":%s,"name":"transport-controller"}]}}}}`, string(changedArgsBytes)))
@@ -239,6 +239,10 @@ var _ = ginkgo.Describe("end to end testing", func() {
 				},
 			)
 
+			// Expect addon-addon-status-deploy-0  and nginx-wds1 manifest works on both clusters.
+			// And the 5 manifestworks for the deployment on cluster1.
+			util.ValidateNumManifestworks(ctx, its, "cluster1", 7)
+			util.ValidateNumManifestworks(ctx, its, "cluster2", 2)
 			util.ValidateNumDeployments(ctx, wec1, ns, 10)
 			util.ValidateNumDeployments(ctx, wec2, ns, 0)
 
@@ -246,11 +250,18 @@ var _ = ginkgo.Describe("end to end testing", func() {
 			BPPatch := []byte(`{"spec": {"clusterSelectors": [{"matchLabels": {"name": "cluster2"}}]}}`)
 			_, err = ksWds.ControlV1alpha1().BindingPolicies().Patch(ctx, "multipledep", types.MergePatchType, BPPatch, metav1.PatchOptions{})
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			// Expect addon-addon-status-deploy-0  and nginx-wds1 manifest works on both clusters.
+			// And the 5 manifestworks for the deployment on cluster2.
+			util.ValidateNumManifestworks(ctx, its, "cluster1", 2)
+			util.ValidateNumManifestworks(ctx, its, "cluster2", 7)
 			util.ValidateNumDeployments(ctx, wec1, ns, 0)
 			util.ValidateNumDeployments(ctx, wec2, ns, 10)
 
 			ginkgo.By("delete of bindingpolicy with sharded wrapped workloads deletes deployments")
 			util.DeleteBindingPolicy(ctx, ksWds, "multipledep")
+			// Expect addon-addon-status-deploy-0  and nginx-wds1 manifest works on both clusters.
+			util.ValidateNumManifestworks(ctx, its, "cluster1", 2)
+			util.ValidateNumManifestworks(ctx, its, "cluster2", 2)
 			util.ValidateNumDeployments(ctx, wec1, ns, 0)
 			util.ValidateNumDeployments(ctx, wec2, ns, 0)
 		})
@@ -261,7 +272,7 @@ var _ = ginkgo.Describe("end to end testing", func() {
 			originalArgsBytes, err := json.Marshal(originalArgs)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			originalArgsPatch := []byte(fmt.Sprintf(`{"spec":{"template":{"spec":{"containers":[{"args":%s,"name":"transport-controller"}]}}}}`, string(originalArgsBytes)))
-			changedArgs := append(originalArgs, "--max-size-wrapped-object=1000")
+			changedArgs := append(originalArgs, "--max-size-wrapped=1000")
 			changedArgsBytes, err := json.Marshal(changedArgs)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			changedArgsPatch := []byte(fmt.Sprintf(`{"spec":{"template":{"spec":{"containers":[{"args":%s,"name":"transport-controller"}]}}}}`, string(changedArgsBytes)))


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
This PR adds the max-num-wrapped parameter to the transport controller.  This parameter enables sharding of the wrapped object (i.e. the manifestwork) based on the number of manifests it contains.  

This PR also changes the name of the max-size-wrapped-object parameter into max-size-wrapped.

## Related issue(s)

Fixes #2016 
