### PR TITLE
🐛 Make an annotation key consistent

### DIFF
--- a/docs/content/direct/transforming.md
+++ b/docs/content/direct/transforming.md
@@ -30,7 +30,7 @@ The following are applied to every workload object.
 
 In a `Service` (core API group) object:
 
-1. remove the following fields from `spec`: `ipFamilies`, `externalTrafficPolicy`, `internalTrafficPolicy`, `ipFamilyPolicy`, `sessionAffinity`. Also remove the `nodePort` field from every port unless the annotation `kubestellar.io/annotations/preserve=nodeport` is present;
+1. remove the following fields from `spec`: `ipFamilies`, `externalTrafficPolicy`, `internalTrafficPolicy`, `ipFamilyPolicy`, `sessionAffinity`. Also remove the `nodePort` field from every port unless the annotation `control.kubestellar.io/preserve=nodeport` is present.
 
 1. in the `spec` remove the field `clusterIP` unless it is present with value "None".
 

--- a/pkg/transport/generic/filtering/service.go
+++ b/pkg/transport/generic/filtering/service.go
@@ -49,7 +49,7 @@ func cleanService(object *unstructured.Unstructured) {
 		}
 	}
 
-	// Set the nodePort to an empty string unelss the annotation "kubestellar.io/annotations/preserve=nodeport" is present
+	// Set the nodePort to an empty string unelss the annotation "control.kubestellar.io/preserve=nodeport" is present
 	if !(object.GetAnnotations() != nil && object.GetAnnotations()[preserveFieldAnnotation] == preserveNodePortValue) {
 		if ports, found, _ := unstructured.NestedSlice(object.Object, "spec", "ports"); found {
 			for i, port := range ports {

--- a/pkg/util/unstructured.go
+++ b/pkg/util/unstructured.go
@@ -60,9 +60,6 @@ const (
 	CombinedStatusResource = "combinedstatuses"
 	CombinedStatusGroup    = "control.kubestellar.io"
 	CombinedStatusVersion  = "v1alpha1"
-
-	AnnotationToPreserveValuesKey = "annotations.kubestellar.io/preserve"
-	PreserveNodePortValue         = "nodeport"
 )
 
 // this type is used in status-addon, which we cannot import due to conflicting versions


### PR DESCRIPTION
## Summary
An annotation is used to signal the preserving of certain fields in workload objects. But the key of the annotation is not consistent across code and doc. This PR is a fix to the inconsistency.
