### PR TITLE
🌱  Include error in warning about sync fail

### DIFF
--- a/pkg/transport/generic/generic_transport_controller.go
+++ b/pkg/transport/generic/generic_transport_controller.go
@@ -496,7 +496,7 @@ func (c *genericTransportController) processNextWorkItem(ctx context.Context) bo
 			logger.V(4).Info("Processed workqueue item successfully.", "item", obj, "itemType", fmt.Sprintf("%T", obj))
 		} else if retry {
 			c.workqueue.AddRateLimited(obj)
-			logger.V(4).Info("Encountered transient error while processing workqueue item; do not be alarmed, this will be retried later", "item", obj, "itemType", fmt.Sprintf("%T", obj))
+			logger.V(4).Info("Encountered transient error while processing workqueue item; do not be alarmed, this will be retried later", "item", obj, "itemType", fmt.Sprintf("%T", obj), "err", err)
 		} else {
 			c.workqueue.Forget(obj)
 			logger.Error(err, "Failed to process workqueue item", "item", obj, "itemType", fmt.Sprintf("%T", obj))


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
This PR fixes an oversight in the generic transport controller. When it logs an info message about a transient error, actually showing the error was overlooked.

## Related issue(s)

Fixes #
