### PR TITLE
🌱  Give some love to ginkgo --fail-fast

### DIFF
--- a/.github/workflows/pr-test-e2e.yml
+++ b/.github/workflows/pr-test-e2e.yml
@@ -60,7 +60,7 @@ jobs:
           TEST_FLAGS: ${{ github.event.inputs.testFlags }}
         run: |
           cd test/e2e/ginkgo
-          KFLEX_DISABLE_CHATTY=true ginkgo -vv --trace --no-color $TEST_FLAGS -- -kubestellar-setup-flags="--kubestellar-controller-manager-verbosity 5 --transport-controller-verbosity 5"
+          KFLEX_DISABLE_CHATTY=true ginkgo -vv --trace --no-color --fail-fast $TEST_FLAGS -- -kubestellar-setup-flags="--kubestellar-controller-manager-verbosity 5 --transport-controller-verbosity 5"
 
       - name: show kubeconfig contexts
         if: always()

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -40,6 +40,10 @@ FYI, if you need to rename a kubeconfig context in order to reach the above conf
 $ kubectl config rename-context <default-wec1-context-name> cluster1
 ```
 
+## Fail fast or run every test case
+
+For the ginkgo-based test, normally every test case is run. However, the script accepts a `--fail-fast` flag --- which will get passed on to `ginkgo`, making it stop after the first failed test case.
+
 ## Verbosity
 
 The kubestellar controller-manager will be invoked with `-v=2` unless otherwise specified on the command line with `--kubestellar-controller-manager-verbosity $number`. This verbosity can not be set to a value other than 2 when using `--released`.

--- a/test/e2e/run-test.sh
+++ b/test/e2e/run-test.sh
@@ -20,11 +20,12 @@ set -x # so users can see what is going on
 
 env="kind"
 test="bash"
+fail_flag=""
 
 
 while [ $# != 0 ]; do
     case "$1" in
-        (-h|--help) echo "$0 usage: (--released | --env | --test-type | --kubestellar-controller-manager-verbosity \$num | --transport-controller-verbosity \$num)*"
+        (-h|--help) echo "$0 usage: (--released | --env | --test-type | --kubestellar-controller-manager-verbosity \$num | --transport-controller-verbosity \$num | --fail-fast)*"
                     exit;;
         (--released) setup_flags="$setup_flags $1";;
         (--kubestellar-controller-manager-verbosity|--transport-controller-verbosity)
@@ -51,6 +52,7 @@ while [ $# != 0 ]; do
             echo "Missing test type value" >&2
             exit 1;
           fi;;
+        (--fail-fast) fail_flag="--fail-fast";;
         (*) echo "$0: unrecognized argument '$1'" >&2
             exit 1
     esac
@@ -85,5 +87,5 @@ if [ $test == "bash" ];then
     "${SRC_DIR}/bash/use-kubestellar.sh" --env "$env"
 elif [ $test == "ginkgo" ];then
     GINKGO_DIR="${SRC_DIR}/ginkgo"
-    KFLEX_DISABLE_CHATTY=true ginkgo --vv --trace --no-color $GINKGO_DIR -- -skip-setup
+    KFLEX_DISABLE_CHATTY=true ginkgo --vv --trace --no-color $fail_flag $GINKGO_DIR -- -skip-setup
 fi


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
This PR does two things. One is to change the GitHub Actions workflow that runs the ginkgo E2E test, to use `--fail-fast`. This is good because it means that the state dumping after the test shows the problem state.

The other thing is to generalize the `test/e2e/run-test.sh` script so that it can be given `--fail-fast`. This is good because rushing past a failure destroys state that a contributor would want to examine.

## Related issue(s)

Fixes #
