### PR TITLE
✨ Create named container port for `/debug/pprof`

### DIFF
--- a/config/default/manager_auth_proxy_patch.yaml
+++ b/config/default/manager_auth_proxy_patch.yaml
@@ -57,7 +57,3 @@ spec:
         - "--its-name={{.Values.ITSName}}"
         - "--api-groups={{.Values.APIGroups}}"
         - -v={{.Values.ControllerManager.Verbosity}}
-        ports:
-        - containerPort: 8082
-          protocol: TCP
-          name: debug-pprof

--- a/config/default/manager_auth_proxy_patch.yaml
+++ b/config/default/manager_auth_proxy_patch.yaml
@@ -39,7 +39,7 @@ spec:
         ports:
         - containerPort: 8443
           protocol: TCP
-          name: https
+          name: metrics
         resources:
           limits:
             cpu: 500m
@@ -51,8 +51,13 @@ spec:
         args:
         - "--health-probe-bind-address=:8081"
         - "--metrics-bind-address=127.0.0.1:8080"
+        - "--pprof-bind-address=:8082"
         - "--leader-elect"
         - "--wds-name={{.Values.ControlPlaneName}}"
         - "--its-name={{.Values.ITSName}}"
         - "--api-groups={{.Values.APIGroups}}"
         - -v={{.Values.ControllerManager.Verbosity}}
+        ports:
+        - containerPort: 8082
+          protocol: TCP
+          name: debug-pprof

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -54,5 +54,9 @@ spec:
           requests:
             cpu: 10m
             memory: 64Mi
+        ports:
+        - containerPort: 8082
+          protocol: TCP
+          name: debug-pprof
       serviceAccountName: controller-manager
       terminationGracePeriodSeconds: 10

--- a/monitoring/configure-metrics-tools.sh
+++ b/monitoring/configure-metrics-tools.sh
@@ -65,10 +65,7 @@ sed s/%WDS_NS%/$wds-system/g ${SCRIPT_DIR}/configuration/ks-ctl-manager-sm.yaml 
 : --------------------------------------------------------------------
 : Configure kubestellar controller manager pod for pyroscope scraping
 : --------------------------------------------------------------------
-: 1. Adding declarations of the pprof port, so that kubestellar service definition can refer to it by name
-kubectl -n $wds-system get deploy kubestellar-controller-manager -o yaml | yq '(del(.status) |.spec.template.spec.containers.[1].ports[0].name |= "http")' | yq '.spec.template.spec.containers.[1].ports[0].protocol |= "TCP"' | yq '.spec.template.spec.containers.[1].ports[0].containerPort |= 8082' | kubectl --context $ctx apply --namespace=$wds-system -f -
-
-: 2. Add labels for pyroscope scraping:
+: 1. Add labels for pyroscope scraping:
 kubectl -n $wds-system get deploy kubestellar-controller-manager -o yaml | yq '.spec.template.metadata.annotations."profiles.grafana.com/cpu.port" |= "8082" |  .spec.template.metadata.annotations."profiles.grafana.com/cpu.scrape"|= "true" | .spec.template.metadata.annotations."profiles.grafana.com/goroutine.port" |= "8082" | .spec.template.metadata.annotations."profiles.grafana.com/goroutine.scrape" |= "true" |
 .spec.template.metadata.annotations."profiles.grafana.com/memory.port" |= "8082" | .spec.template.metadata.annotations."profiles.grafana.com/memory.scrape" |= "true"' | kubectl -n $wds-system apply -f -
 


### PR DESCRIPTION
## Summary

1. rename the named container port 8443 of the proxy from `https` to `metrics`
2. add `debug-pprof` port 8082 to manager container
3. add flag to set the binding address

## Related issue(s)

Fixes #2360
