### PR TITLE
🌱 Make ks/ks repo publish ocm-transport-controller Helm chart

### DIFF
--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -12,7 +12,9 @@ permissions:
 env:
   REGISTRY: ghcr.io
   CONTROLLER_MANAGER_IMAGE: kubestellar/kubestellar/controller-manager
-  CHART_PATH: ./chart
+  TRANSPORT_CONTROLLER_IMAGE: kubestellar/kubestellar/ocm-transport-controller
+  CM_CHART_PATH: ./chart
+  TC_CHART_PATH: ./ocm-transport-controller-chart
   CORE_CHART_PATH: ./core-chart
 
 jobs:
@@ -61,9 +63,13 @@ jobs:
       run: |
         chartVersion=$(echo ${{ github.ref_name }} | cut -c 2-)
         make chart IMG=${{ env.REGISTRY }}/${{ env.CONTROLLER_MANAGER_IMAGE }}:${{github.ref_name}}
-        helm package ${{ env.CHART_PATH }} --destination . --version ${chartVersion} --app-version ${chartVersion}
+        helm package ${{ env.CM_CHART_PATH }} --destination . --version ${chartVersion} --app-version ${chartVersion}
         helm push ./controller-manager-chart*.tgz oci://${{ env.REGISTRY }}/kubestellar/kubestellar
+        
         sed -i "s/^KUBESTELLAR_VERSION:.*$/KUBESTELLAR_VERSION: \"${chartVersion}\"/g" ${{ env.CORE_CHART_PATH }}/values.yaml
         helm package ${{ env.CORE_CHART_PATH }} --destination . --version ${chartVersion} --app-version ${chartVersion} --dependency-update
         helm push ./core-chart*.tgz oci://${{ env.REGISTRY }}/kubestellar/kubestellar
-
+        
+        sed -i 's@OTC_IMAGE_PLACEHOLDER@${{ env.REGISTRY }}/${{ env.TRANSPORT_CONTROLLER_IMAGE }}:'"${chartVersion}"'@g' ${{ env.TC_CHART_PATH }}/templates/controller.yaml
+        helm package ${{ env.TC_CHART_PATH }} --destination . --version ${chartVersion} --app-version ${chartVersion} --dependency-update
+        helm push ./ocm-transport-controller-chart*.tgz oci://${{ env.REGISTRY }}/kubestellar/kubestellar

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -11,10 +11,34 @@ builds:
   - arm64
   env:
   - CGO_ENABLED=0
+- id: "ocm-transport-controller"
+  main: ./pkg/transport/ocm-transport-controller
+  binary: bin/ocm-transport-controller
+  ldflags:
+  - "{{ .Env.LDFLAGS }}"
+  goos:
+  - linux
+  goarch:
+  - amd64
+  - arm64
+  env:
+  - CGO_ENABLED=0
 kos:           
-  - repository: ghcr.io/kubestellar/kubestellar/controller-manager
-    main: ./cmd/controller-manager
+  - id: kubestellar-controller-manager
+    repository: ghcr.io/kubestellar/kubestellar/controller-manager
     build: controller-manager
+    tags:
+    - '{{.Version}}'
+    bare: true
+    preserve_import_paths: false
+    ldflags:
+    - "{{ .Env.LDFLAGS }}"
+    platforms:
+    - linux/amd64
+    - linux/arm64
+  - id: ocm-transport-controller
+    repository: ghcr.io/kubestellar/kubestellar/ocm-transport-controller
+    build: ocm-transport-controller
     tags:
     - '{{.Version}}'
     bare: true

--- a/docs/content/direct/packaging.md
+++ b/docs/content/direct/packaging.md
@@ -71,13 +71,15 @@ The primary product is the OCM Transport Controller, built from generic transpor
 
 ### OCM Transport Controller container image
 
