### PR TITLE
🐛  [release-0.25.1] Stop MW thrashing when max_num_wrapped is 1

### DIFF
--- a/.github/workflows/pr-test-e2e.yml
+++ b/.github/workflows/pr-test-e2e.yml
@@ -16,12 +16,14 @@ on:
   pull_request:
     branches:
       - main
+      - 'release-*'
     paths-ignore:
       - 'docs/**'
       - '**/*.md'
   push:
     branches:
       - main
+      - 'release-*'
     tags:
       - 'v*'
     paths-ignore:

--- a/docs/content/direct/known-issues.md
+++ b/docs/content/direct/known-issues.md
@@ -1,5 +1,9 @@
 # Some known problems
 
+Here are some user and/or environment problems that we have seen.
+
+For bugs, see [the issues on GitHub](https://github.com/kubestellar/kubestellar/issues) and the [release notes](release-notes.md).
+
 ## Wrong value stuck in hidden kflex state in kubeconfig
 
 The symptom is `kflex ctx ...` commands failing. See [Confusion due to hidden state in your kubeconfig](knownissue-kflex-extension.md).

--- a/docs/content/direct/release-notes.md
+++ b/docs/content/direct/release-notes.md
@@ -15,6 +15,9 @@ This patch release fixes some bugs and some documentation oversights. Following 
 * Removing of WorkStatus objects (in the transport namespace) is not supported and may not result in recreation of that object
 * Objects on two different WDSes shouldn't have the exact same identifier (same group, version, kind, name and namespace). Such a conflict is currently not identified.
 * Creation, deletion, and modification of `CustomTransform` objects does not cause corresponding updates to the workload objects in the WECs; the current state of the `CustomTransform` objects is simply read at any moment when the objects in the WECs are being updated for other reasons.
+* It is not known what actually happens when two different `Binding` objects list the same workload object and either or both say "create only".
+* If the workload object count or volume vs the configured limits on content of a `ManifestWork` causes multiple `ManifestWork` to be created for one `Binding` (`BindingPolicy`) then there may be transients where workload objects are deleted and re-created in a WEC --- which, in addition to possibly being troubling on its own, will certainly thwart the "create-only" functionality. Unless you workload is very large, you can avoid this situation by setting the `transport_controller.max_num_wrapped` "value" of [the core Helm chart](core-chart.md) to a number that is larger than the number of your workload objects (double check your count in your `Binding` object).
+
 
 ## 0.25.0 and its candidates
 
@@ -28,6 +31,10 @@ This patch release fixes some bugs and some documentation oversights. Following 
 * Objects on two different WDSes shouldn't have the exact same identifier (same group, version, kind, name and namespace). Such a conflict is currently not identified.
 * Creation, deletion, and modification of `CustomTransform` objects does not cause corresponding updates to the workload objects in the WECs; the current state of the `CustomTransform` objects is simply read at any moment when the objects in the WECs are being updated for other reasons.
 * If the workload object count or volume vs the configured limits on content of a `ManifestWork` causes multiple `ManifestWork` to be created for one `Binding` (`BindingPolicy`) then there are bugs in the updating of workload objects in the WECs.
+* It is not known what actually happens when two different `Binding` objects list the same workload object and either or both say "create only".
+* If the workload object count or volume vs the configured limits on content of a `ManifestWork` causes multiple `ManifestWork` to be created for one `Binding` (`BindingPolicy`) then there may be transients where workload objects are deleted and re-created in a WEC --- which, in addition to possibly being troubling on its own, will certainly thwart the "create-only" functionality. Unless you workload is very large, you can avoid this situation by setting the `transport_controller.max_num_wrapped` "value" of [the core Helm chart](core-chart.md) to a number that is larger than the number of your workload objects (double check your count in your `Binding` object).
+
+
 
 ## 0.25.0-alpha.1 test releases
 
@@ -46,7 +53,8 @@ The main functional change from 0.23.X is the completion of the status combinati
 * Objects on two different WDSes shouldn't have the exact same identifier (same group, version, kind, name and namespace). Such a conflict is currently not identified.
 * Creation, deletion, and modification of `CustomTransform` objects does not cause corresponding updates to the workload objects in the WECs; the current state of the `CustomTransform` objects is simply read at any moment when the objects in the WECs are being updated for other reasons.
 * If the workload object count or volume vs the configured limits on content of a `ManifestWork` causes multiple `ManifestWork` to be created for one `Binding` (`BindingPolicy`) then there are bugs in the updating of workload objects in the WECs.
-
+* It is not known what actually happens when two different `Binding` objects list the same workload object and either or both say "create only".
+* If the workload object count or volume vs the configured limits on content of a `ManifestWork` causes multiple `ManifestWork` to be created for one `Binding` (`BindingPolicy`) then there may be transients where workload objects are deleted and re-created in a WEC --- which, in addition to possibly being troubling on its own, will certainly thwart the "create-only" functionality.
 
 ## 0.23.1
 

--- a/pkg/transport/generic/generic_transport_controller.go
+++ b/pkg/transport/generic/generic_transport_controller.go
@@ -729,10 +729,18 @@ func (c *genericTransportController) updateWrappedObjectsAndFinalizer(ctx contex
 
 // getWrapeesFromWDS returns a slice of Wrapee holding the objects that have been subject to destination-independent transformations
 // but not destination-dependent transformatinos (customizations).
-func (c *genericTransportController) getWrapeesFromWDS(ctx context.Context, binding *v1alpha1.Binding) ([]transport.Wrapee, func(schema.GroupKind) (string, bool), sets.Set[metav1.GroupResource], error) {
+func (c *genericTransportController) getWrapeesFromWDS(ctx context.Context, binding *v1alpha1.Binding) ([]WrapeeWithUID, func(schema.GroupKind) (string, bool), sets.Set[metav1.GroupResource], error) {
 	groupResources := sets.New[metav1.GroupResource]()
-	wrapees := make([]transport.Wrapee, 0)
+	wrapees := make([]WrapeeWithUID, 0)
 	kindToResource := map[schema.GroupKind]string{}
+	appendObj := func(gvr metav1.GroupVersionResource, object *unstructured.Unstructured, createOnly bool) {
+		gr := metav1.GroupResource{Group: gvr.Group, Resource: gvr.Resource}
+		groupResources.Insert(gr)
+		kindToResource[object.GroupVersionKind().GroupKind()] = gvr.Resource
+		wrapees = append(wrapees, WrapeeWithUID{
+			transport.NewWrapee(TransformObject(ctx, c.customTransformCollection, gr, object, binding.Name), createOnly),
+			string(object.GetUID())})
+	}
 	// add cluster-scoped objects to the 'objectsToPropagate' slice
 	for _, clause := range binding.Spec.Workload.ClusterScope {
 		gvr := schema.GroupVersionResource(clause.GroupVersionResource)
@@ -740,10 +748,7 @@ func (c *genericTransportController) getWrapeesFromWDS(ctx context.Context, bind
 		if err != nil {
 			return nil, nil, groupResources, fmt.Errorf("failed to get required cluster-scoped object '%s' with gvr %s from WDS - %w", clause.Name, gvr, err)
 		}
-		gr := metav1.GroupResource{Group: clause.GroupVersionResource.Group, Resource: clause.GroupVersionResource.Resource}
-		groupResources.Insert(gr)
-		kindToResource[object.GroupVersionKind().GroupKind()] = gvr.Resource
-		wrapees = append(wrapees, transport.NewWrapee(TransformObject(ctx, c.customTransformCollection, gr, object, binding.Name), clause.CreateOnly))
+		appendObj(clause.GroupVersionResource, object, clause.CreateOnly)
 	}
 	// add namespace-scoped objects to the 'objectsToPropagate' slice
 	for _, clause := range binding.Spec.Workload.NamespaceScope {
@@ -753,10 +758,7 @@ func (c *genericTransportController) getWrapeesFromWDS(ctx context.Context, bind
 			return nil, nil, groupResources, fmt.Errorf("failed to get required namespace-scoped object '%s' in namespace '%s' with gvr '%s' from WDS - %w", clause.Name,
 				clause.Namespace, gvr, err)
 		}
-		gr := metav1.GroupResource{Group: clause.GroupVersionResource.Group, Resource: clause.GroupVersionResource.Resource}
-		groupResources.Insert(gr)
-		kindToResource[object.GroupVersionKind().GroupKind()] = gvr.Resource
-		wrapees = append(wrapees, transport.NewWrapee(TransformObject(ctx, c.customTransformCollection, gr, object, binding.Name), clause.CreateOnly))
+		appendObj(clause.GroupVersionResource, object, clause.CreateOnly)
 	}
 
 	return wrapees, abstract.PrimitiveMapGet(kindToResource), groupResources, nil
@@ -813,9 +815,9 @@ func (c *genericTransportController) computeDestToWrappedObjects(ctx context.Con
 //
 // This func also updates c.bindingSensitiveDestinations for the given Binding.
 // The input Wrapees have been subject to destination-independent transformation.
-func (c *genericTransportController) computeDestToCustomizedObjects(uncustomizedWrapees []transport.Wrapee, binding *v1alpha1.Binding) (map[v1alpha1.Destination][]transport.Wrapee, []string) {
+func (c *genericTransportController) computeDestToCustomizedObjects(uncustomizedWrapees []WrapeeWithUID, binding *v1alpha1.Binding) (map[v1alpha1.Destination][]WrapeeWithUID, []string) {
 	// This will become non-nil if any object to propagate needs customization
-	var destToCustomizedWrapees map[v1alpha1.Destination][]transport.Wrapee
+	var destToCustomizedWrapees map[v1alpha1.Destination][]WrapeeWithUID
 
 	bindingErrors := []string{}
 
@@ -845,14 +847,14 @@ func (c *genericTransportController) computeDestToCustomizedObjects(uncustomized
 				}
 			}
 			if customizeThisObject && destToCustomizedWrapees == nil {
-				destToCustomizedWrapees = map[v1alpha1.Destination][]transport.Wrapee{}
+				destToCustomizedWrapees = map[v1alpha1.Destination][]WrapeeWithUID{}
 				for _, dest := range binding.Spec.Destinations {
 					destToCustomizedWrapees[dest] = abstract.SliceCopy(uncustomizedWrapees[:objIdx])
 				}
 			}
 			if destToCustomizedWrapees != nil {
 				customizedObjectsSoFar := destToCustomizedWrapees[dest]
-				customizedObjectsSoFar = append(customizedObjectsSoFar, transport.NewWrapee(objC, wrapee.CreateOnly))
+				customizedObjectsSoFar = append(customizedObjectsSoFar, WrapeeWithUID{transport.NewWrapee(objC, wrapee.CreateOnly), wrapee.UID})
 				destToCustomizedWrapees[dest] = customizedObjectsSoFar
 			}
 		}
@@ -869,21 +871,36 @@ func (c *genericTransportController) computeDestToCustomizedObjects(uncustomized
 	return destToCustomizedWrapees, bindingErrors
 }
 
-func (c *genericTransportController) wrapBatch(batchToPropagate []transport.Wrapee, kindToResource func(schema.GroupKind) (string, bool), binding *v1alpha1.Binding, numShard int) (*unstructured.Unstructured, error) {
+// wrapBatch invokes the transport's WrapObjects.
+// uidToPropagate is the UID (in the WDS) of one of the objects in batchToPropagate.
+func (c *genericTransportController) wrapBatch(batchToPropagate []transport.Wrapee, uidToPropagate string, kindToResource func(schema.GroupKind) (string, bool), binding *v1alpha1.Binding, numShard int) (*unstructured.Unstructured, error) {
 	wrapped := c.transport.WrapObjects(batchToPropagate, abstract.DropOK11(kindToResource))
 	wrappedObject, err := convertObjectToUnstructured(wrapped)
 	if err != nil {
 		return nil, fmt.Errorf("failed to convert wrapped object to unstructured - %w", err)
 	}
-	// wrapped object name is (Binding.GetName()-WdsName) or (Binding.GetName()-WdsName-numShard).
-	// pay attention - we cannot use the Binding object name, cause we might have duplicate names coming from different WDS spaces.
-	// we add WdsName to the object name to assure name uniqueness,
-	// in order to easily get the origin Binding object name and wds, we add it as an annotations.
-	wrappedObject.SetName(fmt.Sprintf("%s-%s-%d", binding.GetName(), c.wdsName, numShard))
+	var wrapperName string
+	if c.MaxNumWrapped == 1 {
+		// Make the name a function of the content, to get stability.
+		wrapperName = fmt.Sprintf("%s-%s-%s", binding.UID, c.wdsName, uidToPropagate)
+	} else {
+		// wrapped object name is (Binding.GetName()-WdsName-numShard).
+		// pay attention - we cannot use the Binding object name, cause we might have duplicate names coming from different WDS spaces.
+		// we add WdsName to the object name to assure name uniqueness,
+		// in order to easily get the origin Binding object name and wds, we add it as an annotations.
+		wrapperName = fmt.Sprintf("%s-%s-%d", binding.GetName(), c.wdsName, numShard)
+	}
+	wrappedObject.SetName(wrapperName)
 	setLabel(wrappedObject, originOwnerReferenceLabel, binding.GetName())
 	setLabel(wrappedObject, originWdsLabel, c.wdsName)
 	setAnnotation(wrappedObject, originOwnerGenerationAnnotation, binding.GetGeneration())
 	return wrappedObject, err
+}
+
+type WrapeeWithUID struct {
+	transport.Wrapee
+	// UID of the object in the WDS
+	UID string
 }
 
 // transportTask is one wrapped object and a gloss of its contents
@@ -892,9 +909,10 @@ type transportTask struct {
 	Gloss transport.Gloss
 }
 
-func (c *genericTransportController) wrap(wrapeesToPropagate []transport.Wrapee, kindToResource func(schema.GroupKind) (string, bool), binding *v1alpha1.Binding) ([]transportTask, error) {
+func (c *genericTransportController) wrap(wrapeesToPropagate []WrapeeWithUID, kindToResource func(schema.GroupKind) (string, bool), binding *v1alpha1.Binding) ([]transportTask, error) {
 	var transportTasks []transportTask
 	var batchToPropagate []transport.Wrapee = nil
+	var uidToPropagate string
 	gloss := transport.Gloss{}
 	maxSize := c.MaxSizeWrapped
 	maxCount := c.MaxNumWrapped
@@ -911,7 +929,7 @@ func (c *genericTransportController) wrap(wrapeesToPropagate []transport.Wrapee,
 			return nil, fmt.Errorf("failed to wrap object that is larger than max size")
 		}
 		if (objSize+batchSize >= maxSize) || (batchCount+1 > maxCount) {
-			wrappedObject, err := c.wrapBatch(batchToPropagate, kindToResource, binding, numShard)
+			wrappedObject, err := c.wrapBatch(batchToPropagate, uidToPropagate, kindToResource, binding, numShard)
 			if err != nil {
 				return nil, err
 			}
@@ -922,13 +940,14 @@ func (c *genericTransportController) wrap(wrapeesToPropagate []transport.Wrapee,
 			batchSize = 0
 			batchCount = 0
 		}
-		batchToPropagate = append(batchToPropagate, wrapee)
+		batchToPropagate = append(batchToPropagate, wrapee.Wrapee)
+		uidToPropagate = wrapee.UID
 		gloss.Insert(wrapee.GetID())
 		batchSize += objSize
 		batchCount += 1
 	}
 	if batchToPropagate != nil {
-		wrappedObject, err := c.wrapBatch(batchToPropagate, kindToResource, binding, numShard)
+		wrappedObject, err := c.wrapBatch(batchToPropagate, uidToPropagate, kindToResource, binding, numShard)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/transport/generic/generic_transport_controller.go
+++ b/pkg/transport/generic/generic_transport_controller.go
@@ -496,7 +496,7 @@ func (c *genericTransportController) processNextWorkItem(ctx context.Context) bo
 			logger.V(4).Info("Processed workqueue item successfully.", "item", obj, "itemType", fmt.Sprintf("%T", obj))
 		} else if retry {
 			c.workqueue.AddRateLimited(obj)
-			logger.V(4).Info("Encountered transient error while processing workqueue item; do not be alarmed, this will be retried later", "item", obj, "itemType", fmt.Sprintf("%T", obj))
+			logger.V(4).Info("Encountered transient error while processing workqueue item; do not be alarmed, this will be retried later", "item", obj, "itemType", fmt.Sprintf("%T", obj), "err", err)
 		} else {
 			c.workqueue.Forget(obj)
 			logger.Error(err, "Failed to process workqueue item", "item", obj, "itemType", fmt.Sprintf("%T", obj))

--- a/test/e2e/ginkgo/multiple_cluster_deployment_test.go
+++ b/test/e2e/ginkgo/multiple_cluster_deployment_test.go
@@ -120,6 +120,8 @@ var _ = ginkgo.Describe("end to end testing", func() {
 			})
 			util.ValidateNumDeploymentReplicas(ctx, wec1, ns, 1)
 			util.ValidateNumDeploymentReplicas(ctx, wec2, ns, 1)
+			dep1 := util.GetDeployment(ctx, wec1, ns, "nginx")
+			dep2 := util.GetDeployment(ctx, wec2, ns, "nginx")
 
 			ginkgo.By("modifying the Deployment in the WDS and expecting no change in the WECs")
 			objPatch := []byte(`{"spec":{"replicas": 2}}`)
@@ -130,6 +132,28 @@ var _ = ginkgo.Describe("end to end testing", func() {
 			time.Sleep(30 * time.Second)
 			gomega.Expect(util.GetNumDeploymentReplicas(ctx, wec1, ns)).To(gomega.Equal(1))
 			gomega.Expect(util.GetNumDeploymentReplicas(ctx, wec2, ns)).To(gomega.Equal(1))
+			dep1b := util.GetDeployment(ctx, wec1, ns, "nginx")
+			dep2b := util.GetDeployment(ctx, wec2, ns, "nginx")
+			gomega.Expect(dep1b.UID).To(gomega.Equal(dep1.UID))
+			gomega.Expect(dep2b.UID).To(gomega.Equal(dep2.UID))
+
+			ginkgo.By("Adding Deployment objects to workload, expect no change to first in WECs")
+			util.CreateDeployment(ctx, wds, ns, "nginy",
+				map[string]string{
+					"app.kubernetes.io/name":         "nginx",
+					"test.kubestellar.io/test-label": "here",
+				})
+			util.CreateDeployment(ctx, wds, ns, "enginx",
+				map[string]string{
+					"app.kubernetes.io/name":         "nginx",
+					"test.kubestellar.io/test-label": "here",
+				})
+			util.ValidateNumDeployments(ctx, "wec1", wec1, ns, 3)
+			util.ValidateNumDeployments(ctx, "wec2", wec2, ns, 3)
+			dep1c := util.GetDeployment(ctx, wec1, ns, "nginx")
+			dep2c := util.GetDeployment(ctx, wec2, ns, "nginx")
+			gomega.Expect(dep1c.UID).To(gomega.Equal(dep1.UID))
+			gomega.Expect(dep2c.UID).To(gomega.Equal(dep2.UID))
 		})
 
 		ginkgo.It("handles changes in bindingpolicy ObjectSelector", func(ctx context.Context) {

--- a/test/util/util.go
+++ b/test/util/util.go
@@ -529,6 +529,17 @@ func GetNumDeploymentReplicas(ctx context.Context, wec *kubernetes.Clientset, ns
 	return replicas
 }
 
+func GetDeployment(ctx context.Context, wec *kubernetes.Clientset, ns, name string) *appsv1.Deployment {
+	ginkgo.GinkgoHelper()
+	var ans *appsv1.Deployment
+	gomega.Eventually(func() error {
+		var err error
+		ans, err = wec.AppsV1().Deployments(ns).Get(ctx, name, metav1.GetOptions{})
+		return err
+	}, timeout).ShouldNot(gomega.HaveOccurred())
+	return ans
+}
+
 func ValidateNumDeploymentReplicas(ctx context.Context, wec *kubernetes.Clientset, ns string, numReplicas int) {
 	ginkgo.GinkgoHelper()
 	gomega.Eventually(func() int {


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
This PR attempts to fix Issue #2634 in the release-0.25.1 branch for the case where max_num_wrapped==1, by making the wrapper's name a function of its contents (as well as source).

This PR includes the test expansion from #2640 , and the fix here makes the expanded test succeed.

This PR is built on #2638 .

DO NOT MERGE THIS PR. This PR is just for CI testing. We do not have a documented procedure for making new patch releases after `main` has diverged, so I am making this up as I go along. I think that what we should do is: after #2638 merges into the `release-0.25.1` branch, we should clone that branch into a new one named `release-0.25.2`, close this PR, and create a clone of this PR that updates the `release-0.25.2` branch. That branch should also get corresponding doc updates. From that branch create the 0.25.2 release.

## Related issue(s)

Fixes #
