### PR TITLE
🐛  Various fixes and improvements to create-kubestellar-demo-env.sh

### DIFF
--- a/docs/content/direct/release.md
+++ b/docs/content/direct/release.md
@@ -46,6 +46,8 @@ Making a new kubestellar release requires a contributor to do the following thin
 
 - Update the version in the core chart defaults, `core-chart/values.yaml`.
 
+- In `scripts/create-kubestellar-demo-env.sh`, replace the occurrences of `https://raw.githubusercontent.com/kubestellar/kubestellar/main/` with `https://raw.githubusercontent.com/kubestellar/kubestellar/v${kubestellar_version}/`; delete this instruction from here.
+
 - Update the version in `scripts/create-kubestellar-demo-env.sh`.
 
 - Until we have our first stable release, edit the old docs README(`oldocs/README.md`, section "latest-stable-release") where it wishes it could cite a stable release but instead cites the latest release, to refer to the coming release.

--- a/scripts/create-kind-cluster-with-SSL-passthrough.sh
+++ b/scripts/create-kind-cluster-with-SSL-passthrough.sh
@@ -88,17 +88,17 @@ else
 fi
 
 echo "Installing an nginx ingress..."
-kubectl apply -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/main/deploy/static/provider/kind/deploy.yaml
+kubectl --context "kind-${name}" apply -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/main/deploy/static/provider/kind/deploy.yaml
 
 echo "Pathcing nginx ingress to enable SSL passthrough..."
-kubectl patch deployment ingress-nginx-controller -n ingress-nginx -p '{"spec":{"template":{"spec":{"containers":[{"name":"controller","args":["/nginx-ingress-controller","--election-id=ingress-nginx-leader","--controller-class=k8s.io/ingress-nginx","--ingress-class=nginx","--configmap=$(POD_NAMESPACE)/ingress-nginx-controller","--validating-webhook=:8443","--validating-webhook-certificate=/usr/local/certificates/cert","--validating-webhook-key=/usr/local/certificates/key","--watch-ingress-without-class=true","--publish-status-address=localhost","--enable-ssl-passthrough"]}]}}}}'
+kubectl --context "kind-${name}" patch deployment ingress-nginx-controller -n ingress-nginx -p '{"spec":{"template":{"spec":{"containers":[{"name":"controller","args":["/nginx-ingress-controller","--election-id=ingress-nginx-leader","--controller-class=k8s.io/ingress-nginx","--ingress-class=nginx","--configmap=$(POD_NAMESPACE)/ingress-nginx-controller","--validating-webhook=:8443","--validating-webhook-certificate=/usr/local/certificates/cert","--validating-webhook-key=/usr/local/certificates/key","--watch-ingress-without-class=true","--publish-status-address=localhost","--enable-ssl-passthrough"]}]}}}}'
 
 if [[ "$wait" == "true" ]] ; then
   echo "Waiting for nginx ingress with SSL passthrough to be ready..."
-  while [ -z "$(kubectl get pod --namespace ingress-nginx --selector=app.kubernetes.io/component=controller --no-headers -o name 2> /dev/null)" ] ;  do
+  while [ -z "$(kubectl --context kind-${name} get pod --namespace ingress-nginx --selector=app.kubernetes.io/component=controller --no-headers -o name 2> /dev/null)" ] ;  do
       sleep 5
   done
-  kubectl wait --namespace ingress-nginx \
+  kubectl --context "kind-${name}" wait --namespace ingress-nginx \
     --for=condition=ready pod \
     --selector=app.kubernetes.io/component=controller \
     --timeout=90s

--- a/scripts/create-kubestellar-demo-env.sh
+++ b/scripts/create-kubestellar-demo-env.sh
@@ -155,7 +155,9 @@ kflex ctx --overwrite-existing-context its1
 echo -e "\nWaiting for OCM cluster manager to be ready..."
 kubectl --context kind-kubeflex wait controlplane.tenancy.kflex.kubestellar.org/its1 --for 'jsonpath={.status.postCreateHooks.its}=true' --timeout 90s
 kubectl --context kind-kubeflex wait -n its1-system job.batch/its --for condition=Complete --timeout 300s
-echo -e "\033[33m✔\033[0m OCM cluster manager is ready"
+echo -e "\nWaiting for OCM hub cluster-info to be updated..."
+kubectl --context kind-kubeflex wait -n its1-system job.batch/update-cluster-info --for condition=Complete --timeout 90s
+echo -e "\033[33m✔\033[0m OCM hub is ready"
 
 echo -e "\nRegistering cluster 1 and 2 for remote access with KubeStellar Core..."
 

