### PR TITLE
✨  Update self-references in prep for release 0.26.0-rc.1

### DIFF
--- a/core-chart/values.yaml
+++ b/core-chart/values.yaml
@@ -7,7 +7,7 @@
 # please do not change them unless you know what you are doing.
 HELM_VERSION: "3.16.1"
 KUBECTL_VERSION: "1.31.0"
-KUBESTELLAR_VERSION: "0.26.0-alpha.5"
+KUBESTELLAR_VERSION: "0.26.0-rc.1"
 # TRANSPORT_VERSION: e.g., "0.24.0"; defaults to KUBESTELLAR_VERSION value, if not defined
 CLUSTERADM_VERSION: "0.9.0"
 OCM_STATUS_ADDON_VERSION: "0.2.0-rc14"

--- a/docs/content/direct/get-started.md
+++ b/docs/content/direct/get-started.md
@@ -50,7 +50,7 @@ This walks you through the steps to produce the same configuration as does the s
 The following command will check for the prerequisites that you will need for the later steps. See [the prerequisites doc](pre-reqs.md) for more details.
 
 ```shell
-bash <(curl https://raw.githubusercontent.com/kubestellar/kubestellar/v{{ config.ks_latest_release }}/hack/check_pre_req.sh) kflex ocm helm kubectl docker kind
+bash <(curl https://raw.githubusercontent.com/kubestellar/kubestellar/v{{ config.ks_latest_release }}/scripts/check_pre_req.sh) kflex ocm helm kubectl docker kind
 ```
 
 This setup recipe uses [kind](https://kind.sigs.k8s.io/) to create three Kubernetes clusters on your machine.

--- a/docs/content/direct/release-notes.md
+++ b/docs/content/direct/release-notes.md
@@ -2,6 +2,25 @@
 
 The following sections list the known issues for each release. The issue list is not differential (i.e., compared to previous releases) but a full list representing the overall state of the specific release. 
 
+## 0.26.0 and its RCs
+
+The major changes since 0.25.1 are as follows.
+
+- Increase the Kubernetes release that kubestellar depends on, from 1.28 to 1.29.
+- The demo environment creation script is much more reliable, mainly due to no longer attempting concurrent operations. Still, external network/server hiccups can cause the script to fail.
+- This release removes the thrashing of workload objects in the WEC in the case where the transport controller's `max-num-wrapped` is 1.
+- This release adds reporting, in `BindingPolicy` and `Binding` status, of whether any of the referenced `StatusCollector` objects do not exist.
+- This release changes the schema for a `BindingPolicy` so that the request for sigleton status return is made/not-made independently in each `DownsyncPolicyClause` rather than once on the whole `BindingPolicySpec`. The schema for `Binding` objects is changed correspondingly. **This is a breaking change in the YAML schema for Binding[Policy] objects that request singleton status return.**
+
+### Remaining limitations in 0.26.0
+
+* Although the create-only feature can be used with Job objects to avoid trouble with `.spec.selector`, requesting singleton reported state return will still lead to a controller fight over `.status.replicas` while the Job is in progress.
+* Removing of WorkStatus objects (in the transport namespace) is not supported and may not result in recreation of that object
+* Objects on two different WDSes shouldn't have the exact same identifier (same group, version, kind, name and namespace). Such a conflict is currently not identified.
+* Creation, deletion, and modification of `CustomTransform` objects does not cause corresponding updates to the workload objects in the WECs; the current state of the `CustomTransform` objects is simply read at any moment when the objects in the WECs are being updated for other reasons.
+* It is not known what actually happens when two different `Binding` objects list the same workload object and either or both say "create only".
+* If (a) the workload object count or volume vs the configured limits on content of a `ManifestWork` causes multiple `ManifestWork` to be created for one `Binding` (`BindingPolicy`) AND (b) the limit on number of workload objects in one `ManifestWork` is greater then 1, then there may be transients where workload objects are deleted and re-created in a WEC --- which, in addition to possibly being troubling on its own, will certainly thwart the "create-only" functionality. The default limit on the number of workload objects in one `ManifestWork` is 1, so this issue will only arise when you use a non-default value. In this case you will avoid this issue if you set that limit to be at least the highest number of workload objects that will appear in a `Binding` (do check your `Binding` objects, lest you be surprised) AND your workload is not so large that multiple `ManifestWork` are created due to the limit on their size.
+
 ## 0.26.0-alpha.5
 
 This release is intended to have the same functionality as 0.26.0-alpha.3 and 0.26.0-alpha.4 but test a change to the GitHub Actions workflow that makes a release; the change adds SBOM generation ([PR 2718](https://github.com/kubestellar/kubestellar/pull/2718)).

--- a/docs/content/direct/release.md
+++ b/docs/content/direct/release.md
@@ -43,8 +43,6 @@ Making a new kubestellar release requires a contributor to do the following thin
 
 - If not already in effect, declare a code freeze. There should be nothing but bug fixes and doc improvements while working towards a regular release.
 
-- **AFTER** the next release, replace references to `hack/check_pre_req.sh` with references to `scripts/check_pre_req.sh` in:  `docs/content/direct/get-started.md`, `docs/content/direct/start-from-ocm.md`, `scripts/create-kubestellar-demo-env.sh`, and then delete this step.
-
 - **AFTER** the next regular release: delete `hack/check_pre_req.sh`, delete references to `hack/check_pre_req.sh` in this document, and delete this step.
 
 - Edit `docs/mkdocs.yml` and update the definition of `ks_latest_release` to `$version` (e.g., `'0.23.0-rc42'`). If this is a regular release then also update the definition of `ks_latest_regular_release`.

--- a/docs/content/direct/start-from-ocm.md
+++ b/docs/content/direct/start-from-ocm.md
@@ -39,7 +39,7 @@ story](user-guide-intro.md#the-full-story).
 The following command will check for the prerequisites that KubeStellar will need for the later steps. See [the prerequisites doc](pre-reqs.md) for more details.
 
 ```shell
-bash <(curl https://raw.githubusercontent.com/kubestellar/kubestellar/v{{ config.ks_latest_release }}/hack/check_pre_req.sh) kflex ocm helm kubectl docker kind
+bash <(curl https://raw.githubusercontent.com/kubestellar/kubestellar/v{{ config.ks_latest_release }}/scripts/check_pre_req.sh) kflex ocm helm kubectl docker kind
 ```
 
 ### Cleanup from previous runs

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -14,7 +14,7 @@ edit_uri: edit/main/docs/content
 ks_branch: 'main'
 ks_tag: 'latest'
 ks_latest_regular_release: '0.25.1'
-ks_latest_release: '0.26.0-alpha.5'
+ks_latest_release: '0.26.0-rc.1'
 
 ks_kind_port_num: '1119'
 

--- a/scripts/create-kubestellar-demo-env.sh
+++ b/scripts/create-kubestellar-demo-env.sh
@@ -65,14 +65,14 @@ if ! dunsel=$(docker ps 2>&1); then
 fi
 echo "Container runtime is running."
 
-kubestellar_version=0.26.0-alpha.5
+kubestellar_version=0.26.0-rc.1
 echo -e "KubeStellar Version: ${kubestellar_version}"
 
 echo -e "Checking that pre-req softwares are installed..."
 if [ "$k8s_platform" == "kind" ]; then
-    curl -s https://raw.githubusercontent.com/kubestellar/kubestellar/v${kubestellar_version}/hack/check_pre_req.sh | bash -s -- --assert -V kflex ocm helm kubectl docker kind
+    curl -s https://raw.githubusercontent.com/kubestellar/kubestellar/v${kubestellar_version}/scripts/check_pre_req.sh | bash -s -- --assert -V kflex ocm helm kubectl docker kind
 else
-    curl -s https://raw.githubusercontent.com/kubestellar/kubestellar/v${kubestellar_version}/hack/check_pre_req.sh | bash -s -- --assert -V kflex ocm helm kubectl docker k3d
+    curl -s https://raw.githubusercontent.com/kubestellar/kubestellar/v${kubestellar_version}/scripts/check_pre_req.sh | bash -s -- --assert -V kflex ocm helm kubectl docker k3d
 fi
 
 ##########################################


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
This PR updates the self-references and release notes in preparation for the first RC of the next regular release.

This PR also removes some temporary hackery that is no longer needed.

Preview at https://mikespreitzer.github.io/kcp-edge-mc/doc-prep4-0260rc1/readme/

## Related issue(s)

Fixes #
