### PR TITLE
🌱 Facilitate image loading on k3d

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,6 +30,8 @@ DEFAULT_NAMESPACE=default
 DEFAULT_WDS_NAME=wds1
 # default kind hosting cluster name
 KIND_HOSTING_CLUSTER ?= kubeflex
+# default k3d hosting cluster name
+K3D_HOSTING_CLUSTER ?= kubeflex
 
 # We need bash for some conditional logic below.
 SHELL := /usr/bin/env bash -e
@@ -188,6 +190,11 @@ ko-build-transport-local: ## Build local transport container image with `ko`.
 .PHONY: kind-load-image
 kind-load-image:
 	kind load --name ${KIND_HOSTING_CLUSTER} docker-image ${CONTROLLER_MANAGER_IMAGE}
+
+# this is used for local testing
+.PHONY: k3d-load-image
+k3d-load-image:
+	k3d image import ${CONTROLLER_MANAGER_IMAGE} -c ${K3D_HOSTING_CLUSTER}
 
 .PHONY: chart
 chart: manifests kustomize

--- a/pkg/status/workstatus.go
+++ b/pkg/status/workstatus.go
@@ -126,10 +126,10 @@ func updateObjectStatus(ctx context.Context, objectIdentifier util.ObjectIdentif
 	unstrObj.Object["status"] = status
 
 	if objectIdentifier.ObjectName.Namespace == "" {
-		_, err = wdsDynClient.Resource(gvr).UpdateStatus(ctx, unstrObj, metav1.UpdateOptions{})
+		_, err = wdsDynClient.Resource(gvr).UpdateStatus(ctx, unstrObj, metav1.UpdateOptions{FieldManager: ControllerName})
 	} else {
 		_, err = wdsDynClient.Resource(gvr).Namespace(objectIdentifier.ObjectName.Namespace).UpdateStatus(ctx,
-			unstrObj, metav1.UpdateOptions{})
+			unstrObj, metav1.UpdateOptions{FieldManager: ControllerName})
 	}
 	if err != nil {
 		// if resource not found it may mean no status subresource - try to patch the status


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
This PR adds a (phony) target to Makefile to make it handy to load controller manager image into a host cluster of type k3d.

Also adds FieldManager when the status controller `updateObjectStatus`.
