### PR TITLE
🌱 Use OTC Helm chart from ks/ks instead of ks/OTP

### DIFF
--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -12,7 +12,9 @@ permissions:
 env:
   REGISTRY: ghcr.io
   CONTROLLER_MANAGER_IMAGE: kubestellar/kubestellar/controller-manager
-  CHART_PATH: ./chart
+  TRANSPORT_CONTROLLER_IMAGE: kubestellar/kubestellar/ocm-transport-controller
+  CM_CHART_PATH: ./chart
+  TC_CHART_PATH: ./ocm-transport-controller-chart
   CORE_CHART_PATH: ./core-chart
 
 jobs:
@@ -61,9 +63,13 @@ jobs:
       run: |
         chartVersion=$(echo ${{ github.ref_name }} | cut -c 2-)
         make chart IMG=${{ env.REGISTRY }}/${{ env.CONTROLLER_MANAGER_IMAGE }}:${{github.ref_name}}
-        helm package ${{ env.CHART_PATH }} --destination . --version ${chartVersion} --app-version ${chartVersion}
+        helm package ${{ env.CM_CHART_PATH }} --destination . --version ${chartVersion} --app-version ${chartVersion}
         helm push ./controller-manager-chart*.tgz oci://${{ env.REGISTRY }}/kubestellar/kubestellar
+        
         sed -i "s/^KUBESTELLAR_VERSION:.*$/KUBESTELLAR_VERSION: \"${chartVersion}\"/g" ${{ env.CORE_CHART_PATH }}/values.yaml
         helm package ${{ env.CORE_CHART_PATH }} --destination . --version ${chartVersion} --app-version ${chartVersion} --dependency-update
         helm push ./core-chart*.tgz oci://${{ env.REGISTRY }}/kubestellar/kubestellar
-
+        
+        sed -i 's@OTC_IMAGE_PLACEHOLDER@${{ env.REGISTRY }}/${{ env.TRANSPORT_CONTROLLER_IMAGE }}:'"${chartVersion}"'@g' ${{ env.TC_CHART_PATH }}/templates/controller.yaml
+        helm package ${{ env.TC_CHART_PATH }} --destination . --version ${chartVersion} --app-version ${chartVersion} --dependency-update
+        helm push ./ocm-transport-controller-chart*.tgz oci://${{ env.REGISTRY }}/kubestellar/kubestellar

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -11,10 +11,34 @@ builds:
   - arm64
   env:
   - CGO_ENABLED=0
+- id: "ocm-transport-controller"
+  main: ./pkg/transport/ocm-transport-controller
+  binary: bin/ocm-transport-controller
+  ldflags:
+  - "{{ .Env.LDFLAGS }}"
+  goos:
+  - linux
+  goarch:
+  - amd64
+  - arm64
+  env:
+  - CGO_ENABLED=0
 kos:           
-  - repository: ghcr.io/kubestellar/kubestellar/controller-manager
-    main: ./cmd/controller-manager
+  - id: kubestellar-controller-manager
+    repository: ghcr.io/kubestellar/kubestellar/controller-manager
     build: controller-manager
+    tags:
+    - '{{.Version}}'
+    bare: true
+    preserve_import_paths: false
+    ldflags:
+    - "{{ .Env.LDFLAGS }}"
+    platforms:
+    - linux/amd64
+    - linux/arm64
+  - id: ocm-transport-controller
+    repository: ghcr.io/kubestellar/kubestellar/ocm-transport-controller
+    build: ocm-transport-controller
     tags:
     - '{{.Version}}'
     bare: true

--- a/config/postcreate-hooks/kubestellar.yaml
+++ b/config/postcreate-hooks/kubestellar.yaml
@@ -184,7 +184,7 @@ spec:
               - kubestellar
               - oci://ghcr.io/kubestellar/kubestellar/controller-manager-chart
               - --version
-              - "0.24.0-alpha.2"
+              - "0.24.0-experiment.4"
               - --set
               - "ControlPlaneName={{.ControlPlaneName}}"
             env:
@@ -198,10 +198,10 @@ spec:
               - --install
               - --namespace
               - "{{.Namespace}}"
-              - ocm-transport-plugin
-              - oci://ghcr.io/kubestellar/ocm-transport-plugin/chart/ocm-transport-plugin
+              - ocm-transport-controller
+              - oci://ghcr.io/kubestellar/kubestellar/ocm-transport-controller-chart
               - --version
-              - "0.1.11"
+              - "0.24.0-experiment.4"
               - --set
               - "wds_cp_name={{.ControlPlaneName}}"
             env:

--- a/config/postcreate-hooks/kubestellar.yaml
+++ b/config/postcreate-hooks/kubestellar.yaml
@@ -184,7 +184,7 @@ spec:
               - kubestellar
               - oci://ghcr.io/kubestellar/kubestellar/controller-manager-chart
               - --version
-              - "0.24.0-experiment.4"
+              - "0.24.0-experiment.5"
               - --set
               - "ControlPlaneName={{.ControlPlaneName}}"
             env:
@@ -201,7 +201,7 @@ spec:
               - ocm-transport-controller
               - oci://ghcr.io/kubestellar/kubestellar/ocm-transport-controller-chart
               - --version
-              - "0.24.0-experiment.4"
+              - "0.24.0-experiment.5"
               - --set
               - "wds_cp_name={{.ControlPlaneName}}"
             env:

--- a/core-chart/templates/postcreatehooks/wds.yaml
+++ b/core-chart/templates/postcreatehooks/wds.yaml
@@ -197,7 +197,7 @@ spec:
             env:
             - name: XDG_CACHE_HOME
               value: /tmp/helm/.cache
-          - name: "{{"{{.HookName}}-otp"}}"
+          - name: "{{"{{.HookName}}-otc"}}"
             image: quay.io/kubestellar/helm:{{.Values.HELM_VERSION}}
             imagePullPolicy: IfNotPresent
             args:
@@ -205,10 +205,10 @@ spec:
             - --install
             - --namespace
             - "{{"{{.Namespace}}"}}"
-            - ocm-transport-plugin
-            - oci://ghcr.io/kubestellar/ocm-transport-plugin/chart/ocm-transport-plugin
+            - ocm-transport-controller
+            - oci://ghcr.io/kubestellar/kubestellar/ocm-transport-controller-chart
             - --version
-            - {{.Values.OCM_TRANSPORT_PLUGIN_VERSION}}
+            - {{.Values.KUBESTELLAR_VERSION}}
             - --set
             - "{{"wds_cp_name={{.ControlPlaneName}}"}}"
             - --set

--- a/core-chart/values.yaml
+++ b/core-chart/values.yaml
@@ -4,13 +4,12 @@
 
 
 # Container/chart image versions. These values are set during the chart release process,
-# please do not change them unless you know what your are doing.
+# please do not change them unless you know what you are doing.
 HELM_VERSION: "3.15.0"
 KUBECTL_VERSION: "1.30.1"
 KUBESTELLAR_VERSION: "0.24.0-alpha.2"
 CLUSTERADM_VERSION: "0.8.2"
 OCM_STATUS_ADDON_VERSION: "0.2.0-rc10"
