### PR TITLE
✨ feature: Enable pprof for KubeStellar controller-manager using OCM Status Add-On Helm chart

### DIFF
--- a/core-chart/templates/controlplanes/its.yaml
+++ b/core-chart/templates/controlplanes/its.yaml
@@ -17,4 +17,7 @@ spec:
     namespace: {{ ($cp.bootstrapSecret).namespace | default $.Release.Namespace }}
     inClusterKey: {{ ($cp.bootstrapSecret).key | default "kubeconfig-incluster" }}
   {{- end }}
+  env:
+    - name: PPROF_BIND_ADDR
+      value: {{ $.Values.status_controller.pprof_bind_addr | default ":8081" }}
 {{- end }}

--- a/core-chart/values.yaml
+++ b/core-chart/values.yaml
@@ -54,6 +54,12 @@ status_agent:
   # v: 0 # Level number for the log level verbosity on the agent
   vmodule: "" # pattern=N,... comma-separated list of pattern=N settings for file-filtered logging (only works for text log format) on the agent
 
+# Configuration for the OCM Status Add-On Controller.
+# v here takes precedence over verbosity.status_controller
+status_controller:
+  pprof_bind_addr: ":8081" # string [host]:port at which to listen for HTTP requests for go /debug/pprof requests on the controller
+  # v: 2
+
 # Determine if the Post Create Hooks should be installed by the chart
 InstallPCHs: true
 


### PR DESCRIPTION
✨ feature: Enable pprof for KubeStellar controller-manager using OCM Status Add-On Helm chart

## Summary
This PR enables the `pprof` tool for the KubeStellar controller-manager by leveraging the existing `pprof_bind_addr` parameter from the OCM Status Add-On Helm chart. The parameter is passed to the controller-manager deployment, allowing debugging and performance analysis.

## Related issue(s)
Fixes: A part of issue #2094 (OCM Status Add-On Helm chart has parameter for controller debug port)