### PR TITLE
🐛  Set errexit in hosting cluster creation scripts

### DIFF
--- a/scripts/create-k3s-cluster-with-SSL-passthrough.sh
+++ b/scripts/create-k3s-cluster-with-SSL-passthrough.sh
@@ -15,6 +15,8 @@
 
 # Create a k3s cluster for KubeStellar deployment
 
+set -o errexit
+
 port=9443
 wait=true
 

--- a/scripts/create-kind-cluster-with-SSL-passthrough.sh
+++ b/scripts/create-kind-cluster-with-SSL-passthrough.sh
@@ -15,6 +15,8 @@
 
 # Create a kind cluster for KubeStellar deployment
 
+set -o errexit
+
 name=kubestellar
 port=9443
 wait=true


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
This PR updates `scripts/create-k3s-cluster-with-SSL-passthrough.sh` and `scripts/create-kind-cluster-with-SSL-passthrough.sh` to set the "errexit" option in bash, so that problems are not skipped past.

## Related issue(s)

Fixes #2517
