### PR TITLE
:book: Fix call to mermaid to allow it to change colors when website theme toggles dark/light

### DIFF
--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -138,14 +138,14 @@ theme:
     - media: "(prefers-color-scheme)"
       toggle:
         icon: material/brightness-auto
-        name: Switch to dark mode
+        name: Switch to light mode
 
     # Palette toggle for light mode
     - media: "(prefers-color-scheme: light)"
       scheme: default 
       toggle:
         icon: material/brightness-7
-        name: Switch to light mode
+        name: Switch to dark mode
 
     # Palette toggle for dark mode
     - media: "(prefers-color-scheme: dark)"

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -230,7 +230,7 @@ markdown_extensions:
       custom_fences:
         - name: mermaid
           class: mermaid
-          format: !!python/name:mermaid2.fence_mermaid
+          format: !!python/name:pymdownx.superfences.fence_code_format         
   - attr_list
   - md_in_html
   - toc:               # Builds a table of contents 


### PR DESCRIPTION
## Summary
This updates the **format:** parameter for mermaid in the markdown_extensions section of mkdocs.yml to match that in the current documentation for Material for MKDocs, the theme we are using.

Doing so enables mermaid diagrams to shift their color scheme to display properly in whatever theme (light/dark) the browser is rendering the site in.

Preview at https://kproche.github.io/kubestellar/doc-fixmermaid/direct/packaging/

## Related issue(s)

Fixes #2435
