### PR TITLE
🐛 Enable CR and CRB for proxy to access kube apiserver (issue 2355)

### DIFF
--- a/config/rbac/kustomization.yaml
+++ b/config/rbac/kustomization.yaml
@@ -13,6 +13,6 @@ resources:
 # the auth proxy (https://github.com/brancz/kube-rbac-proxy)
 # which protects your /metrics endpoint.
 # - auth_proxy_service.yaml
-# - auth_proxy_role.yaml
-# - auth_proxy_role_binding.yaml
+- auth_proxy_role.yaml
+- auth_proxy_role_binding.yaml
 # - auth_proxy_client_clusterrole.yaml


### PR DESCRIPTION
## Summary

Update the rbac kustomization yaml to create the CR and CRB in the KS chart template yaml to allow the proxy to access the kube apiserver

## Related issue(s)

Fixes #2455
