### PR TITLE
✨: Added sbom generation

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -52,8 +52,14 @@ release:
   draft: false
   prerelease: auto
   mode: keep-existing
-  skip_upload: true
+
 sboms:
   - id: source
     artifacts: source
+    documents:
+      - "{{ .ProjectName }}_{{ .Version }}_source.sbom"
+  - id: binary
+    artifacts: binary
+    documents:
+      - "{{ .Binary }}_{{ .Os }}_{{ .Arch }}.sbom"
 


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

After multiple reviews, I found out, if we are to build the sbom using the go-releaser functionality, we have remove the `skip_upload: true ` option , this would obviously lead to creation of some unrequired binaries as seen before, but still serves our purpose. Another way to do it is to create a hook in go-releaser and use an external script to create an sbom.

I have tested it in a test repo [here](https://github.com/jaydee029/test)
It consists of a basic go-releaser config, and multiple releases (with variations)

As soon as this is merged I'll create a PR for the signed binary issue
## Related issue(s)

Fixes #2613 
