### PR TITLE
⚠️ breaking change: docs/requirements.txt satisfiable for recent Python releases

### DIFF
--- a/docs/content/direct/get-started.md
+++ b/docs/content/direct/get-started.md
@@ -118,11 +118,9 @@ kubectl --context kind-kubeflex wait -n its1-system job.batch/its-with-clusterad
 ```
 
 ### Create and register two workload execution cluster(s)
+### changes introduced
+{% include-markdown "direct/example-wecs.md" heading-offset=2 %}
 
- {%
-    include-markdown "example-wecs.md"
-    heading-offset=2
- %}
 
 ### Variables for running the example scenarios.
 

--- a/docs/content/direct/get-started.md
+++ b/docs/content/direct/get-started.md
@@ -118,7 +118,6 @@ kubectl --context kind-kubeflex wait -n its1-system job.batch/its-with-clusterad
 ```
 
 ### Create and register two workload execution cluster(s)
-### changes introduced
 {% include-markdown "direct/example-wecs.md" heading-offset=2 %}
 
 

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -205,8 +205,6 @@ extra:
             using our <a href="https://github.com/kubestellar/kubestellar/issues/new?assignees=&labels=kind%2Fbug&projects=&template=bug_report.yaml&title=bug%3A+" target="_blank" rel="noopener">feedback form</a>.
 
 plugins:
-  - search
-  - macros
   - i18n:
       default_language: en
       languages:

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -205,10 +205,17 @@ extra:
             using our <a href="https://github.com/kubestellar/kubestellar/issues/new?assignees=&labels=kind%2Fbug&projects=&template=bug_report.yaml&title=bug%3A+" target="_blank" rel="noopener">feedback form</a>.
 
 plugins:
-  # https://github.com/lukasgeiter/mkdocs-awesome-pages-plugin
-  # Greater control over how navigation links are shown
-  - awesome-pages
-  # apidoc
+  - search
+  - macros
+  - i18n:
+      default_language: en
+      languages:
+        en: "English"
+        fr: "Français"
+
+
+
+  # apidocs
   # - mkdocs-apidoc
   # Docs site search
   - search
@@ -221,11 +228,7 @@ plugins:
       include_dir: 'overrides'
       module_name: 'main'
   # Configure multiple language support
-  - i18n:
-      default_language: en
-      languages:
-        en:
-          name: English
+
   # - redirects:
   #       redirect_maps:
   #           'docs': 'docs/Coding%20Milestones/PoC2023q1/outline/'

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,25 +1,23 @@
-# Core dependencies
-mkdocs>=1.5
-Jinja2>=3.1.5
-Markdown>=3.3.7
-MarkupSafe>=2.1.2
+# Core Dependencies
+mkdocs>=1.5,<2.0
+Jinja2>=3.1.5,<4.0
+Markdown>=3.3.7,<4.0
+MarkupSafe>=2.1.2,<3.0
 
-# MkDocs plugins
-mkdocs-material>=9.5.34
-mkdocs-material-extensions>=1.3
-mkdocs-awesome-pages-plugin>=2.8.0
-mkdocs-mermaid2-plugin>=1.1.1
-mkdocs-macros-plugin>=0.7.0
-mkdocs-static-i18n>=0.53
-mkdocs-open-in-new-tab>=1.0.2
+# MkDocs Plugins
+mkdocs-material>=9.5.34,<10.0
+mkdocs-material-extensions>=1.3,<2.0
+mkdocs-awesome-pages-plugin>=2.8.0,<3.0
+mkdocs-mermaid2-plugin>=1.1.1,<2.0
+mkdocs-macros-plugin>=0.7.0,<1.0
+mkdocs-static-i18n>=0.53,<1.0
+mkdocs-open-in-new-tab>=1.0.2,<2.0
+mike>=1.1.2,<2.0
 
-mike>=1.1.2
+# Markdown Extensions
+markdown-captions>=2.1.2,<3.0
+pymdown-extensions>=10.2,<11.0
+Pygments>=2.16,<3.0
 
-# Markdown extensions
-markdown-captions>=2.1.2
-pymdown-extensions>=10.2
-Pygments>=2.16
-
-# Use the latest compatible version of mkdocs-include-markdown-plugin
-mkdocs-include-markdown-plugin>=7.1.2
-# ../../mkdocs-include-markdown-plugin
+# Include Markdown Plugin
+mkdocs-include-markdown-plugin>=7.1.2,<8.0

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,18 +1,25 @@
-Jinja2==3.1.5
-Markdown==3.3.7
-MarkupSafe==2.1.2
-mike==1.1.2
+# Core dependencies
 mkdocs>=1.5
-mkdocs-awesome-pages-plugin==2.8.0
-mkdocs-mermaid2-plugin==1.1.1
-mkdocs-macros-plugin==0.7.0
+Jinja2>=3.1.5
+Markdown>=3.3.7
+MarkupSafe>=2.1.2
+
+# MkDocs plugins
 mkdocs-material>=9.5.34
 mkdocs-material-extensions>=1.3
-mkdocs-static-i18n==0.53
-markdown-captions==2.1.2
-Pygments>=2.16
+mkdocs-awesome-pages-plugin>=2.8.0
+mkdocs-mermaid2-plugin>=1.1.1
+mkdocs-macros-plugin>=0.7.0
+mkdocs-static-i18n>=0.53
+mkdocs-open-in-new-tab>=1.0.2
+
+mike>=1.1.2
+
+# Markdown extensions
+markdown-captions>=2.1.2
 pymdown-extensions>=10.2
-mkdocs-open-in-new-tab==1.0.2
-mkdocs-include-markdown-plugin==4.0.4
+Pygments>=2.16
+
+# Use the latest compatible version of mkdocs-include-markdown-plugin
+mkdocs-include-markdown-plugin>=7.1.2
 # ../../mkdocs-include-markdown-plugin
-mkdocs-include-markdown-plugin @ git+https://github.com/clubanderson/mkdocs-include-markdown-plugin@879ff41


### PR DESCRIPTION
Fixes #2771

This PR resolves issue https://github.com/kubestellar/kubestellar/issues/2771 by updating the docs/requirements.txt file to ensure compatibility with Python releases 3.12 or higher. The changes include:

Upgraded dependencies in docs/requirements.txt to their latest versions that support Python 3.12+.
Verified compatibility across Python 3.12 and higher to ensure a smooth installation process for documentation-related dependencies.

Fixed :- mkdocs.yml, getstarted.md files for newer compatible versions