-OCM_TRANSPORT_PLUGIN_VERSION: "0.1.11"
 
 
 # Control controller log verbosity

--- a/core-chart/values.yaml
+++ b/core-chart/values.yaml
@@ -7,7 +7,7 @@
 # please do not change them unless you know what you are doing.
 HELM_VERSION: "3.15.0"
 KUBECTL_VERSION: "1.30.1"
-KUBESTELLAR_VERSION: "0.24.0-alpha.2"
+KUBESTELLAR_VERSION: "0.24.0-experiment.5"
 CLUSTERADM_VERSION: "0.8.2"
 OCM_STATUS_ADDON_VERSION: "0.2.0-rc10"
 

--- a/docs/content/direct/packaging.md
+++ b/docs/content/direct/packaging.md
@@ -9,8 +9,6 @@ flowchart LR
     kubestellar --> kubeflex
     kubestellar --> ocm-status-addon
     ocm-status-addon --> kubestellar
-    ocm-transport-plugin --> kubestellar
-    kubestellar --> ocm-transport-plugin
 ```
 
 The references from ocm-status-addon to kubestellar are only in documentation and are in the process of being removed (no big difficulty is anticipated).
@@ -65,23 +63,12 @@ By our development practices and doing doing any manual hacks, we maintain the a
 
 ## OCM Transport Plugin
 
-This thing is in the midst of being moved from a separate repository into the kubestellar repository. The separate repository is [github.com/kubestellar/ocm-transport-plugin](https://github.com/kubestellar/ocm-transport-plugin).
+This repository ([github.com/kubestellar/ocm-transport-plugin](https://github.com/kubestellar/ocm-transport-plugin)) is retired. Its contents have been merged into the kubestellar repository.
 
-The primary product is the OCM Transport Controller, built from generic transport controller code plus code specific to using OCM for transport.
+The primary product was the OCM Transport Controller, built from generic transport controller code plus code specific to using OCM for transport. The published artifacts, which still linger because the GitHub is all about not forgetting things, are as follows. DO NOT USE THEM.
 
-### OCM Transport Controller container image
-
-For this controller, the ks/OTP repo produces a container image that appears at [ghcr.io/kubestellar/ocm-transport-plugin/transport-controller](https://github.com/kubestellar/ocm-transport-plugin/pkgs/container/ocm-transport-plugin%2Ftransport-controller).
-
-For this controller, the ks/ks repo produces a container image that appears at [ghcr.io/kubestellar/kubestellar/ocm-transport-controller](https://github.com/kubestellar/kubestellar/pkgs/container/kubestellar%2Focm-transport-controller). The image tag equals the KubeStellar release identifier (no leading `v`).
-
-TODO: document how the image is built and published, including explain versioning.
-
-### OCM Transport Controller Helm chart
-
-The ks/OTP repo publishes this Helm chart at [ghcr.io/kubestellar/ocm-transport-plugin/chart/ocm-transport-plugin](https://github.com/kubestellar/ocm-transport-plugin/pkgs/container/ocm-transport-plugin%2Fchart%2Focm-transport-plugin).
-
-The ks/ks repo publishes this Helm chart at [ghcr.io/kubestellar/kubestellar/ocm-transport-controller-chart](https://github.com/kubestellar/kubestellar/pkgs/container/kubestellar%2Focm-transport-controller-chart). By our development practices and not doing any manual hacking, we maintain the association that the OCI image tagged `$VERSION` contains a Helm chart that declares its `version` and its `appVersion` to be `$VERSION` and instantiates version `$VERSION` of [OCM Transport Controller container image](#ocm-transport-controller-container-image).
+- OCM Transport Controller container image. Appears at [ghcr.io/kubestellar/ocm-transport-plugin/transport-controller](https://github.com/kubestellar/ocm-transport-plugin/pkgs/container/ocm-transport-plugin%2Ftransport-controller).
+- OCM Transport Controller Helm chart. Appears at [ghcr.io/kubestellar/ocm-transport-plugin/chart/ocm-transport-plugin](https://github.com/kubestellar/ocm-transport-plugin/pkgs/container/ocm-transport-plugin%2Fchart%2Focm-transport-plugin).
 
 ## KubeStellar
 
@@ -115,7 +102,7 @@ flowchart LR
     kcm_hc_repo -.-> kcm_ctr_image
     ks_pch -.-> kcm_hc_repo
     ks_pch -.-> otc_hc_repo[published OTC Helm chart]
-    otc_ctr_image["OTC container image<br>(moved)"]
+    otc_ctr_image[OTC container image]
     otc_ctr_image --> otc_code
     otc_hc_src -.-> otc_ctr_image
     otc_hc_repo --> otc_hc_src
@@ -237,6 +224,12 @@ The [release process](release.md) builds and publishes that container image.
 `make ko-build-controller-manager-local` will make a local image for just the local
 platform. This is used in local testing.
 
+### OCM Transport Controller container image
+
+The [release process](release.md) builds and publishes this image at [ghcr.io/kubestellar/kubestellar/ocm-transport-controller](https://github.com/kubestellar/kubestellar/pkgs/container/kubestellar%2Focm-transport-controller).
+
+By our development practices and not doing any manual hacking we maintain the association that the container image tagged `$VERSION` is built from the Git commit having the Git tag `v$VERSION`.
+
 ### clusteradm container image
 
 The kubestellar GitHub repository has a script,
@@ -284,6 +277,10 @@ The chart is published at the OCI repository
 
 By our development practices and not doing any manual hacking, we maintain the association that the OCI image tagged `$VERSION` contains a Helm chart that declares its `version` and its `appVersion` to be `$VERSION` and that chart has a Deployment that uses the kubestellar-controller-manager container image tagged `$VERSION`.
 
+### OCM Transport Controller Helm chart
+
+The [release process](release.md) packages and publishes this chart at [ghcr.io/kubestellar/kubestellar/ocm-transport-controller-chart](https://github.com/kubestellar/kubestellar/pkgs/container/kubestellar%2Focm-transport-controller-chart). By our development practices and not doing any manual hacking, we maintain the association that the OCI image tagged `$VERSION` contains a Helm chart that declares its `version` and its `appVersion` to be `$VERSION` and instantiates version `$VERSION` of [OCM Transport Controller container image](#ocm-transport-controller-container-image).
+
 ### KubeFlex PostCreateHooks
 
 In addition to the two PostCreateHooks in the core Helm chart described above, there are two more PostCreateHooks defined in the `config/postcreate-hooks/` directory.
@@ -301,17 +298,17 @@ The PostCreateHook defined in `config/postcreate-hooks/ocm.yaml` gets used on an
 The PostCreateHook defined in
 `config/postcreate-hooks/kubestellar.yaml` is intended to be used in
 the hosting cluster, once per WDS, and defines a `Job` that has two containers.
-One uses [the Helm CLI image](#helm-cli-container-image) to instantiate [the KubeStellar controller-manager Helm chart](#kubestellar-controller-manager-helm-chart). The chart version appears as a literal in the PCH definition and is manually updated during the process of creating a release (see [the release process document](release.md)). The other container uses the Helm CLI image to instantiate OCM Transport Helm chart. The version to instantiate appears as a literal in the PCH definition and is manually updated after each OTP release (see [the release process doc](release.md#reacting-to-a-new-ocm-transport-plugin-release)).
+One uses [the Helm CLI image](#helm-cli-container-image) to instantiate [the KubeStellar controller-manager Helm chart](#kubestellar-controller-manager-helm-chart). The chart version appears as a literal in the PCH definition and is manually updated during the process of creating a release (see [the release process document](release.md)). The other container uses the Helm CLI image to instantiate the OCM Transport Controller Helm chart. The version to instantiate appears as a literal in the PCH definition and is also updated during the process of creating a release.
 
 ### Scripts and instructions
 
 There are instructions for using a release ([Getting Started](get-started.md) document) and a setup script for end-to-end testing(`test/e2e/common/setup-kubestellar.sh`). The end-to-end testing can either test the local copy/version of the kubestellar repo or test a release. So there are three cases to consider.
 
-#### Example setup instructions
+#### 'Getting Started' setup instructions
 
-There were two variants of the setup instructions for the examples: an older one --- which is out of service at the moment, is called "step-by-step", and uses the `ocm` and `kubestellar` PostCreateHooks --- and [Getting Started](get-started.md), which uses the [core Helm chart](#kubestellar-core-helm-chart). The latter is the preferred method, and is the only one described here.
+Although we maintained variants in the past, we now maintain just one "getting started" setup recipe. It uses the [core Helm chart](#kubestellar-core-helm-chart).
 
-The instructions are a Markdown file that displays commands for a user to execute. These start with commands that define environment variables that hold the release of ks/kubestellar and of ks/ocm-transport-plugin to use.
+The instructions are a Markdown file that displays commands for a user to execute. These start with commands that define environment variables that hold the release of ks/kubestellar to use.
 
 The instructions display a command to instantiate the core Helm chart, at the version in the relevant environment variable, requesting the creation of one ITS and one WDS.
 
@@ -333,7 +330,7 @@ The scripts builds a local kubestellar controller-manager container image from l
 
 The script temporarily updates the local kubestellar controller-manager Helm chart to reference the kubestellar controller-manager container image that was loaded into the hosting cluster. Then the script invokes the Helm CLI to instantiate that chart in the hosting cluster, configured to apply to the WDS being set up. Then the script partially undoes its temporary modification of the kubestellar controller-manager Helm chart, using `git checkout --`.
 
-The script builds a local container image for the OCM transport controller from (a) local sources for the generic part and (b) the transport plugin in a ks/ocm-transport-plugin release identified by a literal version number in the script. This version is updated as part of tracking a ks/OTP release. Then the script loads this container image into the hosting cluster. Then the setup script invokes `scripts/deploy-transport-controller.sh`, which creates a Deployment object that runs the published transport controller image using a version that appears as a literal in the script and is manually updated in the process of reacting to a new ks/OTP release.
+The script builds a local container image for the OCM transport controller from local sources for the generic part and the OCM-specific part. Then the script loads this container image into the hosting cluster. Then the setup script invokes `scripts/deploy-transport-controller.sh`, which creates a Deployment object that uses the transport controller container image reference passed on its command line.
 
 
 ## Amalgamated graph
@@ -346,10 +343,6 @@ TODO: finish this
 
 ```mermaid
 flowchart LR
