### PR TITLE
📖  Use shell variable rather than environment variable

### DIFF
--- a/docs/content/direct/get-started.md
+++ b/docs/content/direct/get-started.md
@@ -44,7 +44,7 @@ kubectl config delete-context cluster2
 ### Set the Version appropriately as an environment variable
 
 ```shell
-export KUBESTELLAR_VERSION={{ config.ks_latest_release }}
+kubestellar_version={{ config.ks_latest_release }}
 ```
 
 ### Create a kind cluster to host KubeFlex
@@ -59,7 +59,7 @@ bash <(curl -s https://raw.githubusercontent.com/kubestellar/kubestellar/v{{ con
 
 ```shell
 helm upgrade --install ks-core oci://ghcr.io/kubestellar/kubestellar/core-chart \
-    --version $KUBESTELLAR_VERSION \
+    --version $kubestellar_version \
     --set-json='ITSes=[{"name":"its1"}]' \
     --set-json='WDSes=[{"name":"wds1"}]'
 ```

--- a/docs/content/direct/start-from-ocm.md
+++ b/docs/content/direct/start-from-ocm.md
@@ -51,7 +51,7 @@ yq -i 'del(.preferences)' ${KUBECONFIG:-$HOME/.kube/config}
 ### Set the Version appropriately as an environment variable
 
 ```shell
-export KUBESTELLAR_VERSION={{ config.ks_latest_release }}
+kubestellar_version={{ config.ks_latest_release }}
 ```
 
 ### OCM Quick Start with Ingress
@@ -95,7 +95,7 @@ This chart instance will do the following.
 
 ```shell
 helm --kube-context kind-hub upgrade --install ks-core oci://ghcr.io/kubestellar/kubestellar/core-chart \
-    --version $KUBESTELLAR_VERSION \
+    --version $kubestellar_version \
     --set-json='ITSes=[{"name":"its1", "type":"host"}]' \
     --set-json='WDSes=[{"name":"wds1"}]' \
     --set-json='verbosity.default=5' # so we can debug your problem reports


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
This PR updates the two setup recipes to use a variable that is local to the shell rather than exported to processes invoked in the recipes, to hold the KubeStellar release string. This is good because it does not leave the reader wondering whether those processes are sensitive to such an environment variable.

## Related issue(s)

Fixes #
