### PR TITLE
✨ Improve scripts for building some of the service images

### DIFF
--- a/hack/Dockerfile.kubectl
+++ b/hack/Dockerfile.kubectl
@@ -21,7 +21,8 @@ ARG VERSION
 RUN [ "$VERSION" == "" ] && VERSION=$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt) ; \
     curl \
 	-L https://storage.googleapis.com/kubernetes-release/release/v${VERSION#v}/bin/${TARGETOS}/${TARGETARCH}/kubectl \
-	-o /usr/bin/kubectl && chmod +x /usr/bin/kubectl
+	-o /usr/bin/kubectl && \
+	chmod +x /usr/bin/kubectl
 
 USER 1001
 

--- a/hack/Dockerfile.kubectl
+++ b/hack/Dockerfile.kubectl
@@ -21,15 +21,7 @@ ARG VERSION
 RUN [ "$VERSION" == "" ] && VERSION=$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt) ; \
     curl \
 	-L https://storage.googleapis.com/kubernetes-release/release/v${VERSION#v}/bin/${TARGETOS}/${TARGETARCH}/kubectl \
-	-o /usr/bin/kubectl && chmod +x /usr/bin/kubectl && \
-    curl \
-	-L https://github.com/stedolan/jq/releases/latest/download/jq-${TARGETOS}-${TARGETARCH} \
-	-o /usr/bin/jq && \
-	chmod +x /usr/bin/jq && \
-    curl \
-	-L https://github.com/mikefarah/yq/releases/latest/download/yq_${TARGETOS}_${TARGETARCH} \
-	-o /usr/bin/yq && \
-	chmod +x /usr/bin/yq
+	-o /usr/bin/kubectl && chmod +x /usr/bin/kubectl
 
 USER 1001
 

--- a/hack/build-clusteradm-image.sh
+++ b/hack/build-clusteradm-image.sh
@@ -22,7 +22,7 @@
 set -e
 
 clusteradm_version="" # ==> latest
-clusteradm_folder=clusteradm
+clusteradm_folder="/tmp/clusteradm"
 registry=quay.io/kubestellar
 platform=linux/amd64,linux/arm64,linux/ppc64le
 
@@ -73,11 +73,12 @@ echo "Using clusteradm v${clusteradm_version}."
 
 git clone -b "v$clusteradm_version" --depth 1 https://github.com/open-cluster-management-io/clusteradm.git "$clusteradm_folder"
 
-cd "$clusteradm_folder"
+pushd "$clusteradm_folder"
 
 export KO_DOCKER_REPO=$registry
 
 ko build -B ./cmd/clusteradm -t $clusteradm_version --sbom=none --platform $platform
 
-cd ~
+popd
+
 rm -rf $clusteradm_folder

--- a/hack/build-clusteradm-image.sh
+++ b/hack/build-clusteradm-image.sh
@@ -72,8 +72,8 @@ clusteradm_version=${clusteradm_version#v}
 
 echo "Using clusteradm v${clusteradm_version}."
 
-git clone -b "v$clusteradm_version" --depth 1 https://github.com/open-cluster-management-io/clusteradm.git "$clusteradm_folder"
 cd "$clusteradm_folder"
+git clone -b "v$clusteradm_version" --depth 1 https://github.com/open-cluster-management-io/clusteradm.git .
 
 export KO_DOCKER_REPO=$registry
 ko build -B ./cmd/clusteradm -t $clusteradm_version --sbom=none --platform $platform

--- a/hack/build-clusteradm-image.sh
+++ b/hack/build-clusteradm-image.sh
@@ -21,7 +21,7 @@
 
 set -e
 
-clusteradm_folder="$(mktemp -d -p . "clusteradm-XXXX")"
+clusteradm_folder="$(mktemp -d -p $PWD "clusteradm-XXXX")"
 trap 'rm -rf "$clusteradm_folder"' EXIT # delete the temporary folder on exit
 clusteradm_version="" # ==> latest
 registry=quay.io/kubestellar
@@ -73,9 +73,7 @@ clusteradm_version=${clusteradm_version#v}
 echo "Using clusteradm v${clusteradm_version}."
 
 git clone -b "v$clusteradm_version" --depth 1 https://github.com/open-cluster-management-io/clusteradm.git "$clusteradm_folder"
+cd "$clusteradm_folder"
 
-( # Ensure that the temprary folder is deketed even on error
-    cd "$clusteradm_folder"
-    export KO_DOCKER_REPO=$registry
-    ko build -B ./cmd/clusteradm -t $clusteradm_version --sbom=none --platform $platform
-)
+export KO_DOCKER_REPO=$registry
+ko build -B ./cmd/clusteradm -t $clusteradm_version --sbom=none --platform $platform


### PR DESCRIPTION
## Summary

Improve scripts for building some of the service images
- remove `jq` and `yq` from the `kubectl` container image
- fix dir change in `build-clusteradm-image.sh`

## Related issue(s)

Fixes #