-    subgraph otp_repo["ocm-transport-plugin@GitHub"]
-    otp_code_ur["OTP source code<br>(original)"]
-    otp_hc_src[OTC Helm chart source]
-    end
     subgraph osa_repo["ocm-status-addon@GitHub"]
     osa_code[OSA source code]
     osa_hc_src[OSA Helm chart source]
@@ -361,7 +354,7 @@ flowchart LR
     subgraph ks_repo["kubestellar@GitHub"]
     kcm_code[KCM source code]
     gtc_code["generic transport<br>controller code"]
-    otp_code["OTP source code<br>(moved)"]
+    otp_code[OTP source code]
     kcm_hc_src[KCM Helm chart source]
     otc_hc_src[OTC Helm chart source]
     ksc_hc_src[KS Core Helm chart source]
@@ -379,15 +372,10 @@ flowchart LR
     kcm_hc_repo -.-> kcm_ctr_image
     ks_pch -.-> kcm_hc_repo
     ks_pch -.-> otc_hc_repo[published OTC Helm chart]
-    otc_ctr_image["OTC container image<br>(moved)"]
+    otc_ctr_image[OTC container image]
     otc_ctr_image --> gtc_code
     otc_ctr_image --> otp_code
     otc_hc_src -.-> otc_ctr_image
-    otp_hc_repo -.-> otc_ctr_image_ur["OTC container image<br>(original)"]
-    otp_hc_repo --> otp_hc_src
-    otp_hc_src -.-> otc_ctr_image_ur
-    otc_ctr_image_ur --> gtc_code
-    otc_ctr_image_ur --> otp_code_ur
     otc_hc_repo --> otc_hc_src
     otc_hc_repo -.-> otc_ctr_image
     ksc_hc_repo[published KS Core chart] --> ksc_hc_src

--- a/docs/content/direct/packaging.md
+++ b/docs/content/direct/packaging.md
@@ -71,13 +71,15 @@ The primary product is the OCM Transport Controller, built from generic transpor
 
 ### OCM Transport Controller container image
 
