### PR TITLE
🌱 Stop messing with singletonstatus label

### DIFF
--- a/pkg/status/workstatus.go
+++ b/pkg/status/workstatus.go
@@ -79,13 +79,6 @@ func (c *Controller) syncWorkStatus(ctx context.Context, ref workStatusRef) erro
 	return nil
 }
 
-func (c *Controller) syncSingletonWorkStatus(ctx context.Context, ref singletonWorkStatusRef) error {
-	if err := c.reconcileSingletonByWS(ctx, ref); err != nil {
-		return err
-	}
-	return c.syncWorkStatus(ctx, workStatusRef(ref))
-}
-
 func updateObjectStatus(ctx context.Context, objectIdentifier util.ObjectIdentifier, status map[string]interface{},
 	listers util.ConcurrentMap[schema.GroupVersionResource, cache.GenericLister], wdsDynClient dynamic.Interface) error {
 	logger := klog.FromContext(ctx)

--- a/pkg/util/labels.go
+++ b/pkg/util/labels.go
@@ -28,14 +28,8 @@ import (
 )
 
 const (
-	// BindingPolicyLabelSingletonStatusKey is the key for the singleton status reporting requirement.
-	BindingPolicyLabelSingletonStatusKey = "managed-by.kubestellar.io/singletonstatus"
 	// WorkStatusSourceRefKey is the key for the source reference in the WorkStatus.
 	WorkStatusSourceRefKey = "managed-by.kubestellar.io/sourceRef"
-	// BindingPolicyLabelSingletonStatusValueSet is the value when the status reporting is required.
-	BindingPolicyLabelSingletonStatusValueSet = "true"
-	// BindingPolicyLabelSingletonStatusValueUnset is the value when the status reporting is not required.
-	BindingPolicyLabelSingletonStatusValueUnset = "false"
 )
 
 func GetBindingPolicyGVR() schema.GroupVersionResource {


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
This PR removes the code that does stuff with the label whose name (key) is defined at https://github.com/kubestellar/kubestellar/blob/51e221c3f8ae167c1d7ae35c91947346bd9559c5/pkg/util/labels.go#L31-L32 . 

## Related issue(s)

Fixes #2421
