### PR TITLE
✨ Add version checking to the check_pre_req script

### DIFF
--- a/docs/content/direct/pre-reqs.md
+++ b/docs/content/direct/pre-reqs.md
@@ -1,7 +1,7 @@
 # KubeStellar Prerequisites
 
 The following prerequisites are required.
-You can use the [check-pre-req](#automated-check-of-pre-requisites-for-kubestellar) script, to validate if all needed prerequisites are installed.
+You can use the [check-pre-req](#automated-check-of-prerequisites-for-kubestellar) script, to validate if all needed prerequisites are installed.
 
 
 ## Infrastructure (clusters)
@@ -21,11 +21,11 @@ Our documentation has remarks about using the following sorts of clusters:
 <!-- begin software prerequisites -->
 ## Software Prerequisites: for Using KubeStellar
 
-- **kubeflex** version 0.7.1 or higher
+- **kubeflex** version 0.7.1 or higher.
     To install kubeflex go to [https://github.com/kubestellar/kubeflex/blob/main/docs/users.md#installation](https://github.com/kubestellar/kubeflex/blob/main/docs/users.md#installation). To upgrade from an existing installation,
 follow [these instructions](https://github.com/kubestellar/kubeflex/blob/main/docs/users.md#upgrading-kubeflex). At the end of the install make sure that the kubeflex CLI, kflex, is in your `$PATH`.
 
-- **OCM CLI (clusteradm)**
+- **OCM CLI (clusteradm)** version >= 0.7.
     To install OCM CLI use:
 
     ```shell
@@ -43,37 +43,37 @@ follow [these instructions](https://github.com/kubestellar/kubeflex/blob/main/do
 
     At the end of the install make sure that the OCM CLI, clusteradm, is in your `$PATH`.
 
-- **helm** - to deploy the Kubestellar and kubeflex charts
-- [**kubectl**](https://kubernetes.io/docs/tasks/tools/) - to access the kubernetes clusters
+- **helm** version >= 3 - to deploy the Kubestellar and kubeflex charts
+- [**kubectl**](https://kubernetes.io/docs/tasks/tools/) version >= 1.27 - to access the kubernetes clusters
 
 ## Additional Software for the Getting Started setup
 
-- [**kind**](https://kind.sigs.k8s.io/)
-- **docker** (or compatible docker engine that works with kind)
+- [**kind**](https://kind.sigs.k8s.io/) version >= 0.20
+- **docker** (or compatible docker engine that works with kind) (client version >= 20)
 
 ## Additional Software for monitoring
 
 The setup in `montoring/` additional uses the following.
 
-- [`yq`](https://github.com/mikefarah/yq) (also available from [Homebrew](https://formulae.brew.sh/formula/yq))
+- [`yq`](https://github.com/mikefarah/yq) (also available from [Homebrew](https://formulae.brew.sh/formula/yq)) version >= 1.5
 
 ## Additional Software For Running the Examples
 
-- [**argocd**](https://argo-cd.readthedocs.io/en/stable/getting_started/) - for the examples that use it
+- [**argocd**](https://argo-cd.readthedocs.io/en/stable/getting_started/) version >= 2 - for the examples that use it
 
 ## Additional Software For Building KubeStellar from Source and Testing
 
 - [**go**](https://go.dev/doc/install) version 1.21 or higher - to build Kubestellar
-- [**make**](https://www.gnu.org/software/make/) - to build Kubestellar and create the Kubestellar container images
-- [**ko**](https://ko.build/install/) - to create some of the Kubestellar container images
-- **docker** (or equivalent that implements `docker buildx`) - to create other KubeStellar container images
+- [**GNU make**](https://www.gnu.org/software/make/) version >= 3.5 - to build Kubestellar and create the Kubestellar container images
+- [**ko**](https://ko.build/install/) version >= 0.15 - to create some of the Kubestellar container images
+- **docker** (or equivalent that implements `docker buildx`) (client version >= 20) - to create other KubeStellar container images
 
 
 To build and _**test**_ KubeStellar properly, you will also need
 
-- [**kind**](https://kind.sigs.k8s.io/)
+- [**kind**](https://kind.sigs.k8s.io/) version >= 0.20
 - [**OCP**](https://docs.openshift.com/container-platform/4.13/installing/index.html)
-- [`yq`](https://github.com/mikefarah/yq) (also available from [Homebrew](https://formulae.brew.sh/formula/yq)) - for running tests
+- [`yq`](https://github.com/mikefarah/yq) (also available from [Homebrew](https://formulae.brew.sh/formula/yq)) version >= 4 - for running tests
 
 <!-- start tag for check script  include -->
 
@@ -108,18 +108,18 @@ For example, list of prerequisites required by KubeStellar can be checked with t
 ```shell
 $ hack/check_pre_req.sh
 Checking pre-requisites for using KubeStellar:
-✔ Docker
-✔ kubectl
-✔ KubeFlex
-✔ OCM CLI
-✔ Helm
+✔ Docker (Docker version 27.2.1-rd, build cc0ee3e)
+✔ kubectl (v1.29.2)
+✔ KubeFlex (Kubeflex version: v0.6.3.672cc8a 2024-09-23T16:15:47Z)
+✔ OCM CLI (:v0.9.0-0-g56e1fc8)
+✔ Helm (v3.16.1)
 Checking additional pre-requisites for running the examples:
-✔ Kind
-X ArgoCD CLI
+✔ Kind (kind v0.22.0 go1.22.0 darwin/arm64)
+✔ ArgoCD CLI (v2.10.1+a79e0ea)
 Checking pre-requisites for building KubeStellar:
-✔ GNU Make
-✔ Go
-✔ KO
+✔ GNU Make (GNU Make 3.81)
+✔ Go (go version go1.23.2 darwin/arm64)
+✔ KO (0.16.0)
 ```
 
 <!-- end tag for check-prereq script -->
@@ -130,8 +130,8 @@ In another example, a specific list of prerequisites could be asserted by a high
 $ check_pre_req.sh --assert --verbose helm argo docker kind
 Checking KubeStellar pre-requisites:
 ✔ Helm
-  version: version.BuildInfo{Version:"v3.14.0", GitCommit:"3fc9f4b2638e76f26739cd77c7017139be81d0ea", GitTreeState:"clean", GoVersion:"go1.21.5"}
+  version (unstructured): version.BuildInfo{Version:"v3.14.0", GitCommit:"3fc9f4b2638e76f26739cd77c7017139be81d0ea", GitTreeState:"clean", GoVersion:"go1.21.5"}
      path: /usr/sbin/helm
 X ArgoCD CLI
-  how to install: https://argo-cd.readthedocs.io/en/stable/cli_installation/
+  how to install: https://argo-cd.readthedocs.io/en/stable/cli_installation/; get at least version v2
 ```

--- a/docs/content/direct/release.md
+++ b/docs/content/direct/release.md
@@ -14,6 +14,7 @@ Every release should pass all release tests before it can be officially declare 
 ### Reacting to a new KubeFlex release
 
 - Update the KubeFlex release in `docs/content/direct/pre-reqs.md`
+- Update the "kflex" release in `hack/check_pre_req.sh`
 - Update the KubeFlex release in `go.mod`
 - `go mod tidy`
 - Update the KubeFlex release in `core-chart/Chart.yaml`

--- a/hack/check_pre_req.sh
+++ b/hack/check_pre_req.sh
@@ -23,18 +23,30 @@ echoerr() {
 is_installed() {
     # $1 == name
     # $2 == command name to search
-    # $3 == command to get the version
-    # $4 == help
+    # $3 == command to get the version, unstructured
+    # $4 == command to get the version for lexicographic comparison
+    # $5 == help
+    # $6 == min required version
+    # (optional) $7 == another min version (covering case of roll from 9 to 10)
+    wantver="$6"
+    addlver="$7"
     if which $2 > /dev/null ; then
-        echo -e "\033[0;32m\xE2\x9C\x94\033[0m $1"
         if [ $# -gt 2 ]; then
-            echov "  version: $(eval "$3" 2> /dev/null)"
+            gotver=$(eval "$4" 2> /dev/null)
+            echo -e "\033[0;32m\xE2\x9C\x94\033[0m $1 ($gotver)"
+            echov "  version (unstructured): $(eval "$3" 2> /dev/null)"
+            if [[ "$gotver" < "$wantver" ]] && { [ -z "$addlver" ] || [[ "$gotver" < "$addlver" ]]; } ; then
+                echo "  structured version '$gotver' is less than required minimum '$wantver'" $([ -z "$addlver" ] || echo or "'$addlver'") >&2
+                exit 2
+            fi
+        else
+            echo -e "\033[0;32m\xE2\x9C\x94\033[0m $1"
         fi
         echov "     path: $(which $2)"
     else
         echo -e "\033[0;31mX\033[0m $1"
         if [ $# -gt 3 ]; then
-            echov "  how to install: $4"
+            echov "  how to install: $5; get at least version $wantver"
         fi
         if [ "$assert" == "true" ]; then
             exit 2
@@ -45,99 +57,128 @@ is_installed() {
 is_installed_argo() {
     is_installed 'ArgoCD CLI' \
         'argocd' \
-        'argocd version --short' \
-        'https://argo-cd.readthedocs.io/en/stable/cli_installation/'
+        'argocd version --short --client' \
+        'argocd version --short --client -o json | jq -r .client.argocd' \
+        'https://argo-cd.readthedocs.io/en/stable/cli_installation/' \
+        v2
 }
 
 is_installed_brew() {
     is_installed 'Home Brew' \
         'brew' \
         'brew --version' \
-        '/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"'
+        'brew --version | grep "^Homebrew "' \
+        '/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"' \
+        'Homebrew 4'
 }
 
 is_installed_docker() {
     is_installed 'Docker' \
         'docker' \
         'docker --version' \
-        'https://docs.docker.com/engine/install/'
+        'docker --version' \
+        'https://docs.docker.com/engine/install/' \
+        'Docker version 20'
 }
 
 is_installed_go() {
     is_installed 'Go' \
         'go' \
         'go version' \
-        'https://go.dev/doc/install'
+        'go version' \
+        'https://go.dev/doc/install' \
+        'go version 1.21'
 }
 
 is_installed_helm() {
     is_installed 'Helm' \
         'helm' \
         'helm version' \
-        'https://helm.sh/docs/intro/install/'
+        'helm version --template={{.Version}}' \
+        'https://helm.sh/docs/intro/install/' \
+        'v3'
 }
 
 is_installed_jq() {
     is_installed 'jq' \
         'jq' \
         'jq --version' \
-        'https://jqlang.github.io/jq/download/'
+        'jq --version' \
+        'https://jqlang.github.io/jq/download/' \
+        'jq-1.5'
 }
 
 is_installed_kcp() {
     is_installed 'kcp' \
         'kcp' \
         'kcp version' \
-        'https://docs.kcp.io/kcp/main/'
+        'echo dontcare' \
+        'https://docs.kcp.io/kcp/main/' \
+        'dontcare'
 }
 
 is_installed_kflex() {
     is_installed 'KubeFlex' \
         'kflex' \
         'kflex version | head -1' \
-        'https://github.com/kubestellar/kubeflex'
+        'kflex version | head -1' \
+        'https://github.com/kubestellar/kubeflex' \
+        'Kubeflex version: v0.7.1'
 }
 
 is_installed_kind() {
     is_installed 'Kind' \
         'kind' \
         'kind version' \
-        'https://kind.sigs.k8s.io/docs/user/quick-start/#installation'
+        'kind version' \
+        'https://kind.sigs.k8s.io/docs/user/quick-start/#installation' \
+        'kind v0.20'
 }
 
 is_installed_ko() {
     is_installed 'KO' \
         'ko' \
         'ko version' \
-        'https://ko.build/install/'
+        'ko version' \
+        'https://ko.build/install/' \
+        '0.15'
 }
 
 is_installed_kubectl() {
     is_installed 'kubectl' \
         'kubectl' \
-        'kubectl version --short 2> /dev/null | head -1' \
-        'https://kubernetes.io/docs/tasks/tools/install-kubectl-linux/'
+        'kubectl version --client | head -1' \
+        'kubectl version --client -o json 2> /dev/null | jq -r .clientVersion.gitVersion' \
+        'https://kubernetes.io/docs/tasks/tools/install-kubectl-linux/' \
+        v1.27
 }
 
 is_installed_make() {
     is_installed 'GNU Make' \
         'make' \
         'make --version | head -1' \
-        'sudo apt-get install make or brew install make or install XCode Command Line Tools'
+        'make --version | grep "^GNU Make "' \
+        'sudo apt-get install make or brew install make or install XCode Command Line Tools' \
+        'GNU Make 3.5'
 }
 
 is_installed_ocm() {
     is_installed 'OCM CLI' \
         'clusteradm' \
-        'clusteradm version' \
-        'curl -L https://raw.githubusercontent.com/open-cluster-management-io/clusteradm/main/install.sh | bash'
+        'clusteradm version 2> /dev/null | grep ^client' \
+        "clusteradm version 2> /dev/null | grep ^client | awk '"'{ print $3 }'"'" \
+        'curl -L https://raw.githubusercontent.com/open-cluster-management-io/clusteradm/main/install.sh | bash' \
+        :v0.7 \
+        :v0.10
 }
 
 is_installed_yq() {
     is_installed 'yq' \
         'yq' \
         'yq --version' \
-        'brew install yq or snap install yq'
+        "yq --version | sed 's/.*\(version .*\)$/\1/'" \
+        'brew install yq or snap install yq' \
+        'version v4'
 }
 
 


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
This PR enhances `hack/check_pre_req.sh` to know what the minimum required version of each dependency is, and check that. This PR also enhances the pre-reqs doc to list all the minimum required versions.

I had to guess at some of the version requirements.

Preview at https://mikespreitzer.github.io/kcp-edge-mc/doc-check-versions/direct/pre-reqs/

## Related issue(s)

Fixes #2492 
This also completes the work on Issue 2491, which is already marked as complete (although I do not understand why).