-This appears at [ghcr.io/kubestellar/ocm-transport-plugin/transport-controller](https://github.com/kubestellar/ocm-transport-plugin/pkgs/container/ocm-transport-plugin%2Ftransport-controller). This will need to move to something like `ghcr.io/kubestellar/kubestellar/ocm-transport-controller`.
+For this controller, the ks/OTP repo produces a container image that appears at [ghcr.io/kubestellar/ocm-transport-plugin/transport-controller](https://github.com/kubestellar/ocm-transport-plugin/pkgs/container/ocm-transport-plugin%2Ftransport-controller).
+
+For this controller, the ks/ks repo produces a container image that appears at [ghcr.io/kubestellar/kubestellar/ocm-transport-controller](https://github.com/kubestellar/kubestellar/pkgs/container/kubestellar%2Focm-transport-controller).
 
 TODO: document how the image is built and published, including explain versioning.
 
 ### OCM Transport Controller Helm chart
 
-This appears at [ghcr.io/kubestellar/ocm-transport-plugin/chart/ocm-transport-plugin](https://github.com/kubestellar/ocm-transport-plugin/pkgs/container/ocm-transport-plugin%2Fchart%2Focm-transport-plugin). This will need to move to something like `ghcr.io/kubestellar/kubestellar/ocm-transport-controller`.
+This appears at [ghcr.io/kubestellar/ocm-transport-plugin/chart/ocm-transport-plugin](https://github.com/kubestellar/ocm-transport-plugin/pkgs/container/ocm-transport-plugin%2Fchart%2Focm-transport-plugin). This will need to move to something like `ghcr.io/kubestellar/kubestellar/ocm-transport-controller-chart`.
 
 ## KubeStellar
 
@@ -110,6 +112,8 @@ flowchart LR
     kcm_hc_repo -.-> kcm_ctr_image
     ks_pch -.-> kcm_hc_repo
     ks_pch -.-> otp_hc_repo[published OTP Helm chart]
+    otc_ctr_image["OTC container image<br>(moved)"]
+    otc_ctr_image --> otc_code
     otp_hc_repo -.-> otc_ctr_image_ur["OTC container image<br>(original)"]
     ksc_hc_repo[published KS Core chart] --> ksc_hc_src
     ksc_hc_src -.-> osa_hc_repo
@@ -369,6 +373,9 @@ flowchart LR
     kcm_hc_repo -.-> kcm_ctr_image
     ks_pch -.-> kcm_hc_repo
     ks_pch -.-> otp_hc_repo[published OTP Helm chart]
+    otc_ctr_image["OTC container image<br>(moved)"]
+    otc_ctr_image --> gtc_code
+    otc_ctr_image --> otp_code
     otp_hc_repo -.-> otc_ctr_image_ur["OTC container image<br>(original)"]
     otp_hc_repo --> otp_hc_src
     otc_ctr_image_ur --> gtc_code

--- a/docs/content/direct/packaging.md
+++ b/docs/content/direct/packaging.md
@@ -81,7 +81,7 @@ TODO: document how the image is built and published, including explain versionin
 
 The ks/OTP repo publishes this Helm chart at [ghcr.io/kubestellar/ocm-transport-plugin/chart/ocm-transport-plugin](https://github.com/kubestellar/ocm-transport-plugin/pkgs/container/ocm-transport-plugin%2Fchart%2Focm-transport-plugin).
 
-The ks/ks repo publishes this Helm chart at [ghcr.io/kubestellar/kubestellar/ocm-transport-controller-chart](https://github.com/kubestellar/kubestellar/pkgs/container/kubestellar%2Focm-transport-controller-chart). The chart version equals its `appVersion`, both are the KubeStellar release identifier (no leading `v`).
+The ks/ks repo publishes this Helm chart at [ghcr.io/kubestellar/kubestellar/ocm-transport-controller-chart](https://github.com/kubestellar/kubestellar/pkgs/container/kubestellar%2Focm-transport-controller-chart). By our development practices and not doing any manual hacking, we maintain the association that the OCI image tagged `$VERSION` contains a Helm chart that declares its `version` and its `appVersion` to be `$VERSION` and instantiates version `$VERSION` of [OCM Transport Controller container image](#ocm-transport-container-image).
 
 ## KubeStellar
 
@@ -124,10 +124,10 @@ flowchart LR
     otc_hc_repo -.-> otc_ctr_image
     ksc_hc_repo[published KS Core chart] --> ksc_hc_src
     ksc_hc_src -.-> osa_hc_repo
-    ksc_hc_src -.-> otp_hc_repo
+    ksc_hc_src -.-> otc_hc_repo
     ksc_hc_src -.-> kcm_hc_repo
     ksc_hc_repo -.-> osa_hc_repo
-    ksc_hc_repo -.-> otp_hc_repo
+    ksc_hc_repo -.-> otc_hc_repo
     ksc_hc_repo -.-> kcm_hc_repo
     setup_ksc -.-> ksc_hc_repo
     setup_ksc -.-> KubeFlex
@@ -266,9 +266,9 @@ This Helm chart defines and uses two KubeFlex PostCreateHooks, as follows.
 
 - `its` defines a Job with two containers. One container uses the clusteradm container image to initialize the target cluster as an OCM "hub". The other container uses the Helm CLI container image to instantiate the [OCM Status Addon Helm chart](#ocm-status-addon-helm-chart). The version to use is defined in the `values.yaml` of the core chart. This PCH is used for every requested ITS.
 
-- `wds` defines a Job with two containers. One container uses the Helm CLI image to instantiate the [KubeStellar controller-manager Helm chart](#kubestellar-controller-manager-helm-chart). The other container uses the Helm CLI image to instantiate the [OCM Transport Helm chart](#ocm-transport-controller-helm-chart). For both of those subsidiary charts, the version to use is defined in the `values.yaml` of the core chart. This PCH is used for every requested WDS.
+- `wds` defines a Job with two containers. One container uses the Helm CLI image to instantiate the [KubeStellar controller-manager Helm chart](#kubestellar-controller-manager-helm-chart). The other container uses the Helm CLI image to instantiate the [OCM Transport Controller Helm chart](#ocm-transport-controller-helm-chart). For both of those subsidiary charts, the version to use is defined in the `values.yaml` of the core chart. This PCH is used for every requested WDS.
 
-By our development practices and not doing any manual hacking, we maintain the association that the OCI image tagged `$VERSION` contains a Helm chart that declares its `version` and its `appVersion` to be `$VERSION` and instantiates version `$VERSION` of [the KubeStellar controller-manager Helm chart](#kubestellar-controller-manager-helm-chart).
+By our development practices and not doing any manual hacking, we maintain the association that the OCI image tagged `$VERSION` contains a Helm chart that declares its `version` and its `appVersion` to be `$VERSION` and instantiates version `$VERSION` of [the KubeStellar controller-manager Helm chart](#kubestellar-controller-manager-helm-chart) and [the OCM Transport Controller Helm chart](#ocm-transport-controller-helm-chart).
 
 
 ### KubeStellar controller-manager Helm Chart
@@ -395,10 +395,10 @@ flowchart LR
     ksc_hc_repo[published KS Core chart] --> ksc_hc_src
     ksc_hc_src -.-> osa_hc_repo
     ksc_hc_src -.-> kcm_hc_repo
-    ksc_hc_src -.-> otp_hc_repo
+    ksc_hc_src -.-> otc_hc_repo
     ksc_hc_repo -.-> osa_hc_repo
     ksc_hc_repo -.-> kcm_hc_repo
-    ksc_hc_repo -.-> otp_hc_repo
+    ksc_hc_repo -.-> otc_hc_repo
     setup_ksc -.-> ksc_hc_repo
     setup_ksc -.-> KubeFlex
     e2e_local -.-> ocm_pch

--- a/docs/content/direct/packaging.md
+++ b/docs/content/direct/packaging.md
@@ -73,7 +73,7 @@ The primary product is the OCM Transport Controller, built from generic transpor
 
 For this controller, the ks/OTP repo produces a container image that appears at [ghcr.io/kubestellar/ocm-transport-plugin/transport-controller](https://github.com/kubestellar/ocm-transport-plugin/pkgs/container/ocm-transport-plugin%2Ftransport-controller).
 
-For this controller, the ks/ks repo produces a container image that appears at [ghcr.io/kubestellar/kubestellar/ocm-transport-controller](https://github.com/kubestellar/kubestellar/pkgs/container/kubestellar%2Focm-transport-controller).
+For this controller, the ks/ks repo produces a container image that appears at [ghcr.io/kubestellar/kubestellar/ocm-transport-controller](https://github.com/kubestellar/kubestellar/pkgs/container/kubestellar%2Focm-transport-controller). The image tag equals the KubeStellar release identifier (no leading `v`).
 
 TODO: document how the image is built and published, including explain versioning.
 
@@ -81,7 +81,7 @@ TODO: document how the image is built and published, including explain versionin
 
 The ks/OTP repo publishes this Helm chart at [ghcr.io/kubestellar/ocm-transport-plugin/chart/ocm-transport-plugin](https://github.com/kubestellar/ocm-transport-plugin/pkgs/container/ocm-transport-plugin%2Fchart%2Focm-transport-plugin).
 
-The ks/ks repo publishes this Helm chart at [ghcr.io/kubestellar/kubestellar/ocm-transport-controller-chart](https://github.com/kubestellar/kubestellar/pkgs/container/kubestellar/ocm-transport-controller-chart).
+The ks/ks repo publishes this Helm chart at [ghcr.io/kubestellar/kubestellar/ocm-transport-controller-chart](https://github.com/kubestellar/kubestellar/pkgs/container/kubestellar%2Focm-transport-controller-chart). The chart version equals its `appVersion`, both are the KubeStellar release identifier (no leading `v`).
 
 ## KubeStellar
 

--- a/docs/content/direct/packaging.md
+++ b/docs/content/direct/packaging.md
@@ -79,7 +79,9 @@ TODO: document how the image is built and published, including explain versionin
 
 ### OCM Transport Controller Helm chart
 
-This appears at [ghcr.io/kubestellar/ocm-transport-plugin/chart/ocm-transport-plugin](https://github.com/kubestellar/ocm-transport-plugin/pkgs/container/ocm-transport-plugin%2Fchart%2Focm-transport-plugin). This will need to move to something like `ghcr.io/kubestellar/kubestellar/ocm-transport-controller-chart`.
+The ks/OTP repo publishes this Helm chart at [ghcr.io/kubestellar/ocm-transport-plugin/chart/ocm-transport-plugin](https://github.com/kubestellar/ocm-transport-plugin/pkgs/container/ocm-transport-plugin%2Fchart%2Focm-transport-plugin).
+
+The ks/ks repo publishes this Helm chart at [ghcr.io/kubestellar/kubestellar/ocm-transport-controller-chart](https://github.com/kubestellar/kubestellar/pkgs/container/kubestellar/ocm-transport-controller-chart).
 
 ## KubeStellar
 
@@ -98,6 +100,7 @@ flowchart LR
     kcm_code[KCM source code]
     otc_code[OTC source code]
     kcm_hc_src[KCM Helm chart source]
+    otc_hc_src[OTC Helm chart source]
     ksc_hc_src[KS Core Helm chart source]
     ks_pch[kubestellar PostCreateHook]
     ocm_pch["ocm PostCreateHook"]
@@ -114,7 +117,11 @@ flowchart LR
     ks_pch -.-> otp_hc_repo[published OTP Helm chart]
     otc_ctr_image["OTC container image<br>(moved)"]
     otc_ctr_image --> otc_code
+    otc_hc_src -.-> otc_ctr_image
     otp_hc_repo -.-> otc_ctr_image_ur["OTC container image<br>(original)"]
+    otc_hc_repo[published OTC Helm chart]
+    otc_hc_repo --> otc_hc_src
+    otc_hc_repo -.-> otc_ctr_image
     ksc_hc_repo[published KS Core chart] --> ksc_hc_src
     ksc_hc_src -.-> osa_hc_repo
     ksc_hc_src -.-> otp_hc_repo
@@ -358,6 +365,7 @@ flowchart LR
     gtc_code["generic transport<br>controller code"]
     otp_code["OTP source code<br>(moved)"]
     kcm_hc_src[KCM Helm chart source]
+    otc_hc_src[OTC Helm chart source]
     ksc_hc_src[KS Core Helm chart source]
     ks_pch[kubestellar PostCreateHook]
     ocm_pch["ocm PostCreateHook"]
@@ -376,10 +384,14 @@ flowchart LR
     otc_ctr_image["OTC container image<br>(moved)"]
     otc_ctr_image --> gtc_code
     otc_ctr_image --> otp_code
+    otc_hc_src -.-> otc_ctr_image
     otp_hc_repo -.-> otc_ctr_image_ur["OTC container image<br>(original)"]
     otp_hc_repo --> otp_hc_src
     otc_ctr_image_ur --> gtc_code
     otc_ctr_image_ur --> otp_code_ur
+    otc_hc_repo[published OTC Helm chart]
+    otc_hc_repo --> otc_hc_src
+    otc_hc_repo -.-> otc_ctr_image
     ksc_hc_repo[published KS Core chart] --> ksc_hc_src
     ksc_hc_src -.-> osa_hc_repo
     ksc_hc_src -.-> kcm_hc_repo

--- a/docs/content/direct/packaging.md
+++ b/docs/content/direct/packaging.md
@@ -65,7 +65,7 @@ By our development practices and doing doing any manual hacks, we maintain the a
 
 This repository ([github.com/kubestellar/ocm-transport-plugin](https://github.com/kubestellar/ocm-transport-plugin)) is retired. Its contents have been merged into the kubestellar repository.
 
-The primary product was the OCM Transport Controller, built from generic transport controller code plus code specific to using OCM for transport. The published artifacts, which still linger because the GitHub is all about not forgetting things, are as follows. DO NOT USE THEM.
+The primary product was the OCM Transport Controller, which is built from generic transport controller code plus code specific to using OCM for transport. This controller now comes from the ks/ks repository. The published artifacts for this controller from ks/OTP, which still linger because older releases of KubeStellar are still in use and because GitHub is all about not forgetting things, are as follows. DO NOT USE THEM with releases of KubeStellar _after_ `0.24.0-alpha.2`.
 
 - OCM Transport Controller container image. Appears at [ghcr.io/kubestellar/ocm-transport-plugin/transport-controller](https://github.com/kubestellar/ocm-transport-plugin/pkgs/container/ocm-transport-plugin%2Ftransport-controller).
 - OCM Transport Controller Helm chart. Appears at [ghcr.io/kubestellar/ocm-transport-plugin/chart/ocm-transport-plugin](https://github.com/kubestellar/ocm-transport-plugin/pkgs/container/ocm-transport-plugin%2Fchart%2Focm-transport-plugin).

--- a/docs/content/direct/packaging.md
+++ b/docs/content/direct/packaging.md
@@ -99,8 +99,7 @@ flowchart LR
     ksc_hc_src[KS Core Helm chart source]
     ks_pch[kubestellar PostCreateHook]
     ocm_pch["ocm PostCreateHook"]
-    setup_ksc["example setup<br>using core"]
-    setup_steps["example setup<br>step-by-step"]
+    setup_ksc["'Getting Started' setup"]
     e2e_local["E2E setup<br>local"]
     e2e_release["E2E setup<br>release"]
     end
@@ -119,9 +118,6 @@ flowchart LR
     ksc_hc_repo -.-> osa_hc_repo
     ksc_hc_repo -.-> otp_hc_repo
     ksc_hc_repo -.-> kcm_hc_repo
-    setup_steps -.-> ocm_pch
-    setup_steps -.-> ks_pch
-    setup_steps -.-> KubeFlex
     setup_ksc -.-> ksc_hc_repo
     setup_ksc -.-> KubeFlex
     e2e_local -.-> ocm_pch
@@ -148,7 +144,6 @@ flowchart LR
     ksc_hc_src[KS Core Helm chart source]
     ks_pch[kubestellar PostCreateHook]
     ocm_pch["ocm PostCreateHook"]
-    setup_steps["example setup<br>step-by-step"]
     e2e_local["E2E setup<br>local"]
     e2e_release["E2E setup<br>release"]
     end
@@ -162,8 +157,6 @@ flowchart LR
     ksc_hc_src -.-> cladm_image
     ksc_hc_repo -.-> cladm_image
     ksc_hc_repo -.-> helm_image
-    setup_steps -.-> ocm_pch
-    setup_steps -.-> ks_pch
     e2e_local -.-> ocm_pch
     e2e_release -.-> ocm_pch
     e2e_release -.-> ks_pch
@@ -364,8 +357,7 @@ flowchart LR
     ksc_hc_src[KS Core Helm chart source]
     ks_pch[kubestellar PostCreateHook]
     ocm_pch["ocm PostCreateHook"]
-    setup_ksc["example setup<br>using core"]
-    setup_steps["example setup<br>step-by-step"]
+    setup_ksc["'Getting Started' setup"]
     e2e_local["E2E setup<br>local"]
     e2e_release["E2E setup<br>release"]
     end
@@ -388,9 +380,6 @@ flowchart LR
     ksc_hc_repo -.-> osa_hc_repo
     ksc_hc_repo -.-> kcm_hc_repo
     ksc_hc_repo -.-> otp_hc_repo
-    setup_steps -.-> ocm_pch
-    setup_steps -.-> ks_pch
-    setup_steps -.-> KubeFlex
     setup_ksc -.-> ksc_hc_repo
     setup_ksc -.-> KubeFlex
     e2e_local -.-> ocm_pch

--- a/docs/content/direct/packaging.md
+++ b/docs/content/direct/packaging.md
@@ -81,7 +81,7 @@ TODO: document how the image is built and published, including explain versionin
 
 The ks/OTP repo publishes this Helm chart at [ghcr.io/kubestellar/ocm-transport-plugin/chart/ocm-transport-plugin](https://github.com/kubestellar/ocm-transport-plugin/pkgs/container/ocm-transport-plugin%2Fchart%2Focm-transport-plugin).
 
-The ks/ks repo publishes this Helm chart at [ghcr.io/kubestellar/kubestellar/ocm-transport-controller-chart](https://github.com/kubestellar/kubestellar/pkgs/container/kubestellar%2Focm-transport-controller-chart). By our development practices and not doing any manual hacking, we maintain the association that the OCI image tagged `$VERSION` contains a Helm chart that declares its `version` and its `appVersion` to be `$VERSION` and instantiates version `$VERSION` of [OCM Transport Controller container image](#ocm-transport-container-image).
+The ks/ks repo publishes this Helm chart at [ghcr.io/kubestellar/kubestellar/ocm-transport-controller-chart](https://github.com/kubestellar/kubestellar/pkgs/container/kubestellar%2Focm-transport-controller-chart). By our development practices and not doing any manual hacking, we maintain the association that the OCI image tagged `$VERSION` contains a Helm chart that declares its `version` and its `appVersion` to be `$VERSION` and instantiates version `$VERSION` of [OCM Transport Controller container image](#ocm-transport-controller-container-image).
 
 ## KubeStellar
 
@@ -114,12 +114,10 @@ flowchart LR
     kcm_hc_src -.-> kcm_ctr_image
     kcm_hc_repo -.-> kcm_ctr_image
     ks_pch -.-> kcm_hc_repo
-    ks_pch -.-> otp_hc_repo[published OTP Helm chart]
+    ks_pch -.-> otc_hc_repo[published OTC Helm chart]
     otc_ctr_image["OTC container image<br>(moved)"]
     otc_ctr_image --> otc_code
     otc_hc_src -.-> otc_ctr_image
-    otp_hc_repo -.-> otc_ctr_image_ur["OTC container image<br>(original)"]
-    otc_hc_repo[published OTC Helm chart]
     otc_hc_repo --> otc_hc_src
     otc_hc_repo -.-> otc_ctr_image
     ksc_hc_repo[published KS Core chart] --> ksc_hc_src
@@ -380,16 +378,16 @@ flowchart LR
     kcm_hc_src -.-> kcm_ctr_image
     kcm_hc_repo -.-> kcm_ctr_image
     ks_pch -.-> kcm_hc_repo
-    ks_pch -.-> otp_hc_repo[published OTP Helm chart]
+    ks_pch -.-> otc_hc_repo[published OTC Helm chart]
     otc_ctr_image["OTC container image<br>(moved)"]
     otc_ctr_image --> gtc_code
     otc_ctr_image --> otp_code
     otc_hc_src -.-> otc_ctr_image
     otp_hc_repo -.-> otc_ctr_image_ur["OTC container image<br>(original)"]
     otp_hc_repo --> otp_hc_src
+    otp_hc_src -.-> otc_ctr_image_ur
     otc_ctr_image_ur --> gtc_code
     otc_ctr_image_ur --> otp_code_ur
-    otc_hc_repo[published OTC Helm chart]
     otc_hc_repo --> otc_hc_src
     otc_hc_repo -.-> otc_ctr_image
     ksc_hc_repo[published KS Core chart] --> ksc_hc_src

--- a/docs/content/direct/release-notes.md
+++ b/docs/content/direct/release-notes.md
@@ -2,9 +2,9 @@
 
 The following sections list the known issues for each release. The issue list is not differential (i.e., compared to previous releases) but a full list representing the overall state of the specific release. 
 
-## 0.24.0 and its candidates and alphas
+## 0.24.0 and its candidates and their precursors
 
-The main change from 0.23.X is the completion of the status combination and introduction of the create-only feature. There is also further work on the organization of the website.
+The main functional change from 0.23.X is the completion of the status combination and introduction of the create-only feature. There is also further work on the organization of the website. There is also a major change in the GitHub repository structure: the kubestellar/ocm-transport-plugin repo's contents have been merged into the kubestellar/kubestellar repo (after `0.24.0-alpha.2`).
 
 ### 0.24.0-alpha.2
 

--- a/docs/content/direct/release.md
+++ b/docs/content/direct/release.md
@@ -26,7 +26,7 @@ Making a new kubestellar release requires a contributor to do the following thin
 
 - Edit `docs/mkdocs.yml` and update the definition of `ks_latest_release` to `$version` (e.g., `'0.23.0-rc42'`). If this is a regular release then also update the definition of `ks_latest_regular_release`.
 
-- Edit the source for the KCM+OTC PCH (in `config/postcreate-hooks/kubestellar.yaml`) and update the version used of the KubeStellar controller-manager chart and the OCM transport controller chart (they appear in the last object, a `Job`).
+- Edit the source for the KCM+OTC PCH (in `config/postcreate-hooks/kubestellar.yaml`) and update the version there for the KubeStellar controller-manager chart and the OCM transport controller chart (they appear in the last object, a `Job`).
 
 - Update the version in the core chart defaults, `core-chart/values.yaml`.
 

--- a/docs/content/direct/release.md
+++ b/docs/content/direct/release.md
@@ -1,6 +1,6 @@
 # Making KubeStellar Releases
 
-This document defines how releases of the KubeStellar repository are made. This document is a work-in-progress. In particular, the dependency cycle between the `kubestellar` and `ocm-tansport-plugin` repos is not well documented and we do not have a good way to deal with it.
+This document defines how releases of the KubeStellar repository are made. This document is a work-in-progress.
 
 This document starts with step-by-step instructions for the current procedure, then proceeds with the thinking behind them.
 
@@ -50,8 +50,6 @@ Making a new kubestellar release requires a contributor to do the following thin
 
 - If the test results are good and the release is regular (not an RC) then declare the code freeze over.
 
-- If the testing results are good, update [ks/OTP](https://github.com/kubestellar/ocm-transport-plugin) to refer to the new ks/ks release and [make a new release of ks/OTP](https://github.com/kubestellar/ocm-transport-plugin/blob/main/docs/release.md).
-
 ## Goals and limitations
 
 The release process has the following goals.
@@ -74,7 +72,7 @@ We have the following limitations.
 
 ## Dependency cycle with ks/OTP
 
-The [ks/ks repo](https://github.com/kubestellar/kubestellar) and the [ks/OTP repo](https://github.com/kubestellar/ocm-transport-plugin) reference each other. Thus, making consistent immutable recursive-self-reference-free releases is impossible. We have to compromise somehow. There is some discussion in [ks/ks Issue 1786](https://github.com/kubestellar/kubestellar/issues/1786). We currently seem to be following the staggered release approach.
+This is a thing of the past. The kubestellar/ocm-transport-plugin repository is retired now, its contents have been moved into the kubestellar/kubestellar repository.
 
 ## Technology
 

--- a/docs/content/direct/release.md
+++ b/docs/content/direct/release.md
@@ -11,16 +11,6 @@ Every release should pass all release tests before it can be officially declare 
 
 ## Step-by-Step
 
-### Reacting to a new ocm-transport-plugin release
-
-Between each release of [ks/OTP](https://github.com/kubestellar/ocm-transport-plugin) and the next release of ks/ks, the following steps should be done in ks/ks.
-
-- Edit `scripts/deploy-transport-controller.sh`: update the tag in the default transport controller image setting (`export TRANSPORT_CONTROLLER_IMAGE...`) to the latest release of ks/OTP.
-
-- Edit `config/postcreate-hooks/kubestellar.yaml`: update the version of the OTP Helm chart.
-
-- Edit `test/e2e/common/setup-kubestellar.sh`: update the setting of `OCM_TRANSPORT_PLUGIN_RELEASE` to the latest.
-
 ### Reacting to a new ocm-status-addon release
 
 Between each release of [ks/OSA](https://github.com/kubestellar/ocm-status-addon) and the next release of ks/ks, update the references to the ocm-status-addon release in the following files.
@@ -36,7 +26,7 @@ Making a new kubestellar release requires a contributor to do the following thin
 
 - Edit `docs/mkdocs.yml` and update the definition of `ks_latest_release` to `$version` (e.g., `'0.23.0-rc42'`). If this is a regular release then also update the definition of `ks_latest_regular_release`.
 
-- Edit the source for the KCM PCH (in `config/postcreate-hooks/kubestellar.yaml`) and update the tag in the reference to the KCM container image (it appears in the last object, a `Job`).
+- Edit the source for the KCM+OTC PCH (in `config/postcreate-hooks/kubestellar.yaml`) and update the version used of the KubeStellar controller-manager chart and the OCM transport controller chart (they appear in the last object, a `Job`).
 
 - Update the version in the core chart defaults, `core-chart/values.yaml`.
 

--- a/docs/content/direct/release.md
+++ b/docs/content/direct/release.md
@@ -19,10 +19,6 @@ Between each release of [ks/OTP](https://github.com/kubestellar/ocm-transport-pl
 
 - Edit `config/postcreate-hooks/kubestellar.yaml`: update the version of the OTP Helm chart.
 
-- Edit `core-chart/values.yaml`: update the OTP version.
-
-- Edit `docs/content/direct/examples.md` (`docs/content/direct/common-setup-core-chart.md`, `docs/content/direct/common-setup-step-by-step.md`): update the version in the `export OCM_TRANSPORT_PLUGIN=...` statement to the latest release of ks/OTP.
-
 - Edit `test/e2e/common/setup-kubestellar.sh`: update the setting of `OCM_TRANSPORT_PLUGIN_RELEASE` to the latest.
 
 ### Reacting to a new ocm-status-addon release

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -14,7 +14,7 @@ edit_uri: edit/main/docs/content
 ks_branch: 'main'
 ks_tag: 'latest'
 ks_latest_regular_release: '0.23.1'
-ks_latest_release: '0.24.0-alpha.2'
+ks_latest_release: '0.24.0-experiment.5'
 
 ks_kind_port_num: '1119'
 

--- a/ocm-transport-controller-chart/.helmignore
+++ b/ocm-transport-controller-chart/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/ocm-transport-controller-chart/Chart.yaml
+++ b/ocm-transport-controller-chart/Chart.yaml
@@ -1,0 +1,20 @@
+# Copyright 2024 The KubeStellar Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v2
+name: ocm-transport-controller-chart
+description: Helm chart to install the OCM transport operator
+type: application
+version: 0.1.0 # automatically set by goreleaser helm package
+appVersion: 0.1.0 # automatically set by goreleaser helm package

--- a/ocm-transport-controller-chart/templates/controller.yaml
+++ b/ocm-transport-controller-chart/templates/controller.yaml
@@ -153,8 +153,8 @@ spec:
           image: OTC_IMAGE_PLACEHOLDER
           imagePullPolicy: IfNotPresent
           args:
-          - --metrics-bind-addr={{.Values.metrics_bind_addr}}
-          - --pprof-bind-addr={{.Values.pprof_bind_addr}}
+          - --metrics-bind-address={{.Values.metrics_bind_addr}}
+          - --pprof-bind-address={{.Values.pprof_bind_addr}}
           - --transport-kubeconfig=/mnt/shared/transport-kubeconfig
           - --transport-qps={{.Values.transport_qps}}
           - --transport-burst={{.Values.transport_burst}}

--- a/ocm-transport-controller-chart/templates/controller.yaml
+++ b/ocm-transport-controller-chart/templates/controller.yaml
@@ -1,0 +1,176 @@
+# Copyright 2024 The KubeStellar Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: transport-controller
+  namespace: {{.Release.Namespace}}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{.Values.wds_cp_name}}-transport-controller
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - tenancy.kflex.kubestellar.org
+  resources:
+  - controlplanes
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - tenancy.kflex.kubestellar.org
+  resources:
+  - controlplanes/status
+  verbs:
+  - get
+  - patch
+  - update
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{.Values.wds_cp_name}}-transport-controller
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{.Values.wds_cp_name}}-transport-controller
+subjects:
+  - kind: ServiceAccount
+    name: transport-controller
+    namespace: {{.Release.Namespace}}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: transport-controller-config
+  namespace: {{.Release.Namespace}}
+data:
+  get-kubeconfig.sh: |
+    #!/bin/env bash
+    # Get the in-cluster kubeconfig for KubeFlex Control Planes
+    # get-kubeconfig.sh cp_name guess_its_name
+
+    # input parameters
+    cp_name="${1%"-system"}" # cp name or cp namespace
+    guess_its_name="$2" # true: try guessing the name of the ITS CP
+
+    # check if the CP name is valid or needs to be guessed
+    while [ "$cp_name" == "" ] ; do
+      if [ "$guess_its_name" == "true" ] ; then
+        cps=$(kubectl get controlplane -l 'kflex.kubestellar.io/cptype=its' 2> /dev/null | tail -n +2)
+        case $(echo -n "$cps" | grep -c '^') in
+          (0)
+            >&2 echo "Waiting for an ITS control plane to exist..."
+            sleep 10;;
+          (1)
+            cp_name="${cps%% *}"
+            break;;
+          (*)
+            >&2 echo "ERROR: found more than one Control Plane of type its!"
+            exit 1;;
+        esac
+      else
+        >&2 echo "ERROR: no Control Plane name specified!"
+        exit 3
+      fi
+    done
+
+    # wait for the CP to exists and be ready
+    while [[ $(kubectl get controlplane "$cp_name" -o 'jsonpath={..status.conditions[?(@.type=="Ready")].status}') != "True" ]]; do
+      >&2 echo "Waiting for \"$cp_name\" control plane to exist and be ready..."
+      sleep 10
+    done
+
+    # determine the secret name and namespace
+    key=$(kubectl get controlplane $cp_name -o=jsonpath='{.status.secretRef.inClusterKey}')
+    secret_name=$(kubectl get controlplane $cp_name -o=jsonpath='{.status.secretRef.name}')
+    secret_namespace=$(kubectl get controlplane $cp_name -o=jsonpath='{.status.secretRef.namespace}')
+
+    # get the kubeconfig in base64
+    >&2 echo "Getting \"$key\" from \"$secret_name\" secret in \"$secret_namespace\" for control plane \"$cp_name\"..."
+    kubectl get secret $secret_name -n $secret_namespace -o=jsonpath="{.data.$key}"
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: transport-controller
+  namespace: {{.Release.Namespace}}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      name: transport-controller
+  template:
+    metadata:
+      labels:
+        name: transport-controller
+    spec:
+      serviceAccountName: transport-controller
+      initContainers:
+      - name: setup-wds-kubeconfig
+        image: quay.io/kubestellar/kubectl:1.27.8
+        imagePullPolicy: Always
+        command: [ "bin/sh", "-c", "sh /mnt/config/get-kubeconfig.sh '{{.Values.wds_cp_name}}' false | base64 -d > /mnt/shared/wds-kubeconfig"]
+        volumeMounts:
+        - name: config-volume
+          mountPath: /mnt/config
+        - name: shared-volume
+          mountPath: /mnt/shared
+      - name: setup-its-kubeconfig
+        image: quay.io/kubestellar/kubectl:1.27.8
+        imagePullPolicy: Always
+        command: [ "bin/sh", "-c", "sh /mnt/config/get-kubeconfig.sh '{{.Values.transport_cp_name}}' true | base64 -d > /mnt/shared/transport-kubeconfig"]
+        volumeMounts:
+        - name: config-volume
+          mountPath: /mnt/config
+        - name: shared-volume
+          mountPath: /mnt/shared
+      containers:
+        - name: transport-controller
+          image: OTC_IMAGE_PLACEHOLDER
+          imagePullPolicy: IfNotPresent
+          args:
+          - --metrics-bind-addr={{.Values.metrics_bind_addr}}
+          - --pprof-bind-addr={{.Values.pprof_bind_addr}}
+          - --transport-kubeconfig=/mnt/shared/transport-kubeconfig
+          - --transport-qps={{.Values.transport_qps}}
+          - --transport-burst={{.Values.transport_burst}}
+          - --wds-kubeconfig=/mnt/shared/wds-kubeconfig
+          - --wds-name={{.Values.wds_cp_name}}
+          - --wds-qps={{.Values.wds_qps}}
+          - --wds-burst={{.Values.wds_burst}}
+          - -v={{.Values.verbosity | default 4}}
+          volumeMounts:
+          - name: shared-volume
+            mountPath: /mnt/shared
+            readOnly: true
+      volumes:
+      - name: shared-volume
+        emptyDir: {}
+      - name: config-volume
+        configMap:
+          name: transport-controller-config
+          defaultMode: 0744

--- a/ocm-transport-controller-chart/templates/controller.yaml
+++ b/ocm-transport-controller-chart/templates/controller.yaml
@@ -163,6 +163,8 @@ spec:
           - --wds-qps={{.Values.wds_qps}}
           - --wds-burst={{.Values.wds_burst}}
           - -v={{.Values.verbosity | default 4}}
+          - --max-num-wrapped={{.Values.max_num_wrapped}}
+          - --max-size-wrapped={{.Values.max_size_wrapped}}
           volumeMounts:
           - name: shared-volume
             mountPath: /mnt/shared

--- a/ocm-transport-controller-chart/values.yaml
+++ b/ocm-transport-controller-chart/values.yaml
@@ -34,3 +34,7 @@ transport_burst: 10
 # QPS and burst for accessing the WDS
 wds_qps: 5
 wds_burst: 10
+
+# Bundling parameters
+max_num_wrapped: 512000
+max_size_wrapped: 512000

--- a/ocm-transport-controller-chart/values.yaml
+++ b/ocm-transport-controller-chart/values.yaml
@@ -1,0 +1,36 @@
+# Copyright 2024 The KubeStellar Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Set the name of the transport control plane
+transport_cp_name: ""
+
+# Set the name of the WDS control plane
+wds_cp_name: wds1
+
+# Set the controller verbosity
+verbosity: 4
+
+# [host]:port at which to listen for HTTP GET /metrics
+metrics_bind_addr: ":8090"
+
+# [host]:port at which to listen for HTTP GET /debug/pprof
+pprof_bind_addr: ":8092"
+
+# QPS and burst for accessing the ITS
+transport_qps: 5
+transport_burst: 10
+
+# QPS and burst for accessing the WDS
+wds_qps: 5
+wds_burst: 10


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
This PR finishes the functional part of the campaign to merge kubestellar/ocm-transport-plugin into kubestellar/kubestellar. More documentation work should be done (notably including the architecture document), but this PR should be functional.

This PR includes self-reference updates preparing for a test release named `0.24.0-experiment.5`.

Doc preview is at https://mikespreitzer.github.io/kcp-edge-mc/doc-tport-move-4/direct/packaging/ .

This PR is built on #2433 and I will rebase if that merges first.

## Related issue(s)


