### PR TITLE
📖  Use explicit releases instead of main

### DIFF
--- a/docs/content/direct/release.md
+++ b/docs/content/direct/release.md
@@ -45,6 +45,8 @@ Making a new kubestellar release requires a contributor to do the following thin
 
 - Update the version in the core chart defaults, `core-chart/values.yaml`.
 
+- Replace the reference to `main` in `docs/content/direct/start-from-ocm.md` with a reference to the upcoming release, and change this here instruction to updating that reference.
+
 - Until we have our first stable release, edit the old docs README(`oldocs/README.md`, section "latest-stable-release") where it wishes it could cite a stable release but instead cites the latest release, to refer to the coming release.
 
 - Edit the release notes in `docs/content/direct/release-notes.md`.

--- a/docs/content/direct/start-from-ocm.md
+++ b/docs/content/direct/start-from-ocm.md
@@ -56,7 +56,7 @@ export KUBESTELLAR_VERSION={{ config.ks_latest_release }}
 
 ### OCM Quick Start with Ingress
 
-This recipe uses a modified version of [the OCM Quick Start](https://raw.githubusercontent.com/open-cluster-management-io/OCM/main/solutions/setup-dev-environment/local-up.sh). The modification is because KubeStellar needs the hosting cluster to have an Ingress controller with SSL passthrough enabled. The modified Quick Start script has the following modifications compared to the baseline.
+This recipe uses a modified version of [the OCM Quick Start](https://raw.githubusercontent.com/open-cluster-management-io/OCM/v0.15.0/solutions/setup-dev-environment/local-up.sh). The modification is because KubeStellar needs the hosting cluster to have an Ingress controller with SSL passthrough enabled. The modified Quick Start script has the following modifications compared to the baseline.
 
 1. The `kind` cluster created for the hub has an additional port mapping, where the Ingress controller listens.
 1. The script installs [the NGINX Ingress Controller](https://docs.nginx.com/nginx-ingress-controller/) into the hub cluster, then patches the controller to enable SSL passthrough, and later waits for it to be in service.


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
This PR is a bit of cleanup after #2515 . This PR does two things.

1. Use an explicit version in the reference to the OCM Quick Start.
2. Note that the upcoming release should replace the reference to KubeStellar `main` with that release.

Preview at https://mikespreitzer.github.io/kcp-edge-mc/doc-release-for-ocm/direct/release/

## Related issue(s)

Fixes #
