### PR TITLE
🐛 Fix script name handling in Bash scripts when piped via curl

### DIFF
--- a/scripts/create-k3s-cluster-with-SSL-passthrough.sh
+++ b/scripts/create-k3s-cluster-with-SSL-passthrough.sh
@@ -17,12 +17,15 @@
 
 set -o errexit
 
+# Script info
+SCRIPT_NAME="Create K3s Cluster with SSL Passthrough" 
+
 port=9443
 wait=true
 
 display_help() {
   cat << EOF
-Usage: $0 [--port port] [--nowait][-X]
+Usage: ${SCRIPT_NAME} [--port port] [--nowait][-X]
 
 --port port     map the specified host port to the kind cluster port 443 (default: 9443)
 --nowait        when set to true, the script proceeds without waiting for the nginx ingress patching to complete
@@ -35,7 +38,7 @@ while (( $# > 0 )); do
         (-p|--port)
             if (( $# > 1 ));
             then { port="$2"; shift; }
-            else { echo "$0: missing port number" >&2; exit 1; }
+            else { echo "${SCRIPT_NAME}: missing port number" >&2; exit 1; }
             fi;;
         (--nowait)
             wait=false;;
@@ -45,10 +48,10 @@ while (( $# > 0 )); do
             display_help
             exit 0;;
         (-*)
-            echo "$0: unknown flag" >&2
+            echo "${SCRIPT_NAME}: unknown flag" >&2
             exit 1;;
         (*)
-            echo "$0: unknown positional argument" >&2
+            echo "${SCRIPT_NAME}: unknown positional argument" >&2
             exit 1;;
     esac
     shift

--- a/scripts/create-kind-cluster-with-SSL-passthrough.sh
+++ b/scripts/create-kind-cluster-with-SSL-passthrough.sh
@@ -17,6 +17,9 @@
 
 set -o errexit
 
+# Script info
+SCRIPT_NAME="Create Kind Cluster with SSL Passthrough"
+
 NGINX_INGRESS_URL="https://raw.githubusercontent.com/kubernetes/ingress-nginx/refs/tags/controller-v1.12.0/deploy/static/provider/kind/deploy.yaml"
 name=kubestellar
 port=9443
@@ -24,9 +27,10 @@ wait=true
 prefetch=false
 setcontext=true
 
+
 display_help() {
   cat << EOF
-Usage: $0 [options]
+Usage: ${SCRIPT_NAME} [options]
 
 --name name     set a specific name of the kind cluster (default: kubestellar)
 --port port     map the specified host port to the kind cluster port 443 (default: 9443)
@@ -42,12 +46,12 @@ while (( $# > 0 )); do
   (-n|--name)
     if (( $# > 1 ));
     then { name="$2"; shift; }
-    else { echo "$0: missing name for the kind cluster" >&2; exit 1; }
+    else { echo "${SCRIPT_NAME}: missing name for the kind cluster" >&2; exit 1; }
     fi;;
   (-p|--port)
     if (( $# > 1 ));
     then { port="$2"; shift; }
-    else { echo "$0: missing port number" >&2; exit 1; }
+    else { echo "$: missing port number" >&2; exit 1; }
     fi;;
   (--nowait)
     wait=false;;
@@ -61,10 +65,10 @@ while (( $# > 0 )); do
     display_help
     exit 0;;
   (-*)
-    echo "$0: unknown flag" >&2
+    echo "${SCRIPT_NAME}: unknown flag" >&2
     exit 1;;
   (*)
-    echo "$0: unknown positional argument" >&2
+    echo "${SCRIPT_NAME}: unknown positional argument" >&2
     exit 1;;
   esac
   shift

--- a/scripts/create-kubestellar-demo-env.sh
+++ b/scripts/create-kubestellar-demo-env.sh
@@ -15,6 +15,9 @@
 
 set -e
 
+# Script info
+SCRIPT_NAME="Create KubeStellar Demo Environment"
+
 # Default Kubernetes platform parameter
 k8s_platform="kind"
 
@@ -24,12 +27,12 @@ while [[ "$#" -gt 0 ]]; do
         --platform) k8s_platform="$2"; shift ;;
         -X) set -x ;;
         -h|--help)
-            echo "Usage: $0 [--platform <kind|k3d>] [-X] [-h|--help]" >&2
+            echo "Usage: ${SCRIPT_NAME} [--platform <kind|k3d>] [-X] [-h|--help]" >&2
             exit 0
             ;;
         *)
             echo "Unknown parameter passed: $1" >&2
-            echo "Usage: $0 [--platform <kind|k3d>] [-X] [-h|--help]" >&2
+            echo "Usage: ${SCRIPT_NAME} [--platform <kind|k3d>] [-X] [-h|--help]" >&2
             exit 1
             ;;
     esac

--- a/scripts/kubestellar-snapshot.sh
+++ b/scripts/kubestellar-snapshot.sh
@@ -56,7 +56,7 @@ arg_verbose=false
 # Display the command line help
 display_help() {
   cat << EOF
-Usage: $0 [options]
+Usage: ${SCRIPT_NAME} [options]
 
 Options:
 --kubeconfig|-K <filename> use the specified kubeconfig to find KubeStellar Helm chart
@@ -208,12 +208,12 @@ while (( $# > 0 )); do
     (--kubeconfig|-K)
         if (( $# > 1 ));
         then { arg_kubeconfig="$2"; shift; }
-        else { echo "$0: missing kubeconfig filename" >&2; exit 1; }
+        else { echo "${SCRIPT_NAME}: missing kubeconfig filename" >&2; exit 1; }
         fi;;
     (--context|-C)
         if (( $# > 1 ));
         then { arg_context="$2"; shift; }
-        else { echo "$0: missing context name" >&2; exit 1; }
+        else { echo "${SCRIPT_NAME}: missing context name" >&2; exit 1; }
         fi;;
     (--logs|-L)
         arg_logs=true;;
@@ -230,10 +230,10 @@ while (( $# > 0 )); do
         display_help
         exit 0;;
     (-*)
-        echo "$0: unknown flag \"$1\"" >&2
+        echo "${SCRIPT_NAME}: unknown flag \"$1\"" >&2
         exit 1;;
     (*)
-        echo "$0: unknown positional argument \"$1\"" >&2
+        echo "${SCRIPT_NAME}: unknown positional argument \"$1\"" >&2
         exit 1;;
     esac
     shift


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

Fix script name handling in Bash scripts when piped via curl. Previously, `$0` was used to get the script name, but when the script is piped into Bash, `$0` expands to "bash" instead of the actual script name. This update replaces `$0` with a hardcoded variable `$script_name` to ensure correct script name attribution.  

## Related issue(s)

Fixes #
#2816