### PR TITLE
🐛 Stop transport-controller thrashing finalizers

### DIFF
--- a/pkg/transport/generic/generic_transport_controller.go
+++ b/pkg/transport/generic/generic_transport_controller.go
@@ -1125,8 +1125,9 @@ func (c *genericTransportController) createOrUpdateWrappedObject(ctx context.Con
 		}
 		return nil
 	}
-	// // if we reached here object already exists, try update object
+	// if we reached here object already exists, try update object
 	wrappedObject.SetResourceVersion(existingWrappedObject.GetResourceVersion())
+	wrappedObject.SetFinalizers(existingWrappedObject.GetFinalizers())
 	wrappedObject2, err := c.transportClient.Resource(c.wrappedObjectGVR).Namespace(namespace).Update(ctx, wrappedObject, metav1.UpdateOptions{
 		FieldManager: ControllerName,
 	})


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
This PR changes the generic transport controller code so that it does not thrash the finalizers of the wrapped object.

## Related issue(s)

Fixes #
