### PR TITLE
🐛  Add/fix wait for ITS to finish OCM setup

### DIFF
--- a/core-chart/templates/postcreatehooks/its.yaml
+++ b/core-chart/templates/postcreatehooks/its.yaml
@@ -20,6 +20,7 @@ spec:
             args:
             - init
             - -v={{.Values.verbosity.clusteradm | default .Values.verbosity.default | default 2 }}
+            - --wait
             env:
             - name: KUBECONFIG
               value: "{{"/etc/kube/{{.ITSkubeconfig}}"}}"

--- a/docs/content/direct/get-started.md
+++ b/docs/content/direct/get-started.md
@@ -76,6 +76,15 @@ kflex ctx --overwrite-existing-context wds1
 kflex ctx --overwrite-existing-context its1
 ```
 
+#### Wait for ITS to be fully initialized
+
+The Helm chart above has a Job that initializes the ITS as an OCM "hub" cluster. Helm does not have a way to wait for that initialization to finish. So you have to do the wait yourself. The following commands will do that.
+
+```shell
+kubectl --context kind-kubeflex wait controlplane.tenancy.kflex.kubestellar.org/its1 --for 'jsonpath={.status.postCreateHooks.its}=true' --timeout 90s
+kubectl --context kind-kubeflex wait -n its1-system job.batch/its --for condition=Complete --timeout 150s
+```
+
 ### Create and register two workload execution cluster(s)
 
  {%

--- a/test/e2e/common/setup-kubestellar.sh
+++ b/test/e2e/common/setup-kubestellar.sh
@@ -147,13 +147,18 @@ function add_wec() {
     case "$CLUSTER_SOURCE" in
         (kind)
             kind create cluster --name $cluster
-            kubectl config rename-context kind-${cluster} $cluster;;
-        (existing) ;;
+            kubectl config rename-context kind-${cluster} $cluster
+            joinflags="--force-internal-endpoint-lookup";;
+        (existing)
+            joinflags="";;
     esac
-  clusteradm --context its1 get token | grep '^clusteradm join' | sed "s/<cluster_name>/${cluster}/" | awk '{print $0 " --context '${cluster}' --singleton --force-internal-endpoint-lookup"}' | sh
+    clusteradm --context its1 get token | grep '^clusteradm join' | sed "s/<cluster_name>/${cluster}/" | awk '{print $0 " --context '${cluster}' --singleton '${joinflags}'"}' | sh
 }
 
 "${SRC_DIR}/../../../hack/check_pre_req.sh" --assert --verbose ocm
+
+kubectl --context $HOSTING_CONTEXT wait controlplane.tenancy.kflex.kubestellar.org/its1 --for 'jsonpath={.status.postCreateHooks.its}=true' --timeout 90s
+kubectl --context $HOSTING_CONTEXT wait -n its1-system job.batch/its --for condition=Complete --timeout 150s
 
 add_wec cluster1
 add_wec cluster2


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
This PR updates the setup recipes to wait for the completion of the initialization of the ITS as an OCM hub cluster. This is good because there was a timing splinter that caused grief and confusion (e.g., #2549).

This PR updates all copies of the setup recipe to wait in the same way. This way has the advantage of breaking as few abstraction layers as is required. A Helm chart does not give the author a way to program a general wait, so our recipe has to understand what is in the core Helm chart. A KF PCH also does not give the author a way to program a general wait, so our recipe has to understand what is in the "its" PCH. This PR adds `--wait` to the `clusteradm init` command, so that Job "completion" will imply completion of the OCM hub setup.

For a preview of a new section, see https://mikespreitzer.github.io/kcp-edge-mc/doc-wait-for-ocm/direct/get-started/#wait-for-its-to-be-fully-initialized

## Related issue(s)

Fixes #2549
