### PR TITLE
🐛  Remove spurious escaping of brackets in NOTES.txt template

### DIFF
--- a/core-chart/templates/NOTES.txt
+++ b/core-chart/templates/NOTES.txt
@@ -4,7 +4,7 @@ ITSes) that you just created (a host-type control plane is just an
 alias for the KubeFlex hosting cluster). You can do that with the
 following `kflex` commands; each creates a context and makes it the
 current one. See
-https://github.com/kubestellar/kubestellar/blob/\{\{ .Values.KUBESTELLAR_VERSION \}\}/docs/content/direct/core-chart.md#kubeconfig-files-and-contexts-for-control-planes
+https://github.com/kubestellar/kubestellar/blob/{{ .Values.KUBESTELLAR_VERSION }}/docs/content/direct/core-chart.md#kubeconfig-files-and-contexts-for-control-planes
 for a way to do this without using `kflex`.
 Start by setting your current kubeconfig context to the one you used
 when installing this chart.


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
This PR removes spurious escaping of the brackets in the NOTES.txt template in the core Helm chart.

## Related issue(s)

Fixes #
