### PR TITLE
✨ Expose verbosity controls from kubestellar PCH

### DIFF
--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -1,4 +1,4 @@
-# Default values for kubestellar.
+# Default values for kubestellar-controller-manager chart.
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 

--- a/config/postcreate-hooks/kubestellar.yaml
+++ b/config/postcreate-hooks/kubestellar.yaml
@@ -187,6 +187,8 @@ spec:
               - "0.24.0-experiment.5"
               - --set
               - "ControlPlaneName={{.ControlPlaneName}}"
+              - --set
+              - "ControllerManager.Verbosity={{.ControllerManagerVerbosity}}"
             env:
             - name: XDG_CACHE_HOME
               value: /tmp/helm/.cache
@@ -204,6 +206,8 @@ spec:
               - "0.24.0-experiment.5"
               - --set
               - "wds_cp_name={{.ControlPlaneName}}"
+              - --set
+              - "verbosity={{.TransportControllerVerbosity}}"
             env:
             - name: XDG_CACHE_HOME
               value: /tmp/helm/.cache

--- a/test/e2e/common/setup-kubestellar.sh
+++ b/test/e2e/common/setup-kubestellar.sh
@@ -24,10 +24,10 @@ HOSTING_CONTEXT=kind-kubeflex
 
 while [ $# != 0 ]; do
     case "$1" in
-        (-h|--help) echo "$0 usage: (--released | --kubestellar-controller-manager-verbosity \$num | --transport-controller-verbosity \$num | --env \$kind_or_ocp)*"
-                    exit;;
+        (-h|--help)
+            echo "$0 usage: (--released | --kubestellar-controller-manager-verbosity \$num | --transport-controller-verbosity \$num | --env \$kind_or_ocp)*"
+            exit;;
         (--released)
-            wds_extra="-p kubestellar"
             use_release=true;;
         (--kubestellar-controller-manager-verbosity)
           if (( $# > 1 )); then
@@ -55,7 +55,7 @@ while [ $# != 0 ]; do
             (ocp)  CLUSTER_SOURCE=existing; HOSTING_CONTEXT=kscore;;
             (*) echo "--env must be given 'kind' or 'ocp'" >&2
                 exit 1;;
-	  esac
+          esac
           shift;;
         (*) echo "$0: unrecognized argument/flag '$1'" >&2
             exit 1
@@ -63,9 +63,19 @@ while [ $# != 0 ]; do
     shift
 done
 
-if [ "$use_release" = true ] && [ "$KUBESTELLAR_CONTROLLER_MANAGER_VERBOSITY" != 2 ]
-then echo "$0: kubestellar-controller-manager-verbosity must be 2 when using --released" >&2
+if ! [[ "$KUBESTELLAR_CONTROLLER_MANAGER_VERBOSITY" =~ [0-9]+ ]]
+then echo "$0: \$KUBESTELLAR_CONTROLLER_MANAGER_VERBOSITY must be an integer" >&2
      exit 1
+fi
+
+if ! [[ "$TRANSPORT_CONTROLLER_VERBOSITY" =~ [0-9]+ ]]
+then echo "$0: \$TRANSPORT_CONTROLLER_VERBOSITY must be an integer" >&2
+     exit 1
+fi
+
+if [ "$use_release" = true ]
+then wds_extra="-p kubestellar --set ControllerManagerVerbosity=$KUBESTELLAR_CONTROLLER_MANAGER_VERBOSITY --set TransportControllerVerbosity=$TRANSPORT_CONTROLLER_VERBOSITY"
+else wds_extra=""
 fi
 
 if [[ "$KFLEX_DISABLE_CHATTY" = true ]] ; then


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
This PR generalizes the `kubestellar` PostCreateHook to take two controller verbosity parameters and the `test/e2e/common/setup-kubestellar.sh` script to pass them. This removes the need for a restriction on the those verbosity settings when using that PostCreateHook.

## Related issue(s)

Fixes #2439 
