### PR TITLE
🐛  Increase scripting timeouts to 1 day

### DIFF
--- a/scripts/create-kind-cluster-with-SSL-passthrough.sh
+++ b/scripts/create-kind-cluster-with-SSL-passthrough.sh
@@ -101,7 +101,7 @@ if [[ "$wait" == "true" ]] ; then
   kubectl --context "kind-${name}" wait --namespace ingress-nginx \
     --for=condition=ready pod \
     --selector=app.kubernetes.io/component=controller \
-    --timeout=200s
+    --timeout=24h
 fi
 
 if [[ "$setcontext" == "true" ]] ; then

--- a/scripts/create-kubestellar-demo-env.sh
+++ b/scripts/create-kubestellar-demo-env.sh
@@ -155,10 +155,10 @@ kflex ctx --overwrite-existing-context wds1
 kflex ctx --overwrite-existing-context its1
 
 echo -e "\nWaiting for OCM cluster manager to be ready..."
-kubectl --context kind-kubeflex wait controlplane.tenancy.kflex.kubestellar.org/its1 --for 'jsonpath={.status.postCreateHooks.its}=true' --timeout 90s
-kubectl --context kind-kubeflex wait -n its1-system job.batch/its --for condition=Complete --timeout 300s
+kubectl --context kind-kubeflex wait controlplane.tenancy.kflex.kubestellar.org/its1 --for 'jsonpath={.status.postCreateHooks.its}=true' --timeout 24h
+kubectl --context kind-kubeflex wait -n its1-system job.batch/its --for condition=Complete --timeout 24h
 echo -e "\nWaiting for OCM hub cluster-info to be updated..."
-kubectl --context kind-kubeflex wait -n its1-system job.batch/update-cluster-info --for condition=Complete --timeout 90s
+kubectl --context kind-kubeflex wait -n its1-system job.batch/update-cluster-info --for condition=Complete --timeout 24h
 echo -e "\033[33m✔\033[0m OCM hub is ready"
 
 echo -e "\nRegistering cluster 1 and 2 for remote access with KubeStellar Core..."


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
This PR increases the timeouts in `scripts/create-kind-cluster-with-SSL-passthrough.sh` and `scripts/create-kubestellar-demo-env.sh` to a day, because we are getting reports of very long times to pull the images. Note that `kubectl wait` insists on having _some_ timeout.

## Related issue(s)

Fixes #
