### PR TITLE
🐛  Make setup-kubestellar overwrite kflex hidden state

### DIFF
--- a/test/e2e/common/setup-kubestellar.sh
+++ b/test/e2e/common/setup-kubestellar.sh
@@ -135,10 +135,11 @@ wait-for-cmd "(kubectl --context '$HOSTING_CONTEXT' -n wds1-system wait --for=co
 
 echo "transport controller is running."
 
-kubectl config delete-context its1 || true
-kflex ctx its1
-kubectl config delete-context wds1 || true
-kflex ctx wds1
+kubectl config use-context "$HOSTING_CONTEXT"
+kflex ctx --set-current-for-hosting
+kflex ctx --overwrite-existing-context wds1
+kflex ctx --overwrite-existing-context its1
+
 kflex ctx
 
 wait-for-cmd 'kubectl --context its1 get ns customization-properties'


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
This PR fixes the setup-kubestellar.sh script to unconditionally overwrite any pre-existing setting in kflex's kubeconfig extension that holds the name of the hosting cluster context.

## Related issue(s)

Fixes #2587 
