### PR TITLE
✨  [release 0.25.1] Test for workload object thrashing

### DIFF
--- a/.github/workflows/pr-test-e2e.yml
+++ b/.github/workflows/pr-test-e2e.yml
@@ -16,12 +16,14 @@ on:
   pull_request:
     branches:
       - main
+      - 'release-*'
     paths-ignore:
       - 'docs/**'
       - '**/*.md'
   push:
     branches:
       - main
+      - 'release-*'
     tags:
       - 'v*'
     paths-ignore:

--- a/docs/content/direct/known-issues.md
+++ b/docs/content/direct/known-issues.md
@@ -1,5 +1,9 @@
 # Some known problems
 
+Here are some user and/or environment problems that we have seen.
+
+For bugs, see [the issues on GitHub](https://github.com/kubestellar/kubestellar/issues) and the [release notes](release-notes.md).
+
 ## Wrong value stuck in hidden kflex state in kubeconfig
 
 The symptom is `kflex ctx ...` commands failing. See [Confusion due to hidden state in your kubeconfig](knownissue-kflex-extension.md).

--- a/docs/content/direct/release-notes.md
+++ b/docs/content/direct/release-notes.md
@@ -15,6 +15,9 @@ This patch release fixes some bugs and some documentation oversights. Following 
 * Removing of WorkStatus objects (in the transport namespace) is not supported and may not result in recreation of that object
 * Objects on two different WDSes shouldn't have the exact same identifier (same group, version, kind, name and namespace). Such a conflict is currently not identified.
 * Creation, deletion, and modification of `CustomTransform` objects does not cause corresponding updates to the workload objects in the WECs; the current state of the `CustomTransform` objects is simply read at any moment when the objects in the WECs are being updated for other reasons.
+* It is not known what actually happens when two different `Binding` objects list the same workload object and either or both say "create only".
+* If the workload object count or volume vs the configured limits on content of a `ManifestWork` causes multiple `ManifestWork` to be created for one `Binding` (`BindingPolicy`) then there may be transients where workload objects are deleted and re-created in a WEC --- which, in addition to possibly being troubling on its own, will certainly thwart the "create-only" functionality. Unless you workload is very large, you can avoid this situation by setting the `transport_controller.max_num_wrapped` "value" of [the core Helm chart](core-chart.md) to a number that is larger than the number of your workload objects (double check your count in your `Binding` object).
+
 
 ## 0.25.0 and its candidates
 
@@ -28,6 +31,10 @@ This patch release fixes some bugs and some documentation oversights. Following 
 * Objects on two different WDSes shouldn't have the exact same identifier (same group, version, kind, name and namespace). Such a conflict is currently not identified.
 * Creation, deletion, and modification of `CustomTransform` objects does not cause corresponding updates to the workload objects in the WECs; the current state of the `CustomTransform` objects is simply read at any moment when the objects in the WECs are being updated for other reasons.
 * If the workload object count or volume vs the configured limits on content of a `ManifestWork` causes multiple `ManifestWork` to be created for one `Binding` (`BindingPolicy`) then there are bugs in the updating of workload objects in the WECs.
+* It is not known what actually happens when two different `Binding` objects list the same workload object and either or both say "create only".
+* If the workload object count or volume vs the configured limits on content of a `ManifestWork` causes multiple `ManifestWork` to be created for one `Binding` (`BindingPolicy`) then there may be transients where workload objects are deleted and re-created in a WEC --- which, in addition to possibly being troubling on its own, will certainly thwart the "create-only" functionality. Unless you workload is very large, you can avoid this situation by setting the `transport_controller.max_num_wrapped` "value" of [the core Helm chart](core-chart.md) to a number that is larger than the number of your workload objects (double check your count in your `Binding` object).
+
+
 
 ## 0.25.0-alpha.1 test releases
 
@@ -46,7 +53,8 @@ The main functional change from 0.23.X is the completion of the status combinati
 * Objects on two different WDSes shouldn't have the exact same identifier (same group, version, kind, name and namespace). Such a conflict is currently not identified.
 * Creation, deletion, and modification of `CustomTransform` objects does not cause corresponding updates to the workload objects in the WECs; the current state of the `CustomTransform` objects is simply read at any moment when the objects in the WECs are being updated for other reasons.
 * If the workload object count or volume vs the configured limits on content of a `ManifestWork` causes multiple `ManifestWork` to be created for one `Binding` (`BindingPolicy`) then there are bugs in the updating of workload objects in the WECs.
-
+* It is not known what actually happens when two different `Binding` objects list the same workload object and either or both say "create only".
+* If the workload object count or volume vs the configured limits on content of a `ManifestWork` causes multiple `ManifestWork` to be created for one `Binding` (`BindingPolicy`) then there may be transients where workload objects are deleted and re-created in a WEC --- which, in addition to possibly being troubling on its own, will certainly thwart the "create-only" functionality.
 
 ## 0.23.1
 

--- a/test/e2e/ginkgo/multiple_cluster_deployment_test.go
+++ b/test/e2e/ginkgo/multiple_cluster_deployment_test.go
@@ -120,6 +120,8 @@ var _ = ginkgo.Describe("end to end testing", func() {
 			})
 			util.ValidateNumDeploymentReplicas(ctx, wec1, ns, 1)
 			util.ValidateNumDeploymentReplicas(ctx, wec2, ns, 1)
+			dep1 := util.GetDeployment(ctx, wec1, ns, "nginx")
+			dep2 := util.GetDeployment(ctx, wec2, ns, "nginx")
 
 			ginkgo.By("modifying the Deployment in the WDS and expecting no change in the WECs")
 			objPatch := []byte(`{"spec":{"replicas": 2}}`)
@@ -130,6 +132,28 @@ var _ = ginkgo.Describe("end to end testing", func() {
 			time.Sleep(30 * time.Second)
 			gomega.Expect(util.GetNumDeploymentReplicas(ctx, wec1, ns)).To(gomega.Equal(1))
 			gomega.Expect(util.GetNumDeploymentReplicas(ctx, wec2, ns)).To(gomega.Equal(1))
+			dep1b := util.GetDeployment(ctx, wec1, ns, "nginx")
+			dep2b := util.GetDeployment(ctx, wec2, ns, "nginx")
+			gomega.Expect(dep1b.UID).To(gomega.Equal(dep1.UID))
+			gomega.Expect(dep2b.UID).To(gomega.Equal(dep2.UID))
+
+			ginkgo.By("Adding Deployment objects to workload, expect no change to first in WECs")
+			util.CreateDeployment(ctx, wds, ns, "nginy",
+				map[string]string{
+					"app.kubernetes.io/name":         "nginx",
+					"test.kubestellar.io/test-label": "here",
+				})
+			util.CreateDeployment(ctx, wds, ns, "enginx",
+				map[string]string{
+					"app.kubernetes.io/name":         "nginx",
+					"test.kubestellar.io/test-label": "here",
+				})
+			util.ValidateNumDeployments(ctx, "wec1", wec1, ns, 3)
+			util.ValidateNumDeployments(ctx, "wec2", wec2, ns, 3)
+			dep1c := util.GetDeployment(ctx, wec1, ns, "nginx")
+			dep2c := util.GetDeployment(ctx, wec2, ns, "nginx")
+			gomega.Expect(dep1c.UID).To(gomega.Equal(dep1.UID))
+			gomega.Expect(dep2c.UID).To(gomega.Equal(dep2.UID))
 		})
 
 		ginkgo.It("handles changes in bindingpolicy ObjectSelector", func(ctx context.Context) {

--- a/test/util/util.go
+++ b/test/util/util.go
@@ -529,6 +529,17 @@ func GetNumDeploymentReplicas(ctx context.Context, wec *kubernetes.Clientset, ns
 	return replicas
 }
 
+func GetDeployment(ctx context.Context, wec *kubernetes.Clientset, ns, name string) *appsv1.Deployment {
+	ginkgo.GinkgoHelper()
+	var ans *appsv1.Deployment
+	gomega.Eventually(func() error {
+		var err error
+		ans, err = wec.AppsV1().Deployments(ns).Get(ctx, name, metav1.GetOptions{})
+		return err
+	}, timeout).ShouldNot(gomega.HaveOccurred())
+	return ans
+}
+
 func ValidateNumDeploymentReplicas(ctx context.Context, wec *kubernetes.Clientset, ns string, numReplicas int) {
 	ginkgo.GinkgoHelper()
 	gomega.Eventually(func() int {


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
This PR extends the ginkgo-based end-to-end test to cover thrashing of workload objects that have create-only set. This PR fails CI because this test fails as it should.

This PR is built on #2638 

DO NOT MERGE THIS PR, because it adds testing that exposes a bug. Instead, look at #2639, which also includes the fix for the bug.

## Related issue(s)

This tests for Issue #2634 in release 0.25.1
