### PR TITLE
🌱 Make ks/ks build transport controller container image

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -11,10 +11,34 @@ builds:
   - arm64
   env:
   - CGO_ENABLED=0
+- id: "ocm-transport-controller"
+  main: ./pkg/transport/ocm-transport-controller
+  binary: bin/ocm-transport-controller
+  ldflags:
+  - "{{ .Env.LDFLAGS }}"
+  goos:
+  - linux
+  goarch:
+  - amd64
+  - arm64
+  env:
+  - CGO_ENABLED=0
 kos:           
-  - repository: ghcr.io/kubestellar/kubestellar/controller-manager
-    main: ./cmd/controller-manager
+  - id: kubestellar-controller-manager
+    repository: ghcr.io/kubestellar/kubestellar/controller-manager
     build: controller-manager
+    tags:
+    - '{{.Version}}'
+    bare: true
+    preserve_import_paths: false
+    ldflags:
+    - "{{ .Env.LDFLAGS }}"
+    platforms:
+    - linux/amd64
+    - linux/arm64
+  - id: ocm-transport-controller
+    repository: ghcr.io/kubestellar/kubestellar/ocm-transport-controller
+    build: ocm-transport-controller
     tags:
     - '{{.Version}}'
     bare: true

--- a/docs/content/direct/packaging.md
+++ b/docs/content/direct/packaging.md
@@ -71,13 +71,15 @@ The primary product is the OCM Transport Controller, built from generic transpor
 
 ### OCM Transport Controller container image
 
