### PR TITLE
✨ fix: sometimes cluster1 or cluster2 kubeconfig context alias does not create on the first try

### DIFF
--- a/scripts/create-kubestellar-demo-env.sh
+++ b/scripts/create-kubestellar-demo-env.sh
@@ -125,7 +125,7 @@ for cluster in "${clusters[@]}"; do
 done
 
 for cluster in "${clusters[@]}"; do
-  if kubectl config get-contexts | grep -w "\b${cluster}\b" >/dev/null 2>&1; then
+  if kubectl config get-contexts | grep -w " ${cluster} " >/dev/null 2>&1; then
     echo -e "\033[33m✔\033[0m $cluster context exists."
   else
     if kubectl config rename-context "kind-${cluster}" "${cluster}" >/dev/null 2>&1; then

--- a/scripts/create-kubestellar-demo-env.sh
+++ b/scripts/create-kubestellar-demo-env.sh
@@ -116,6 +116,7 @@ for cluster in "${clusters[@]}"; do
      echo -e "Creating cluster ${cluster}..."
      kind create cluster --name "${cluster}" >/dev/null 2>&1 &&
      kubectl config rename-context "kind-${cluster}" "${cluster}" >/dev/null 2>&1
+     kubectl config rename-context "kind-${cluster}" "${cluster}" >/dev/null 2>&1
      echo -e "${cluster} creation and context setup complete"
    ) &
 done

--- a/scripts/create-kubestellar-demo-env.sh
+++ b/scripts/create-kubestellar-demo-env.sh
@@ -103,11 +103,11 @@ cluster_clean_up "kind delete cluster --name kubeflex" &
 cluster_clean_up "kind delete cluster --name cluster1" &
 cluster_clean_up "kind delete cluster --name cluster2" &
 wait
-echo -e "Cluster space clean up has been completed"
+echo -e "\033[33m✔\033[0m Cluster space clean up has been completed"
 
 echo -e "\nStarting context clean up..."
 context_clean_up
-echo "Context space clean up completed"
+echo -e "\033[33m✔\033[0m Context space clean up completed"
 
 echo -e "\nStarting the process to install KubeStellar core: kind-kubeflex..."
 clusters=(cluster1 cluster2)
@@ -115,16 +115,30 @@ for cluster in "${clusters[@]}"; do
    (
      echo -e "Creating cluster ${cluster}..."
      kind create cluster --name "${cluster}" >/dev/null 2>&1 &&
-     kubectl config rename-context "kind-${cluster}" "${cluster}" >/dev/null 2>&1
-     kubectl config rename-context "kind-${cluster}" "${cluster}" >/dev/null 2>&1
-     echo -e "${cluster} creation and context setup complete"
+     echo -e "\033[33m✔\033[0m ${cluster} creation and context setup complete"
    ) &
 done
 wait 
 
+for cluster in "${clusters[@]}"; do
+   kubectl config rename-context "kind-${cluster}" "${cluster}" >/dev/null 2>&1
+done
+
+for cluster in "${clusters[@]}"; do
+  if kubectl config get-contexts | grep -w "\b${cluster}\b" >/dev/null 2>&1; then
+    echo -e "\033[33m✔\033[0m $cluster context exists."
+  else
+    if kubectl config rename-context "kind-${cluster}" "${cluster}" >/dev/null 2>&1; then
+      echo -e "\033[33m✔\033[0m Renamed context 'kind-${cluster}' to '${cluster}'."
+    else
+      echo -e "Failed to rename context 'kind-${cluster}' to '${cluster}'. It may not exist."
+    fi
+  fi
+done
+
 echo -e "Creating KubeFlex cluster with SSL Passthrough"
 curl -s https://raw.githubusercontent.com/kubestellar/kubestellar/v${kubestellar_version}/scripts/create-kind-cluster-with-SSL-passthrough.sh | bash -s -- --name kubeflex --port 9443 
-echo -e "Completed KubeFlex cluster with SSL Passthrough"
+echo -e "\033[33m✔\033[0m Completed KubeFlex cluster with SSL Passthrough"
 
 echo -e "\nPulling container images local..."
 images=("ghcr.io/loft-sh/vcluster:0.16.4"
@@ -151,7 +165,7 @@ kflex ctx --overwrite-existing-context its1
 echo -e "\nWaiting for OCM cluster manager to be ready..."
 
 wait-for-cmd "[[ \$(kubectl --context its1 get deployments.apps -n open-cluster-management -o jsonpath='{.status.readyReplicas}' cluster-manager 2>/dev/null) -ge 1 ]]"
-echo -e "OCM cluster manager is ready"
+echo -e "\033[33m✔\033[0m OCM cluster manager is ready"
 
 echo -e "\nRegistering cluster 1 and 2 for remote access with KubeStellar Core..."
 
@@ -175,7 +189,7 @@ kubectl --context its1 get managedclusters
 kubectl --context its1 label managedcluster cluster1 location-group=edge name=cluster1
 kubectl --context its1 label managedcluster cluster2 location-group=edge name=cluster2
 echo""
-echo "Congratulations! Your KubeStellar demo environment is now ready to use."
+echo -e "\033[33m✔\033[0m Congratulations! Your KubeStellar demo environment is now ready to use."
 
 cat <<"EOF"
 


### PR DESCRIPTION
I have discovered that every so often that 1 of the cluster1 and cluster2 aliases in kubeconfig do not create propertly - I assume there is a blocking happening since both clusters are create simultaneously - to avoid this I added a retry for both clusters - not pretty, but necessary to avoid missed config

<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

## Related issue(s)

Fixes #
