### PR TITLE
📖  Add known issue for botched StatusCollector reference

### DIFF
--- a/docs/content/direct/known-issues.md
+++ b/docs/content/direct/known-issues.md
@@ -11,3 +11,7 @@ The symptom is `kind` cluster(s) that get created but fail to get their job done
 ## Authorization fail for WSL fetching Helm chart from ghcr
 
 The symptom is that attempting to instantiate the core Helm chart gets an authorization failure, for a user running a Linux distro using WSL. See [Authorization failure in WSL while fetching Helm chart from ghcr.io](knownissue-wsl-ghcr-helm.md).
+
+## Missing results in a CombinedStatus object
+
+The symptom is a missing entry in the `results` of a `CombinedStatus` object. See [Missing results in a CombinedStatus object](knownissue-collector-miss.md).

--- a/docs/content/direct/knownissue-collector-miss.md
+++ b/docs/content/direct/knownissue-collector-miss.md
@@ -1,0 +1,15 @@
+# Missing results in a CombinedStatus object
+
+## Description of the Issue
+
+A `CombinedStatus` object, which is specific to one `Binding`
+(`BindingPolicy`) and one workload object, lacks an entry in `results`
+for some `StatusCollector` whose name is associated with the workload
+object by the `Binding`.
+
+## Root Cause
+
+There is no `StatusCollector` object with the name given in the `Binding`.
+
+This could be because of a typo in the `Binding` or because something
+failed to create the intended `StatusCollector`.

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -69,6 +69,7 @@ nav:
               - Hidden state in kubeconfig: direct/knownissue-kflex-extension.md
               - Kind needs OS reconfig: direct/knownissue-kind-config.md
               - Authorization failure in WSL while fetching Helm chart from ghcr.io: direct/knownissue-wsl-ghcr-helm.md
+              - Missing results in a CombinedStatus object: direct/knownissue-collector-miss.md
   - Contributing: 
       - How to join in: direct/contribute.md
       - Code of Conduct: contribution-guidelines/coc.md


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
This PR adds an entry in the "known issues" compendium for a botched reference from a Binding[Policy] to a StatusCollector.

Preview at https://mikespreitzer.github.io/kcp-edge-mc/doc-collector-miss/direct/knownissue-collector-miss/

## Related issue(s)

This PR does _not_ resolve Issue #2574 . Resolving that issue _might_ make it unnecessary to list this particular "known issue", but that would be new work that should not merge before the next release.