-This appears at [ghcr.io/kubestellar/ocm-transport-plugin/transport-controller](https://github.com/kubestellar/ocm-transport-plugin/pkgs/container/ocm-transport-plugin%2Ftransport-controller). This will need to move to something like `ghcr.io/kubestellar/kubestellar/ocm-transport-controller`.
+For this controller, the ks/OTP repo produces a container image that appears at [ghcr.io/kubestellar/ocm-transport-plugin/transport-controller](https://github.com/kubestellar/ocm-transport-plugin/pkgs/container/ocm-transport-plugin%2Ftransport-controller).
+
+For this controller, the ks/ks repo produces a container image that appears at [ghcr.io/kubestellar/kubestellar/ocm-transport-controller](https://github.com/kubestellar/kubestellar/pkgs/container/kubestellar%2Focm-transport-controller).
 
 TODO: document how the image is built and published, including explain versioning.
 
 ### OCM Transport Controller Helm chart
 
-This appears at [ghcr.io/kubestellar/ocm-transport-plugin/chart/ocm-transport-plugin](https://github.com/kubestellar/ocm-transport-plugin/pkgs/container/ocm-transport-plugin%2Fchart%2Focm-transport-plugin). This will need to move to something like `ghcr.io/kubestellar/kubestellar/ocm-transport-controller`.
+This appears at [ghcr.io/kubestellar/ocm-transport-plugin/chart/ocm-transport-plugin](https://github.com/kubestellar/ocm-transport-plugin/pkgs/container/ocm-transport-plugin%2Fchart%2Focm-transport-plugin). This will need to move to something like `ghcr.io/kubestellar/kubestellar/ocm-transport-controller-chart`.
 
 ## KubeStellar
 
@@ -110,6 +112,8 @@ flowchart LR
     kcm_hc_repo -.-> kcm_ctr_image
     ks_pch -.-> kcm_hc_repo
     ks_pch -.-> otp_hc_repo[published OTP Helm chart]
+    otc_ctr_image["OTC container image<br>(moved)"]
+    otc_ctr_image --> otc_code
     otp_hc_repo -.-> otc_ctr_image_ur["OTC container image<br>(original)"]
     ksc_hc_repo[published KS Core chart] --> ksc_hc_src
     ksc_hc_src -.-> osa_hc_repo
@@ -369,6 +373,9 @@ flowchart LR
     kcm_hc_repo -.-> kcm_ctr_image
     ks_pch -.-> kcm_hc_repo
     ks_pch -.-> otp_hc_repo[published OTP Helm chart]
+    otc_ctr_image["OTC container image<br>(moved)"]
+    otc_ctr_image --> gtc_code
+    otc_ctr_image --> otp_code
     otp_hc_repo -.-> otc_ctr_image_ur["OTC container image<br>(original)"]
     otp_hc_repo --> otp_hc_src
     otc_ctr_image_ur --> gtc_code

--- a/docs/content/direct/packaging.md
+++ b/docs/content/direct/packaging.md
@@ -99,8 +99,7 @@ flowchart LR
     ksc_hc_src[KS Core Helm chart source]
     ks_pch[kubestellar PostCreateHook]
     ocm_pch["ocm PostCreateHook"]
-    setup_ksc["example setup<br>using core"]
-    setup_steps["example setup<br>step-by-step"]
+    setup_ksc["'Getting Started' setup"]
     e2e_local["E2E setup<br>local"]
     e2e_release["E2E setup<br>release"]
     end
@@ -119,9 +118,6 @@ flowchart LR
     ksc_hc_repo -.-> osa_hc_repo
     ksc_hc_repo -.-> otp_hc_repo
     ksc_hc_repo -.-> kcm_hc_repo
-    setup_steps -.-> ocm_pch
-    setup_steps -.-> ks_pch
-    setup_steps -.-> KubeFlex
     setup_ksc -.-> ksc_hc_repo
     setup_ksc -.-> KubeFlex
     e2e_local -.-> ocm_pch
@@ -148,7 +144,6 @@ flowchart LR
     ksc_hc_src[KS Core Helm chart source]
     ks_pch[kubestellar PostCreateHook]
     ocm_pch["ocm PostCreateHook"]
-    setup_steps["example setup<br>step-by-step"]
     e2e_local["E2E setup<br>local"]
     e2e_release["E2E setup<br>release"]
     end
@@ -162,8 +157,6 @@ flowchart LR
     ksc_hc_src -.-> cladm_image
     ksc_hc_repo -.-> cladm_image
     ksc_hc_repo -.-> helm_image
-    setup_steps -.-> ocm_pch
-    setup_steps -.-> ks_pch
     e2e_local -.-> ocm_pch
     e2e_release -.-> ocm_pch
     e2e_release -.-> ks_pch
@@ -364,8 +357,7 @@ flowchart LR
     ksc_hc_src[KS Core Helm chart source]
     ks_pch[kubestellar PostCreateHook]
     ocm_pch["ocm PostCreateHook"]
-    setup_ksc["example setup<br>using core"]
-    setup_steps["example setup<br>step-by-step"]
+    setup_ksc["'Getting Started' setup"]
     e2e_local["E2E setup<br>local"]
     e2e_release["E2E setup<br>release"]
     end
@@ -388,9 +380,6 @@ flowchart LR
     ksc_hc_repo -.-> osa_hc_repo
     ksc_hc_repo -.-> kcm_hc_repo
     ksc_hc_repo -.-> otp_hc_repo
-    setup_steps -.-> ocm_pch
-    setup_steps -.-> ks_pch
-    setup_steps -.-> KubeFlex
     setup_ksc -.-> ksc_hc_repo
     setup_ksc -.-> KubeFlex
     e2e_local -.-> ocm_pch


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
This PR continues the campaign to merge ks/OTP into ks/ks my extending the goreleaser config of ks/ks to also build the transport controller container image.

Doc preview is at https://mikespreitzer.github.io/kcp-edge-mc/doc-tport-move-2/direct/packaging/ .

FYI, documentation on how to use `ko` from `goreleaser` can be found at https://goreleaser.com/blog/goreleaser-ko/?h=ko and https://goreleaser.com/customization/ko/ . Documentation about configuring a goreleaser "build" is at https://goreleaser.com/customization/builds/ .

## Related issue(s)

This PR is built on top of #2432 and I will rebase if that one merges first.
