### PR TITLE
📖 Note incompleteness of create-only

### DIFF
--- a/docs/content/direct/release-notes.md
+++ b/docs/content/direct/release-notes.md
@@ -9,10 +9,11 @@ These test the release-building functionality, which has been revised in the cou
 
 ## 0.24.0 and its candidates and their precursors
 
-The main functional change from 0.23.X is the completion of the status combination and introduction of the create-only feature. There is also further work on the organization of the website. There is also a major change in the GitHub repository structure: the kubestellar/ocm-transport-plugin repo's contents have been merged into the kubestellar/kubestellar repo (after `0.24.0-alpha.2`).
+The main functional change from 0.23.X is the completion of the status combination and the partial introduction of the create-only feature (its API is there but its implementation is not --- DO NOT TRY TO USE THIS FEATURE). There is also further work on the organization of the website. There is also a major change in the GitHub repository structure: the kubestellar/ocm-transport-plugin repo's contents have been merged into the kubestellar/kubestellar repo (after `0.24.0-alpha.2`).
 
 ### Remaining limitations in 0.24.0
 
+* Job objects are not properly supported.
 * Removing of WorkStatus objects (in the transport namespace) is not supported and may not result in recreation of that object
 * Singleton status return: It is the user responsibility to make sure that if a BindingPolicy requesting singleton status return matches a given workload object then no other BindingPolicy matches the same object. Currently there is no enforcement of that.
 * Objects on two different WDSes shouldn't have the exact same identifier (same group, version, kind, name and namespace). Such a conflict is currently not identified.
@@ -23,6 +24,7 @@ The main change from 0.23.0 is a re-organization of the website, which is still 
 
 ### Remaining limitations in 0.23.1
 
+* Job objects are not properly supported.
 * Removing of WorkStatus objects (in the transport namespace) is not supported and may not result in recreation of that object
 * Singleton status return: It is the user responsibility to make sure that if a BindingPolicy requesting singleton status return matches a given workload object then no other BindingPolicy matches the same object. Currently there is no enforcement of that.
 * Objects on two different WDSes shouldn't have the exact same identifier (same group, version, kind, name and namespace). Such a conflict is currently not identified.
@@ -37,6 +39,7 @@ This release also features better observability (`/metrics` and `/debug/pprof`) 
 
 ### Remaining limitations in 0.23.0 and its release candidates
 
+* Job objects are not properly supported.
 * Removing of WorkStatus objects (in the transport namespace) is not supported and may not result in recreation of that object
 * Singleton status return: It is the user responsibility to make sure that if a BindingPolicy requesting singleton status return matches a given workload object then no other BindingPolicy matches the same object. Currently there is no enforcement of that.
 * Objects on two different WDSes shouldn't have the exact same identifier (same group, version, kind, name and namespace). Such a conflict is currently not identified.
@@ -58,6 +61,7 @@ See [the changelogs on GitHub](https://github.com/kubestellar/kubestellar/releas
 
 ### Remaining limitations in 0.22.0 and its release candidates
 
+* Job objects are not properly supported.
 * Removing of WorkStatus objects (in the transport namespace) is not supported and may not result in recreation of that object
 * Singleton status return: It is the user responsibility to make sure that if a BindingPolicy requesting singleton status return matches a given workload object then no other BindingPolicy matches the same object. Currently there is no enforcement of that.
 * Objects on two different WDSes shouldn't have the exact same identifier (same group, version, kind, name and namespace). Such a conflict is currently not identified.
@@ -87,12 +91,14 @@ This release mainly updates the documentation exposed under kubestellar.io.
 
 ### Remaining limitations in 0.21.0 and its release candidates
 
+* Job objects are not properly supported.
 * Removing of WorkStatus objects (on the transport namespace) is not supported and may not result in recreation of that object
 * Singleton status return: It is the user responsibility to make sure that if a BindingPolicy requesting singleton status return matches a given workload object then no other BindingPolicy matches the same object. Currently there is no enforcement of that.
 * Objects on two different WDSes shouldn't have the exact same identifier (same group, version, kind, name and namespace). Such a conflict is currently not identified.
 
 ## 0.20.0 and its release candidates
 
+* Job objects are not properly supported.
 * Dynamic changes to WECs are not supported. Existing ManifestWorks will not be updated when new WECs are added or when labels are added/deleted on existing WECs
 * Removing of WorkStatus objects (on the transport namespace) is not supported and may not result in recreation of that object
 * Singleton status return: It is the user responsibility to make sure that if a BindingPolicy requesting singleton status return matches a given workload object then no other BindingPolicy matches the same object. Currently there is no enforcement of that.


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
This PR updates the release notes to say that release 0.24.0 has an incomplete introduction of create-only and that every release (thus far) does not support Job objects properly.

## Related issue(s)

Proper release notes would probably have prevented @cwiklik from wasting his time testing release 0.24.0.