### PR TITLE
✨ Improve status controller using existing assets

### DIFF
--- a/cmd/controller-manager/main.go
+++ b/cmd/controller-manager/main.go
@@ -196,7 +196,7 @@ func main() {
 		(len(ctlrsToStart) == 0 || ctlrsToStart.Has(strings.ToLower(status.ControllerName))) {
 		setupLog.Info("Starting controller", "name", status.ControllerName)
 		statusController, err := status.NewController(wdsRestConfig, itsRestConfig, wdsName,
-			bindingController.GetBindingPolicyResolutionBroker())
+			bindingController.GetBindingPolicyResolver())
 		if err != nil {
 			setupLog.Error(err, "unable to create status controller")
 			os.Exit(1)

--- a/pkg/binding/controller.go
+++ b/pkg/binding/controller.go
@@ -342,6 +342,10 @@ func (c *Controller) GetBindingPolicyResolutionBroker() ResolutionBroker {
 	return c.bindingPolicyResolver.Broker()
 }
 
+func (c *Controller) GetBindingPolicyResolver() BindingPolicyResolver {
+	return c.bindingPolicyResolver
+}
+
 // Invoked by Start() to run the controller
 func (c *Controller) run(ctx context.Context, workers int, cListers chan interface{}) error {
 	defer c.workqueue.ShutDown()

--- a/pkg/status/binding.go
+++ b/pkg/status/binding.go
@@ -26,7 +26,7 @@ func (c *Controller) syncBinding(ctx context.Context, key string) error {
 	logger := klog.FromContext(ctx)
 
 	isDeleted := false
-	resolution := c.bindingResolutionBroker.GetResolution(key)
+	resolution := c.bindingPolicyResolver.Broker().GetResolution(key)
 	if resolution == nil {
 		// If a binding key gets here and no resolution exists, then isDeleted can be set to true.
 		isDeleted = true

--- a/pkg/status/binding.go
+++ b/pkg/status/binding.go
@@ -40,7 +40,7 @@ func (c *Controller) syncBinding(ctx context.Context, key string) error {
 		c.workqueue.AddAfter(combinedStatusRef(combinedStatus.ObjectName.AsNamespacedName().String()), queueingDelay)
 	}
 
-	if err := c.reconcileSingletonByBdg(ctx, key); err != nil {
+	if err := c.alsoReconcileSingletonByBdg(ctx, key); err != nil {
 		return err
 	}
 

--- a/pkg/status/binding.go
+++ b/pkg/status/binding.go
@@ -40,7 +40,7 @@ func (c *Controller) syncBinding(ctx context.Context, key string) error {
 		c.workqueue.AddAfter(combinedStatusRef(combinedStatus.ObjectName.AsNamespacedName().String()), queueingDelay)
 	}
 
-	if err := c.alsoReconcileSingletonByBdg(ctx, key); err != nil {
+	if err := c.reconcileSingletonByBdg(ctx, key); err != nil {
 		return err
 	}
 

--- a/pkg/status/singletonstatus.go
+++ b/pkg/status/singletonstatus.go
@@ -33,14 +33,14 @@ func (c *Controller) reconcileSingletonByBdg(ctx context.Context, bdgName string
 	for i := range wObjIDs {
 		wObjID, r, n := wObjIDs[i], requested[i], nWECs[i]
 		if !r || n != 1 {
-			logger.V(4).Info("Singleton workload object should not have status synced, cleaning",
+			logger.V(4).Info("Workload object should not have singleton status synced, cleaning",
 				"resource", wObjID.Resource, "objectName", wObjID.ObjectName,
 				"requested", r, "nWECs", n)
 			if err := c.reconcileSingletonWObj(ctx, wObjID, false); err != nil {
 				return err
 			}
 		} else {
-			logger.V(4).Info("Singleton workload object should have status synced, updating",
+			logger.V(4).Info("Workload object should have singleton status synced, updating",
 				"resource", wObjID.Resource, "objectName", wObjID.ObjectName)
 			if err := c.reconcileSingletonWObj(ctx, wObjID, true); err != nil {
 				return err
@@ -57,12 +57,12 @@ func (c *Controller) reconcileSingletonByWS(ctx context.Context, ref singletonWo
 
 	requested, nWECs := c.bindingPolicyResolver.GetSingletonReportedStateRequestForObject(wObjID)
 	if !requested || nWECs != 1 {
-		logger.V(4).Info("Singleton workload object should not have status synced, cleaning",
+		logger.V(4).Info("Workload object should not have singleton status synced, cleaning",
 			"resource", ref.SourceObjectIdentifier.Resource, "objectName", ref.SourceObjectIdentifier.ObjectName,
 			"requested", requested, "nWECs", nWECs)
 		return c.reconcileSingletonWObj(ctx, wObjID, false)
 	} else {
-		logger.V(4).Info("Singleton workload object should have status synced, updating",
+		logger.V(4).Info("Workload object should have singleton status synced, updating",
 			"resource", ref.SourceObjectIdentifier.Resource, "objectName", ref.SourceObjectIdentifier.ObjectName)
 		wsObj, err := c.workStatusLister.ByNamespace(ref.WECName).Get(ref.Name)
 		if err != nil {
@@ -82,7 +82,7 @@ func (c *Controller) reconcileSingletonByWS(ctx context.Context, ref singletonWo
 
 func (c *Controller) reconcileSingletonWObj(ctx context.Context, wObjID util.ObjectIdentifier, sync bool) error {
 	logger := klog.FromContext(ctx)
-	logger.V(4).Info("Reconciling singleton workload object", "resource", wObjID.Resource, "objectName", wObjID.ObjectName)
+	logger.V(4).Info("Reconciling workload object for singleton status", "resource", wObjID.Resource, "objectName", wObjID.ObjectName)
 
 	if !sync {
 		emptyStatus := make(map[string]interface{})

--- a/pkg/status/singletonstatus.go
+++ b/pkg/status/singletonstatus.go
@@ -18,63 +18,14 @@ package status
 
 import (
 	"context"
-	"fmt"
 
-	"k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
-	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/client-go/tools/cache"
 	"k8s.io/klog/v2"
 
-	"github.com/kubestellar/kubestellar/api/control/v1alpha1"
 	"github.com/kubestellar/kubestellar/pkg/util"
 )
 
-// reconcileSingletonByBdg goes over the binding-covered workload objects, decides sync or not for each of the workload objects,
-// then maintains their statuses based on the decisions.
 func (c *Controller) reconcileSingletonByBdg(ctx context.Context, bdgName string) error {
-	logger := klog.FromContext(ctx)
-	logger.V(4).Info("Reconciling singleton status due to binding change", "binding", bdgName)
-
-	binding, err := c.wdsKsClient.ControlV1alpha1().Bindings().Get(ctx, bdgName, metav1.GetOptions{})
-	if err != nil {
-		if errors.IsNotFound(err) {
-			// A deleted Binding is equivalent to one that references zero workload objects
-			return nil
-		}
-		return fmt.Errorf("could not get binding %s: %w", bdgName, err)
-	}
-
-	sync := make(map[util.ObjectIdentifier]bool)
-	if err = c.checkSingletonWorkloadInBinding(ctx, *binding, sync, true); err != nil {
-		return err
-	}
-
-	allBdgs, err := c.wdsKsClient.ControlV1alpha1().Bindings().List(ctx, metav1.ListOptions{})
-	if err != nil {
-		return err
-	}
-
-	for _, bdg := range allBdgs.Items {
-		if bdg.Name == binding.Name {
-			continue
-		}
-		if err = c.checkSingletonWorkloadInBinding(ctx, bdg, sync, false); err != nil {
-			return err
-		}
-	}
-
-	for wObjIdentifier, v := range sync {
-		if err := c.reconcileSingletonWObj(ctx, wObjIdentifier, v); err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
-func (c *Controller) alsoReconcileSingletonByBdg(ctx context.Context, bdgName string) error {
 	logger := klog.FromContext(ctx)
 	logger.V(4).Info("Reconciling singleton status due to binding change", "binding", bdgName)
 
@@ -97,6 +48,36 @@ func (c *Controller) alsoReconcileSingletonByBdg(ctx context.Context, bdgName st
 		}
 	}
 	return nil
+}
+
+func (c *Controller) reconcileSingletonByWS(ctx context.Context, ref singletonWorkStatusRef) error {
+	logger := klog.FromContext(ctx)
+	logger.V(4).Info("Reconciling singleton status due to workstatus changes", "name", string(ref.Name))
+	wObjID := ref.SourceObjectIdentifier
+
+	requested, nWECs := c.bindingPolicyResolver.GetSingletonReportedStateRequestForObject(wObjID)
+	if !requested || nWECs != 1 {
+		logger.V(4).Info("Singleton workload object should not have status synced, cleaning",
+			"resource", ref.SourceObjectIdentifier.Resource, "objectName", ref.SourceObjectIdentifier.ObjectName,
+			"requested", requested, "nWECs", nWECs)
+		return c.reconcileSingletonWObj(ctx, wObjID, false)
+	} else {
+		logger.V(4).Info("Singleton workload object should have status synced, updating",
+			"resource", ref.SourceObjectIdentifier.Resource, "objectName", ref.SourceObjectIdentifier.ObjectName)
+		wsObj, err := c.workStatusLister.ByNamespace(ref.WECName).Get(ref.Name)
+		if err != nil {
+			return err
+		}
+		status, err := util.GetWorkStatusStatus(wsObj)
+		if err != nil {
+			return err
+		}
+		if status == nil {
+			return nil
+		}
+		logger.V(4).Info("Updating singleton status", "workstatus", ref.Name, "wecName", ref.WECName)
+		return updateObjectStatus(ctx, &wObjID, status, c.listers, c.wdsDynClient)
+	}
 }
 
 func (c *Controller) reconcileSingletonWObj(ctx context.Context, wObjID util.ObjectIdentifier, sync bool) error {
@@ -128,166 +109,6 @@ func (c *Controller) reconcileSingletonWObj(ctx context.Context, wObjID util.Obj
 		}
 		logger.V(4).Info("Updating singleton status", "workstatus", wsRef.Name, "wecName", wsRef.WECName)
 		return updateObjectStatus(ctx, &wsRef.SourceObjectIdentifier, status, c.listers, c.wdsDynClient)
-	}
-	return nil
-}
-
-// reconcileSingletonByWs decides sync or not for the corresponding workload object,
-// then maintains its status based on the decision.
-func (c *Controller) reconcileSingletonByWs(ctx context.Context, ref singletonWorkStatusRef) error {
-	logger := klog.FromContext(ctx)
-	logger.V(4).Info("Reconciling singleton status due to workstatus changes", "name", string(ref.Name))
-
-	wObjID := ref.SourceObjectIdentifier
-	wObjGVR := wObjID.GVR()
-	lister, found := c.listers.Get(wObjGVR)
-	if !found {
-		return fmt.Errorf("could not get lister for gvr: %s", wObjGVR)
-	}
-
-	var wObj runtime.Object
-	var err error
-	if wObjID.ObjectName.Namespace != "" {
-		wObj, err = lister.ByNamespace(wObjID.ObjectName.Namespace).Get(wObjID.ObjectName.Name)
-	} else {
-		wObj, err = lister.Get(wObjID.ObjectName.Name)
-	}
-	if err != nil {
-		return err
-	}
-
-	labels := wObj.(metav1.Object).GetLabels()
-	if v, ok := labels[util.BindingPolicyLabelSingletonStatusKey]; !ok {
-		return nil
-	} else if v == util.BindingPolicyLabelSingletonStatusValueUnset {
-		return c.reconcileSingletonWObj(ctx, wObjID, false)
-	}
-
-	sync := map[util.ObjectIdentifier]bool{wObjID: false}
-	allBdgs, err := c.wdsKsClient.ControlV1alpha1().Bindings().List(ctx, metav1.ListOptions{})
-	if err != nil {
-		return err
-	}
-	for _, bdg := range allBdgs.Items {
-		if err = c.checkSingletonWorkloadInBinding(ctx, bdg, sync, false); err != nil {
-			return err
-		}
-	}
-
-	if !sync[wObjID] {
-		logger.V(4).Info("Singleton workload object should not have status synced, cleaning",
-			"resource", ref.SourceObjectIdentifier.Resource, "objectName", ref.SourceObjectIdentifier.ObjectName)
-		return c.reconcileSingletonWObj(ctx, wObjID, false)
-	} else {
-		logger.V(4).Info("Singleton workload object should have status synced, updating",
-			"resource", ref.SourceObjectIdentifier.Resource, "objectName", ref.SourceObjectIdentifier.ObjectName)
-		wsObj, err := c.workStatusLister.ByNamespace(ref.WECName).Get(ref.Name)
-		if err != nil {
-			return err
-		}
-		status, err := util.GetWorkStatusStatus(wsObj)
-		if err != nil {
-			return err
-		}
-		if status == nil {
-			return nil
-		}
-		return updateObjectStatus(ctx, &wObjID, status, c.listers, c.wdsDynClient)
-	}
-}
-
-func (c *Controller) alsoReconcileSingletonByWS(ctx context.Context, ref singletonWorkStatusRef) error {
-	logger := klog.FromContext(ctx)
-	logger.V(4).Info("Reconciling singleton status due to workstatus changes", "name", string(ref.Name))
-	wObjID := ref.SourceObjectIdentifier
-
-	requested, nWECs := c.bindingPolicyResolver.GetSingletonReportedStateRequestForObject(wObjID)
-	if !requested || nWECs != 1 {
-		logger.V(4).Info("Singleton workload object should not have status synced, cleaning",
-			"resource", ref.SourceObjectIdentifier.Resource, "objectName", ref.SourceObjectIdentifier.ObjectName,
-			"requested", requested, "nWECs", nWECs)
-		return c.reconcileSingletonWObj(ctx, wObjID, false)
-	} else {
-		logger.V(4).Info("Singleton workload object should have status synced, updating",
-			"resource", ref.SourceObjectIdentifier.Resource, "objectName", ref.SourceObjectIdentifier.ObjectName)
-		wsObj, err := c.workStatusLister.ByNamespace(ref.WECName).Get(ref.Name)
-		if err != nil {
-			return err
-		}
-		status, err := util.GetWorkStatusStatus(wsObj)
-		if err != nil {
-			return err
-		}
-		if status == nil {
-			return nil
-		}
-		logger.V(4).Info("Updating singleton status", "workstatus", ref.Name, "wecName", ref.WECName)
-		return updateObjectStatus(ctx, &wObjID, status, c.listers, c.wdsDynClient)
-	}
-}
-
-func (c *Controller) checkSingletonWorkloadInBinding(ctx context.Context, binding v1alpha1.Binding, sync map[util.ObjectIdentifier]bool, init bool) error {
-	logger := klog.FromContext(ctx)
-	logger.V(5).Info("Checking singleton workload object", "binding", binding.Name)
-	for _, item := range binding.Spec.Workload.NamespaceScope {
-		nsWObjRef := item.NamespaceScopeDownsyncObject
-		lister, found := c.listers.Get(schema.GroupVersionResource(nsWObjRef.GroupVersionResource))
-		if !found {
-			return fmt.Errorf("could not get lister for gvr: %s", nsWObjRef.GroupVersionResource)
-		}
-		nsWObj, err := lister.ByNamespace(nsWObjRef.Namespace).Get(nsWObjRef.Name)
-		if err != nil {
-			return err
-		}
-		labels := nsWObj.(metav1.Object).GetLabels()
-		if v, ok := labels[util.BindingPolicyLabelSingletonStatusKey]; ok {
-			wObjIdentifier := util.ObjectIdentifier{
-				GVK:        schema.GroupVersionKind{Group: nsWObjRef.Group, Version: nsWObjRef.Version, Kind: nsWObj.GetObjectKind().GroupVersionKind().Kind},
-				Resource:   nsWObjRef.Resource,
-				ObjectName: cache.NewObjectName(nsWObjRef.Namespace, nsWObjRef.Name),
-			}
-			if init {
-				sync[wObjIdentifier] = false // hold a place
-			} else {
-				if _, ok = sync[wObjIdentifier]; !ok {
-					continue
-				}
-			}
-			if v == util.BindingPolicyLabelSingletonStatusValueSet && binding.GetDeletionTimestamp() == nil && len(binding.Spec.Destinations) > 0 {
-				logger.V(5).Info("Singleton workload object should have status synced because of binding", "resource", wObjIdentifier.Resource, "objectName", wObjIdentifier.ObjectName, "binding", binding.Name)
-				sync[wObjIdentifier] = true
-			}
-		}
-	}
-	for _, item := range binding.Spec.Workload.ClusterScope {
-		cWObjRef := item.ClusterScopeDownsyncObject
-		lister, found := c.listers.Get(schema.GroupVersionResource(cWObjRef.GroupVersionResource))
-		if !found {
-			return fmt.Errorf("could not get lister for gvr: %s", cWObjRef.GroupVersionResource)
-		}
-		clusterWObj, err := lister.Get(cWObjRef.Name)
-		if err != nil {
-			return err
-		}
-		labels := clusterWObj.(metav1.Object).GetLabels()
-		if v, ok := labels[util.BindingPolicyLabelSingletonStatusKey]; ok {
-			wObjIdentifier := util.ObjectIdentifier{
-				GVK:        schema.GroupVersionKind{Group: cWObjRef.Group, Version: cWObjRef.Version, Kind: clusterWObj.GetObjectKind().GroupVersionKind().Kind},
-				Resource:   cWObjRef.Resource,
-				ObjectName: cache.NewObjectName("", cWObjRef.Name),
-			}
-			if init {
-				sync[wObjIdentifier] = false // hold a place
-			} else {
-				if _, ok = sync[wObjIdentifier]; !ok {
-					continue
-				}
-			}
-			if v == util.BindingPolicyLabelSingletonStatusValueSet && binding.GetDeletionTimestamp() == nil && len(binding.Spec.Destinations) > 0 {
-				logger.V(5).Info("Singleton workload object should have status synced because of binding", "resource", wObjIdentifier.Resource, "objectName", wObjIdentifier.ObjectName, "binding", binding.Name)
-				sync[wObjIdentifier] = true
-			}
-		}
 	}
 	return nil
 }

--- a/pkg/status/workstatus.go
+++ b/pkg/status/workstatus.go
@@ -77,7 +77,7 @@ func (c *Controller) syncWorkStatus(ctx context.Context, ref workStatusRef) erro
 }
 
 func (c *Controller) syncSingletonWorkStatus(ctx context.Context, ref singletonWorkStatusRef) error {
-	if err := c.reconcileSingletonByWs(ctx, ref); err != nil {
+	if err := c.alsoReconcileSingletonByWS(ctx, ref); err != nil {
 		return err
 	}
 	return c.syncWorkStatus(ctx, workStatusRef(ref))

--- a/pkg/status/workstatus.go
+++ b/pkg/status/workstatus.go
@@ -77,7 +77,7 @@ func (c *Controller) syncWorkStatus(ctx context.Context, ref workStatusRef) erro
 }
 
 func (c *Controller) syncSingletonWorkStatus(ctx context.Context, ref singletonWorkStatusRef) error {
-	if err := c.alsoReconcileSingletonByWS(ctx, ref); err != nil {
+	if err := c.reconcileSingletonByWS(ctx, ref); err != nil {
 		return err
 	}
 	return c.syncWorkStatus(ctx, workStatusRef(ref))


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
This PR uses some existing data structures and logic in (also adds some to) the binding controller, to help the status controller handle singleton statuses.

Now status controller
    - doesn’t have functionally duplicated code;
    - doesn't have to read the `managed-by.kubestellar.io/singletonstatus` label when reconciling singleton statuses.

## Related issue(s)

Fixes #
