### PR TITLE
🌱  Always save spellcheck output to workflow artifact

### DIFF
--- a/.github/workflows/spellcheck_action.yml
+++ b/.github/workflows/spellcheck_action.yml
@@ -40,7 +40,7 @@ jobs:
 #         source_files: "docs/content/*"
         
     - uses: actions/upload-artifact@v4
-      if: github.repository_owner == 'kubestellar'
+      if: success() || failure()
       with:
         name: Spellcheck Output
         path: spellcheck-output.txt


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
This PR changes the condition under which an attempt is made to save the spell checking output to a workflow artifact. This PR removes the restriction to the "kubestellar" organization, so that contributors can also get these artifacts for their own branches. This PR allows the saving to be attempted even if the spell checking finds errors.

## Related issue(s)

Fixes #2628 
