### PR TITLE
🐛 Fix a problem with `echov` in `kubestellar-snapshot` script

### DIFF
--- a/scripts/kubestellar-snapshot.sh
+++ b/scripts/kubestellar-snapshot.sh
@@ -79,10 +79,15 @@ EOF
 }
 
 
+# Define default behavior
+echov() { :; }
+
+
 # Indent JSON
 indent() {
     sed 's/^/  /'
 }
+
 
 # Echo in color
 echocolor() {
@@ -239,12 +244,8 @@ done
 ###############################################################################
 # Alias definitions
 ###############################################################################
-# Define the echov function based on verbosity
-if [ "$arg_verbose" == "true" ]; then
-    echov() { echo "$@" ; }
-else
-    echov() { :; }
-fi
+# Redefine the echov function based on verbosity
+[ "$arg_verbose" == "true" ] && echov() { echo "$@" ; }
 
 
 ###############################################################################

--- a/scripts/kubestellar-snapshot.sh
+++ b/scripts/kubestellar-snapshot.sh
@@ -232,10 +232,10 @@ while (( $# > 0 )); do
         display_help
         exit 0;;
     (-*)
-        echo "$0: unknown flag" >&2
+        echo "$0: unknown flag \"$1\"" >&2
         exit 1;;
     (*)
-        echo "$0: unknown positional argument" >&2
+        echo "$0: unknown positional argument \"$1\"" >&2
         exit 1;;
     esac
     shift

--- a/scripts/kubestellar-snapshot.sh
+++ b/scripts/kubestellar-snapshot.sh
@@ -221,6 +221,7 @@ while (( $# > 0 )); do
     (--yaml|-Y)
         arg_yaml=true;;
     (--verbose|-V)
+        echov() { echo "$@" ; }
         arg_verbose=true;;
     (--version|-v)
         echo "${SCRIPT_NAME} v${SCRIPT_VERSION}"
@@ -239,13 +240,6 @@ while (( $# > 0 )); do
     esac
     shift
 done
-
-
-###############################################################################
-# Alias definitions
-###############################################################################
-# Redefine the echov function based on verbosity
-[ "$arg_verbose" == "true" ] && echov() { echo "$@" ; }
 
 
 ###############################################################################


### PR DESCRIPTION
## Summary

Fix a problem with `echov` being invoked by the `on_exit` function before being defined

Here is an example of the problem being solved:

```shell
$ kubestellar-snapshot.sh --foo
kubestellar-snapshot.sh: unknown flag
kubestellar-snapshot.sh: line 182: echov: command not found
```

## Related issue(s)

Fixes #