-This appears at [ghcr.io/kubestellar/ocm-transport-plugin/transport-controller](https://github.com/kubestellar/ocm-transport-plugin/pkgs/container/ocm-transport-plugin%2Ftransport-controller). This will need to move to something like `ghcr.io/kubestellar/kubestellar/ocm-transport-controller`.
+For this controller, the ks/OTP repo produces a container image that appears at [ghcr.io/kubestellar/ocm-transport-plugin/transport-controller](https://github.com/kubestellar/ocm-transport-plugin/pkgs/container/ocm-transport-plugin%2Ftransport-controller).
+
+For this controller, the ks/ks repo produces a container image that appears at [ghcr.io/kubestellar/kubestellar/ocm-transport-controller](https://github.com/kubestellar/kubestellar/pkgs/container/kubestellar%2Focm-transport-controller).
 
 TODO: document how the image is built and published, including explain versioning.
 
 ### OCM Transport Controller Helm chart
 
-This appears at [ghcr.io/kubestellar/ocm-transport-plugin/chart/ocm-transport-plugin](https://github.com/kubestellar/ocm-transport-plugin/pkgs/container/ocm-transport-plugin%2Fchart%2Focm-transport-plugin). This will need to move to something like `ghcr.io/kubestellar/kubestellar/ocm-transport-controller`.
+This appears at [ghcr.io/kubestellar/ocm-transport-plugin/chart/ocm-transport-plugin](https://github.com/kubestellar/ocm-transport-plugin/pkgs/container/ocm-transport-plugin%2Fchart%2Focm-transport-plugin). This will need to move to something like `ghcr.io/kubestellar/kubestellar/ocm-transport-controller-chart`.
 
 ## KubeStellar
 
@@ -110,6 +112,8 @@ flowchart LR
     kcm_hc_repo -.-> kcm_ctr_image
     ks_pch -.-> kcm_hc_repo
     ks_pch -.-> otp_hc_repo[published OTP Helm chart]
+    otc_ctr_image["OTC container image<br>(moved)"]
+    otc_ctr_image --> otc_code
     otp_hc_repo -.-> otc_ctr_image_ur["OTC container image<br>(original)"]
     ksc_hc_repo[published KS Core chart] --> ksc_hc_src
     ksc_hc_src -.-> osa_hc_repo
@@ -369,6 +373,9 @@ flowchart LR
     kcm_hc_repo -.-> kcm_ctr_image
     ks_pch -.-> kcm_hc_repo
     ks_pch -.-> otp_hc_repo[published OTP Helm chart]
+    otc_ctr_image["OTC container image<br>(moved)"]
+    otc_ctr_image --> gtc_code
+    otc_ctr_image --> otp_code
     otp_hc_repo -.-> otc_ctr_image_ur["OTC container image<br>(original)"]
     otp_hc_repo --> otp_hc_src
     otc_ctr_image_ur --> gtc_code

--- a/docs/content/direct/packaging.md
+++ b/docs/content/direct/packaging.md
@@ -73,7 +73,7 @@ The primary product is the OCM Transport Controller, built from generic transpor
 
 For this controller, the ks/OTP repo produces a container image that appears at [ghcr.io/kubestellar/ocm-transport-plugin/transport-controller](https://github.com/kubestellar/ocm-transport-plugin/pkgs/container/ocm-transport-plugin%2Ftransport-controller).
 
-For this controller, the ks/ks repo produces a container image that appears at [ghcr.io/kubestellar/kubestellar/ocm-transport-controller](https://github.com/kubestellar/kubestellar/pkgs/container/kubestellar%2Focm-transport-controller).
+For this controller, the ks/ks repo produces a container image that appears at [ghcr.io/kubestellar/kubestellar/ocm-transport-controller](https://github.com/kubestellar/kubestellar/pkgs/container/kubestellar%2Focm-transport-controller). The image tag equals the KubeStellar release identifier (no leading `v`).
 
 TODO: document how the image is built and published, including explain versioning.
 
@@ -81,7 +81,7 @@ TODO: document how the image is built and published, including explain versionin
 
 The ks/OTP repo publishes this Helm chart at [ghcr.io/kubestellar/ocm-transport-plugin/chart/ocm-transport-plugin](https://github.com/kubestellar/ocm-transport-plugin/pkgs/container/ocm-transport-plugin%2Fchart%2Focm-transport-plugin).
 
-The ks/ks repo publishes this Helm chart at [ghcr.io/kubestellar/kubestellar/ocm-transport-controller-chart](https://github.com/kubestellar/kubestellar/pkgs/container/kubestellar/ocm-transport-controller-chart).
+The ks/ks repo publishes this Helm chart at [ghcr.io/kubestellar/kubestellar/ocm-transport-controller-chart](https://github.com/kubestellar/kubestellar/pkgs/container/kubestellar%2Focm-transport-controller-chart). The chart version equals its `appVersion`, both are the KubeStellar release identifier (no leading `v`).
 
 ## KubeStellar
 

--- a/docs/content/direct/packaging.md
+++ b/docs/content/direct/packaging.md
@@ -79,7 +79,9 @@ TODO: document how the image is built and published, including explain versionin
 
 ### OCM Transport Controller Helm chart
 
-This appears at [ghcr.io/kubestellar/ocm-transport-plugin/chart/ocm-transport-plugin](https://github.com/kubestellar/ocm-transport-plugin/pkgs/container/ocm-transport-plugin%2Fchart%2Focm-transport-plugin). This will need to move to something like `ghcr.io/kubestellar/kubestellar/ocm-transport-controller-chart`.
+The ks/OTP repo publishes this Helm chart at [ghcr.io/kubestellar/ocm-transport-plugin/chart/ocm-transport-plugin](https://github.com/kubestellar/ocm-transport-plugin/pkgs/container/ocm-transport-plugin%2Fchart%2Focm-transport-plugin).
+
+The ks/ks repo publishes this Helm chart at [ghcr.io/kubestellar/kubestellar/ocm-transport-controller-chart](https://github.com/kubestellar/kubestellar/pkgs/container/kubestellar/ocm-transport-controller-chart).
 
 ## KubeStellar
 
@@ -98,6 +100,7 @@ flowchart LR
     kcm_code[KCM source code]
     otc_code[OTC source code]
     kcm_hc_src[KCM Helm chart source]
+    otc_hc_src[OTC Helm chart source]
     ksc_hc_src[KS Core Helm chart source]
     ks_pch[kubestellar PostCreateHook]
     ocm_pch["ocm PostCreateHook"]
@@ -114,7 +117,11 @@ flowchart LR
     ks_pch -.-> otp_hc_repo[published OTP Helm chart]
     otc_ctr_image["OTC container image<br>(moved)"]
     otc_ctr_image --> otc_code
+    otc_hc_src -.-> otc_ctr_image
     otp_hc_repo -.-> otc_ctr_image_ur["OTC container image<br>(original)"]
+    otc_hc_repo[published OTC Helm chart]
+    otc_hc_repo --> otc_hc_src
+    otc_hc_repo -.-> otc_ctr_image
     ksc_hc_repo[published KS Core chart] --> ksc_hc_src
     ksc_hc_src -.-> osa_hc_repo
     ksc_hc_src -.-> otp_hc_repo
@@ -358,6 +365,7 @@ flowchart LR
     gtc_code["generic transport<br>controller code"]
     otp_code["OTP source code<br>(moved)"]
     kcm_hc_src[KCM Helm chart source]
+    otc_hc_src[OTC Helm chart source]
     ksc_hc_src[KS Core Helm chart source]
     ks_pch[kubestellar PostCreateHook]
     ocm_pch["ocm PostCreateHook"]
@@ -376,10 +384,14 @@ flowchart LR
     otc_ctr_image["OTC container image<br>(moved)"]
     otc_ctr_image --> gtc_code
     otc_ctr_image --> otp_code
+    otc_hc_src -.-> otc_ctr_image
     otp_hc_repo -.-> otc_ctr_image_ur["OTC container image<br>(original)"]
     otp_hc_repo --> otp_hc_src
     otc_ctr_image_ur --> gtc_code
     otc_ctr_image_ur --> otp_code_ur
+    otc_hc_repo[published OTC Helm chart]
+    otc_hc_repo --> otc_hc_src
+    otc_hc_repo -.-> otc_ctr_image
     ksc_hc_repo[published KS Core chart] --> ksc_hc_src
     ksc_hc_src -.-> osa_hc_repo
     ksc_hc_src -.-> kcm_hc_repo

--- a/docs/content/direct/packaging.md
+++ b/docs/content/direct/packaging.md
@@ -99,8 +99,7 @@ flowchart LR
     ksc_hc_src[KS Core Helm chart source]
     ks_pch[kubestellar PostCreateHook]
     ocm_pch["ocm PostCreateHook"]
-    setup_ksc["example setup<br>using core"]
-    setup_steps["example setup<br>step-by-step"]
+    setup_ksc["'Getting Started' setup"]
     e2e_local["E2E setup<br>local"]
     e2e_release["E2E setup<br>release"]
     end
@@ -119,9 +118,6 @@ flowchart LR
     ksc_hc_repo -.-> osa_hc_repo
     ksc_hc_repo -.-> otp_hc_repo
     ksc_hc_repo -.-> kcm_hc_repo
-    setup_steps -.-> ocm_pch
-    setup_steps -.-> ks_pch
-    setup_steps -.-> KubeFlex
     setup_ksc -.-> ksc_hc_repo
     setup_ksc -.-> KubeFlex
     e2e_local -.-> ocm_pch
@@ -148,7 +144,6 @@ flowchart LR
     ksc_hc_src[KS Core Helm chart source]
     ks_pch[kubestellar PostCreateHook]
     ocm_pch["ocm PostCreateHook"]
-    setup_steps["example setup<br>step-by-step"]
     e2e_local["E2E setup<br>local"]
     e2e_release["E2E setup<br>release"]
     end
@@ -162,8 +157,6 @@ flowchart LR
     ksc_hc_src -.-> cladm_image
     ksc_hc_repo -.-> cladm_image
     ksc_hc_repo -.-> helm_image
-    setup_steps -.-> ocm_pch
-    setup_steps -.-> ks_pch
     e2e_local -.-> ocm_pch
     e2e_release -.-> ocm_pch
     e2e_release -.-> ks_pch
@@ -364,8 +357,7 @@ flowchart LR
     ksc_hc_src[KS Core Helm chart source]
     ks_pch[kubestellar PostCreateHook]
     ocm_pch["ocm PostCreateHook"]
-    setup_ksc["example setup<br>using core"]
-    setup_steps["example setup<br>step-by-step"]
+    setup_ksc["'Getting Started' setup"]
     e2e_local["E2E setup<br>local"]
     e2e_release["E2E setup<br>release"]
     end
@@ -388,9 +380,6 @@ flowchart LR
     ksc_hc_repo -.-> osa_hc_repo
     ksc_hc_repo -.-> kcm_hc_repo
     ksc_hc_repo -.-> otp_hc_repo
-    setup_steps -.-> ocm_pch
-    setup_steps -.-> ks_pch
-    setup_steps -.-> KubeFlex
     setup_ksc -.-> ksc_hc_repo
     setup_ksc -.-> KubeFlex
     e2e_local -.-> ocm_pch

--- a/ocm-transport-controller-chart/.helmignore
+++ b/ocm-transport-controller-chart/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/ocm-transport-controller-chart/Chart.yaml
+++ b/ocm-transport-controller-chart/Chart.yaml
@@ -1,0 +1,20 @@
+# Copyright 2024 The KubeStellar Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v2
+name: ocm-transport-controller-chart
+description: Helm chart to install the OCM transport operator
+type: application
+version: 0.1.0 # automatically set by goreleaser helm package
+appVersion: 0.1.0 # automatically set by goreleaser helm package

--- a/ocm-transport-controller-chart/templates/controller.yaml
+++ b/ocm-transport-controller-chart/templates/controller.yaml
@@ -153,8 +153,8 @@ spec:
           image: OTC_IMAGE_PLACEHOLDER
           imagePullPolicy: IfNotPresent
           args:
-          - --metrics-bind-addr={{.Values.metrics_bind_addr}}
-          - --pprof-bind-addr={{.Values.pprof_bind_addr}}
+          - --metrics-bind-address={{.Values.metrics_bind_addr}}
+          - --pprof-bind-address={{.Values.pprof_bind_addr}}
           - --transport-kubeconfig=/mnt/shared/transport-kubeconfig
           - --transport-qps={{.Values.transport_qps}}
           - --transport-burst={{.Values.transport_burst}}

--- a/ocm-transport-controller-chart/templates/controller.yaml
+++ b/ocm-transport-controller-chart/templates/controller.yaml
@@ -1,0 +1,176 @@
+# Copyright 2024 The KubeStellar Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: transport-controller
+  namespace: {{.Release.Namespace}}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{.Values.wds_cp_name}}-transport-controller
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - tenancy.kflex.kubestellar.org
+  resources:
+  - controlplanes
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - tenancy.kflex.kubestellar.org
+  resources:
+  - controlplanes/status
+  verbs:
+  - get
+  - patch
+  - update
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{.Values.wds_cp_name}}-transport-controller
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{.Values.wds_cp_name}}-transport-controller
+subjects:
+  - kind: ServiceAccount
+    name: transport-controller
+    namespace: {{.Release.Namespace}}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: transport-controller-config
+  namespace: {{.Release.Namespace}}
+data:
+  get-kubeconfig.sh: |
+    #!/bin/env bash
+    # Get the in-cluster kubeconfig for KubeFlex Control Planes
+    # get-kubeconfig.sh cp_name guess_its_name
+
+    # input parameters
+    cp_name="${1%"-system"}" # cp name or cp namespace
+    guess_its_name="$2" # true: try guessing the name of the ITS CP
+
+    # check if the CP name is valid or needs to be guessed
+    while [ "$cp_name" == "" ] ; do
+      if [ "$guess_its_name" == "true" ] ; then
+        cps=$(kubectl get controlplane -l 'kflex.kubestellar.io/cptype=its' 2> /dev/null | tail -n +2)
+        case $(echo -n "$cps" | grep -c '^') in
+          (0)
+            >&2 echo "Waiting for an ITS control plane to exist..."
+            sleep 10;;
+          (1)
+            cp_name="${cps%% *}"
+            break;;
+          (*)
+            >&2 echo "ERROR: found more than one Control Plane of type its!"
+            exit 1;;
+        esac
+      else
+        >&2 echo "ERROR: no Control Plane name specified!"
+        exit 3
+      fi
+    done
+
+    # wait for the CP to exists and be ready
+    while [[ $(kubectl get controlplane "$cp_name" -o 'jsonpath={..status.conditions[?(@.type=="Ready")].status}') != "True" ]]; do
+      >&2 echo "Waiting for \"$cp_name\" control plane to exist and be ready..."
+      sleep 10
+    done
+
+    # determine the secret name and namespace
+    key=$(kubectl get controlplane $cp_name -o=jsonpath='{.status.secretRef.inClusterKey}')
+    secret_name=$(kubectl get controlplane $cp_name -o=jsonpath='{.status.secretRef.name}')
+    secret_namespace=$(kubectl get controlplane $cp_name -o=jsonpath='{.status.secretRef.namespace}')
+
+    # get the kubeconfig in base64
+    >&2 echo "Getting \"$key\" from \"$secret_name\" secret in \"$secret_namespace\" for control plane \"$cp_name\"..."
+    kubectl get secret $secret_name -n $secret_namespace -o=jsonpath="{.data.$key}"
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: transport-controller
+  namespace: {{.Release.Namespace}}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      name: transport-controller
+  template:
+    metadata:
+      labels:
+        name: transport-controller
+    spec:
+      serviceAccountName: transport-controller
+      initContainers:
+      - name: setup-wds-kubeconfig
+        image: quay.io/kubestellar/kubectl:1.27.8
+        imagePullPolicy: Always
+        command: [ "bin/sh", "-c", "sh /mnt/config/get-kubeconfig.sh '{{.Values.wds_cp_name}}' false | base64 -d > /mnt/shared/wds-kubeconfig"]
+        volumeMounts:
+        - name: config-volume
+          mountPath: /mnt/config
+        - name: shared-volume
+          mountPath: /mnt/shared
+      - name: setup-its-kubeconfig
+        image: quay.io/kubestellar/kubectl:1.27.8
+        imagePullPolicy: Always
+        command: [ "bin/sh", "-c", "sh /mnt/config/get-kubeconfig.sh '{{.Values.transport_cp_name}}' true | base64 -d > /mnt/shared/transport-kubeconfig"]
+        volumeMounts:
+        - name: config-volume
+          mountPath: /mnt/config
+        - name: shared-volume
+          mountPath: /mnt/shared
+      containers:
+        - name: transport-controller
+          image: OTC_IMAGE_PLACEHOLDER
+          imagePullPolicy: IfNotPresent
+          args:
+          - --metrics-bind-addr={{.Values.metrics_bind_addr}}
+          - --pprof-bind-addr={{.Values.pprof_bind_addr}}
+          - --transport-kubeconfig=/mnt/shared/transport-kubeconfig
+          - --transport-qps={{.Values.transport_qps}}
+          - --transport-burst={{.Values.transport_burst}}
+          - --wds-kubeconfig=/mnt/shared/wds-kubeconfig
+          - --wds-name={{.Values.wds_cp_name}}
+          - --wds-qps={{.Values.wds_qps}}
+          - --wds-burst={{.Values.wds_burst}}
+          - -v={{.Values.verbosity | default 4}}
+          volumeMounts:
+          - name: shared-volume
+            mountPath: /mnt/shared
+            readOnly: true
+      volumes:
+      - name: shared-volume
+        emptyDir: {}
+      - name: config-volume
+        configMap:
+          name: transport-controller-config
+          defaultMode: 0744

--- a/ocm-transport-controller-chart/templates/controller.yaml
+++ b/ocm-transport-controller-chart/templates/controller.yaml
@@ -163,6 +163,8 @@ spec:
           - --wds-qps={{.Values.wds_qps}}
           - --wds-burst={{.Values.wds_burst}}
           - -v={{.Values.verbosity | default 4}}
+          - --max-num-wrapped={{.Values.max_num_wrapped}}
+          - --max-size-wrapped={{.Values.max_size_wrapped}}
           volumeMounts:
           - name: shared-volume
             mountPath: /mnt/shared

--- a/ocm-transport-controller-chart/values.yaml
+++ b/ocm-transport-controller-chart/values.yaml
@@ -34,3 +34,7 @@ transport_burst: 10
 # QPS and burst for accessing the WDS
 wds_qps: 5
 wds_burst: 10
+
+# Bundling parameters
+max_num_wrapped: 512000
+max_size_wrapped: 512000

--- a/ocm-transport-controller-chart/values.yaml
+++ b/ocm-transport-controller-chart/values.yaml
@@ -1,0 +1,36 @@
+# Copyright 2024 The KubeStellar Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Set the name of the transport control plane
+transport_cp_name: ""
+
+# Set the name of the WDS control plane
+wds_cp_name: wds1
+
+# Set the controller verbosity
+verbosity: 4
+
+# [host]:port at which to listen for HTTP GET /metrics
+metrics_bind_addr: ":8090"
+
+# [host]:port at which to listen for HTTP GET /debug/pprof
+pprof_bind_addr: ":8092"
+
+# QPS and burst for accessing the ITS
+transport_qps: 5
+transport_burst: 10
+
+# QPS and burst for accessing the WDS
+wds_qps: 5
+wds_burst: 10


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
This PR continues the campaign of merging the ks/ocm-transport-plugin repo into ks/ks. The step here is moving where the Helm chart source is and where the packaged chart is published to.

Doc preview is at https://mikespreitzer.github.io/kcp-edge-mc/doc-tport-move-3/direct/packaging/ .

## Related issue(s)

This PR is based on PR #2429 and I will rebase if 2429 merges first.