### PR TITLE
🌱 Pin ko to release that has binary assets

### DIFF
--- a/.github/workflows/pr-test-e2e.yml
+++ b/.github/workflows/pr-test-e2e.yml
@@ -45,6 +45,8 @@ jobs:
         id: install
 
       - uses: ko-build/setup-ko@v0.7
+        with:
+          version: v0.16.0
 
       - name: Install dependencies
         run: |
@@ -176,6 +178,8 @@ jobs:
         id: install
 
       - uses: ko-build/setup-ko@v0.7
+        with:
+          version: v0.16.0
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/pr-test-integration.yml
+++ b/.github/workflows/pr-test-integration.yml
@@ -30,6 +30,8 @@ jobs:
         id: install
 
       - uses: ko-build/setup-ko@v0.7
+        with:
+          version: v0.16.0
 
       - name: Install dependencies
         run: |


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
This PR updates the GitHub Actions workflows that use `ko` to specify release 0.16 of `ko`. This is good because they made a newer release today but it does not have the binary assets that we need and I am not confident that this will be remedied soon.

## Related issue(s)

Fixes #
