### PR TITLE
🌱 Improve default max-num-wrapped of transport controller

### DIFF
--- a/pkg/transport/generic/cmd/options.go
+++ b/pkg/transport/generic/cmd/options.go
@@ -17,8 +17,6 @@ limitations under the License.
 package cmd
 
 import (
-	"math"
-
 	"github.com/spf13/pflag"
 
 	ksopts "github.com/kubestellar/kubestellar/options"
@@ -39,12 +37,13 @@ type TransportOptions struct {
 }
 
 func NewTransportOptions() *TransportOptions {
+	maxSizeWrapped := 500 * 1024
 	return &TransportOptions{
 		Concurrency:            defaultConcurrency,
 		WdsClientOptions:       ksopts.NewClientOptions[*pflag.FlagSet]("wds", "accessing the WDS"),
 		TransportClientOptions: ksopts.NewClientOptions[*pflag.FlagSet]("transport", "accessing the ITS"),
-		MaxNumWrapped:          math.MaxInt,
-		MaxSizeWrapped:         500 * 1024,
+		MaxNumWrapped:          maxSizeWrapped,
+		MaxSizeWrapped:         maxSizeWrapped,
 		ProcessOptions: ksopts.ProcessOptions{
 			MetricsBindAddr: ":8090",
 			PProfBindAddr:   ":8092",


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
The PR changes the default value for the `--max-num-wrapped` command line flag of the generic transport controller. The old value was 9223372036854775807, a huge value that stuns the eyes does not correspond to anything reasonable. The new value is the same as the default for `--max-size-wrapped`, which is a much more sensible value. Each wrapped object will certainly require multiple bytes.

## Related issue(s)

Fixes #
