### PR TITLE
✨  Update self-references for 0.26.0-alpha.3 release

### DIFF
--- a/core-chart/values.yaml
+++ b/core-chart/values.yaml
@@ -7,7 +7,7 @@
 # please do not change them unless you know what you are doing.
 HELM_VERSION: "3.16.1"
 KUBECTL_VERSION: "1.31.0"
-KUBESTELLAR_VERSION: "0.26.0-alpha.2"
+KUBESTELLAR_VERSION: "0.26.0-alpha.3"
 # TRANSPORT_VERSION: e.g., "0.24.0"; defaults to KUBESTELLAR_VERSION value, if not defined
 CLUSTERADM_VERSION: "0.9.0"
 OCM_STATUS_ADDON_VERSION: "0.2.0-rc14"

--- a/docs/content/direct/release-notes.md
+++ b/docs/content/direct/release-notes.md
@@ -2,6 +2,20 @@
 
 The following sections list the known issues for each release. The issue list is not differential (i.e., compared to previous releases) but a full list representing the overall state of the specific release. 
 
+## 0.26.0-alpha.3
+
+This release adds the option for the core Helm chart to not take responsibility for running `clusteradm init` on an ITS. **Somebody** has to, but not necessarily this chart.
+
+### Remaining limitations in 0.26.0-alpha.3
+
+* Although the create-only feature can be used with Job objects to avoid trouble with `.spec.selector`, requesting singleton reported state return will still lead to a controller fight over `.status.replicas` while the Job is in progress.
+* Removing of WorkStatus objects (in the transport namespace) is not supported and may not result in recreation of that object
+* Objects on two different WDSes shouldn't have the exact same identifier (same group, version, kind, name and namespace). Such a conflict is currently not identified.
+* Creation, deletion, and modification of `CustomTransform` objects does not cause corresponding updates to the workload objects in the WECs; the current state of the `CustomTransform` objects is simply read at any moment when the objects in the WECs are being updated for other reasons.
+* It is not known what actually happens when two different `Binding` objects list the same workload object and either or both say "create only".
+* If (a) the workload object count or volume vs the configured limits on content of a `ManifestWork` causes multiple `ManifestWork` to be created for one `Binding` (`BindingPolicy`) AND (b) the limit on number of workload objects in one `ManifestWork` is greater then 1, then there may be transients where workload objects are deleted and re-created in a WEC --- which, in addition to possibly being troubling on its own, will certainly thwart the "create-only" functionality. The default limit on the number of workload objects in one `ManifestWork` is 1, so this issue will only arise when you use a non-default value. In this case you will avoid this issue if you set that limit to be at least the highest number of workload objects that will appear in a `Binding` (do check your `Binding` objects, lest you be surprised) AND your workload is not so large that multiple `ManifestWork` are created due to the limit on their size.
+
+
 ## 0.26.0-alpha.1, 0.26.0-alpha.2
 
 This release removes the thrashing of workload objects in the WEC in the case where the transport controller's `max-num-wrapped` is 1.

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -14,7 +14,7 @@ edit_uri: edit/main/docs/content
 ks_branch: 'main'
 ks_tag: 'latest'
 ks_latest_regular_release: '0.25.1'
-ks_latest_release: '0.26.0-alpha.2'
+ks_latest_release: '0.26.0-alpha.3'
 
 ks_kind_port_num: '1119'
 

--- a/scripts/create-kubestellar-demo-env.sh
+++ b/scripts/create-kubestellar-demo-env.sh
@@ -53,7 +53,7 @@ if ! dunsel=$(docker ps 2>&1); then
 fi
 echo "Container runtime is running."
 
-kubestellar_version=0.26.0-alpha.2
+kubestellar_version=0.26.0-alpha.3
 echo -e "KubeStellar Version: ${kubestellar_version}"
 
 echo -e "Checking that pre-req softwares are installed..."


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
This PR updates the self-references in preparation for the next alpha release. This is urgent because merging #2645 broke `main`.

Preview in https://mikespreitzer.github.io/kcp-edge-mc/doc-prep4-0260a3/readme/

## Related issue(s)

Fixes #
