### PR TITLE
✨ Update self-references for 0.24.0-rc.1 release

### DIFF
--- a/config/postcreate-hooks/kubestellar.yaml
+++ b/config/postcreate-hooks/kubestellar.yaml
@@ -184,7 +184,7 @@ spec:
               - kubestellar
               - oci://ghcr.io/kubestellar/kubestellar/controller-manager-chart
               - --version
-              - "0.24.0-experiment.5"
+              - "0.24.0-rc.1"
               - --set
               - "ControlPlaneName={{.ControlPlaneName}}"
             env:
@@ -201,7 +201,7 @@ spec:
               - ocm-transport-controller
               - oci://ghcr.io/kubestellar/kubestellar/ocm-transport-controller-chart
               - --version
-              - "0.24.0-experiment.5"
+              - "0.24.0-rc.1"
               - --set
               - "wds_cp_name={{.ControlPlaneName}}"
             env:

--- a/core-chart/values.yaml
+++ b/core-chart/values.yaml
@@ -7,7 +7,7 @@
 # please do not change them unless you know what you are doing.
 HELM_VERSION: "3.15.0"
 KUBECTL_VERSION: "1.30.1"
-KUBESTELLAR_VERSION: "0.24.0-experiment.5"
+KUBESTELLAR_VERSION: "0.24.0-rc.1"
 CLUSTERADM_VERSION: "0.8.2"
 OCM_STATUS_ADDON_VERSION: "0.2.0-rc10"
 

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -14,7 +14,7 @@ edit_uri: edit/main/docs/content
 ks_branch: 'main'
 ks_tag: 'latest'
 ks_latest_regular_release: '0.23.1'
-ks_latest_release: '0.24.0-experiment.5'
+ks_latest_release: '0.24.0-rc.1'
 
 ks_kind_port_num: '1119'
 


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
This PR updates the self-references in preparation for test release 0.24.0-rc1.

This is not to say that we might not merge https://github.com/kubestellar/kubestellar/pull/2442 and/or #2444 (which tracks the [latest ks/OSA release](https://github.com/kubestellar/ocm-status-addon/releases/tag/v0.2.0-rc11)) and/or others before actually making this test release.

## Related issue(s)

Fixes #
