### PR TITLE
📖  Versioned reference to create-kubestellar-demo-env.sh

### DIFF
--- a/docs/content/direct/get-started.md
+++ b/docs/content/direct/get-started.md
@@ -27,7 +27,7 @@ The script will check for the pre-reqs and exit if they are not present.
 ### Run the script!
 
 ```shell
-bash <(curl -s https://raw.githubusercontent.com/kubestellar/kubestellar/refs/heads/main/scripts/create-kubestellar-demo-env.sh)
+bash <(curl -s https://raw.githubusercontent.com/kubestellar/kubestellar/refs/tags/v{{ config.ks_latest_release }}/scripts/create-kubestellar-demo-env.sh)
 ```
 
 If successful, the script will output the variable definitions that you would use when proceeding to the example scenarios. After successfully running the script, proceed to the [Exercise KubeStellar](#exercise-kubestellar) section below.


### PR DESCRIPTION
This was supposed to be switched to a versioned reference at the point of first release of the new script.

<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
This PR fixes an oversight that happened when first documenting the `create-kubestellar-demo-env.sh` script. The versioned document should have used a versioned reference to the script.

Preview at https://mikespreitzer.github.io/kcp-edge-mc/doc-overlooked-version/direct/get-started/#run-the-script

## Related issue(s)

Fixes #
