### PR TITLE
📖  Remove outdated and unneeded example listing of manifestworks

### DIFF
--- a/docs/content/direct/example-scenarios.md
+++ b/docs/content/direct/example-scenarios.md
@@ -95,14 +95,6 @@ spec:
 EOF
 ```
 
-Verify that *manifestworks* wrapping the objects have been created in the mailbox
-namespaces with the following command. Expect to see a `ManifestWork` object named "nginx-bpolicy-wds1" in each namespace.
-
-```shell
-kubectl --context "$its_context" get manifestworks -n "$wec1_name"
-kubectl --context "$its_context" get manifestworks -n "$wec2_name"
-```
-
 Verify that the deployment has been created in both clusters
 
 ```shell


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
This PR excises the now-incorrect and never-needed listing of ManifestWork objects from example scenario 1.

Preview at https://mikespreitzer.github.io/kcp-edge-mc/doc-not-manifestworks/direct/example-scenarios/#scenario-1-multi-cluster-workload-deployment-with-kubectl

## Related issue(s)

Fixes #