--- a/scripts/create-kubestellar-demo-env.sh
+++ b/scripts/create-kubestellar-demo-env.sh
@@ -21,7 +21,7 @@ kubestellar_version=0.25.0-rc.2
 echo -e "KubeStellar Version: ${kubestellar_version}"
 
 echo -e "Checking that pre-req softwares are installed..."
-curl -s https://raw.githubusercontent.com/kubestellar/kubestellar/v${kubestellar_version}/hack/check_pre_req.sh | bash -s -- -V kflex ocm helm kubectl docker kind
+curl -s https://raw.githubusercontent.com/kubestellar/kubestellar/main/hack/check_pre_req.sh | bash -s -- -V kflex ocm helm kubectl docker kind
 
 ##########################################
 cluster_clean_up() {

--- a/scripts/create-kubestellar-demo-env.sh
+++ b/scripts/create-kubestellar-demo-env.sh
@@ -99,7 +99,15 @@ trap "rm -rf $cluster_log_dir" EXIT
 for cluster in "${clusters[@]}"; do
     kind create cluster --name "${cluster}" >"${cluster_log_dir}/${cluster}.log" 2>&1 && touch "${cluster_log_dir}/${cluster}.success" &
 done
+
+echo -e "Creating KubeFlex cluster with SSL Passthrough"
+curl -s https://raw.githubusercontent.com/MikeSpreitzer/kcp-edge-mc/refs/heads/better-create-wecs/scripts/create-kind-cluster-with-SSL-passthrough.sh | bash -s -- --name kubeflex --nosetcontext
+: TODO: restore that URL to https://raw.githubusercontent.com/kubestellar/kubestellar/main/scripts/create-kind-cluster-with-SSL-passthrough.sh after this PR merges
+: TODO: restore that URL to https://raw.githubusercontent.com/kubestellar/kubestellar/v${kubestellar_version}/scripts/create-kind-cluster-with-SSL-passthrough.sh when making the next release
+echo -e "\033[33m✔\033[0m Completed KubeFlex cluster with SSL Passthrough"
+
 wait
+kubectl config use-context kind-kubeflex
 some_failed=false
 for cluster in "${clusters[@]}"; do
     if ! [ -f "${cluster_log_dir}/${cluster}.success" ]; then
@@ -124,10 +132,6 @@ for cluster in "${clusters[@]}"; do
     fi
   fi
 done
-
-echo -e "Creating KubeFlex cluster with SSL Passthrough"
-curl -s https://raw.githubusercontent.com/kubestellar/kubestellar/v${kubestellar_version}/scripts/create-kind-cluster-with-SSL-passthrough.sh | bash -s -- --name kubeflex --port 9443 
-echo -e "\033[33m✔\033[0m Completed KubeFlex cluster with SSL Passthrough"
 
 echo -e "\nPulling container images local..."
 images=("ghcr.io/loft-sh/vcluster:0.16.4"

--- a/test/e2e/common/setup-kubestellar.sh
+++ b/test/e2e/common/setup-kubestellar.sh
@@ -126,6 +126,11 @@ else
   fi
 popd
 
+: Waiting for OCM hub to be ready...
+kubectl wait controlplane.tenancy.kflex.kubestellar.org/its1 --for 'jsonpath={.status.postCreateHooks.its}=true' --timeout 90s
+kubectl wait -n its1-system job.batch/its --for condition=Complete --timeout 300s
+kubectl wait -n its1-system job.batch/update-cluster-info --for condition=Complete --timeout 90s
+
 wait-for-cmd "(kubectl --context '$HOSTING_CONTEXT' -n wds1-system wait --for=condition=Ready pod/\$(kubectl --context '$HOSTING_CONTEXT' -n wds1-system get pods -l name=transport-controller -o jsonpath='{.items[0].metadata.name}'))"
 
 echo "transport controller is running."


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
This PR improves the demo environment creation script in the following ways.

- The script retains, and displays if there is a failure, the logging from `kind`.
- The whole script fails if any WEC creation fails.
- This PR adds a wait for the update-cluster-info Job to complete before running the `clusteradm join` commands, because the latter depends on the former.
- Change `scripts/create-kind-cluster-with-SSL-passthrough.sh` to explicitly specify the kubeconfig context in each command, so that this script can be used in parallel with other activity that sets/requires the current context to be something else.
- Change `create-kubestellar-demo-env.sh` to create the hub cluster concurrently with creating the WECs, for improved total execution time.
- Use the `check_pre_req.sh` script from the `main` branch, to pick up #2557 .

## Related issue(s)

Fixes #2558 
