### PR TITLE
🐛  Increase timeout wainting for nginx Ingress controller

### DIFF
--- a/scripts/create-kind-cluster-with-SSL-passthrough.sh
+++ b/scripts/create-kind-cluster-with-SSL-passthrough.sh
@@ -101,7 +101,7 @@ if [[ "$wait" == "true" ]] ; then
   kubectl --context "kind-${name}" wait --namespace ingress-nginx \
     --for=condition=ready pod \
     --selector=app.kubernetes.io/component=controller \
-    --timeout=90s
+    --timeout=200s
 fi
 
 if [[ "$setcontext" == "true" ]] ; then


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
This PR increases the timeout that `scripts/create-kind-cluster-with-SSL-passthrough.sh` uses when waiting for the nginx Ingress controller to become ready. This is good because I observed the pull to take about 140 seconds, which is longer than the current timeout of 90 seconds.

## Related issue(s)

Fixes #2573 
