### PR TITLE
📖 Refer getting-started reader to Helm chart notes about contexts

### DIFF
--- a/docs/content/direct/get-started.md
+++ b/docs/content/direct/get-started.md
@@ -62,6 +62,8 @@ helm upgrade --install ks-core oci://ghcr.io/kubestellar/kubestellar/core-chart 
     --set-json='WDSes=[{"name":"wds1"}]'
 ```
 
+That command will print some notes about how to get kubeconfig "contexts" named "its1" and "wds1" defined. Do that, because those contexts are used in the following.
+
 ### Create and register two workload execution cluster(s)
 
  {%


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
This PR adds a note to the getting-started.md doc emphasizing that the reader should not ignore the Helm chart's notes about establishing the "its1" and "wds1" contexts.

Preview at https://mikespreitzer.github.io/kcp-edge-mc/doc-update-801b/direct/get-started/

## Related issue(s)

Fixes #2372 
