### PR TITLE
🐛 Update the kubeflex version in the GitHub workflows

### DIFF
--- a/.github/workflows/ocp-self-runner.yml
+++ b/.github/workflows/ocp-self-runner.yml
@@ -32,7 +32,7 @@ jobs:
           mkdir clusteradm
           export INSTALL_DIR="$PWD/clusteradm"
           curl -L https://raw.githubusercontent.com/open-cluster-management-io/clusteradm/main/install.sh | bash
-          curl -L https://github.com/kubestellar/kubeflex/releases/download/v0.4.2/kubeflex_0.4.2_linux_amd64.tar.gz --output kubeflex.tar.gz
+          curl -L https://github.com/kubestellar/kubeflex/releases/download/v0.6.1/kubeflex_0.6.1_linux_amd64.tar.gz --output kubeflex.tar.gz
           tar -xvf kubeflex.tar.gz bin/kflex
           go install github.com/onsi/ginkgo/v2/ginkgo
           curl -L https://mirror.openshift.com/pub/openshift-v4/clients/ocp/stable-4.15/openshift-client-linux.tar.gz --output openshift-client-linux.tar.gz
@@ -84,7 +84,7 @@ jobs:
           export USE_SUDO=false
           export INSTALL_DIR="$PWD/clusteradm"
           curl -L https://raw.githubusercontent.com/open-cluster-management-io/clusteradm/main/install.sh | bash
-          curl -L https://github.com/kubestellar/kubeflex/releases/download/v0.4.2/kubeflex_0.4.2_linux_amd64.tar.gz --output kubeflex.tar.gz
+          curl -L https://github.com/kubestellar/kubeflex/releases/download/v0.6.1/kubeflex_0.6.1_linux_amd64.tar.gz --output kubeflex.tar.gz
           tar -xvf kubeflex.tar.gz bin/kflex
           go install github.com/onsi/ginkgo/v2/ginkgo
           curl -L https://mirror.openshift.com/pub/openshift-v4/clients/ocp/stable-4.15/openshift-client-linux.tar.gz --output openshift-client-linux.tar.gz

--- a/.github/workflows/pr-test-e2e.yml
+++ b/.github/workflows/pr-test-e2e.yml
@@ -49,10 +49,10 @@ jobs:
       - name: Install dependencies
         run: |
           curl -L https://raw.githubusercontent.com/open-cluster-management-io/clusteradm/main/install.sh | bash
-          wget https://github.com/kubestellar/kubeflex/releases/download/v0.4.2/kubeflex_0.4.2_linux_amd64.tar.gz
-          tar -xvf kubeflex_0.4.2_linux_amd64.tar.gz bin/kflex
+          wget https://github.com/kubestellar/kubeflex/releases/download/v0.6.1/kubeflex_0.6.1_linux_amd64.tar.gz
+          tar -xvf kubeflex_0.6.1_linux_amd64.tar.gz bin/kflex
           mv bin/kflex /usr/local/bin
-          rm -fr bin kubeflex_0.4.2_linux_amd64.tar.gz
+          rm -fr bin kubeflex_0.6.1_linux_amd64.tar.gz
           go install github.com/onsi/ginkgo/v2/ginkgo
 
       - name: Run test
@@ -180,10 +180,10 @@ jobs:
       - name: Install dependencies
         run: |
           curl -L https://raw.githubusercontent.com/open-cluster-management-io/clusteradm/main/install.sh | bash
-          wget https://github.com/kubestellar/kubeflex/releases/download/v0.4.2/kubeflex_0.4.2_linux_amd64.tar.gz
-          tar -xvf kubeflex_0.4.2_linux_amd64.tar.gz bin/kflex
+          wget https://github.com/kubestellar/kubeflex/releases/download/v0.6.1/kubeflex_0.6.1_linux_amd64.tar.gz
+          tar -xvf kubeflex_0.6.1_linux_amd64.tar.gz bin/kflex
           mv bin/kflex /usr/local/bin
-          rm -fr bin kubeflex_0.4.2_linux_amd64.tar.gz
+          rm -fr bin kubeflex_0.6.1_linux_amd64.tar.gz
 
       - name: Run test
         env:

--- a/.github/workflows/pr-test-integration.yml
+++ b/.github/workflows/pr-test-integration.yml
@@ -34,10 +34,10 @@ jobs:
       - name: Install dependencies
         run: |
           curl -L https://raw.githubusercontent.com/open-cluster-management-io/clusteradm/main/install.sh | bash
-          wget https://github.com/kubestellar/kubeflex/releases/download/v0.4.2/kubeflex_0.4.2_linux_amd64.tar.gz
-          tar -xvf kubeflex_0.4.2_linux_amd64.tar.gz bin/kflex
+          wget https://github.com/kubestellar/kubeflex/releases/download/v0.6.1/kubeflex_0.6.1_linux_amd64.tar.gz
+          tar -xvf kubeflex_0.6.1_linux_amd64.tar.gz bin/kflex
           mv bin/kflex /usr/local/bin
-          rm -fr bin kubeflex_0.4.2_linux_amd64.tar.gz
+          rm -fr bin kubeflex_0.6.1_linux_amd64.tar.gz
 
       - name: Run test
         env:

--- a/.github/workflows/test-latest-release.yml
+++ b/.github/workflows/test-latest-release.yml
@@ -32,10 +32,10 @@ jobs:
       - name: Install dependencies
         run: |
           curl -L https://raw.githubusercontent.com/open-cluster-management-io/clusteradm/main/install.sh | bash
-          wget https://github.com/kubestellar/kubeflex/releases/download/v0.4.2/kubeflex_0.4.2_linux_amd64.tar.gz
-          tar -xvf kubeflex_0.4.2_linux_amd64.tar.gz bin/kflex
+          wget https://github.com/kubestellar/kubeflex/releases/download/v0.6.1/kubeflex_0.6.1_linux_amd64.tar.gz
+          tar -xvf kubeflex_0.6.1_linux_amd64.tar.gz bin/kflex
           mv bin/kflex /usr/local/bin
-          rm -fr bin kubeflex_0.4.2_linux_amd64.tar.gz
+          rm -fr bin kubeflex_0.6.1_linux_amd64.tar.gz
           go install github.com/onsi/ginkgo/v2/ginkgo
 
       - name: Run test
@@ -107,10 +107,10 @@ jobs:
       - name: Install dependencies
         run: |
           curl -L https://raw.githubusercontent.com/open-cluster-management-io/clusteradm/main/install.sh | bash
-          wget https://github.com/kubestellar/kubeflex/releases/download/v0.4.2/kubeflex_0.4.2_linux_amd64.tar.gz
-          tar -xvf kubeflex_0.4.2_linux_amd64.tar.gz bin/kflex
+          wget https://github.com/kubestellar/kubeflex/releases/download/v0.6.1/kubeflex_0.6.1_linux_amd64.tar.gz
+          tar -xvf kubeflex_0.6.1_linux_amd64.tar.gz bin/kflex
           mv bin/kflex /usr/local/bin
-          rm -fr bin kubeflex_0.4.2_linux_amd64.tar.gz
+          rm -fr bin kubeflex_0.6.1_linux_amd64.tar.gz
 
       - name: Run test
         run: |


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
This PR updates the GitHub Actions workflows to use release 0.6.1 of kubeflex rather than 0.4.2, because 0.6.1 is now the minimum required version.

## Related issue(s)

Fixes #
