### PR TITLE
📖 Clarify documentation about signoff and signing

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,13 +32,18 @@ Your assistance in improving documentation is highly valued, regardless of your 
 To claim an issue that you are interested in, kindly leave a comment on the issue and request the maintainers to assign it to you.
 
 ### Committing
-We encourage all contributors to adopt [best practices in git commit management](https://hackmd.io/q22nrXjERBeIGb-fqwrUSg) to facilitate efficient reviews and retrospective analysis. Your git commits should provide ample context for reviewers and future codebase readers.
+We encourage all contributors to adopt [best practices in git commit management](https://hackmd.io/q22nrXjERBeIGb-fqwrUSg) to facilitate efficient reviews and retrospective analysis. Note: that document was written for projects where some of the contributors are doing merges into the main branch, but in KubeStellar we have GitHub doing that for us. For the kubestellar repository, this is controlled by [Prow](https://docs.prow.k8s.io/); for the other repositories in the kubestellar organization we use the GitHub mechanisms directly.
+
+Your git commits should provide ample context for reviewers and future codebase readers.
 
 A recommended format for final commit messages is as follows:
 
 ```
 {Short Title}: {Problem this commit is solving and any important contextual information} {issue number if applicable}
 ```
+
+In conformance with CNCF expectations, we will only merge commits that indicate your agreement with the [Developer Certificate of Origin](#certificate-of-origin). The CNCF defines how to do this, and there are two cases: one for developers working for an organization that is a CNCF member, and one for contributors acting as individuals. For the latter, assent is indicated by doing a Git "sign-off" on the commit. See [Git Commit Signoff and Signing](docs/content/direct/pr-signoff.md) for more information on how to do that.
+
 ### Pull Requests
 When submitting a pull request, clear communication is appreciated. This can be achieved by providing the following information:
 
@@ -48,6 +53,16 @@ When submitting a pull request, clear communication is appreciated. This can be 
 - Updates to relevant documentation and examples, if applicable
 
 The pull request template has been designed to assist you in communicating this information effectively.
+
+We require that the title of each pull request start with a special character that classifies the request into one of the following categories.
+
+- ✨ (write `:sparkles:`) feature
+- 🐛 (write `:bug:`) bug fix
+- 📖 (write `:book:`) docs
+- 📝 (write `:memo:`)  proposal
+- ⚠️ (write `:warning:`) breaking change
+- 🌱 (write `:seedling:`) other/misc
+- ❓ (write `:question:`) requires manual review/categorization
 
 Smaller pull requests are typically easier to review and merge than larger ones. If your pull request is big, it is always recommended to collaborate with the maintainers to find the best way to divide it.
 

--- a/docs/content/direct/pr-signoff.md
+++ b/docs/content/direct/pr-signoff.md
@@ -32,8 +32,8 @@ adds commits that are not signed-off then you can repair this by
 adding the signoff to each using `git commit -s --amend` on each of
 them. Following is an outline of how to do it for a branch that adds
 **exactly one** commit. If your branch adds more than one commit then
-you can extrapolate using `git cherry-pick` to build up a revised
-series of commits one-by-one.
+you can extrapolate using `git cherry-pick -s -S` to build up a
+revised series of commits one-by-one.
 
 The following instructions provide a basic walk-through if you have already created your own fork of the repository but yet not made a clone on your workstation. If you have set up your SSH and GPG keys and include `-S` on the `git commit` command line or have configured automatic signing then this will also get the commits signed.
 

--- a/docs/content/direct/pr-signoff.md
+++ b/docs/content/direct/pr-signoff.md
@@ -1,8 +1,64 @@
-# How to Sign-off on Your Pull Requests
+# Git Commit Signoff and Signing
 
-In order to get your pull requests approved, you must first complete a DCO sign-off. This process is defined by the CNCF, and there are two cases: individual contributors and contributors that work for a corporate CNCF member. To do this as an individual contributor, you must have a GPG and SSH key. Basic setup instructions can be found below (For more detailed instructions, refer to the Github [GPG](https://docs.github.com/en/authentication/managing-commit-signature-verification/generating-a-new-gpg-key) and [SSH](https://docs.github.com/en/authentication/connecting-to-github-with-ssh/generating-a-new-ssh-key-and-adding-it-to-the-ssh-agent#generating-a-new-ssh-key) setup pages):
+**NOTE**: "sign-off" is different from "signing" a commit or tag.  The
+former indicates your assent to the repository's terms for
+contributors, the latter adds a cryptographic checksum that is rarely
+displayed.  See [the git
+book](https://git-scm.com/book/en/v2/Git-Tools-Signing-Your-Work)
+about signing. For commit signoff, do a web search on `git
+signoff`. GitHub has a concept of [a commit being
+"verified"](https://docs.github.com/en/authentication/managing-commit-signature-verification)
+that extends the Git concept of signing.
 
----
+In order to get your pull requests approved, you must first complete a
+DCO sign-off. This process is defined by the CNCF, and there are two
+cases: individual contributors and contributors that work for a
+corporate CNCF member. Both mean consent with the terms stated in the
+`DCO` file at the root of this Git repository.
+
+In the case of an individual, DCO sign-off is done with a Git "signoff".
+
+We prefer that commits contributed to this repository be signed and
+GitHub verified, but this is not strictly necessary or enforced.
+
+## Commit Sign-off
+
+Your submitted PR must pass the automated checks in order to be reviewed. One of these checks that each commit that you propose to contribute is signed-off. If you use the `git` shell command, this involves passing the `-s` flag on the command line. For other tools, consult their documentation.
+
+### Repairing non-signed-off commits
+
+If you have already created a PR that proposes to merge a branch that
+adds commits that are not signed-off then you can repair this by
+adding the signoff to each using `git commit -s --amend` on each of
+them. Following is an outline of how to do it for a branch that adds
+**exactly one** commit. If your branch adds more than one commit then
+you can extrapolate using `git cherry-pick` to build up a revised
+series of commits one-by-one.
+
+The following instructions provide a basic walk-through if you have already created your own fork of the repository but yet not made a clone on your workstation. If you have set up your SSH and GPG keys and include `-S` on the `git commit` command line or have configured automatic signing then this will also get the commits signed.
+
+1. Navigate to the **Code** page of the Kubestellar github.
+   
+2. Click the **Fork** dropdown in the top right corner of the page.
+    - Under "Existing Forks" click your fork (should look something like "your_username/kubestellar")
+3. Once in your fork, click the **Code** dropdown.
+    - Under the "Local" tab at the top of the dropdown, select the SSH tab
+    - Copy the SSH repo URL to your clipboard
+4. Open Git Bash (or your CLI of choice), create or change to a different directory if desired.
+5. Clone the repository using `git clone` followed by pasting the URL you just copied.
+6. Change your directory to the Kubestellar repo using `cd kubestellar`.
+7. `git checkout` to the branch in your fork where the changes were committed.
+    - The branch name should be written at the top of your submitted PR page and looks something like "patch-*X*" (where "X" should be the number of PRs made on your fork to date)
+8. Once in your branch, type `git commit -s --amend` to sign off your PR.
+    - You may replace `--amend` with a `-m` followed by a commit message if you desire; the `--amend` simply uses the same commit message as the one you wrote when initially submitting the PR
+    - If prompted with a sign-off page in your Git Bash (or alternative CLI), type `:wq!` to exit the prompt
+9. Type `git push -f origin [branch_name]`, replacing `[branch_name]` with the actual name of your branch.
+10. Navigate back to your PR github page.
+    - A green `dco-signoff: yes` label indicates that your PR is successfully signed
+
+## Signing Commits
+
+To sign a commit, you must have a GPG and SSH key. Basic setup instructions can be found below (For more detailed instructions, refer to the Github [GPG](https://docs.github.com/en/authentication/managing-commit-signature-verification/generating-a-new-gpg-key) and [SSH](https://docs.github.com/en/authentication/connecting-to-github-with-ssh/generating-a-new-ssh-key-and-adding-it-to-the-ssh-agent#generating-a-new-ssh-key) setup pages.)
 
 Before starting, make sure that your user email is verified on Github. To check for this:
 
@@ -103,7 +159,7 @@ Before starting, make sure that your user email is verified on Github. To check 
 
 <br />
 
-## Creating Pull Requests
+## Creating Pull Requests Using the GitHub Website
 
 Whether it's editing files from Kubestellar.io or directly from the Kubestellar Github, there are a couple steps to follow that streamlines the workflow of your PR:
 
@@ -113,39 +169,3 @@ Whether it's editing files from Kubestellar.io or directly from the Kubestellar 
      
 2. Click **Propose Changes** after writing the commit message, review your changes, and then create the PR.
 3. If your PR addresses an already opened issue on the github, make sure to close the issue once your PR is approved and closed.
-
-<br />
-
-## Pull Request Sign-off
-
-**NOTE**: "sign-off" is different from "signing" a commit or tag (see [the git book](https://git-scm.com/book/en/v2/Git-Tools-Signing-Your-Work) about signing). The former indicates your assent to the repository's terms for contributors, the latter adds a cryptographic checksum that is rarely displayed.
-
-Your submitted PR must pass the automated checks in order to be reviewed. This requires for you to perform a DCO sign-off for your PR. The following instructions provide a basic walk-through if you have already set up your GPG and SSH keys:
-
-1. Navigate to the **Code** page of the Kubestellar github.
-   
-2. Click the **Fork** dropdown in the top right corner of the page.
-    - Under "Existing Forks" click your fork (should look something like "your_username/kubestellar")
-3. Once in your fork, click the **Code** dropdown.
-    - Under the "Local" tab at the top of the dropdown, select the SSH tab
-    - Copy the SSH repo URL to your clipboard
-4. Open Git Bash (or your CLI of choice), create or change to a different directory if desired.
-5. Clone the repository using `git clone` followed by pasting the URL you just copied.
-6. Change your directory to the Kubestellar repo using `cd kubestellar`.
-7. `git checkout` to the branch in your fork where the changes were committed.
-    - The branch name should be written at the top of your submitted PR page and looks something like "patch-*X*" (where "X" should be the number of PRs made on your fork to date)
-8. Once in your branch, type `git commit -s --amend` to sign off your PR.
-    - You may replace `--amend` with a `-m` followed by a commit message if you desire; the `--amend` simply uses the same commit message as the one you wrote when initially submitting the PR
-    - If prompted with a sign-off page in your Git Bash (or alternative CLI), type `:wq!` to exit the prompt
-9. Type `git push -f origin [branch_name]`, replacing `[branch_name]` with the actual name of your branch.
-10. Navigate back to your PR github page.
-    - A green `dco-signoff: yes` label indicates that your PR is successfully signed
-
-
-
-
-
-
-
-
-

--- a/docs/content/direct/pr-signoff.md
+++ b/docs/content/direct/pr-signoff.md
@@ -1,64 +1,49 @@
 # Git Commit Signoff and Signing
 
-**NOTE**: "sign-off" is different from "signing" a commit or tag.  The
-former indicates your assent to the repository's terms for
-contributors, the latter adds a cryptographic checksum that is rarely
-displayed.  See [the git
+**NOTE**: "sign-off" is different from "signing" a commit.  The former
+indicates your assent to the repository's terms for contributors, the
+latter adds a cryptographic signature that is rarely displayed.  See
+[the git
 book](https://git-scm.com/book/en/v2/Git-Tools-Signing-Your-Work)
 about signing. For commit signoff, do a web search on `git
 signoff`. GitHub has a concept of [a commit being
 "verified"](https://docs.github.com/en/authentication/managing-commit-signature-verification)
 that extends the Git concept of signing.
 
-In order to get your pull requests approved, you must first complete a
-DCO sign-off. This process is defined by the CNCF, and there are two
+In order to get a pull request approved, you must first complete a DCO
+sign-off for each commit that the request is asking to add to the
+repository. This process is defined by the CNCF, and there are two
 cases: individual contributors and contributors that work for a
-corporate CNCF member. Both mean consent with the terms stated in the
-`DCO` file at the root of this Git repository.
-
-In the case of an individual, DCO sign-off is done with a Git "signoff".
+corporate CNCF member. Both mean consent with the terms stated in [the
+`DCO` file at the root of this Git
+repository](https://github.com/kubestellar/kubestellar/blob/main/DCO). In
+the case of an individual, DCO sign-off is accomplished by doing a Git
+"sign-off" on the commit.
 
 We prefer that commits contributed to this repository be signed and
 GitHub verified, but this is not strictly necessary or enforced.
 
 ## Commit Sign-off
 
-Your submitted PR must pass the automated checks in order to be reviewed. One of these checks that each commit that you propose to contribute is signed-off. If you use the `git` shell command, this involves passing the `-s` flag on the command line. For other tools, consult their documentation.
+Your submitted PR must pass the automated checks in order to be merged. One of these checks that each commit that you propose to contribute is signed-off. If you use the `git` shell command, this involves passing the `-s` flag on the command line. For example, the following command will create a signed-off commit but _not_ sign it.
 
-### Repairing non-signed-off commits
+```shell
+git commit -s
+```
 
-If you have already created a PR that proposes to merge a branch that
-adds commits that are not signed-off then you can repair this by
-adding the signoff to each using `git commit -s --amend` on each of
-them. Following is an outline of how to do it for a branch that adds
-**exactly one** commit. If your branch adds more than one commit then
-you can extrapolate using `git cherry-pick -s -S` to build up a
-revised series of commits one-by-one.
+Alternatively, the following command will create a commit that is both signed-off and signed.
 
-The following instructions provide a basic walk-through if you have already created your own fork of the repository but yet not made a clone on your workstation. If you have set up your SSH and GPG keys and include `-S` on the `git commit` command line or have configured automatic signing then this will also get the commits signed.
+```shell
+git commit -s -S
+```
 
-1. Navigate to the **Code** page of the Kubestellar github.
-   
-2. Click the **Fork** dropdown in the top right corner of the page.
-    - Under "Existing Forks" click your fork (should look something like "your_username/kubestellar")
-3. Once in your fork, click the **Code** dropdown.
-    - Under the "Local" tab at the top of the dropdown, select the SSH tab
-    - Copy the SSH repo URL to your clipboard
-4. Open Git Bash (or your CLI of choice), create or change to a different directory if desired.
-5. Clone the repository using `git clone` followed by pasting the URL you just copied.
-6. Change your directory to the Kubestellar repo using `cd kubestellar`.
-7. `git checkout` to the branch in your fork where the changes were committed.
-    - The branch name should be written at the top of your submitted PR page and looks something like "patch-*X*" (where "X" should be the number of PRs made on your fork to date)
-8. Once in your branch, type `git commit -s --amend` to sign off your PR.
-    - You may replace `--amend` with a `-m` followed by a commit message if you desire; the `--amend` simply uses the same commit message as the one you wrote when initially submitting the PR
-    - If prompted with a sign-off page in your Git Bash (or alternative CLI), type `:wq!` to exit the prompt
-9. Type `git push -f origin [branch_name]`, replacing `[branch_name]` with the actual name of your branch.
-10. Navigate back to your PR github page.
-    - A green `dco-signoff: yes` label indicates that your PR is successfully signed
+For other tools, consult their documentation.
 
 ## Signing Commits
 
-To sign a commit, you must have a GPG and SSH key. Basic setup instructions can be found below (For more detailed instructions, refer to the Github [GPG](https://docs.github.com/en/authentication/managing-commit-signature-verification/generating-a-new-gpg-key) and [SSH](https://docs.github.com/en/authentication/connecting-to-github-with-ssh/generating-a-new-ssh-key-and-adding-it-to-the-ssh-agent#generating-a-new-ssh-key) setup pages.)
+Before signing any commits, you must have a GPG and SSH key. Basic setup instructions can be found below (For more detailed instructions, refer to the Github [GPG](https://docs.github.com/en/authentication/managing-commit-signature-verification/generating-a-new-gpg-key) and [SSH](https://docs.github.com/en/authentication/connecting-to-github-with-ssh/generating-a-new-ssh-key-and-adding-it-to-the-ssh-agent#generating-a-new-ssh-key) setup pages.)
+
+To sign a particular commit, you must either include `-S` on the `git commit` command line (see the command exhibited above for an example) or have configured automatic signing (see ["Everyone Must Sign" in the Git Book](https://git-scm.com/book/en/v2/Git-Tools-Signing-Your-Work#_everyone_must_sign) for a hint about that).
 
 Before starting, make sure that your user email is verified on Github. To check for this:
 
@@ -71,7 +56,7 @@ Before starting, make sure that your user email is verified on Github. To check 
 
 <br />
 
-**Git Bash** is also highly recommended.
+For Windows users, **Git Bash** is also highly recommended.
 
 <br />
 
@@ -161,11 +146,45 @@ Before starting, make sure that your user email is verified on Github. To check 
 
 ## Creating Pull Requests Using the GitHub Website
 
+This is not recommended for individual contributors, because the commits that it produces are not "signed-off" (as defined by Git) and thus do not carry assent to the DCO; see [Repairing commits](#repairing-commits) below for a way to recover if you have inadvertently made such a PR. For corporate contributors the DCO assent is indicated differently.
+
 Whether it's editing files from Kubestellar.io or directly from the Kubestellar Github, there are a couple steps to follow that streamlines the workflow of your PR:
 
 1. Changes made to any file are automatically committed to a new branch in your fork.
-    - When committing, make sure to specify the type of PR at the beginning of your commit message (i.e. :bug: if it addresses a bug-type issue)
-    - If the PR addresses a specific issue that has already been opened in the github, make sure to include the opened issue in **additional comments** (i.e. `fixes Issue #XXXX`)
-     
-2. Click **Propose Changes** after writing the commit message, review your changes, and then create the PR.
-3. If your PR addresses an already opened issue on the github, make sure to close the issue once your PR is approved and closed.
+    - After clicking **Commit changes...**, write your commit message summary line and any extended desription that you want. Then click **Propose changes**, review your changes, and then create the PR.
+    - When making the PR, make sure to specify the type of PR at the beginning of the PR's title (i.e. :bug: if it addresses a bug-type issue)
+
+1. If the PR addresses a specific issue that has already been opened in GitHub, make sure to include the open issue number in **Related Issue(s)** (i.e. `Fixes #NNNN`); this will cause GitHub to automatically close the Issue once the PR is merged. If you have finished addressing an open issue without getting it automatically closed then explicitly close it.
+
+## Repairing commits
+
+If you have already created a PR that proposes to merge a branch that
+adds commits that are not signed-off then you can repair this (and
+lack of signing, if you choose) by adding the signoff to each using
+`git commit -s --amend` on each of them. If you also want those
+commits signed then you would use `git commit -s -S --amend` or
+configure automatic signing. Following is an outline of how to do it
+for a branch that adds **exactly one** commit. If your branch adds
+more than one commit then you can extrapolate using `git cherry-pick
+-s -S` to build up a revised series of commits one-by-one.
+
+The following instructions provide a basic walk-through if you have already created your own fork of the repository but yet not made a clone on your workstation.
+
+1. Navigate to the **Code** page of the Kubestellar github.
+   
+2. Click the **Fork** dropdown in the top right corner of the page.
+    - Under "Existing Forks" click your fork (should look something like "your_username/kubestellar")
+3. Once in your fork, click the **Code** dropdown.
+    - Under the "Local" tab at the top of the dropdown, select the SSH tab
+    - Copy the SSH repo URL to your clipboard
+4. Open Git Bash (or your CLI of choice), create or change to a different directory if desired.
+5. Clone the repository using `git clone` followed by pasting the URL you just copied.
+6. Change your directory to the Kubestellar repo using `cd kubestellar`.
+7. `git checkout` to the branch in your fork where the changes were committed.
+    - The branch name should be written at the top of your submitted PR page and looks something like "patch-*X*" (where "X" should be the number of PRs made on your fork to date)
+8. Once in your branch, type `git commit -s --amend` to sign off your PR.
+    - The commit will also be signed if either you have set up automatic signing or both include the `-S` flag on that command and have set up your GPG key.
+    - You may extend that command with `-m` followed by a quoted commit message if you desire. Otherwise `git` will pop up an editor for you to use in making any desired adjustment to the commit message. After making any desired changes, save and exit the editor. FYI: in `vi` (which GitBash uses), when it is in Command mode (which is the normal mode, and contrasts with Insert mode) the keystrokes `:wq!` will attempt to save and then will exit no matter what.
+9. Type `git push -f origin [branch_name]`, replacing `[branch_name]` with the actual name of your branch.
+10. Navigate back to your PR github page.
+    - A green `dco-signoff: yes` label indicates that your PR is successfully signed

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -88,7 +88,7 @@ nav:
       - Release Process: direct/release.md
       - Release Testing: direct/release-testing.md
       - Guidelines: contribution-guidelines/CONTRIBUTING.md
-      - Sign-off on Contributions: direct/pr-signoff.md
+      - Sign-off and Signing Contributions: direct/pr-signoff.md
   - Community: 
     - Get Involved: Community/_index.md
     - Contact Us:


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
This PR updates the website page about sign-off and signing. This is good because the page mixed up the two in a confusing way.

Preview at https://mikespreitzer.github.io/kcp-edge-mc/doc-signoff/direct/pr-signoff/

## Related issue(s)

Fixes #
