### PR TITLE
🐛  Change check_pre_req.sh script to not use jq

### DIFF
--- a/hack/check_pre_req.sh
+++ b/hack/check_pre_req.sh
@@ -148,7 +148,7 @@ is_installed_kubectl() {
     is_installed 'kubectl' \
         'kubectl' \
         'kubectl version --client | head -1' \
-        'kubectl version --client -o json 2> /dev/null | jq -r .clientVersion.gitVersion' \
+        "kubectl version --client -o json 2> /dev/null | grep gitVersion | cut '-d\"' -f4" \
         'https://kubernetes.io/docs/tasks/tools/install-kubectl-linux/' \
         v1.27
 }


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
This PR changes the check-pre_req.sh script so that it does not use `jq`. This is good because it removes a circularity, needing a prerequisite in order to run the script that checks prerequisties.

## Related issue(s)

Fixes #2554 
