### PR TITLE
🐛  Fix speling error in kubestellar-snapshot.sh

### DIFF
--- a/scripts/kubestellar-snapshot.sh
+++ b/scripts/kubestellar-snapshot.sh
@@ -487,8 +487,8 @@ for j in "${!cp_pch[@]}" ; do
                 echo -n -e "${COLOR_NONE}"
             fi
             if [[ "$arg_yaml" == "true" ]] ; then
-                mkdir -p "$OUTPUT_FOLDER/${bp_cp[bp_n]}/binding-politcies"
-                KUBECONFIG="${cp_kubeconfig[$j]}" kubectl get bindingpolicy ${bp_name[bp_n]} -o yaml > "$OUTPUT_FOLDER/${bp_cp[bp_n]}/binding-politcies/$name.yaml"
+                mkdir -p "$OUTPUT_FOLDER/${bp_cp[bp_n]}/binding-policies"
+                KUBECONFIG="${cp_kubeconfig[$j]}" kubectl get bindingpolicy ${bp_name[bp_n]} -o yaml > "$OUTPUT_FOLDER/${bp_cp[bp_n]}/binding-policies/$name.yaml"
             fi
             bp_n=$((bp_n+1))
         done


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
This PR fixes a spelling error in the directory name where BindingPolicy objects are dumped by the `kubestellar-snapshot.sh` script.

## Related issue(s)

Fixes #
