### PR TITLE
🐛  Check for empty DownsyncObjectTest

### DIFF
--- a/api/control/v1alpha1/types.go
+++ b/api/control/v1alpha1/types.go
@@ -162,9 +162,8 @@ type StatusCollection struct {
 // - the `objectSelectors` criterion is satisfied.
 // At least one of the fields must make some discrimination;
 // it is not valid for every field to match all objects.
-// Validation might not be fully checked by apiservers until the Kubernetes dependency is release 1.25;
-// in the meantime validation error messages will appear
-// in annotations whose key is `validation-error.kubestellar.io/{number}`.
+// Validation might not be fully checked by apiservers;
+// if not prevented by the apiserver then violations will be reported in `.status.errors`.
 type DownsyncObjectTest struct {
 	// `apiGroup` is the API group of the referenced object, empty string for the core API group.
 	// `nil` matches every API group.

--- a/config/crd/patches/more_validations_in_bindingpolicies.yaml
+++ b/config/crd/patches/more_validations_in_bindingpolicies.yaml
@@ -10,3 +10,12 @@
 - op: add
   path: /spec/versions/0/schema/openAPIV3Schema/properties/spec/properties/clusterSelectors/items/properties/matchExpressions/items/properties/values/items/pattern
   value: "^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$"
+- op: add
+  path: /spec/versions/0/schema/openAPIV3Schema/properties/spec/properties/downsync/items/anyOf
+  value:
+  - required: [apiGroup]
+  - required: [resources]
+  - required: [namespaces]
+  - required: [namespaceSelectors]
+  - required: [objectSelectors]
+  - required: [objectNames]

--- a/docs/content/direct/binding.md
+++ b/docs/content/direct/binding.md
@@ -41,7 +41,8 @@ in `spec.clusterSelectors`.
 The workload object selection predicate is in `spec.downsync`, which
 holds a list of `DownsyncPolicyClause`s; each includes both a workload
 object selection predicate and also two kinds of information that
-modulate the downsync.
+modulate the downsync. Note that each such clause must have at least
+one field specifying part of the workload selection predicate.
 
 For more definitional details about a `BindingPolicy`, see [the API reference](https://pkg.go.dev/github.com/kubestellar/kubestellar@v{{ config.ks_latest_release }}/api/control/v1alpha1#BindingPolicy){# readers of the unrendered sources should see [the Go source](../../../api/control/v1alpha1/types.go) instead #}.
 

--- a/docs/content/direct/testing.md
+++ b/docs/content/direct/testing.md
@@ -12,7 +12,7 @@ make test
 
 ## Integration testing
 
-There are currently two integration tests. Contributors can run them. There is also a GitHub Actions workflow (in `.github/workflows/pr-test-integration.yml`) that runs these tests.
+There are currently three integration tests. Contributors can run them. There is also a GitHub Actions workflow (in `.github/workflows/pr-test-integration.yml`) that runs these tests.
 
 These tests require you to already have `etcd` on your `$PATH`.
 See https://github.com/kubernetes/kubernetes/blob/v1.28.2/hack/install-etcd.sh for an example of how to do that.

--- a/pkg/crd/crds.go
+++ b/pkg/crd/crds.go
@@ -80,7 +80,7 @@ func ApplyCRDs(ctx context.Context, controllerName string,
 		if err != nil {
 			return fmt.Errorf("unable to convert from Unstructured to CRD, name=%s: %w", crdU.GetName(), err)
 		}
-		_, err = clientsetExt.Create(ctx, desiredCRD, metav1.CreateOptions{FieldManager: controllerName})
+		_, err = clientsetExt.Create(ctx, desiredCRD, metav1.CreateOptions{FieldValidation: metav1.FieldValidationStrict, FieldManager: controllerName})
 		if err == nil {
 			logger.Info("Created CRD", "name", desiredCRD.Name)
 		} else if !errors.IsAlreadyExists(err) {

--- a/pkg/crd/files/crds.yaml
+++ b/pkg/crd/files/crds.yaml
@@ -113,6 +113,19 @@ spec:
                   match the same workload object: the `createOnly` bits are ORed together,
                   and the StatusCollector reference sets are combined by union.'
                 items:
+                  anyOf:
+                  - required:
+                    - apiGroup
+                  - required:
+                    - resources
+                  - required:
+                    - namespaces
+                  - required:
+                    - namespaceSelectors
+                  - required:
+                    - objectSelectors
+                  - required:
+                    - objectNames
                   description: DownsyncPolicyClause identifies some objects (by a
                     predicate) and modulates how they are downsynced. One modulation
                     is specifying a set of StatusCollectors to apply to returned status.

--- a/test/integration/controller-manager/cr-validation_test.go
+++ b/test/integration/controller-manager/cr-validation_test.go
@@ -1,0 +1,126 @@
+/*
+Copyright 2024 The KubeStellar Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cmtest
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	apiextensionsclientset "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	runtime "k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/klog/v2/ktesting"
+	kastesting "k8s.io/kubernetes/cmd/kube-apiserver/app/testing"
+	"k8s.io/kubernetes/test/integration/framework"
+	"sigs.k8s.io/yaml"
+
+	ksapi "github.com/kubestellar/kubestellar/api/control/v1alpha1"
+	kscrd "github.com/kubestellar/kubestellar/pkg/crd"
+)
+
+func TestBindingPolicyValidation(t *testing.T) {
+	testWriter := framework.NewTBWriter(t)
+	logger, ctx := ktesting.NewTestContext(t)
+	logger.Info("Starting etcd server")
+	framework.StartEtcd(t, testWriter)
+	logger.Info("Starting TestController")
+	t.Log("Beginning TestController")
+	ctx, cancel := context.WithCancel(ctx)
+	testServer, err := kastesting.StartTestServer(t, kastesting.NewDefaultTestServerOptions(), []string{}, framework.SharedEtcd())
+	if err != nil {
+		t.Fatalf("Failed to kastesting.StartTestServer: %s", err)
+	}
+	fullTeardwon := func() {
+		cancel()
+		testServer.TearDownFn()
+	}
+	t.Cleanup(fullTeardwon)
+	config := testServer.ClientConfig
+	if err != nil {
+		t.Fatalf("Failed to create Kubernetes client: %s", err)
+	}
+	logger.Info("Started test server", "config", config)
+	configCopy := *config
+	config4json := &configCopy
+	config4json.ContentType = "application/json"
+	logger.Info("REST config for JSON marshaling", "config", config4json)
+	apiextClient, err := apiextensionsclientset.NewForConfig(config)
+	if err != nil {
+		t.Fatalf("Failed to create apiextensions client: %s", err)
+	}
+	err = kscrd.ApplyCRDs(ctx, "test", apiextClient.ApiextensionsV1().CustomResourceDefinitions(), logger)
+	if err != nil {
+		t.Fatalf("Failed to apply KubeStellar CRDs: %s", err)
+	}
+	bpCRD, err := apiextClient.ApiextensionsV1().CustomResourceDefinitions().Get(ctx, "bindingpolicies.control.kubestellar.io", metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("Failed to fetch BindingPolicy CRD: %s", err)
+	}
+	bpYAML, err := yaml.Marshal(bpCRD)
+	if err != nil {
+		t.Fatalf("Failed to marshal BindingPolicy CRD: %s", err)
+	}
+	t.Log("Fetched BindingPolicy CRD:\n" + string(bpYAML))
+	dynClient, err := dynamic.NewForConfig(config)
+	if err != nil {
+		t.Fatalf("Failed to create dynamic client: %s", err)
+	}
+	dynIfc := dynClient.Resource(ksapi.SchemeGroupVersion.WithResource("bindingpolicies"))
+	converter := runtime.DefaultUnstructuredConverter
+	for _, testCase := range []struct {
+		name     string
+		specJSON string
+		expectOK bool
+	}{
+		{name: "junk-field-in-spec", specJSON: `{"junk": 1}`, expectOK: false},
+		{name: "junk-field-in-policy", specJSON: `{"downsync": [{"junq": true}]}`},
+		{name: "no-test-in-policy", specJSON: `{"downsync": [{"createOnly": true, "statusCollection": {"statusCollectors": ["phred"]}}]}`},
+		{name: "match-all-resources", specJSON: `{"downsync": [{"resources": ["*"]}]}`, expectOK: true},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			blankBP := ksapi.BindingPolicy{
+				TypeMeta:   metav1.TypeMeta{APIVersion: ksapi.SchemeGroupVersion.String(), Kind: "BindingPolicy"},
+				ObjectMeta: metav1.ObjectMeta{Name: testCase.name},
+			}
+			srcM, err := converter.ToUnstructured(&blankBP)
+			if err != nil {
+				t.Fatalf("Failed to convert to Unstructured: %s", err)
+			}
+			spec := map[string]any{}
+			err = json.Unmarshal([]byte(testCase.specJSON), &spec)
+			if err != nil {
+				t.Fatalf("Failed to unmarshal spec: %s", err)
+			}
+			unstructured.SetNestedMap(srcM, spec, "spec")
+			srcU := &unstructured.Unstructured{Object: srcM}
+			echo, err := dynIfc.Create(ctx, srcU, metav1.CreateOptions{FieldValidation: metav1.FieldValidationStrict, FieldManager: "test"})
+			if testCase.expectOK == (err == nil) {
+				t.Logf("Success; err=%s", err)
+			} else if err == nil {
+				t.Errorf("Failed to get expected error; echo=%#v", echo.Object)
+			} else {
+				t.Errorf("Got unexpected error: %s; srcM=%#v", err, srcM)
+			}
+			if err == nil {
+				dynIfc.Delete(ctx, srcU.GetName(), metav1.DeleteOptions{})
+			}
+		})
+	}
+}

--- a/test/integration/controller-manager/crd-handling_test.go
+++ b/test/integration/controller-manager/crd-handling_test.go
@@ -74,9 +74,6 @@ func TestCRDHandling(t *testing.T) {
 	config4json := &configCopy
 	config4json.ContentType = "application/json"
 	logger.Info("REST config for JSON marshaling", "config", config4json)
-	if err != nil {
-		t.Fatalf("Failed to create KubeStellar client: %s", err)
-	}
 	apiextClient, err := apiextensionsclientset.NewForConfig(config)
 	if err != nil {
 		t.Fatalf("Failed to create apiextensions client: %s", err)

--- a/test/integration/controller-manager/matching_test.go
+++ b/test/integration/controller-manager/matching_test.go
@@ -397,21 +397,12 @@ func TestMatching(t *testing.T) {
 
 var crdGVK = apiextensionsapi.SchemeGroupVersion.WithKind("CustomResourceDefinition")
 
-func createCRD(t *testing.T, ctx context.Context, kind, url string, serializer *k8sjson.Serializer, apiextClient apiextensionsclientset.Interface) error {
+func createCRD(t *testing.T, ctx context.Context, kind, url string, serializer *k8sjson.Serializer, apiextClient apiextensionsclientset.Interface) (*apiextensionsapi.CustomResourceDefinition, error) {
 	crdYAML, err := urlGet(url)
 	if err != nil {
 		t.Fatalf("Failed to read %s CRD from %s: %s", kind, url, err)
 	}
-	crdAny, _, err := serializer.Decode([]byte(crdYAML), &crdGVK, &apiextensionsapi.CustomResourceDefinition{})
-	if err != nil {
-		t.Fatalf("Failed to Decode %s CRD: %s", kind, err)
-	}
-	crd := crdAny.(*apiextensionsapi.CustomResourceDefinition)
-	_, err = apiextClient.ApiextensionsV1().CustomResourceDefinitions().Create(ctx, crd, metav1.CreateOptions{})
-	if err != nil {
-		t.Fatalf("Failed to create %s CRD: %s", kind, err)
-	}
-	return nil
+	return createCRDFromLiteral(t, ctx, kind, crdYAML, serializer, apiextClient)
 }
 
 type gvrnn struct {


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
This PR adds validation checking to BindingPolicy regarding the prohibition on an empty DownsyncObjectTest, and updates the statement in the API about how validation errors are reported.

This PR adds this validation in two ways, because the first way does not work and I do not understand why. Hopefully it is some small thing that can be rectified, which is why I have not abandoned it. The first technique adds some validation to the JSON schema for BindingPolicy, but the kube-apiserver accepts this extra validation without complaint but also trashes it so that it has no effect (it empties out the schemas in the array value of the `anyOf`, so they all trivially validate; the integration test displays the returned CRD, where you can see the trashed schemas). This PR has a second commit which adds checking in the binding controller.

## Related issue(s)

Fixes #2500 
