### PR TITLE
🐛 Fixing spellcheck

### DIFF
--- a/.github/spellcheck/.spellcheck.yml
+++ b/.github/spellcheck/.spellcheck.yml
@@ -8,11 +8,7 @@ matrix:
     encoding: utf-8
   pipeline:
   - pyspelling.filters.markdown:
-  - pyspelling.filters.html:
-      comments: false
-      ignores:
-      - code
-      - pre
+  - pyspelling.filters.text:
   sources:
   - '**/*.md'
   default_encoding: utf-8


### PR DESCRIPTION
## Summary
Added `pyspelling.filters.text:`  so that it work without rendering html
## Related issue(s)

Fixes #2507 
