### PR TITLE
✨ feature: Enable pprof for kubestellar controller-manager

### DIFF
--- a/core-chart/templates/NOTES.txt
+++ b/core-chart/templates/NOTES.txt
@@ -17,5 +17,10 @@ kflex ctx --overwrite-existing-context {{ $cp.name }}
 {{- end }}
 {{- end }}
 
+To debug the Kubestellar controller-manager using `pprof`, forward the debug port (default: 6060) and access it:
+```bash
+kubectl port-forward <controller-manager-pod> 6060:6060
+go tool pprof http://localhost:6060/debug/pprof/profile
+
 Finally, you can use `kflex ctx` to switch back to the kubeconfig
 context for your KubeFlex hosting cluster.

--- a/core-chart/templates/_helpers.tpl
+++ b/core-chart/templates/_helpers.tpl
@@ -67,3 +67,12 @@ Expand ITS PCH statusaddon container.
     mountPath: "/etc/kube"
     readOnly: true
 {{- end }}
+
+{{/*
+  Expand controller-manager arguments.
+  */}}
+  {{- define "controller-manager.args" -}}
+  - "--pprof"
+  - "--debug-port={{ .Values.controllerManager.debugPort }}"
+  - "--metrics-bind-addr={{ .Values.controllerManager.metrics_bind_addr }}"
+{{- end }}

--- a/core-chart/values.yaml
+++ b/core-chart/values.yaml
@@ -106,3 +106,9 @@ WDSes: # all the CPs in this list will execute the wds.yaml PCH
   #   type: host # optional type of control plane host or k8s (default to k8s, if not specified)
   #   APIGroups: "" # optional string holding a comma-separated list of APIGroups
   #   ITSName: its1 # optional name of the ITS control plane, this MUST be specified if more than one ITS exists at the moment the WDS PCH starts
+
+# Add this section for the controller-manager configuration
+controllerManager:
+  debugPort: 6060  # Default debug port for pprof
+  pprof_bind_addr: ":6060"  # Bind address for pprof
+  metrics_bind_addr: ":8080"  # Optional: Bind address for metrics (if not already defined)


### PR DESCRIPTION
## Summary

This PR enables the `pprof` tool for the Kubestellar controller-manager to help debug and resolve performance issues. The following changes are made:

1. Added `debugPort` and `pprof_bind_addr` parameters to `values.yaml`.
2. Updated `_helpers.tpl` to include `pprof` and `debugPort` flags in the controller-manager arguments.
3. Added instructions for accessing the `pprof` endpoint in `NOTES.txt`.

## Related issue(s)

Fixes #2094 (kubestellar core Helm chart has parameter for debug port of kubestellar controller-managers)