### PR TITLE
:book: update requirements.txt for Materials for MKDocs theme to properly support light/dark autoswitching

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -11,7 +11,6 @@ mkdocs-material-extensions>=1.3
 mkdocs-static-i18n==0.53
 markdown-captions==2.1.2
 Pygments>=2.16
-# pymdown-extensions==9.9.2
 pymdown-extensions>=10.2
 mkdocs-open-in-new-tab==1.0.2
 mkdocs-include-markdown-plugin==4.0.4

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -2,16 +2,17 @@ Jinja2==3.1.2
 Markdown==3.3.7
 MarkupSafe==2.1.2
 mike==1.1.2
-mkdocs==1.4.2
+mkdocs>=1.5
 mkdocs-awesome-pages-plugin==2.8.0
 mkdocs-mermaid2-plugin==1.1.1
 mkdocs-macros-plugin==0.7.0
-mkdocs-material==9.1.0
-mkdocs-material-extensions==1.1.1
+mkdocs-material>=9.5.34
+mkdocs-material-extensions>=1.3
 mkdocs-static-i18n==0.53
 markdown-captions==2.1.2
-Pygments==2.14.0
-pymdown-extensions==9.9.2
+Pygments>=2.16
+# pymdown-extensions==9.9.2
+pymdown-extensions>=10.2
 mkdocs-open-in-new-tab==1.0.2
 mkdocs-include-markdown-plugin==4.0.4
 # ../../mkdocs-include-markdown-plugin


### PR DESCRIPTION
Effect of this PR may be previewed at https://kproche.github.io/kubestellar/doc-autodark

Problem: The previous PR #2411, while it fixed the rendering issue for browsers in dark mode, did not respond properly to system settings for dark/light mode.

Investigation revealed that the auto-switching function was only supported in the **Material for MKDocs** theme after release 9.5.50, and our requirements.txt file was only specifying 9.1.0

This PR updates the Material theme specification to the latest release (9.5.34), and also specifies the mkdocs and other library component versions needed to support it properly.