### PR TITLE
📖 Improve doc linkage

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ KubeStellar simplifies this process by allowing developers to define a binding p
 
 ## Website
 
-See [kubestellar.io](https://kubestellar.io).
+For usage, architecture, and other documentation, see [the website](https://kubestellar.io).
 
 ## Contributing
 

--- a/docs/content/direct/testing.md
+++ b/docs/content/direct/testing.md
@@ -1,9 +1,4 @@
-# Notes for KubeStellar Contributors
-
-These notes are incomplete; as mentioned in the introduction, if you are interested in contributing directly to the development of KubeStellar, we recommend joining in via the [KubeStellar github repository](https://github.com/kubestellar/kubestellar) and [KubeStellar Slack](https://kubernetes.slack.com/archives/C058SUSL5AA/)
-
----
-
+# Testing
 
 Make sure all pre-requisites are installed as described in [pre-reqs](pre-reqs.md).
 
@@ -39,6 +34,10 @@ To run one of the individual tests, issue a command like the following example.
 go test -v -timeout 60s -run ^TestCRDHandling$ ./test/integration/controller-manager
 ```
 
-## Making releases
+## End-to-end testing
 
-See [the release process document](release.md).
+See `test/e2e/` in the GitHub repository. It has a README.
+
+## Testing releases
+
+See [the release testing doc](release-testing.md).

--- a/docs/content/readme.md
+++ b/docs/content/readme.md
@@ -38,6 +38,10 @@ In a single-cluster setup, developers typically access the cluster and deploy Ku
 
 KubeStellar simplifies this process by allowing developers to define a binding policy between clusters and Kubernetes objects. It then uses your regular single-cluster tooling to deploy and configure each cluster based on these binding policies, making multi-cluster operations as straightforward as managing a single cluster. This approach enhances productivity and efficiency, making KubeStellar a valuable tool in a multi-cluster Kubernetes environment.
 
+## Getting Started
+
+See the [Getting Started setup guide](direct/get-started.md) for getting started with kicking the tires.
+
 ## Contributing
 
 We ❤️ our contributors! If you're interested in helping us out, please head over to our [Contributing](Contribution%20guidelines/CONTRIBUTING.md) guide.

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -75,13 +75,12 @@ nav:
       - Security:
           - Policy: Contribution guidelines/security/security.md
           - Contacts: Contribution guidelines/security/security_contacts.md
-      - Contribution Notes:
-        - For Contributors: direct/contributor.md
-        - Packaging: direct/packaging.md
-        - Release Process: direct/release.md
-        - Release Testing: direct/release-testing.md
-        - Guidelines: Contribution guidelines/CONTRIBUTING.md
-        - Sign-off on Contributions: direct/pr-signoff.md
+      - Testing: direct/testing.md
+      - Packaging: direct/packaging.md
+      - Release Process: direct/release.md
+      - Release Testing: direct/release-testing.md
+      - Guidelines: Contribution guidelines/CONTRIBUTING.md
+      - Sign-off on Contributions: direct/pr-signoff.md
   - Community: 
     - Get Involved: Community/_index.md
     - Contact Us:


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
This PR makes some organizational changes to the documentation: adding a few links, removing the "Contribution Notes" vertex in the hierarchy (promoting its children), recognizing that the "For Contributors" doc is really just about testing.

Preview of website part at https://mikespreitzer.github.io/kcp-edge-mc/doc-fixlinx-1010/readme/

## Related issue(s)

Fixes #
