### PR TITLE
🐛  Fix reference to modified OCM quickstart script

### DIFF
--- a/docs/content/direct/get-started.md
+++ b/docs/content/direct/get-started.md
@@ -43,6 +43,10 @@ kubectl config delete-context cluster1
 kubectl config delete-context cluster2
 ```
 
+After that cleanup, you may want to `set -e` so that failures do not
+go unnoticed (the various cleanup commands may legitimately "fail" if
+there is nothing to clean up).
+
 ### Set the Version appropriately as an environment variable
 
 ```shell

--- a/docs/content/direct/start-from-ocm.md
+++ b/docs/content/direct/start-from-ocm.md
@@ -37,6 +37,24 @@ The following command will check for the prerequisites that you will need for th
 bash <(curl https://raw.githubusercontent.com/kubestellar/kubestellar/v{{ config.ks_latest_release }}/hack/check_pre_req.sh) kflex ocm helm kubectl docker kind
 ```
 
+### Cleanup from previous runs
+
+If you have run this recipe or any related recipe previously then
+you will first want to remove any related debris. The following
+commands tear down the state established by this recipe.
+
+```shell
+kind delete cluster --name hub
+kind delete cluster --name cluster1
+kind delete cluster --name cluster2
+kubectl config delete-context cluster1
+kubectl config delete-context cluster2
+```
+
+After that cleanup, you may want to `set -e` so that failures do not
+go unnoticed (the various cleanup commands may legitimately "fail" if
+there is nothing to clean up).
+
 ### Set the Version appropriately as an environment variable
 
 ```shell
@@ -53,7 +71,7 @@ This recipe uses a modified version of [the OCM Quick Start](https://raw.githubu
 You can invoke the modified OCM Quick Start as follows.
 
 ```shell
-curl -L https://raw.githubusercontent.com/kubestellar/kubestellar/refs/heads/{{ config.ks_latest_release }}/scripts/ocm-local-up-for-ingress.sh | bash
+curl -L https://raw.githubusercontent.com/kubestellar/kubestellar/refs/tags/v{{ config.ks_latest_release }}/scripts/ocm-local-up-for-ingress.sh | bash
 ```
 
 Like the baseline, this script creates a `kind` cluster named "hub" to


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
This PR fixes the reference from the start-from-ocm document to the modified OCM quickstart script.

This PR also adds a warning to that doc about cleanup.

This PR also restores the recommendation to `set -e`.

Preview at https://mikespreitzer.github.io/kcp-edge-mc/doc-fix-ocm-ref/direct/start-from-ocm/

## Related issue(s)

Fixes #
