### PR TITLE
📖 Add Core Helm Chart link in Get Started guide

### DIFF
--- a/docs/content/direct/get-started.md
+++ b/docs/content/direct/get-started.md
@@ -88,7 +88,7 @@ For convenience, a new local **Kind** cluster that satisfies the requirements fo
 bash <(curl -s https://raw.githubusercontent.com/kubestellar/kubestellar/v{{ config.ks_latest_release }}/scripts/create-kind-cluster-with-SSL-passthrough.sh) --name kubeflex --port 9443
 ```
 
-### Use Core Helm chart to initialize KubeFlex and create ITS and WDS
+### Use Core Helm chart to initialize KubeFlex and create ITS and WDS (*[Learn more about the Core Helm Chart](./core-chart.md)* )
 
 ```shell
 helm upgrade --install ks-core oci://ghcr.io/kubestellar/kubestellar/core-chart \


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
This PR adds a reference link to the Core Helm Chart documentation in the Get Started guide where it is mentioned
## Related issue(s)

Fixes #2823 
