### PR TITLE
✨ Update self-references for 0.25.0-rc.1

### DIFF
--- a/core-chart/values.yaml
+++ b/core-chart/values.yaml
@@ -7,7 +7,7 @@
 # please do not change them unless you know what you are doing.
 HELM_VERSION: "3.16.1"
 KUBECTL_VERSION: "1.31.0"
-KUBESTELLAR_VERSION: "0.25.0-alpha.1.test.2"
+KUBESTELLAR_VERSION: "0.25.0-rc.1"
 # TRANSPORT_VERSION: e.g., "0.24.0"; defaults to KUBESTELLAR_VERSION value, if not defined
 CLUSTERADM_VERSION: "0.8.2"
 OCM_STATUS_ADDON_VERSION: "0.2.0-rc12"

--- a/docs/content/direct/release-notes.md
+++ b/docs/content/direct/release-notes.md
@@ -2,6 +2,17 @@
 
 The following sections list the known issues for each release. The issue list is not differential (i.e., compared to previous releases) but a full list representing the overall state of the specific release. 
 
+## 0.25.0 and its candidates
+
+The main advance in this release is finishing the implementation of the create-only feature. It is now available for use.
+
+### Remaining limitations in 0.24.0
+
+* Although the create-only feature can be used with Job objects to avoid trouble with `.spec.selector`, requesting singleton reported state return will still lead to a controller fight over `.status.replicas` while the Job is in progress.
+* Removing of WorkStatus objects (in the transport namespace) is not supported and may not result in recreation of that object
+* Singleton status return: It is the user responsibility to make sure that if a BindingPolicy requesting singleton status return matches a given workload object then no other BindingPolicy matches the same object. Currently there is no enforcement of that.
+* Objects on two different WDSes shouldn't have the exact same identifier (same group, version, kind, name and namespace). Such a conflict is currently not identified.
+
 ## 0.25.0-alpha.1 test releases
 
 These test the release-building functionality, which has been revised in the course of merge the controller-manager and transport-controller Helm charts into the core Helm chart.

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -14,7 +14,7 @@ edit_uri: edit/main/docs/content
 ks_branch: 'main'
 ks_tag: 'latest'
 ks_latest_regular_release: '0.24.0'
-ks_latest_release: '0.25.0-alpha.1.test.2'
+ks_latest_release: '0.25.0-rc.1'
 
 ks_kind_port_num: '1119'
 

--- a/scripts/create-kubestellar-demo-env.sh
+++ b/scripts/create-kubestellar-demo-env.sh
@@ -17,10 +17,12 @@
 
 set -e
 
-echo -e "Checking that pre-req softwares are installed..."
-curl -s https://raw.githubusercontent.com/kubestellar/kubestellar/v0.23.1/hack/check_pre_req.sh | bash -s -- -V kflex ocm helm kubectl docker kind
+kubestellar_version=0.25.0-rc.1
 
-output=$(curl -s https://raw.githubusercontent.com/kubestellar/kubestellar/v0.23.1/hack/check_pre_req.sh | bash -s -- -A -V kflex ocm helm kubectl docker kind
+echo -e "Checking that pre-req softwares are installed..."
+curl -s https://raw.githubusercontent.com/kubestellar/kubestellar/v${kubestellar_version}/hack/check_pre_req.sh | bash -s -- -V kflex ocm helm kubectl docker kind
+
+output=$(curl -s https://raw.githubusercontent.com/kubestellar/kubestellar/v${kubestellar_version}/hack/check_pre_req.sh | bash -s -- -A -V kflex ocm helm kubectl docker kind
 )
 
 echo -e "\nStarting environment clean up..."
@@ -74,11 +76,10 @@ context_clean_up
 echo "Context space clean up completed"
 
 echo -e "\nStarting the process to install KubeStellar core: kind-kubeflex..."
-export KUBESTELLAR_VERSION=0.23.1
 
-curl -s https://raw.githubusercontent.com/kubestellar/kubestellar/v${KUBESTELLAR_VERSION}/scripts/create-kind-cluster-with-SSL-passthrough.sh | bash -s -- --name kubeflex --port 9443
+curl -s https://raw.githubusercontent.com/kubestellar/kubestellar/v${kubestellar_version}/scripts/create-kind-cluster-with-SSL-passthrough.sh | bash -s -- --name kubeflex --port 9443
 
-helm upgrade --install ks-core oci://ghcr.io/kubestellar/kubestellar/core-chart --version $KUBESTELLAR_VERSION --set-json='ITSes=[{"name":"its1"}]' --set-json='WDSes=[{"name":"wds1"}]'
+helm upgrade --install ks-core oci://ghcr.io/kubestellar/kubestellar/core-chart --version $kubestellar_version --set-json='ITSes=[{"name":"its1"}]' --set-json='WDSes=[{"name":"wds1"}]'
 
 echo -e "\nWaiting for new non-host KubeFlex Control Planes to be Ready:"
 for cpname in its1 wds1; do


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
This PR updates the self-references in preparation for release 0.25.0-rc.1.

This PR also reworks `scripts/create-kubestellar-demo-env.sh` (which is still not documented) a bit so that it needs to hold only one copy of the release version.

Website preview at https://mikespreitzer.github.io/kcp-edge-mc/doc-prep-for-0250rc1/readme/

## Related issue(s)

Fixes #
