### PR TITLE
✨  Add OwnerReference from CombinedStatus to workload obj

### DIFF
--- a/pkg/status/combinedstatus-resolver.go
+++ b/pkg/status/combinedstatus-resolver.go
@@ -23,6 +23,7 @@ import (
 
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	machtypes "k8s.io/apimachinery/pkg/types"
 	runtime2 "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/tools/cache"
@@ -255,6 +256,7 @@ func (c *combinedStatusResolver) NoteBindingResolution(ctx context.Context, bind
 			logger.V(3).Info("Introducing CombinedStatus resolution", "binding", bindingName, "objectId", objectIdentifier)
 			csResolution = &combinedStatusResolution{
 				Name:                      getCombinedStatusName(policyUID, objectData.UID),
+				workloadObjectUID:         machtypes.UID(objectData.UID),
 				StatusCollectorNameToData: make(map[string]*statusCollectorData),
 			}
 			objectIdentifierToResolution[objectIdentifier] = csResolution


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
This PR updates the status controller to make each CombinedStatus object have an OwnerReference to its workload object.

## Related issue(s)

Fixes #2808 
