### PR TITLE
🌱 Stop using singletonstatus label

### DIFF
--- a/cmd/controller-manager/main.go
+++ b/cmd/controller-manager/main.go
@@ -177,7 +177,7 @@ func main() {
 				break
 			}
 			if (i & (i - 1)) == 0 {
-				setupLog.Info("Not statrting status controller yet because WorkStatus is not defined in the ITS")
+				setupLog.Info("Not creating status controller yet because WorkStatus is not defined in the ITS")
 			}
 			i++
 			time.Sleep(15 * time.Second)
@@ -215,9 +215,13 @@ func main() {
 	select {}
 }
 
+// workloadEventRelay implements binding.WorkloadEventHandler and relays the notifications
+// to the status controller.
 type workloadEventRelay struct {
 	statusController *status.Controller
 }
+
+var _ binding.WorkloadEventHandler = &workloadEventRelay{}
 
 func (wer *workloadEventRelay) HandleWorkloadObjectEvent(gvr schema.GroupVersionResource, oldObj, obj util.MRObject, eventType binding.WorkloadEventType, wasDeletedFinalStateUnknown bool) {
 	if wer.statusController != nil {

--- a/pkg/abstract/map-map.go
+++ b/pkg/abstract/map-map.go
@@ -46,6 +46,13 @@ func (wrapper MapValueMapper[Key, Val, Mapped]) Get(key Key) (Mapped, bool) {
 	return wrapper.mapVal(val), true
 }
 
+func (wrapper MapValueMapper[Key, Val, Mapped]) ContGet(key Key, cont func(Mapped)) {
+	val, have := wrapper.inner.Get(key)
+	if have {
+		cont(wrapper.mapVal(val))
+	}
+}
+
 func (wrapper MapValueMapper[Key, Val, Mapped]) Iterate2(yield func(Key, Mapped) error) error {
 	return wrapper.inner.Iterate2(func(key Key, val Val) error {
 		mapped := wrapper.mapVal(val)

--- a/pkg/abstract/map-to-comparable.go
+++ b/pkg/abstract/map-to-comparable.go
@@ -1,0 +1,144 @@
+/*
+Copyright 2024 The KubeStellar Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package abstract
+
+import (
+	"sync"
+
+	"k8s.io/apimachinery/pkg/util/sets"
+)
+
+// MutableMapToComparable is an indexed mutable map where
+// the domain and range types are both comparable.
+type MutableMapToComparable[Key, Val comparable] interface {
+	MutableMap[Key, Val]
+
+	ReadInverse() MapToLocked[Val, sets.Set[Key]]
+}
+
+type IndexedMapToComparable[Key, Val comparable] struct {
+	forward MutableMap[Key, Val]
+	reverse MutableMap[Val, sets.Set[Key]]
+}
+
+func NewPrimitiveMapToComparable[Key, Val comparable]() *IndexedMapToComparable[Key, Val] {
+	return &IndexedMapToComparable[Key, Val]{
+		forward: AsPrimitiveMap(map[Key]Val{}),
+		reverse: AsPrimitiveMap(map[Val]sets.Set[Key]{}),
+	}
+}
+
+var _ MutableMapToComparable[string, int] = &IndexedMapToComparable[string, int]{}
+
+func (imc *IndexedMapToComparable[Key, Val]) Length() int {
+	return imc.forward.Length()
+}
+
+func (imc *IndexedMapToComparable[Key, Val]) ContGet(key Key, cont func(Val)) {
+	imc.forward.ContGet(key, cont)
+}
+
+func (imc *IndexedMapToComparable[Key, Val]) Get(key Key) (Val, bool) {
+	return imc.forward.Get(key)
+}
+
+func (imc *IndexedMapToComparable[Key, Val]) Put(key Key, val Val) (Val, bool) {
+	oldVal, had := imc.forward.Put(key, val)
+	if had {
+		oldKeys, _ := imc.reverse.Get(oldVal)
+		oldKeys.Delete(key)
+	}
+	valKeys, hadVal := imc.reverse.Get(val)
+	if hadVal {
+		valKeys.Insert(key)
+	} else {
+		valKeys = sets.New[Key](key)
+		imc.reverse.Put(val, valKeys)
+	}
+	return oldVal, had
+}
+
+func (imc *IndexedMapToComparable[Key, Val]) Delete(key Key) (Val, bool) {
+	oldVal, had := imc.forward.Delete(key)
+	if had {
+		oldKeys, _ := imc.reverse.Get(oldVal)
+		oldKeys.Delete(key)
+	}
+	return oldVal, had
+}
+
+func (imc *IndexedMapToComparable[Key, Val]) Iterate2(yield func(Key, Val) error) error {
+	return imc.forward.Iterate2(yield)
+}
+
+func (imc *IndexedMapToComparable[Key, Val]) ReadInverse() MapToLocked[Val, sets.Set[Key]] {
+	return imc.reverse
+}
+
+type LockedMapToComparable[Key, Val comparable] struct {
+	lock  *sync.RWMutex
+	inner MutableMapToComparable[Key, Val]
+}
+
+func NewLockedMapToComparable[Key, Val comparable](lock *sync.RWMutex, inner MutableMapToComparable[Key, Val]) *LockedMapToComparable[Key, Val] {
+	if lock == nil {
+		lock = new(sync.RWMutex)
+	}
+	return &LockedMapToComparable[Key, Val]{lock, inner}
+}
+
+var _ MutableMapToComparable[int, bool] = &LockedMapToComparable[int, bool]{}
+
+func (lmc *LockedMapToComparable[Key, Val]) ContGet(key Key, cont func(Val)) {
+	lmc.lock.RLock()
+	defer lmc.lock.RUnlock()
+	lmc.inner.ContGet(key, cont)
+}
+
+func (lmc *LockedMapToComparable[Key, Val]) Get(key Key) (Val, bool) {
+	lmc.lock.RLock()
+	defer lmc.lock.RUnlock()
+	return lmc.inner.Get(key)
+}
+
+func (lmc *LockedMapToComparable[Key, Val]) Iterate2(yield func(Key, Val) error) error {
+	lmc.lock.RLock()
+	defer lmc.lock.RUnlock()
+	return lmc.inner.Iterate2(yield)
+}
+
+func (lmc *LockedMapToComparable[Key, Val]) Length() int {
+	lmc.lock.RLock()
+	defer lmc.lock.RUnlock()
+	return lmc.inner.Length()
+}
+
+func (lmc *LockedMapToComparable[Key, Val]) Put(key Key, val Val) (Val, bool) {
+	lmc.lock.Lock()
+	defer lmc.lock.Unlock()
+	return lmc.inner.Put(key, val)
+}
+
+func (lmc *LockedMapToComparable[Key, Val]) Delete(key Key) (Val, bool) {
+	lmc.lock.Lock()
+	defer lmc.lock.Unlock()
+	return lmc.inner.Delete(key)
+}
+
+func (lmc *LockedMapToComparable[Key, Val]) ReadInverse() MapToLocked[Val, sets.Set[Key]] {
+	return NewMapToLockedLocker(lmc.lock, lmc.inner.ReadInverse())
+}

--- a/pkg/abstract/map-to-comparable_test.go
+++ b/pkg/abstract/map-to-comparable_test.go
@@ -1,0 +1,107 @@
+/*
+Copyright 2024 The KubeStellar Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package abstract
+
+import (
+	"math/rand"
+	"sync"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/util/sets"
+)
+
+type Pair[First, Second any] struct {
+	First  First
+	Second Second
+}
+
+func NewPair[First, Second any](first First, second Second) Pair[First, Second] {
+	return Pair[First, Second]{first, second}
+}
+
+func TestLockedMapToComparable(t *testing.T) {
+	rg := rand.New(rand.NewSource(42))
+	var randMutex sync.Mutex
+	intn := func(bound int) int {
+		randMutex.Lock()
+		defer randMutex.Unlock()
+		return rg.Intn(bound)
+	}
+	for round := 1; round <= 16; round++ {
+		t.Logf("Start of round %d", round)
+		lmc := NewLockedMapToComparable[int, int](nil,
+			NewPrimitiveMapToComparable[int, int]())
+		N := 24
+		goChan := make(chan sets.Empty, N)
+		allowed := sets.New[Pair[int, int]]()
+		var allowedLock sync.Mutex
+		var wgTrigger, wgDone sync.WaitGroup
+		wgTrigger.Add(N)
+		wgDone.Add(N)
+		for i := 0; i < N; i++ {
+			go func() {
+				kv := NewPair(intn(N), intn(N))
+				add := intn(12) < 8
+				wgTrigger.Add(-1)
+				<-goChan
+				if add {
+					lmc.Put(kv.First, kv.Second)
+				} else {
+					lmc.Delete(kv.First)
+				}
+				if add {
+					allowedLock.Lock()
+					defer allowedLock.Unlock()
+					allowed.Insert(kv)
+				}
+				wgDone.Add(-1)
+			}()
+		}
+		wgTrigger.Wait()
+		close(goChan)
+		wgDone.Wait()
+		mtcCheckConsistency(t, lmc)
+		lmc.Iterate2(func(key, val int) error {
+			kv := NewPair(key, val)
+			if !allowed.Has(kv) {
+				t.Errorf("Found disallowed entry %v", kv)
+			}
+			return nil
+		})
+	}
+}
+
+func mtcCheckConsistency(t *testing.T, mtc MutableMapToComparable[int, int]) {
+	inverse := mtc.ReadInverse()
+	mtc.Iterate2(func(key, val int) error {
+		inverse.ContGet(val, func(keys sets.Set[int]) {
+			if !keys.Has(key) {
+				t.Errorf("Forward entry %v:%v not found in reverse", key, val)
+			}
+		})
+		return nil
+	})
+	inverse.Iterate2(func(val int, keys sets.Set[int]) error {
+		for key := range keys {
+			fwdVal, have := mtc.Get(key)
+			if !have || fwdVal != val {
+				t.Errorf("Reverse entry %v:%v mismatches forward result %v,%v", key, val, fwdVal, have)
+			}
+		}
+		return nil
+	})
+}

--- a/pkg/abstract/primitive-map-as-map.go
+++ b/pkg/abstract/primitive-map-as-map.go
@@ -16,11 +16,11 @@ limitations under the License.
 
 package abstract
 
-// PrimitiveMap is a Map implemented by a Go primitve map.
+// PrimitiveMap is a MutableMap implemented by a Go primitve map.
 type PrimitiveMap[Key comparable, Val any] map[Key]Val
 
-// Assert that PrimitiveMap implements Map
-var _ Map[int, func()] = PrimitiveMap[int, func()]{}
+// Assert that PrimitiveMap implements MutableMap
+var _ MutableMap[int, func()] = PrimitiveMap[int, func()]{}
 
 // AsPrimitiveMap makes a primitive map look like a PrimitiveMap.
 func AsPrimitiveMap[Key comparable, Val any](pm map[Key]Val) PrimitiveMap[Key, Val] {
@@ -34,6 +34,13 @@ func (pm PrimitiveMap[Key, Val]) Get(key Key) (Val, bool) {
 	return val, have
 }
 
+func (pm PrimitiveMap[Key, Val]) ContGet(key Key, cont func(Val)) {
+	val, have := pm[key]
+	if have {
+		cont(val)
+	}
+}
+
 func (pm PrimitiveMap[Key, Val]) Iterate2(yield func(Key, Val) error) error {
 	for key, val := range pm {
 		err := yield(key, val)
@@ -42,4 +49,16 @@ func (pm PrimitiveMap[Key, Val]) Iterate2(yield func(Key, Val) error) error {
 		}
 	}
 	return nil
+}
+
+func (pm PrimitiveMap[Key, Val]) Put(key Key, val Val) (Val, bool) {
+	old, had := pm[key]
+	pm[key] = val
+	return old, had
+}
+
+func (pm PrimitiveMap[Key, Val]) Delete(key Key) (Val, bool) {
+	old, had := pm[key]
+	delete(pm, key)
+	return old, had
 }

--- a/pkg/binding/binding-controller.go
+++ b/pkg/binding/binding-controller.go
@@ -34,6 +34,7 @@ import (
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	apiextensionsclientset "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
@@ -62,6 +63,18 @@ import (
 const (
 	ControllerName      = "Binding"
 	defaultResyncPeriod = time.Duration(0)
+)
+
+type WorkloadEventHandler interface {
+	HandleWorkloadObjectEvent(gvr schema.GroupVersionResource, oldObj, newObj util.MRObject, eventType WorkloadEventType, wasDeletedFinalStateUnknown bool)
+}
+
+type WorkloadEventType string
+
+const (
+	WorkloadAdd    WorkloadEventType = "add"
+	WorkloadUpdate WorkloadEventType = "update"
+	WorkloadDelete WorkloadEventType = "delete"
 )
 
 // Resource groups to exclude for watchers as they should not be delivered to other clusters
@@ -109,6 +122,7 @@ type Controller struct {
 	clusterInformer             cache.SharedIndexInformer // used for ManagedCluster in ITS
 	clusterLister               clusterlisters.ManagedClusterLister
 	dynamicClient               dynamic.Interface // used for workload
+	workloadObserver            WorkloadEventHandler
 
 	discoveryClient discovery.DiscoveryInterface                                                   // for WDS
 	namespaceClient ksmetrics.ClientModNamespace[*k8scoreapi.Namespace, *k8scoreapi.NamespaceList] // for WDS
@@ -139,7 +153,8 @@ type bindingRef string
 func NewController(parentLogger logr.Logger,
 	wdsClientMetrics, itsClientMetrics ksmetrics.ClientMetrics,
 	wdsRestConfig *rest.Config, itsRestConfig *rest.Config,
-	wdsName string, allowedGroupsSet sets.Set[string]) (*Controller, error) {
+	wdsName string, allowedGroupsSet sets.Set[string],
+	workloadObsserver WorkloadEventHandler) (*Controller, error) {
 	logger := parentLogger.WithName(ControllerName)
 
 	kubernetesClient, err := kubernetes.NewForConfig(wdsRestConfig)
@@ -193,7 +208,11 @@ func NewController(parentLogger logr.Logger,
 	}
 	clusterInformerFactory := clusterpkginformers.NewSharedInformerFactory(clusterClient, defaultResyncPeriod)
 
-	return makeController(logger, wdsClientMetrics, itsClientMetrics, ksClient.ControlV1alpha1(), ksInformerFactory.Start, ksInformerFactory.Control().V1alpha1(), dynamicClient, kubernetesClient, extClient, clusterClient, clusterInformerFactory.Start, clusterInformerFactory.Cluster().V1().ManagedClusters(), apiResourceLists, wdsName, allowedGroupsSet)
+	return makeController(logger, wdsClientMetrics, itsClientMetrics,
+		ksClient.ControlV1alpha1(), ksInformerFactory.Start, ksInformerFactory.Control().V1alpha1(),
+		dynamicClient, kubernetesClient, extClient, clusterClient,
+		clusterInformerFactory.Start, clusterInformerFactory.Cluster().V1().ManagedClusters(),
+		apiResourceLists, wdsName, allowedGroupsSet, workloadObsserver)
 }
 
 // doDiscovery contains the exact one occurence of ServerPreferredResources() in this repository.
@@ -255,7 +274,8 @@ func makeController(logger logr.Logger,
 	clusterInformerFactoryStart func(<-chan struct{}),
 	clusterPreInformer clusterinformers.ManagedClusterInformer, // used for ManagedCluster in ITS
 	apiResourceLists []*metav1.APIResourceList,
-	wdsName string, allowedGroupsSet sets.Set[string]) (*Controller, error) {
+	wdsName string, allowedGroupsSet sets.Set[string],
+	workloadObserver WorkloadEventHandler) (*Controller, error) {
 
 	ratelimiter := workqueue.NewMaxOfRateLimiter(
 		workqueue.NewItemExponentialFailureRateLimiter(5*time.Millisecond, 1000*time.Second),
@@ -278,6 +298,7 @@ func makeController(logger logr.Logger,
 		clusterInformer:             clusterInformer,
 		clusterLister:               clusterPreInformer.Lister(),
 		dynamicClient:               dynamicClient,
+		workloadObserver:            workloadObserver,
 		discoveryClient:             kubernetesClient.Discovery(),
 		namespaceClient:             ksmetrics.NewWrappedClusterScopedClient(wdsClientMetrics, k8scoreapi.SchemeGroupVersion.WithResource("namespaces"), kubernetesClient.CoreV1().Namespaces()),
 		extClient:                   ksmetrics.NewWrappedClusterScopedClient(wdsClientMetrics, apiextensionsv1.SchemeGroupVersion.WithResource("customresourcedefinitions"), extClient.ApiextensionsV1().CustomResourceDefinitions()),
@@ -395,18 +416,26 @@ func (c *Controller) run(ctx context.Context, workers int, cListers chan interfa
 
 				// add the event handler functions
 				informer.AddEventHandler(cache.ResourceEventHandlerFuncs{
+					// IMPORTANT: the loop variables `list` and `resource` cannot be used in these closures.
 					AddFunc: func(obj interface{}) {
-						// IMPORTANT: the resource loop variable cannot be used in these closures.
-						c.handleObject(obj, gvr.Resource, "add")
+						var oldObj *unstructured.Unstructured
+						c.handleObject(oldObj, obj, gvr.Resource, WorkloadAdd, false)
 					},
 					UpdateFunc: func(old, new interface{}) {
 						if shouldSkipUpdate(old, new) {
 							return
 						}
-						c.handleObject(new, gvr.Resource, "update")
+						c.handleObject(old, new, gvr.Resource, WorkloadUpdate, false)
 					},
 					DeleteFunc: func(obj interface{}) {
-						c.handleObject(obj, gvr.Resource, "delete")
+						var oldObj *unstructured.Unstructured
+						wasDeletedFinalStateUnknown := false
+						switch typed := obj.(type) {
+						case cache.DeletedFinalStateUnknown:
+							obj = typed.Obj
+							wasDeletedFinalStateUnknown = true
+						}
+						c.handleObject(oldObj, obj, gvr.Resource, WorkloadDelete, wasDeletedFinalStateUnknown)
 					},
 				})
 
@@ -590,18 +619,16 @@ func verbsSupportInformers(verbs []string) bool {
 // Event handler: enqueues the objects to be processed
 // At this time it is very simple, more complex processing might be required
 // here.
-func (c *Controller) handleObject(obj any, resource string, eventType string) {
-	wasDeletedFinalStateUnknown := false
-	switch typed := obj.(type) {
-	case cache.DeletedFinalStateUnknown:
-		obj = typed.Obj
-		wasDeletedFinalStateUnknown = true
-	}
+func (c *Controller) handleObject(oldObj, obj any, resource string, eventType WorkloadEventType, wasDeletedFinalStateUnknown bool) {
+	objMR := obj.(mrObject)
+	oldObjMR := oldObj.(mrObject)
 	c.logger.V(5).Info("Got object event", "eventType", eventType,
-		"wasDeletedFinalStateUnknown", wasDeletedFinalStateUnknown, "obj", util.RefToRuntimeObj(obj.(runtime.Object)),
+		"wasDeletedFinalStateUnknown", wasDeletedFinalStateUnknown, "obj", util.RefToRuntimeObj(objMR),
 		"resource", resource)
 
-	c.enqueueObject(obj, resource)
+	objIdentifier := util.IdentifierForObject(objMR, resource)
+	c.enqueueObjectIdentifier(objIdentifier)
+	c.workloadObserver.HandleWorkloadObjectEvent(objIdentifier.GVR(), oldObjMR, objMR, eventType, wasDeletedFinalStateUnknown)
 }
 
 // enqueueObject converts an object into an ObjectIdentifier struct which is

--- a/pkg/binding/binding-controller.go
+++ b/pkg/binding/binding-controller.go
@@ -65,7 +65,15 @@ const (
 	defaultResyncPeriod = time.Duration(0)
 )
 
+// WorkloadEventHandler is like cache.ResourceEventHandler but more convenient.
+// WorkloadEventHandler is called based on notifications from one or more informers.
+// It has one method instead of three.
+// It has the GroupVersionResource already decoded.
+// The object has already been cast to metav1.Object and runtime.Object.
 type WorkloadEventHandler interface {
+	// HandleWorkloadObjectEvent is the method called when an informer reports an add, update, or delete.
+	// For add and update, oldObj is `nil`.
+	// `wasDeletedFinalStateUnknown` is meaningful only for delete.
 	HandleWorkloadObjectEvent(gvr schema.GroupVersionResource, oldObj, newObj util.MRObject, eventType WorkloadEventType, wasDeletedFinalStateUnknown bool)
 }
 
@@ -149,7 +157,9 @@ type bindingPolicyRef string
 // bindingRef is a workqueue item that references a Binding
 type bindingRef string
 
-// Create a new binding controller
+// Create a new binding controller.
+// This controller will call the given `workloadObsserver WorkloadEventHandler` for
+// every workload object event from any of the controller's informers.
 func NewController(parentLogger logr.Logger,
 	wdsClientMetrics, itsClientMetrics ksmetrics.ClientMetrics,
 	wdsRestConfig *rest.Config, itsRestConfig *rest.Config,

--- a/pkg/binding/binding.go
+++ b/pkg/binding/binding.go
@@ -38,7 +38,7 @@ func (c *Controller) syncBinding(ctx context.Context, bindingName string) error 
 		// then the bindingpolicy has been deleted, and the binding
 		// will eventually be garbage collected. We can safely ignore this.
 
-		c.bindingPolicyResolver.Broker().NotifyCallbacks(bindingName)
+		c.bindingPolicyResolver.Broker().NotifyBindingPolicyCallbacks(bindingName)
 		return nil
 	}
 
@@ -85,7 +85,7 @@ func (c *Controller) syncBinding(ctx context.Context, bindingName string) error 
 		}
 
 		// notify the bindingpolicy resolution broker that the binding has been updated
-		c.bindingPolicyResolver.Broker().NotifyCallbacks(bindingPolicyIdentifier)
+		c.bindingPolicyResolver.Broker().NotifyBindingPolicyCallbacks(bindingPolicyIdentifier)
 	}
 	srPerObj := c.bindingPolicyResolver.GetSingletonReportedStateRequestsForBinding(bindingPolicyIdentifier)
 	policyErrors := append([]string{}, binding.Status.Errors...)

--- a/pkg/binding/bindingpolicy.go
+++ b/pkg/binding/bindingpolicy.go
@@ -50,8 +50,6 @@ const (
 //   - requeue workload objects to account for changes in bindingpolicy
 //
 // otherwise:
-//   - if binding policy wants singleton-status reported, requeue all selected
-//     workload objects to remove the singleton label.
 //   - delete the bindingpolicy's finalizer and remove its resolution.
 func (c *Controller) syncBindingPolicy(ctx context.Context, bindingPolicyName string) error {
 	logger := klog.FromContext(ctx)
@@ -105,18 +103,9 @@ func (c *Controller) syncBindingPolicy(ctx context.Context, bindingPolicyName st
 }
 
 func (c *Controller) deleteResolutionForBindingPolicy(ctx context.Context, bindingPolicyName string) error {
-	if c.bindingPolicyResolver.ResolutionRequiresSingletonReportedState(bindingPolicyName) {
-		// if the bindingpolicy required a singleton status, all selected objects should
-		// be requeued in order to remove the label
-		if err := c.requeueSelectedWorkloadObjects(ctx, bindingPolicyName); err != nil {
-			return fmt.Errorf("failed to c.requeueForBindingPolicyChanges: %w", err)
-		}
-	}
-
 	logger := klog.FromContext(ctx)
 	c.bindingPolicyResolver.DeleteResolution(bindingPolicyName)
 	logger.V(2).Info("Deleted resolution for bindingpolicy", "name", bindingPolicyName)
-
 	return nil
 }
 

--- a/pkg/binding/bindingpolicy.go
+++ b/pkg/binding/bindingpolicy.go
@@ -25,7 +25,6 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
-	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -250,10 +249,7 @@ func (c *Controller) handleBindingPolicyFinalizer(ctx context.Context, bindingPo
 	return nil
 }
 
-type mrObject interface {
-	metav1.Object
-	runtime.Object
-}
+type mrObject = util.MRObject
 
 func labelsMatchAny(logger logr.Logger, labelSet map[string]string, selectors []metav1.LabelSelector) bool {
 	for _, ls := range selectors {

--- a/pkg/status/binding.go
+++ b/pkg/status/binding.go
@@ -42,10 +42,6 @@ func (c *Controller) syncBinding(ctx context.Context, key string) error {
 		c.workqueue.AddAfter(combinedStatusRef(combinedStatus.ObjectName.AsNamespacedName().String()), queueingDelay)
 	}
 
-	if err := c.reconcileSingletonByBdg(ctx, key); err != nil {
-		return err
-	}
-
 	logger.V(5).Info("Synced Binding", "key", key)
 	return nil
 }

--- a/pkg/status/singletonstatus.go
+++ b/pkg/status/singletonstatus.go
@@ -76,7 +76,7 @@ func (c *Controller) reconcileSingletonByWS(ctx context.Context, ref workStatusR
 	if status == nil {
 		return nil
 	}
-	if err := updateObjectStatus(ctx, wObjID, status, c.listers, c.wdsDynClient); err != nil {
+	if err := c.updateObjectStatus(ctx, wObjID, status, c.listers); err != nil {
 		return err
 	}
 	logger.V(4).Info("Updated singleton status for workload object",
@@ -89,8 +89,7 @@ func (c *Controller) reconcileSingletonWObj(ctx context.Context, wObjID util.Obj
 	logger.V(4).Info("Reconciling workload object for singleton status", "gvk", wObjID.GVK, "objectName", wObjID.ObjectName, "sync", sync)
 
 	if !sync {
-		emptyStatus := make(map[string]interface{})
-		return updateObjectStatus(ctx, wObjID, emptyStatus, c.listers, c.wdsDynClient)
+		return c.updateObjectStatus(ctx, wObjID, nil, c.listers)
 	}
 
 	list, _ := c.workStatusLister.ByNamespace("").List(labels.Everything())
@@ -110,7 +109,7 @@ func (c *Controller) reconcileSingletonWObj(ctx context.Context, wObjID util.Obj
 		if status == nil {
 			return nil
 		}
-		return updateObjectStatus(ctx, wsRef.SourceObjectIdentifier, status, c.listers, c.wdsDynClient)
+		return c.updateObjectStatus(ctx, wsRef.SourceObjectIdentifier, status, c.listers)
 	}
 	return nil
 }

--- a/pkg/status/singletonstatus.go
+++ b/pkg/status/singletonstatus.go
@@ -19,53 +19,76 @@ package status
 import (
 	"context"
 
-	"k8s.io/apimachinery/pkg/labels"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/client-go/tools/cache"
 	"k8s.io/klog/v2"
 
 	"github.com/kubestellar/kubestellar/pkg/util"
 )
 
-func (c *Controller) reconcileSingletonByBdg(ctx context.Context, bdgName string) error {
+func (c *Controller) updateWorkStatusToObject(ctx context.Context, workStatusON cache.ObjectName) error {
 	logger := klog.FromContext(ctx)
-	logger.V(4).Info("Reconciling singleton status due to binding change", "binding", bdgName)
-
-	statusPerObj := c.bindingPolicyResolver.GetSingletonReportedStateRequestsForBinding(bdgName)
-	for _, status := range statusPerObj {
-		wObjID, r, n := status.ObjectId, status.WantSingletonReportedState, status.NumWECs
-		if !r || n != 1 {
-			if err := c.reconcileSingletonWObj(ctx, wObjID, false); err != nil {
-				return err
-			}
-			logger.V(4).Info("Cleaned singleton status for workload object",
-				"gvk", wObjID.GVK, "objectName", wObjID.ObjectName,
-				"requested", r, "nWECs", n)
+	logger.V(4).Info("Reconciling singleton status due to workstatus changes", "workStatus", workStatusON)
+	wsObj, err := c.workStatusLister.ByNamespace(workStatusON.Namespace).Get(workStatusON.Name)
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			wsObj = nil
 		} else {
-			if err := c.reconcileSingletonWObj(ctx, wObjID, true); err != nil {
-				return err
-			}
-			logger.V(4).Info("Updated singleton status for workload object",
-				"gvk", wObjID.GVK, "objectName", wObjID.ObjectName)
+			return err
+		}
+	}
+	if wsObj == nil {
+		objId, had := c.workStatusToObject.Delete(workStatusON)
+		if had {
+			logger.V(5).Info("Enqueuing workload object due to absense of WorkStatus", "workStatus", workStatusON, "workloadObject", objId)
+			c.workqueue.Add(workloadObjectRef{objId})
+		}
+	} else {
+		source, err := util.GetWorkStatusSourceRef(wsObj)
+		if err != nil {
+			return err
+		}
+		objId := util.ObjectIdentifierFromSourceRef(source)
+		formerSource, had := c.workStatusToObject.Put(workStatusON, objId)
+		logger.V(5).Info("Enqueuing workload object due to existence of WorkStatus", "workStatus", workStatusON, "workloadObject", objId)
+		c.workqueue.Add(workloadObjectRef{objId})
+		if had {
+			logger.V(5).Info("Enqueuing workload object due to change in WorkStatus", "workStatus", workStatusON, "workloadObject", formerSource)
+			c.workqueue.Add(workloadObjectRef{formerSource})
 		}
 	}
 	return nil
 }
 
-func (c *Controller) reconcileSingletonByWS(ctx context.Context, ref workStatusRef) error {
+func (c *Controller) syncWorkloadObject(ctx context.Context, wObjID util.ObjectIdentifier) error {
 	logger := klog.FromContext(ctx)
-	logger.V(4).Info("Reconciling singleton status due to workstatus changes", "name", string(ref.Name))
-
-	wObjID := ref.SourceObjectIdentifier
 	requested, nWECs := c.bindingPolicyResolver.GetSingletonReportedStateRequestForObject(wObjID)
-	if !requested || nWECs != 1 {
-		if err := c.reconcileSingletonWObj(ctx, wObjID, false); err != nil {
+	var wsONs [2]cache.ObjectName
+	var numWS int
+	if requested && nWECs == 1 {
+		c.workStatusToObject.ReadInverse().ContGet(wObjID, func(wsONSet sets.Set[cache.ObjectName]) {
+			numWS = wsONSet.Len()
+			var idx int
+			for it := range wsONSet {
+				wsONs[idx] = it
+				idx++
+				if idx > 1 {
+					break
+				}
+			}
+		})
+	}
+	if !requested || nWECs != 1 || numWS != 1 {
+		if err := c.updateObjectStatus(ctx, wObjID, nil, c.listers); err != nil {
 			return err
 		}
 		logger.V(4).Info("Cleaned singleton status for workload object",
-			"gvk", ref.SourceObjectIdentifier.GVK, "objectName", ref.SourceObjectIdentifier.ObjectName,
-			"requested", requested, "nWECs", nWECs)
+			"object", wObjID, "requested", requested, "nWECs", nWECs, "numWS", numWS)
 		return nil
 	}
-	wsObj, err := c.workStatusLister.ByNamespace(ref.WECName).Get(ref.Name)
+	wsON := wsONs[0]
+	wsObj, err := c.workStatusLister.ByNamespace(wsON.Namespace).Get(wsON.Name)
 	if err != nil {
 		return err
 	}
@@ -79,37 +102,6 @@ func (c *Controller) reconcileSingletonByWS(ctx context.Context, ref workStatusR
 	if err := c.updateObjectStatus(ctx, wObjID, status, c.listers); err != nil {
 		return err
 	}
-	logger.V(4).Info("Updated singleton status for workload object",
-		"gvk", ref.SourceObjectIdentifier.GVK, "objectName", ref.SourceObjectIdentifier.ObjectName)
-	return nil
-}
-
-func (c *Controller) reconcileSingletonWObj(ctx context.Context, wObjID util.ObjectIdentifier, sync bool) error {
-	logger := klog.FromContext(ctx)
-	logger.V(4).Info("Reconciling workload object for singleton status", "gvk", wObjID.GVK, "objectName", wObjID.ObjectName, "sync", sync)
-
-	if !sync {
-		return c.updateObjectStatus(ctx, wObjID, nil, c.listers)
-	}
-
-	list, _ := c.workStatusLister.ByNamespace("").List(labels.Everything())
-	for _, obj := range list {
-		wsRef, err := runtimeObjectToWorkStatusRef(obj)
-		if err != nil {
-			return err
-		}
-		sourceObjID := wsRef.SourceObjectIdentifier
-		if sourceObjID != wObjID {
-			continue
-		}
-		status, err := util.GetWorkStatusStatus(obj)
-		if err != nil {
-			return err
-		}
-		if status == nil {
-			return nil
-		}
-		return c.updateObjectStatus(ctx, wsRef.SourceObjectIdentifier, status, c.listers)
-	}
+	logger.V(4).Info("Updated singleton status for workload object", "objId", wObjID, "workStatus", wsON)
 	return nil
 }

--- a/pkg/status/singletonstatus.go
+++ b/pkg/status/singletonstatus.go
@@ -50,7 +50,7 @@ func (c *Controller) reconcileSingletonByBdg(ctx context.Context, bdgName string
 	return nil
 }
 
-func (c *Controller) reconcileSingletonByWS(ctx context.Context, ref singletonWorkStatusRef) error {
+func (c *Controller) reconcileSingletonByWS(ctx context.Context, ref workStatusRef) error {
 	logger := klog.FromContext(ctx)
 	logger.V(4).Info("Reconciling singleton status due to workstatus changes", "name", string(ref.Name))
 

--- a/pkg/status/status-controller.go
+++ b/pkg/status/status-controller.go
@@ -103,10 +103,6 @@ type combinedStatusRef string
 // statusCollectorRef is a workqueue item that references a StatusCollector
 type statusCollectorRef string
 
-// singletonWorkStatusRef is a workqueue item that references a WorkStatus
-// that is a singleton status
-type singletonWorkStatusRef workStatusRef
-
 // Create a new  status controller
 func NewController(logger logr.Logger,
 	wdsClientMetrics, itsClientMetrics ksmetrics.ClientMetrics,
@@ -336,36 +332,21 @@ func (c *Controller) runWorkStatusInformer(ctx context.Context) {
 			if objNotInThisWDS(obj, c.wdsName) {
 				return
 			}
-			c.handleWorkStatus(ctx, obj)
+			c.handleWorkStatus(ctx, "add", obj)
 		},
 		UpdateFunc: func(old, new interface{}) {
 			if objNotInThisWDS(new, c.wdsName) || shouldSkipUpdate(old, new) {
 				return
 			}
-
-			// if old has singleton status label and new does not, then we need to pass the label to
-			// handleWorkStatus for it to remove the status from the source object
-			if _, ok := old.(metav1.Object).GetLabels()[util.BindingPolicyLabelSingletonStatusKey]; ok {
-				if _, ok := new.(metav1.Object).GetLabels()[util.BindingPolicyLabelSingletonStatusKey]; !ok {
-					// add label to new object
-					labels := new.(metav1.Object).GetLabels()
-					if labels == nil {
-						labels = make(map[string]string)
-					}
-
-					labels[util.BindingPolicyLabelSingletonStatusKey] = util.BindingPolicyLabelSingletonStatusValueUnset
-				}
-			}
-			c.handleWorkStatus(ctx, new)
+			c.handleWorkStatus(ctx, "update", new)
 		},
 		DeleteFunc: func(obj interface{}) {
 			if objNotInThisWDS(obj, c.wdsName) {
 				return
 			}
-			c.handleWorkStatus(ctx, obj)
+			c.handleWorkStatus(ctx, "delete", obj)
 		},
 	})
-
 	informerFactory.Start(ctx.Done())
 
 	logger.Info("waiting for workstatus cache to sync")
@@ -395,7 +376,7 @@ func objNotInThisWDS(obj interface{}, thisWDS string) bool {
 
 // Event handler: enqueues the workstatus objects to be processed
 // At this time it is very simple, more complex processing might be required here
-func (c *Controller) handleWorkStatus(ctx context.Context, obj any) {
+func (c *Controller) handleWorkStatus(ctx context.Context, eventType string, obj any) {
 	wsRef, err := runtimeObjectToWorkStatusRef(obj.(runtime.Object))
 	if err != nil {
 		utilruntime.HandleError(err)
@@ -403,16 +384,11 @@ func (c *Controller) handleWorkStatus(ctx context.Context, obj any) {
 	}
 	logger := klog.FromContext(ctx)
 
-	_, ok := obj.(metav1.Object).GetLabels()[util.BindingPolicyLabelSingletonStatusKey]
 	logger.V(5).Info("Enqueuing reference to WorkStatus because of informer event",
 		"sourceObjectName", wsRef.SourceObjectIdentifier.ObjectName,
 		"sourceObjectGVK", wsRef.SourceObjectIdentifier.GVK, "wecName", wsRef.WECName,
-		"labeledAboutSingletonStatus", ok)
-	if !ok {
-		c.workqueue.Add(*wsRef)
-	} else {
-		c.workqueue.Add(singletonWorkStatusRef(*wsRef))
-	}
+		"eventType", eventType)
+	c.workqueue.Add(*wsRef)
 }
 
 // runWorker is a long-running function that will continually call the
@@ -469,8 +445,6 @@ func (c *Controller) reconcile(ctx context.Context, item any) error {
 	switch ref := item.(type) {
 	case workStatusRef:
 		return c.syncWorkStatus(ctx, ref)
-	case singletonWorkStatusRef:
-		return c.syncSingletonWorkStatus(ctx, ref)
 	case bindingRef:
 		return c.syncBinding(ctx, string(ref))
 	case statusCollectorRef:

--- a/pkg/status/status-controller.go
+++ b/pkg/status/status-controller.go
@@ -19,6 +19,7 @@ package status
 import (
 	"context"
 	"fmt"
+	"sync"
 	"time"
 
 	"github.com/go-logr/logr"
@@ -39,6 +40,7 @@ import (
 	"k8s.io/klog/v2"
 
 	"github.com/kubestellar/kubestellar/api/control/v1alpha1"
+	"github.com/kubestellar/kubestellar/pkg/abstract"
 	"github.com/kubestellar/kubestellar/pkg/binding"
 	ksclient "github.com/kubestellar/kubestellar/pkg/generated/clientset/versioned"
 	ksinformers "github.com/kubestellar/kubestellar/pkg/generated/informers/externalversions"
@@ -82,10 +84,23 @@ type Controller struct {
 	celEvaluator           *celEvaluator
 	bindingPolicyResolver  binding.BindingPolicyResolver
 	combinedStatusResolver CombinedStatusResolver
+
+	// workStatusToObject maps the namespace/name of WorkStatus to the ID of its workload object.
+	// This map has entries for WorkStatus objects that exist.
+	// This map is safe for concurrent access, but
+	// the Set values revealed by workStatusToObject.ReadInverse can not be retained outside of
+	// the funcs that are given them.
+	workStatusToObject abstract.MutableMapToComparable[cache.ObjectName, util.ObjectIdentifier]
+
+	mutex sync.RWMutex // used in workStatusToObject
 }
+
+type workloadObjectRef struct{ util.ObjectIdentifier }
 
 // bindingRef is a workqueue item that references a Binding
 type bindingRef string
+
+type workStatusON cache.ObjectName
 
 // workStatusRef is a workqueue item that references a WorkStatus
 type workStatusRef struct {
@@ -95,6 +110,10 @@ type workStatusRef struct {
 	WECName string
 	// SourceObjectIdentifier is the identifier of the source object
 	SourceObjectIdentifier util.ObjectIdentifier
+}
+
+func (wsr workStatusRef) ObjectName() cache.ObjectName {
+	return cache.ObjectName{Namespace: wsr.WECName, Name: wsr.Name}
 }
 
 // combinedStatusRef is a workqueue item that references a CombinedStatus
@@ -145,8 +164,35 @@ func NewController(logger logr.Logger,
 		workqueue:             workqueue.NewRateLimitingQueueWithConfig(ratelimiter, workqueue.RateLimitingQueueConfig{Name: ControllerName + "-" + wdsName}),
 		bindingPolicyResolver: bindingPolicyResolver,
 	}
+	controller.workStatusToObject = abstract.NewLockedMapToComparable(&controller.mutex,
+		abstract.NewPrimitiveMapToComparable[cache.ObjectName, util.ObjectIdentifier]())
+
+	broker := controller.bindingPolicyResolver.Broker()
+	klog.Infof("Registering callbacks with broker=%p=%v", broker, broker)
+	err = broker.RegisterCallbacks(binding.ResolutionCallbacks{
+		BindingPolicyChanged: func(bindingPolicyKey string) {
+			// add binding to workqueue
+			logger.V(5).Info("Enqueuing reference to Binding due to notification from BindingResolutionBroker", "name", bindingPolicyKey)
+			controller.workqueue.Add(bindingRef(bindingPolicyKey))
+		},
+		SingletonReportedStateRequestChanged: func(bindingPolicyKey string, objId util.ObjectIdentifier) {
+			logger.V(5).Info("Enqueuing reference to workload object due to change in singleton return request", "binding", bindingPolicyKey, "objId", objId)
+			controller.workqueue.Add(workloadObjectRef{objId})
+		}})
+	if err != nil {
+		return controller, err
+	}
+	logger.Info("Registered binding resolution broker callback")
 
 	return controller, nil
+}
+
+func (c *Controller) HandleWorkloadObjectEvent(gvr schema.GroupVersionResource, oldObj, obj util.MRObject, eventType binding.WorkloadEventType, wasDeletedFinalStateUnknown bool) {
+	objId := util.IdentifierForObject(obj, gvr.Resource)
+	labels := obj.GetLabels()
+	if _, hasLabel := labels[util.BindingPolicyLabelSingletonStatusKey]; hasLabel {
+		c.workqueue.Add(workloadObjectRef{objId})
+	}
 }
 
 // Start the status controller
@@ -202,13 +248,6 @@ func (c *Controller) run(ctx context.Context, workers int, cListers chan interfa
 
 	c.celEvaluator = celEvaluator
 	c.combinedStatusResolver = NewCombinedStatusResolver(celEvaluator, c.listers)
-
-	c.bindingPolicyResolver.Broker().RegisterCallback(func(bindingPolicyKey string) {
-		// add binding to workqueue
-		logger.V(5).Info("Enqueuing reference to Binding due to notification from BindingResolutionBroker", "name", bindingPolicyKey)
-		c.workqueue.Add(bindingRef(bindingPolicyKey))
-	}) // this will have the broker call the callback for all existing resolutions
-	logger.Info("Registered binding resolution broker callback")
 
 	logger.Info("Starting workers", "count", workers)
 	for i := 0; i < workers; i++ {
@@ -374,20 +413,18 @@ func objNotInThisWDS(obj interface{}, thisWDS string) bool {
 	return false
 }
 
-// Event handler: enqueues the workstatus objects to be processed
+// Informer event handler: enqueues the workstatus objects to be processed
 // At this time it is very simple, more complex processing might be required here
 func (c *Controller) handleWorkStatus(ctx context.Context, eventType string, obj any) {
+	logger := klog.FromContext(ctx)
 	wsRef, err := runtimeObjectToWorkStatusRef(obj.(runtime.Object))
 	if err != nil {
 		utilruntime.HandleError(err)
 		return
 	}
-	logger := klog.FromContext(ctx)
-
-	logger.V(5).Info("Enqueuing reference to WorkStatus because of informer event",
+	logger.V(5).Info("Enqueuing reference to WorkStatus because of informer event", "eventType", eventType,
 		"sourceObjectName", wsRef.SourceObjectIdentifier.ObjectName,
-		"sourceObjectGVK", wsRef.SourceObjectIdentifier.GVK, "wecName", wsRef.WECName,
-		"eventType", eventType)
+		"sourceObjectGVK", wsRef.SourceObjectIdentifier.GVK, "wecName", wsRef.WECName)
 	c.workqueue.Add(*wsRef)
 }
 
@@ -443,6 +480,8 @@ func (c *Controller) reconcile(ctx context.Context, item any) error {
 	logger := klog.FromContext(ctx)
 
 	switch ref := item.(type) {
+	case workloadObjectRef:
+		return c.syncWorkloadObject(ctx, ref.ObjectIdentifier)
 	case workStatusRef:
 		return c.syncWorkStatus(ctx, ref)
 	case bindingRef:

--- a/pkg/status/workstatus.go
+++ b/pkg/status/workstatus.go
@@ -50,6 +50,10 @@ func (ws *workStatus) Content() map[string]interface{} {
 func (c *Controller) syncWorkStatus(ctx context.Context, ref workStatusRef) error {
 	logger := klog.FromContext(ctx)
 
+	if err := c.reconcileSingletonByWS(ctx, ref); err != nil {
+		return err
+	}
+
 	workStatus := &workStatus{
 		workStatusRef: ref, //readonly
 		status:        nil,
@@ -77,13 +81,6 @@ func (c *Controller) syncWorkStatus(ctx context.Context, ref workStatusRef) erro
 	}
 
 	return nil
-}
-
-func (c *Controller) syncSingletonWorkStatus(ctx context.Context, ref singletonWorkStatusRef) error {
-	if err := c.reconcileSingletonByWS(ctx, ref); err != nil {
-		return err
-	}
-	return c.syncWorkStatus(ctx, workStatusRef(ref))
 }
 
 func updateObjectStatus(ctx context.Context, objectIdentifier util.ObjectIdentifier, status map[string]interface{},

--- a/pkg/status/workstatus.go
+++ b/pkg/status/workstatus.go
@@ -27,7 +27,6 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/klog/v2"
 
@@ -84,8 +83,12 @@ func (c *Controller) syncWorkStatus(ctx context.Context, ref workStatusRef) erro
 	return nil
 }
 
-func updateObjectStatus(ctx context.Context, objectIdentifier util.ObjectIdentifier, status map[string]interface{},
-	listers util.ConcurrentMap[schema.GroupVersionResource, cache.GenericLister], wdsDynClient dynamic.Interface) error {
+// updateObjectStatus puts returned `.status` into the given workload object
+// and updates the label indicating that this has been done, or
+// updates both to indicate that singleton status return has not been done.
+// `status == nil` indicates that singleton status return is not desired.
+func (c *Controller) updateObjectStatus(ctx context.Context, objectIdentifier util.ObjectIdentifier, status map[string]interface{},
+	listers util.ConcurrentMap[schema.GroupVersionResource, cache.GenericLister]) error {
 	logger := klog.FromContext(ctx)
 
 	if util.WEC2WDSExceptions.Has(objectIdentifier.GVK.GroupKind()) {
@@ -102,11 +105,11 @@ func updateObjectStatus(ctx context.Context, objectIdentifier util.ObjectIdentif
 
 	var obj runtime.Object
 	var err error
-	if objectIdentifier.ObjectName.Namespace == "" {
-		obj, err = lister.Get(objectIdentifier.ObjectName.Name)
-	} else {
-		obj, err = lister.ByNamespace(objectIdentifier.ObjectName.Namespace).Get(objectIdentifier.ObjectName.Name)
+	var listerIfc cache.GenericNamespaceLister = lister
+	if objectIdentifier.ObjectName.Namespace != "" {
+		listerIfc = lister.ByNamespace(objectIdentifier.ObjectName.Namespace)
 	}
+	obj, err = listerIfc.Get(objectIdentifier.ObjectName.Name)
 	if err != nil {
 		if errors.IsNotFound(err) {
 			logger.V(4).Info("Did not update workload object because it is not in local cache, presumably because it was recently deleted", "objectIdentifier", objectIdentifier)
@@ -119,30 +122,76 @@ func updateObjectStatus(ctx context.Context, objectIdentifier util.ObjectIdentif
 	if !ok {
 		return fmt.Errorf("object cannot be cast to *unstructured.Unstructured: object: %s", util.RefToRuntimeObj(obj))
 	}
+	wantReturn := status != nil
+	_, haveReturn := unstrObj.GetLabels()[util.BindingPolicyLabelSingletonStatusKey]
 
-	if apiequality.Semantic.DeepEqual(unstrObj.Object["status"], status) {
-		logger.V(5).Info("Workload object found to already have intended status", "objectIdentifier", objectIdentifier)
+	if !(wantReturn || haveReturn) {
+		logger.V(5).Info("Workload object neither wants nor has returned status", "objectIdentifier", objectIdentifier)
+		return nil
 	}
 
-	// set the status and update the object
-	unstrObj.Object["status"] = status
-
-	if objectIdentifier.ObjectName.Namespace == "" {
-		_, err = wdsDynClient.Resource(gvr).UpdateStatus(ctx, unstrObj, metav1.UpdateOptions{FieldManager: ControllerName})
-	} else {
-		_, err = wdsDynClient.Resource(gvr).Namespace(objectIdentifier.ObjectName.Namespace).UpdateStatus(ctx,
-			unstrObj, metav1.UpdateOptions{FieldManager: ControllerName})
-	}
-	if err != nil {
-		// if resource not found it may mean no status subresource - try to patch the status
-		if errors.IsNotFound(err) {
-			return util.PatchStatus(ctx, unstrObj, status, objectIdentifier.ObjectName.Namespace, gvr, wdsDynClient)
-			// PatchStatus returns nil if the full object is not found
+	if wantReturn {
+		if !haveReturn { // Ensure workload object is labeled as having returned reported state
+			err = c.handleSingletonLabel(ctx, unstrObj, objectIdentifier.GVR(), true)
+			if err != nil {
+				return err
+			}
 		}
-		return fmt.Errorf("failed to update status of %v: %w", objectIdentifier, err)
+		if apiequality.Semantic.DeepEqual(unstrObj.Object["status"], status) {
+			logger.V(5).Info("Workload object found to already have intended status", "objectIdentifier", objectIdentifier)
+			return nil
+		}
+		// set the status and update the object
+		unstrObj.Object["status"] = status
+
+		rscIfc := util.DynamicForResource(c.wdsDynClient, gvr, unstrObj.GetNamespace())
+		_, err = rscIfc.UpdateStatus(ctx, unstrObj, metav1.UpdateOptions{FieldManager: ControllerName})
+		if err != nil {
+			// if resource not found it may mean no status subresource - try to patch the status
+			if errors.IsNotFound(err) {
+				return util.PatchStatus(ctx, unstrObj, status, objectIdentifier.ObjectName.Namespace, gvr, c.wdsDynClient)
+				// PatchStatus returns nil if the full object is not found
+			}
+			return fmt.Errorf("failed to update status of %v: %w", objectIdentifier, err)
+		}
+		logger.V(5).Info("Updated status of workload object", "objectIdentifier", objectIdentifier)
+		return nil
+	} else {
+		// Need to remove the label alleging that the workload object has returned reported state
+		return c.handleSingletonLabel(ctx, unstrObj, objectIdentifier.GVR(), false)
 	}
-	logger.V(5).Info("Updated status of workload object", "objectIdentifier", objectIdentifier)
-	return nil
+}
+
+func (c *Controller) handleSingletonLabel(ctx context.Context, unstructuredObj *unstructured.Unstructured,
+	objGVR schema.GroupVersionResource, wantLabel bool) error {
+
+	labels := unstructuredObj.GetLabels() // gets a copy of the labels
+	_, foundLabel := labels[util.BindingPolicyLabelSingletonStatusKey]
+	if foundLabel == wantLabel {
+		return nil
+	}
+	message := "Added managed-by.kubestellar.io/singletonstatus label to workload object"
+	if wantLabel {
+		if labels == nil {
+			labels = map[string]string{}
+		}
+		labels[util.BindingPolicyLabelSingletonStatusKey] = "true"
+	} else {
+		message = "Removed managed-by.kubestellar.io/singletonstatus label from workload object"
+		delete(labels, util.BindingPolicyLabelSingletonStatusKey)
+	}
+	unstructuredObj = unstructuredObj.DeepCopy() // avoid mutating the original object
+	unstructuredObj.SetLabels(labels)
+	namespace := unstructuredObj.GetNamespace()
+	rscIfc := util.DynamicForResource(c.wdsDynClient, objGVR, namespace)
+	_, err := rscIfc.Update(ctx, unstructuredObj, metav1.UpdateOptions{FieldManager: ControllerName})
+	if errors.IsNotFound(err) {
+		return nil // object was deleted after getting into this function. This is not an error.
+	}
+	if err == nil {
+		klog.FromContext(ctx).V(5).Info(message, "gvr", objGVR, "namespace", namespace, "name", unstructuredObj.GetName())
+	}
+	return err
 }
 
 func runtimeObjectToWorkStatus(obj runtime.Object) (*workStatus, error) {

--- a/pkg/util/labels.go
+++ b/pkg/util/labels.go
@@ -28,14 +28,8 @@ import (
 )
 
 const (
-	// BindingPolicyLabelSingletonStatusKey is the key for the singleton status reporting requirement.
-	BindingPolicyLabelSingletonStatusKey = "managed-by.kubestellar.io/singletonstatus"
 	// WorkStatusSourceRefKey is the key for the source reference in the WorkStatus.
 	WorkStatusSourceRefKey = "managed-by.kubestellar.io/sourceRef"
-	// BindingPolicyLabelSingletonStatusValueSet is the value when the status reporting is required.
-	BindingPolicyLabelSingletonStatusValueSet = "true"
-	// BindingPolicyLabelSingletonStatusValueUnset is the value when the status reporting is not required.
-	BindingPolicyLabelSingletonStatusValueUnset = "false"
 )
 
 func GetBindingPolicyGVR() schema.GroupVersionResource {

--- a/pkg/util/labels.go
+++ b/pkg/util/labels.go
@@ -28,6 +28,9 @@ import (
 )
 
 const (
+	// BindingPolicyLabelSingletonStatusKey is the key for the singleton status reporting requirement.
+	BindingPolicyLabelSingletonStatusKey = "managed-by.kubestellar.io/singletonstatus"
+
 	// WorkStatusSourceRefKey is the key for the source reference in the WorkStatus.
 	WorkStatusSourceRefKey = "managed-by.kubestellar.io/sourceRef"
 )

--- a/test/integration/controller-manager/crd-handling_test.go
+++ b/test/integration/controller-manager/crd-handling_test.go
@@ -35,6 +35,7 @@ import (
 
 	"github.com/kubestellar/kubestellar/pkg/binding"
 	ksmetrics "github.com/kubestellar/kubestellar/pkg/metrics"
+	"github.com/kubestellar/kubestellar/pkg/util"
 )
 
 // An integration test for the binding controller.
@@ -87,7 +88,7 @@ func TestCRDHandling(t *testing.T) {
 	createCRD(t, ctx, "ManagedCluster", managedClusterCRDURL, serializer, apiextClient)
 	createCRD(t, ctx, "ManifestWork", manifestWorkCRDURL, serializer, apiextClient)
 	time.Sleep(5 * time.Second)
-	ctlr, err := binding.NewController(logger, wdsClientMetrics, itsClientMetrics, config4json, config, "test-wds", nil)
+	ctlr, err := binding.NewController(logger, wdsClientMetrics, itsClientMetrics, config4json, config, "test-wds", nil, testWorkloadObserver{})
 	if err != nil {
 		t.Fatalf("Failed to create controller: %s", err)
 	}
@@ -196,6 +197,11 @@ func TestCRDHandling(t *testing.T) {
 	}
 
 	logger.Info("Success")
+}
+
+type testWorkloadObserver struct{}
+
+func (two testWorkloadObserver) HandleWorkloadObjectEvent(gvr schema.GroupVersionResource, oldObj, obj util.MRObject, eventType binding.WorkloadEventType, wasDeletedFinalStateUnknown bool) {
 }
 
 func createCRDFromLiteral(t *testing.T, ctx context.Context, kind, literal string, serializer *k8sjson.Serializer,

--- a/test/integration/controller-manager/matching_test.go
+++ b/test/integration/controller-manager/matching_test.go
@@ -148,7 +148,7 @@ func TestMatching(t *testing.T) {
 	createCRD(t, ctx, "ManagedCluster", managedClusterCRDURL, serializer, apiextClient)
 	createCRD(t, ctx, "ManifestWork", manifestWorkCRDURL, serializer, apiextClient)
 	time.Sleep(5 * time.Second)
-	ctlr, err := binding.NewController(logger, wdsClientMetrics, itsClientMetrics, config4json, config, "test-wds", nil)
+	ctlr, err := binding.NewController(logger, wdsClientMetrics, itsClientMetrics, config4json, config, "test-wds", nil, testWorkloadObserver{})
 	if err != nil {
 		t.Fatalf("Failed to create controller: %s", err)
 	}


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
This PR updates the KubeStellar controller-manager to do nothing with labels named `managed-by.kubestellar.io/singletonstatus`. This is good because it is not necessary to run controller internal state through API object labels.

This PR also enhances some debug logging and adds a missing FieldManager attribution.

## Related issue(s)

Fixes #2420 
Fixes #2421 
Fixes #2505 