### PR TITLE
:book: [release-0.26.0-alpha.3] Track change in where `wantSingletonReportedState` appears

### DIFF
--- a/docs/content/direct/example-scenarios.md
+++ b/docs/content/direct/example-scenarios.md
@@ -334,8 +334,8 @@ kubectl --context "$wds_context" delete bindingpolicies postgres-bpolicy
 
 ## Scenario 4 - Singleton status
 
-This scenario shows how to get the full status updated when setting `wantSingletonReportedState`
-in the BindingPolicy. This still an experimental feature.
+This scenario shows how to get the full status updated, by setting `wantSingletonReportedState`
+in a `DownsyncPolicyClause`. This still an experimental feature.
 
 Apply a BindingPolicy with the `wantSingletonReportedState` flag set:
 
@@ -346,12 +346,12 @@ kind: BindingPolicy
 metadata:
   name: nginx-singleton-bpolicy
 spec:
-  wantSingletonReportedState: true
   clusterSelectors:
   - matchLabels: {"name":"cluster1"}
   downsync:
   - objectSelectors:
     - matchLabels: {"app.kubernetes.io/name":"nginx-singleton"}
+    wantSingletonReportedState: true
 EOF
 ```
 


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
This PR updates Example Scenario 4 to track the recent API change wrt where `wantSingletonReportedState` appears.

Preview at https://mikespreitzer.github.io/kcp-edge-mc/doc-0260a3-fix-ex4/direct/example-scenarios/#scenario-4-singleton-status

## Related issue(s)

This addresses #2694 in one of the relevant branches.
