### PR TITLE
🌱  Bump kube-rbac-proxy to v0.17.1

### DIFF
--- a/config/default/manager_auth_proxy_patch.yaml
+++ b/config/default/manager_auth_proxy_patch.yaml
@@ -30,7 +30,7 @@ spec:
           capabilities:
             drop:
               - "ALL"
-        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.13.1
+        image: quay.io/brancz/kube-rbac-proxy:v0.17.1
         args:
         - "--secure-listen-address=0.0.0.0:8443"
         - "--upstream=http://127.0.0.1:8080/"

--- a/core-chart/templates/postcreatehooks/wds.yaml
+++ b/core-chart/templates/postcreatehooks/wds.yaml
@@ -371,7 +371,7 @@ spec:
                 - --upstream=http://127.0.0.1:8080/
                 - --logtostderr=true
                 - --v=0
-              image: gcr.io/kubebuilder/kube-rbac-proxy:v0.13.1
+              image: quay.io/brancz/kube-rbac-proxy:v0.17.1
               name: kube-rbac-proxy
               ports:
                 - containerPort: 8443


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
This PR ups the release of https://github.com/brancz/kube-rbac-proxy used from 0.13.1 to 0.17.1. This will hopefully have fewer vulnerabilities.

The kubebuilder project has deprecated the use of kube-rbac-proxy and newer releases are no longer available from gcr.io/kubebuilder . This PR switches to using the container images from quay.io/brancz .

## Related issue(s)

Fixes #
