### PR TITLE
📖  Update ocm-status-addon version in monitoring/README

### DIFF
--- a/docs/content/direct/release.md
+++ b/docs/content/direct/release.md
@@ -35,6 +35,7 @@ find * .github/workflows \( -name "*.svg" -prune \) -or \( -path "*venv" -prune 
 Between each release of [ks/OSA](https://github.com/kubestellar/ocm-status-addon) and the next release of ks/ks, update the references to the ocm-status-addon release in the following files.
 
 - `core-chart/values.yaml`
+- `monitoring/README.md`
 
 ### Making a new kubestellar release
 

--- a/monitoring/README.md
+++ b/monitoring/README.md
@@ -4,7 +4,7 @@
 
 
 ### Requirement
-To follow the instructions here you need to use KubeStellar `main` branch or any future KubeStellar release higher than `0.24.0`. Also, you need to have release `v0.2.0-rc12` or higher for the status-addon controller and agent installed in your environment. If you're using an older release, please follow these instructions to update your environment: 
+To follow the instructions here you need to use KubeStellar `main` branch or any future KubeStellar release higher than `0.24.0`. Also, you need to have release `v0.2.0-rc14` or higher for the status-addon controller and agent installed in your environment. If you're using an older release, please follow these instructions to update your environment: 
 
 1.  Remove the status-addon-controller and status-addon-agent from your current environment:
 
@@ -16,7 +16,7 @@ kubectl --context its1 -n cluster1 delete manifestwork addon-addon-status-deploy
 2. Re-deploy the status-addon controller and agents: 
 
 ```bash
-helm --kube-context its1 upgrade --install ocm-status-addon -n open-cluster-management oci://ghcr.io/kubestellar/ocm-status-addon-chart --version v0.2.0-rc12
+helm --kube-context its1 upgrade --install ocm-status-addon -n open-cluster-management oci://ghcr.io/kubestellar/ocm-status-addon-chart --version v0.2.0-rc14
 ```
 
 ### Description


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
This PR fixes a couple of oversights. The first is the mention of the version of ks/ocm-status-addon to use in `monitoring/README.md`. The other oversight is the fact that this was not mentioned in the release process document.

Preview at https://mikespreitzer.github.io/kcp-edge-mc/doc-monitoring-dependency/direct/release/#reacting-to-a-new-ocm-status-addon-release

## Related issue(s)

Fixes #
