### PR TITLE
🌱  Make clusteradm build folder evident to user

### DIFF
--- a/hack/build-clusteradm-image.sh
+++ b/hack/build-clusteradm-image.sh
@@ -72,8 +72,9 @@ clusteradm_version=${clusteradm_version#v}
 
 echo "Using clusteradm v${clusteradm_version}."
 
+git clone -b "v$clusteradm_version" --depth 1 https://github.com/open-cluster-management-io/clusteradm.git "$clusteradm_folder"
+
 cd "$clusteradm_folder"
-git clone -b "v$clusteradm_version" --depth 1 https://github.com/open-cluster-management-io/clusteradm.git .
 
 export KO_DOCKER_REPO=$registry
 ko build -B ./cmd/clusteradm -t $clusteradm_version --sbom=none --platform $platform


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
This PR changes the script for building the clusteradm image so that it is informative rather than confusing about where the checkout is going. This undoes a bad suggestion that I made to the earlier PR on this script.

## Related issue(s)

Fixes #
