### PR TITLE
🌱  Fix remaining wrong go versions in CI

### DIFF
--- a/.github/workflows/ocp-self-runner.yml
+++ b/.github/workflows/ocp-self-runner.yml
@@ -14,7 +14,7 @@ jobs:
       
       - uses: actions/setup-go@v5
         with:
-          go-version: v1.20
+          go-version: v1.21
           cache: true
 
       - name: Set up Helm
@@ -66,7 +66,7 @@ jobs:
       
       - uses: actions/setup-go@v5
         with:
-          go-version: v1.20
+          go-version: v1.21
           cache: true
 
       - name: Set up Helm

--- a/.github/workflows/pr-test-e2e.yml
+++ b/.github/workflows/pr-test-e2e.yml
@@ -37,7 +37,7 @@ jobs:
       
       - uses: actions/setup-go@v5
         with:
-          go-version: v1.20
+          go-version: v1.21
           cache: true
 
       - name: Install kubectl
@@ -168,7 +168,7 @@ jobs:
       
       - uses: actions/setup-go@v5
         with:
-          go-version: v1.20
+          go-version: v1.21
           cache: true
 
       - name: Install kubectl

--- a/.github/workflows/pr-test-integration.yml
+++ b/.github/workflows/pr-test-integration.yml
@@ -22,7 +22,7 @@ jobs:
       
       - uses: actions/setup-go@v5
         with:
-          go-version: v1.20
+          go-version: v1.21
           cache: true
 
       - name: Install kubectl

--- a/.github/workflows/test-latest-release.yml
+++ b/.github/workflows/test-latest-release.yml
@@ -20,7 +20,7 @@ jobs:
       
       - uses: actions/setup-go@v5
         with:
-          go-version: v1.20
+          go-version: v1.21
           cache: true
 
       - name: Install kubectl
@@ -95,7 +95,7 @@ jobs:
       
       - uses: actions/setup-go@v5
         with:
-          go-version: v1.20
+          go-version: v1.21
           cache: true
 
       - name: Install kubectl

--- a/.prow.yaml
+++ b/.prow.yaml
@@ -41,7 +41,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: ghcr.io/kcp-dev/infra/build:1.20.13-1
+        - image: ghcr.io/kcp-dev/infra/build:1.21.8-1
           command:
             - make
             - test


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
This PR fixes the remaining places where CI was saying to use go release 1.22.

## Related issue(s)

Fixes #
