### PR TITLE
✨ Make controller-manager use plain Kubernetes

### DIFF
--- a/cmd/controller-manager/main.go
+++ b/cmd/controller-manager/main.go
@@ -20,7 +20,6 @@ package main
 // to ensure that exec-entrypoint and run can make use of them.
 
 import (
-	"context"
 	"flag"
 	"fmt"
 	"os"
@@ -33,15 +32,17 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
+	"k8s.io/component-base/metrics/legacyregistry"
+	_ "k8s.io/component-base/metrics/prometheus/clientgo"
+	_ "k8s.io/component-base/metrics/prometheus/version"
 	"k8s.io/klog/v2"
 	ctrl "sigs.k8s.io/controller-runtime"
-	"sigs.k8s.io/controller-runtime/pkg/healthz"
-	crmetrics "sigs.k8s.io/controller-runtime/pkg/metrics/server"
-	crwebhook "sigs.k8s.io/controller-runtime/pkg/webhook"
 
 	v1alpha1 "github.com/kubestellar/kubestellar/api/control/v1alpha1"
 	clientopts "github.com/kubestellar/kubestellar/options"
 	"github.com/kubestellar/kubestellar/pkg/binding"
+	ksctlr "github.com/kubestellar/kubestellar/pkg/controller"
+	ksmetrics "github.com/kubestellar/kubestellar/pkg/metrics"
 	"github.com/kubestellar/kubestellar/pkg/status"
 	"github.com/kubestellar/kubestellar/pkg/util"
 )
