### PR TITLE
📖  Document transport controller bugs in release notes

### DIFF
--- a/docs/content/direct/release-notes.md
+++ b/docs/content/direct/release-notes.md
@@ -11,9 +11,9 @@ The following sections list the known issues for each release. The issue list is
 
 * Although the create-only feature can be used with Job objects to avoid trouble with `.spec.selector`, requesting singleton reported state return will still lead to a controller fight over `.status.replicas` while the Job is in progress.
 * Removing of WorkStatus objects (in the transport namespace) is not supported and may not result in recreation of that object
-* Singleton status return: It is the user responsibility to make sure that if a BindingPolicy requesting singleton status return matches a given workload object then no other BindingPolicy matches the same object. Currently there is no enforcement of that.
 * Objects on two different WDSes shouldn't have the exact same identifier (same group, version, kind, name and namespace). Such a conflict is currently not identified.
-* The value of transport controller's `max-num-wrapped` flag is not handled properly, if the value leads to multiple ManifestWork objects with multiple workload objects in them.
+* Creation, deletion, and modification of `CustomTransform` objects does not cause corresponding updates to the workload objects in the WECs; the current state of the `CustomTransform` objects is simply read at any moment when the objects in the WECs are being updated for other reasons.
+* If the workload object count or volume vs the configured limits on content of a `ManifestWork` causes multiple `ManifestWork` to be created for one `Binding` (`BindingPolicy`) then there are bugs in the updating of workload objects in the WECs.
 
 ## 0.25.0-alpha.1 test releases
 
@@ -30,7 +30,9 @@ The main functional change from 0.23.X is the completion of the status combinati
 * Removing of WorkStatus objects (in the transport namespace) is not supported and may not result in recreation of that object
 * Singleton status return: It is the user responsibility to make sure that if a BindingPolicy requesting singleton status return matches a given workload object then no other BindingPolicy matches the same object. Currently there is no enforcement of that.
 * Objects on two different WDSes shouldn't have the exact same identifier (same group, version, kind, name and namespace). Such a conflict is currently not identified.
-* The value of transport controller's `max-num-wrapped` flag is not handled properly, if the value leads to multiple ManifestWork objects with multiple workload objects in them.
+* Creation, deletion, and modification of `CustomTransform` objects does not cause corresponding updates to the workload objects in the WECs; the current state of the `CustomTransform` objects is simply read at any moment when the objects in the WECs are being updated for other reasons.
+* If the workload object count or volume vs the configured limits on content of a `ManifestWork` causes multiple `ManifestWork` to be created for one `Binding` (`BindingPolicy`) then there are bugs in the updating of workload objects in the WECs.
+
 
 ## 0.23.1
 


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
This PR updates the bug lists in the release notes to mention the two transport controller bugs that I have been thinking about (one was fixed in #2589, the other has not been fixed).

Preview at https://mikespreitzer.github.io/kcp-edge-mc/doc-xc-bug/direct/release-notes/#remaining-limitations-in-0250-and-its-candidates

## Related issue(s)

Fixes #