@@ -63,15 +64,16 @@ func init() {
 }
 
 func main() {
-	var metricsAddr, pprofAddr, probeAddr string
+	processOpts := clientopts.ProcessOptions[*pflag.FlagSet]{
+		MetricsBindAddr:     ":8080",
+		HealthProbeBindAddr: ":8081",
+		PProfBindAddr:       ":8082",
+	}
 	var enableLeaderElection bool
 	var itsName string
 	var wdsName string
 	var allowedGroupsString string
 	var controllers []string
-	pflag.StringVar(&metricsAddr, "metrics-bind-address", ":8080", "The [host]:port from which /metrics is served.")
-	pflag.StringVar(&pprofAddr, "pprof-bind-address", ":8082", "The [host]:port fron which /debug/pprof is served.")
-	pflag.StringVar(&probeAddr, "health-probe-bind-address", ":8081", "The address the probe endpoint binds to.")
 	pflag.StringVar(&itsName, "its-name", "", "name of the Inventory and Transport Space to connect to (empty string means to use the only one)")
 	pflag.StringVar(&wdsName, "wds-name", "", "name of the workload description space to connect to")
 	pflag.StringVar(&allowedGroupsString, "api-groups", "", "list of allowed api groups, comma separated. Empty string means all API groups are allowed")
@@ -82,15 +84,16 @@ func main() {
 
 	itsClientLimits := clientopts.NewClientLimits[*pflag.FlagSet]("its", "accessing the ITS")
 	wdsClientLimits := clientopts.NewClientLimits[*pflag.FlagSet]("wds", "accessing the WDS")
+	processOpts.AddToFlags(pflag.CommandLine)
 	itsClientLimits.AddFlags(pflag.CommandLine)
 	wdsClientLimits.AddFlags(pflag.CommandLine)
 	klog.InitFlags(nil)
 	pflag.CommandLine.AddGoFlagSet(flag.CommandLine)
 	pflag.Parse()
-	ctx := context.Background()
+	ctx, _ := ksctlr.InitialContext()
 	logger := klog.FromContext(ctx)
 	ctrl.SetLogger(logger)
-	setupLog := ctrl.Log.WithName("setup")
+	setupLog := logger.WithName("setup")
 
 	pflag.VisitAll(func(flg *pflag.Flag) {
 		setupLog.Info("Command line flag", "name", flg.Name, "value", flg.Value)
@@ -109,40 +112,14 @@ func main() {
 		os.Exit(1)
 	}
 
-	// setup manager
-	// manager here is mainly used for leader election and health checks
-	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
-		Scheme:                 scheme,
-		Metrics:                crmetrics.Options{BindAddress: metricsAddr},
-		PprofBindAddress:       pprofAddr,
-		WebhookServer:          crwebhook.NewServer(crwebhook.Options{}),
-		HealthProbeBindAddress: probeAddr,
-		LeaderElection:         enableLeaderElection,
-		LeaderElectionID:       "c6f71c85.kflex.kubestellar.org",
-		// LeaderElectionReleaseOnCancel defines if the leader should step down voluntarily
-		// when the Manager ends. This requires the binary to immediately end when the
-		// Manager is stopped, otherwise, this setting is unsafe. Setting this significantly
-		// speeds up voluntary leader transitions as the new leader don't have to wait
-		// LeaseDuration time first.
-		//
-		// In the default scaffold provided, the program ends immediately after
-		// the manager stops, so would be fine to enable this option. However,
-		// if you are doing or is intended to do any operation such as perform cleanups
-		// after the manager stops then its usage might be unsafe.
-		// LeaderElectionReleaseOnCancel: true,
-	})
-	if err != nil {
-		setupLog.Error(err, "unable to create manager")
-		os.Exit(1)
-	}
-	if err := mgr.AddHealthzCheck("healthz", healthz.Ping); err != nil {
-		setupLog.Error(err, "unable to set up health check")
-		os.Exit(1)
-	}
-	if err := mgr.AddReadyzCheck("readyz", healthz.Ping); err != nil {
-		setupLog.Error(err, "unable to set up ready check")
-		os.Exit(1)
-	}
+	ksctlr.Start(ctx, processOpts)
+
+	spacesClientMetrics := ksmetrics.NewMultiSpaceClientMetrics()
+	ksmetrics.MustRegister(legacyregistry.Register, spacesClientMetrics)
+	wdsClientMetrics := spacesClientMetrics.MetricsForSpace("wds")
+	itsClientMetrics := spacesClientMetrics.MetricsForSpace("its")
+
+	// TODO: engage leader election if requested
 
 	// get the config for WDS
 	setupLog.Info("Getting config for WDS", "name", wdsName)
@@ -165,7 +142,7 @@ func main() {
 	itsRestConfig = itsClientLimits.LimitConfig(itsRestConfig)
 
 	// start the binding controller
-	bindingController, err := binding.NewController(mgr.GetLogger(), wdsRestConfig, itsRestConfig, wdsName, allowedGroupsSet)
+	bindingController, err := binding.NewController(logger, wdsClientMetrics, itsClientMetrics, wdsRestConfig, itsRestConfig, wdsName, allowedGroupsSet)
 	if err != nil {
 		setupLog.Error(err, "unable to create binding controller")
 		os.Exit(1)
@@ -195,7 +172,7 @@ func main() {
 	if util.CheckWorkStatusPresence(itsRestConfig) &&
 		(len(ctlrsToStart) == 0 || ctlrsToStart.Has(strings.ToLower(status.ControllerName))) {
 		setupLog.Info("Starting controller", "name", status.ControllerName)
-		statusController, err := status.NewController(wdsRestConfig, itsRestConfig, wdsName,
+		statusController, err := status.NewController(logger, wdsClientMetrics, itsClientMetrics, wdsRestConfig, itsRestConfig, wdsName,
 			bindingController.GetBindingPolicyResolver())
 		if err != nil {
 			setupLog.Error(err, "unable to create status controller")
@@ -208,10 +185,5 @@ func main() {
 		}
 	}
 
-	setupLog.Info("starting manager")
-	if err := mgr.Start(ctrl.SetupSignalHandler()); err != nil {
-		setupLog.Error(err, "problem running manager")
-		os.Exit(1)
-	}
 	select {}
 }

--- a/cmd/controller-manager/main.go
+++ b/cmd/controller-manager/main.go
@@ -64,7 +64,7 @@ func init() {
 }
 
 func main() {
-	processOpts := clientopts.ProcessOptions[*pflag.FlagSet]{
+	processOpts := clientopts.ProcessOptions{
 		MetricsBindAddr:     ":8080",
 		HealthProbeBindAddr: ":8081",
 		PProfBindAddr:       ":8082",

--- a/go.mod
+++ b/go.mod
@@ -61,7 +61,6 @@ require (
 	github.com/felixge/httpsnoop v1.0.3 // indirect
 	github.com/fsnotify/fsnotify v1.6.0 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
-	github.com/go-logr/zapr v1.2.4 // indirect
 	github.com/go-openapi/jsonpointer v0.19.6 // indirect
 	github.com/go-openapi/jsonreference v0.20.2 // indirect
 	github.com/go-openapi/swag v0.22.3 // indirect

--- a/go.sum
+++ b/go.sum
@@ -86,7 +86,6 @@ github.com/antlr/antlr4/runtime/Go/antlr/v4 v4.0.0-20230305170008-8188dc5388df h
 github.com/antlr/antlr4/runtime/Go/antlr/v4 v4.0.0-20230305170008-8188dc5388df/go.mod h1:pSwJ0fSY5KhvocuWSx4fz3BA8OrA1bQn+K1Eli3BRwM=
 github.com/asaskevich/govalidator v0.0.0-20200428143746-21a406dcc535 h1:4daAzAu0S6Vi7/lbWECcX0j45yZReDZ56BQsrVBOEEY=
 github.com/asaskevich/govalidator v0.0.0-20200428143746-21a406dcc535/go.mod h1:oGkLhpf+kjZl6xBf758TQhh5XrAeiJv/7FRz/2spLIg=
-github.com/benbjohnson/clock v1.1.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=
 github.com/benbjohnson/clock v1.3.0 h1:ip6w0uFQkncKQ979AypyG0ER7mqUSBdKLOgAle/AT8A=
 github.com/benbjohnson/clock v1.3.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
@@ -172,7 +171,6 @@ github.com/go-gl/glfw/v3.3/glfw v0.0.0-20200222043503-6f7a984d4dc4/go.mod h1:tQ2
 github.com/go-logr/logr v0.1.0/go.mod h1:ixOQHD9gLJUVQQ2ZOR7zLEifBX6tGkNJF4QyIY7sIas=
 github.com/go-logr/logr v0.2.0/go.mod h1:z6/tIYblkpsD+a4lm/fGIIU9mZ+XfAiaFtq7xTgseGU=
 github.com/go-logr/logr v1.2.2/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
-github.com/go-logr/logr v1.2.4/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
 github.com/go-logr/logr v1.3.0 h1:2y3SDp0ZXuc6/cjLSZ+Q3ir+QB9T/iG5yYRXqsagWSY=
 github.com/go-logr/logr v1.3.0/go.mod h1:9T104GzyrTigFIr8wt5mBrctHMim0Nb2HLGrmQ40KvY=
 github.com/go-logr/stdr v1.2.2 h1:hSWxHoqTgW2S2qGc0LTAI563KZ5YKYRhT3MFKZMbjag=
@@ -469,14 +467,10 @@ go.opentelemetry.io/otel/trace v1.14.0/go.mod h1:8avnQLK+CG77yNLUae4ea2JDQ6iT+go
 go.opentelemetry.io/proto/otlp v0.7.0/go.mod h1:PqfVotwruBrMGOCsRd/89rSnXhoiJIqeYNgFYFoEGnI=
 go.opentelemetry.io/proto/otlp v0.19.0 h1:IVN6GR+mhC4s5yfcTbmzHYODqvWAp3ZedA2SJPI1Nnw=
 go.opentelemetry.io/proto/otlp v0.19.0/go.mod h1:H7XAot3MsfNsj7EXtrA2q5xSNQ10UqI405h3+duxN4U=
-go.uber.org/atomic v1.7.0/go.mod h1:fEN4uk6kAWBTFdckzkM89CLk9XfWZrxpCo0nPH17wJc=
-go.uber.org/goleak v1.1.11/go.mod h1:cwTWslyiVhfpKIDGSZEM2HlOvcqm+tG4zioyIeLoqMQ=
 go.uber.org/goleak v1.2.1 h1:NBol2c7O1ZokfZ0LEU9K6Whx/KnwvepVetCUhtKja4A=
 go.uber.org/goleak v1.2.1/go.mod h1:qlT2yGI9QafXHhZZLxlSuNsMw3FFLxBr+tBRlmO1xH4=
-go.uber.org/multierr v1.6.0/go.mod h1:cdWPpRnG4AhwMwsgIHip0KRBQjJy5kYEpYjJxpXp9iU=
 go.uber.org/multierr v1.11.0 h1:blXXJkSxSSfBVBlC76pxqeO+LN3aDfLQo+309xJstO0=
 go.uber.org/multierr v1.11.0/go.mod h1:20+QtiLqy0Nd6FdQB9TLXag12DsQkrbs3htMFfDN80Y=
-go.uber.org/zap v1.24.0/go.mod h1:2kMP+WWQ8aoFoedH3T2sq6iJ2yDWpHbP0f6MQbS9Gkg=
 go.uber.org/zap v1.25.0 h1:4Hvk6GtkucQ790dqmj7l1eEnRdKm3k3ZUrUMS2d5+5c=
 go.uber.org/zap v1.25.0/go.mod h1:JIAUzQIH94IC4fOJQm7gMmBJP5k7wQfdcnYdPoEXJYk=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=

--- a/options/process-options.go
+++ b/options/process-options.go
@@ -1,0 +1,35 @@
+/*
+Copyright 2024 The KubeStellar Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package clientsopts
+
+type ProcessOptions[FS FlagSet] struct {
+	MetricsBindAddr     string
+	PProfBindAddr       string
+	HealthProbeBindAddr string
+}
+
+func (po *ProcessOptions[FS]) AddToFlags(flags FS) {
+	flags.StringVar(&po.MetricsBindAddr, "metrics-bind-address", po.MetricsBindAddr, "the [host]:port from which to serve /metrics")
+	flags.StringVar(&po.PProfBindAddr, "pprof-bind-address", po.PProfBindAddr, "the [host]:port from which to serve /debug/pprof")
+	flags.StringVar(&po.HealthProbeBindAddr, "health-probe-bind-address", po.HealthProbeBindAddr, "the [host]:port from which to serve /healthz,/readyz (empty string to not serve)")
+}
+
+func (po *ProcessOptions[FS]) DeprecatedAddToFlags(flags FS) {
+	flags.StringVar(&po.MetricsBindAddr, "metrics-bind-addr", po.MetricsBindAddr, "the [host]:port from which to serve /metrics")
+	flags.StringVar(&po.PProfBindAddr, "pprof-bind-addr", po.PProfBindAddr, "the [host]:port from which to serve /debug/pprof")
+	flags.StringVar(&po.HealthProbeBindAddr, "health-bind-addr", po.HealthProbeBindAddr, "the [host]:port from which to serve /healthz,/readyz (empty string to not serve)")
+}

--- a/options/process-options.go
+++ b/options/process-options.go
@@ -16,19 +16,23 @@ limitations under the License.
 
 package clientsopts
 
-type ProcessOptions[FS FlagSet] struct {
+import (
+	"github.com/spf13/pflag"
+)
+
+type ProcessOptions struct {
 	MetricsBindAddr     string
 	PProfBindAddr       string
 	HealthProbeBindAddr string
 }
 
-func (po *ProcessOptions[FS]) AddToFlags(flags FS) {
+func (po *ProcessOptions) AddToFlags(flags *pflag.FlagSet) {
 	flags.StringVar(&po.MetricsBindAddr, "metrics-bind-address", po.MetricsBindAddr, "the [host]:port from which to serve /metrics")
 	flags.StringVar(&po.PProfBindAddr, "pprof-bind-address", po.PProfBindAddr, "the [host]:port from which to serve /debug/pprof")
 	flags.StringVar(&po.HealthProbeBindAddr, "health-probe-bind-address", po.HealthProbeBindAddr, "the [host]:port from which to serve /healthz,/readyz (empty string to not serve)")
 }
 
-func (po *ProcessOptions[FS]) DeprecatedAddToFlags(flags FS) {
+func (po *ProcessOptions) DeprecatedAddToFlags(flags *pflag.FlagSet) {
 	flags.StringVar(&po.MetricsBindAddr, "metrics-bind-addr", po.MetricsBindAddr, "the [host]:port from which to serve /metrics")
 	flags.StringVar(&po.PProfBindAddr, "pprof-bind-addr", po.PProfBindAddr, "the [host]:port from which to serve /debug/pprof")
 	flags.StringVar(&po.HealthProbeBindAddr, "health-bind-addr", po.HealthProbeBindAddr, "the [host]:port from which to serve /healthz,/readyz (empty string to not serve)")

--- a/pkg/binding/binding.go
+++ b/pkg/binding/binding.go
@@ -97,11 +97,11 @@ func (c *Controller) updateOrCreateBinding(ctx context.Context, bdg *v1alpha1.Bi
 	bdg.SetOwnerReferences([]metav1.OwnerReference{ownerReference})
 
 	logger := klog.FromContext(ctx)
-	bdgEcho, err := c.controlClient.Bindings().Update(ctx, bdg, metav1.UpdateOptions{FieldManager: ControllerName})
+	bdgEcho, err := c.bindingClient.Update(ctx, bdg, metav1.UpdateOptions{FieldManager: ControllerName})
 
 	if err != nil {
 		if errors.IsNotFound(err) {
-			bdgEcho, err = c.controlClient.Bindings().Create(ctx, bdg, metav1.CreateOptions{FieldManager: ControllerName})
+			bdgEcho, err = c.bindingClient.Create(ctx, bdg, metav1.CreateOptions{FieldManager: ControllerName})
 			if err != nil {
 				return fmt.Errorf("failed to create binding (name=%s): %w", bdg.Name, err)
 			}

--- a/pkg/controller/run.go
+++ b/pkg/controller/run.go
@@ -1,0 +1,80 @@
+/*
+Copyright 2024 The KubeStellar Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"context"
+	"net/http"
+	"os"
+	"os/signal"
+	"syscall"
+
+	"k8s.io/apiserver/pkg/server/mux"
+	"k8s.io/apiserver/pkg/server/routes"
+	"k8s.io/component-base/metrics/legacyregistry"
+	"k8s.io/klog/v2"
+
+	ksopts "github.com/kubestellar/kubestellar/options"
+)
+
+func InitialContext() (context.Context, func()) {
+	ctx, cancel := context.WithCancel(context.Background())
+	sigChan := make(chan os.Signal, 2)
+	go func() {
+		<-sigChan
+		cancel()
+		<-sigChan
+		os.Exit(2)
+	}()
+	signal.Notify(sigChan, os.Interrupt, syscall.SIGTERM)
+	return ctx, cancel
+}
+
+func Start[FS ksopts.FlagSet](ctx context.Context, processOpts ksopts.ProcessOptions[FS]) {
+	logger := klog.FromContext(ctx)
+	if processOpts.HealthProbeBindAddr != "" {
+		go func() {
+			err := http.ListenAndServe(processOpts.HealthProbeBindAddr, http.HandlerFunc(HappyDumbHandler))
+			if err != nil {
+				logger.Error(err, "Failed to serve health probes", "bindAddress", processOpts.HealthProbeBindAddr)
+				panic(err)
+			}
+		}()
+
+	}
+	go func() {
+		err := http.ListenAndServe(processOpts.MetricsBindAddr, legacyregistry.Handler())
+		if err != nil {
+			logger.Error(err, "Failed to serve Prometheus metrics", "bindAddress", processOpts.MetricsBindAddr)
+			panic(err)
+		}
+	}()
+
+	mymux := mux.NewPathRecorderMux("debug")
+	routes.Profiling{}.Install(mymux)
+	go func() {
+		err := http.ListenAndServe(processOpts.PProfBindAddr, mymux)
+		if err != nil {
+			logger.Error(err, "Failure in serving /debug/pprof", "bindAddress", processOpts.PProfBindAddr)
+			panic(err)
+		}
+	}()
+}
+
+func HappyDumbHandler(resp http.ResponseWriter, req *http.Request) {
+	resp.Write([]byte("ok\r\n"))
+}

--- a/pkg/controller/run.go
+++ b/pkg/controller/run.go
@@ -44,7 +44,7 @@ func InitialContext() (context.Context, func()) {
 	return ctx, cancel
 }
 
-func Start[FS ksopts.FlagSet](ctx context.Context, processOpts ksopts.ProcessOptions[FS]) {
+func Start(ctx context.Context, processOpts ksopts.ProcessOptions) {
 	logger := klog.FromContext(ctx)
 	if processOpts.HealthProbeBindAddr != "" {
 		go func() {

--- a/pkg/ocm/ocm.go
+++ b/pkg/ocm/ocm.go
@@ -20,13 +20,15 @@ import (
 	"context"
 	"fmt"
 
-	clusterclientset "open-cluster-management.io/api/client/cluster/clientset/versioned"
+	managedclusterapi "open-cluster-management.io/api/cluster/v1"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
+
+	ksmetrics "github.com/kubestellar/kubestellar/pkg/metrics"
 )
 
-func FindClustersBySelectors(ctx context.Context, client clusterclientset.Interface, selectors []metav1.LabelSelector) (sets.Set[string], error) {
+func FindClustersBySelectors(ctx context.Context, client ksmetrics.ClientModNamespace[*managedclusterapi.ManagedCluster, *managedclusterapi.ManagedClusterList], selectors []metav1.LabelSelector) (sets.Set[string], error) {
 	// in order to support OR between label selectors in a straightforward manner, we perform List for each selector.
 	// additionally, to support complex selectors (such as set selectors), we avoid conversion to maps.
 	clusterNames := sets.New[string]()
@@ -35,7 +37,7 @@ func FindClustersBySelectors(ctx context.Context, client clusterclientset.Interf
 		if err != nil {
 			return clusterNames, fmt.Errorf("failed to convert metav1.LabelSelector to labels.Selector: %w", err)
 		}
-		clusters, err := client.ClusterV1().ManagedClusters().List(ctx, metav1.ListOptions{LabelSelector: ls.String()})
+		clusters, err := client.List(ctx, metav1.ListOptions{LabelSelector: ls.String()})
 		if err != nil {
 			return nil, fmt.Errorf("error listing clusters with selector %s: %w", ls, err)
 		}

--- a/pkg/status/combinedstatus.go
+++ b/pkg/status/combinedstatus.go
@@ -82,7 +82,7 @@ func (c *Controller) updateOrCreateCombinedStatus(ctx context.Context,
 	logger := klog.FromContext(ctx)
 
 	if generatedCombinedStatus.ResourceVersion != "" {
-		csEcho, err := c.wdsKsClient.ControlV1alpha1().CombinedStatuses(generatedCombinedStatus.Namespace).Update(ctx,
+		csEcho, err := c.combinedStatusClient.Namespace(generatedCombinedStatus.Namespace).Update(ctx,
 			generatedCombinedStatus, metav1.UpdateOptions{FieldManager: ControllerName})
 		if err != nil {
 			if errors.IsNotFound(err) {
@@ -102,7 +102,7 @@ func (c *Controller) updateOrCreateCombinedStatus(ctx context.Context,
 		return nil
 	}
 
-	csEcho, err := c.wdsKsClient.ControlV1alpha1().CombinedStatuses(generatedCombinedStatus.Namespace).Create(ctx,
+	csEcho, err := c.combinedStatusClient.Namespace(generatedCombinedStatus.Namespace).Create(ctx,
 		generatedCombinedStatus, metav1.CreateOptions{FieldManager: ControllerName})
 	if err != nil {
 		return fmt.Errorf("failed to create CombinedStatus (ns, name = %v, %v): %w",
@@ -118,7 +118,7 @@ func (c *Controller) updateOrCreateCombinedStatus(ctx context.Context,
 func (c *Controller) deleteCombinedStatus(ctx context.Context, ns, name string) error {
 	logger := klog.FromContext(ctx)
 
-	err := c.wdsKsClient.ControlV1alpha1().CombinedStatuses(ns).Delete(ctx, name, metav1.DeleteOptions{})
+	err := c.combinedStatusClient.Namespace(ns).Delete(ctx, name, metav1.DeleteOptions{})
 	if err != nil {
 		if errors.IsNotFound(err) {
 			logger.V(2).Info("CombinedStatus not found (deletion skipped)", "ns", ns, "name", name)

--- a/pkg/status/statuscollector.go
+++ b/pkg/status/statuscollector.go
@@ -141,7 +141,7 @@ func (c *Controller) updateStatusCollectorErrors(ctx context.Context, statusColl
 
 	statusCollector.Status.Errors = abstract.SliceMap(errs, error.Error)
 
-	scEcho, err := c.wdsKsClient.ControlV1alpha1().StatusCollectors().UpdateStatus(ctx,
+	scEcho, err := c.statusCollectorClient.UpdateStatus(ctx,
 		statusCollector, metav1.UpdateOptions{FieldManager: ControllerName})
 
 	if err != nil {

--- a/pkg/transport/generic/cmd/options.go
+++ b/pkg/transport/generic/cmd/options.go
@@ -30,12 +30,12 @@ const (
 
 type TransportOptions struct {
 	Concurrency            int
-	WdsClientOptions       *ksopts.ClientOptions[*pflag.FlagSet]
-	TransportClientOptions *ksopts.ClientOptions[*pflag.FlagSet]
+	WdsClientOptions       *ksopts.ClientOptions
+	TransportClientOptions *ksopts.ClientOptions
 	MaxSizeWrapped         int
 	MaxNumWrapped          int
 	WdsName                string
-	ksopts.ProcessOptions[*pflag.FlagSet]
+	ksopts.ProcessOptions
 }
 
 func NewTransportOptions() *TransportOptions {
@@ -45,7 +45,7 @@ func NewTransportOptions() *TransportOptions {
 		TransportClientOptions: ksopts.NewClientOptions[*pflag.FlagSet]("transport", "accessing the ITS"),
 		MaxNumWrapped:          math.MaxInt,
 		MaxSizeWrapped:         500 * 1024,
-		ProcessOptions: ksopts.ProcessOptions[*pflag.FlagSet]{
+		ProcessOptions: ksopts.ProcessOptions{
 			MetricsBindAddr: ":8090",
 			PProfBindAddr:   ":8092",
 		},

--- a/pkg/transport/generic/cmd/options.go
+++ b/pkg/transport/generic/cmd/options.go
@@ -21,7 +21,7 @@ import (
 
 	"github.com/spf13/pflag"
 
-	clientopts "github.com/kubestellar/kubestellar/options"
+	ksopts "github.com/kubestellar/kubestellar/options"
 )
 
 const (
@@ -30,24 +30,25 @@ const (
 
 type TransportOptions struct {
 	Concurrency            int
-	WdsClientOptions       *clientopts.ClientOptions[*pflag.FlagSet]
-	TransportClientOptions *clientopts.ClientOptions[*pflag.FlagSet]
+	WdsClientOptions       *ksopts.ClientOptions[*pflag.FlagSet]
+	TransportClientOptions *ksopts.ClientOptions[*pflag.FlagSet]
 	MaxSizeWrapped         int
 	MaxNumWrapped          int
 	WdsName                string
-	metricsBindAddr        string
-	pprofBindAddr          string
+	ksopts.ProcessOptions[*pflag.FlagSet]
 }
 
 func NewTransportOptions() *TransportOptions {
 	return &TransportOptions{
 		Concurrency:            defaultConcurrency,
-		WdsClientOptions:       clientopts.NewClientOptions[*pflag.FlagSet]("wds", "accessing the WDS"),
-		TransportClientOptions: clientopts.NewClientOptions[*pflag.FlagSet]("transport", "accessing the ITS"),
+		WdsClientOptions:       ksopts.NewClientOptions[*pflag.FlagSet]("wds", "accessing the WDS"),
+		TransportClientOptions: ksopts.NewClientOptions[*pflag.FlagSet]("transport", "accessing the ITS"),
 		MaxNumWrapped:          math.MaxInt,
 		MaxSizeWrapped:         500 * 1024,
-		metricsBindAddr:        ":8090",
-		pprofBindAddr:          ":8092",
+		ProcessOptions: ksopts.ProcessOptions[*pflag.FlagSet]{
+			MetricsBindAddr: ":8090",
+			PProfBindAddr:   ":8092",
+		},
 	}
 }
 
@@ -58,6 +59,5 @@ func (options *TransportOptions) AddFlags(fs *pflag.FlagSet) {
 	fs.IntVar(&options.MaxSizeWrapped, "max-size-wrapped", options.MaxSizeWrapped, "Max size of the wrapped object in bytes")
 	fs.IntVar(&options.MaxNumWrapped, "max-num-wrapped", options.MaxNumWrapped, "Max number of objects inside the wrapped object")
 	fs.StringVar(&options.WdsName, "wds-name", options.WdsName, "name of the wds to connect to. name should be unique")
-	fs.StringVar(&options.metricsBindAddr, "metrics-bind-addr", options.metricsBindAddr, "the [host]:port from which to serve /metrics")
-	fs.StringVar(&options.pprofBindAddr, "pprof-bind-addr", options.pprofBindAddr, "the [host]:port from which to serve /debug/pprof")
+	options.ProcessOptions.AddToFlags(fs)
 }


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
This PR switches the KubeStellar controller-manager from using controller-runtime to using plain Kubernetes.

There remains some relatively isolated use of just part of controller-runtime, the non-typed client, due to https://github.com/kubestellar/kubeflex/issues/277 .

## Related issue(s)

Fixes #
