### PR TITLE
🐛 Patch NGINX vulnerabilities

### DIFF
--- a/scripts/create-kind-cluster-with-SSL-passthrough.sh
+++ b/scripts/create-kind-cluster-with-SSL-passthrough.sh
@@ -18,9 +18,9 @@
 set -o errexit
 
 # Script info
-SCRIPT_NAME="Ccreate-kind-cluster-with-SSL-passthrough.sh"
+SCRIPT_NAME="create-kind-cluster-with-SSL-passthrough.sh"
 
-NGINX_INGRESS_URL="https://raw.githubusercontent.com/kubernetes/ingress-nginx/refs/tags/controller-v1.12.0/deploy/static/provider/kind/deploy.yaml"
+NGINX_INGRESS_URL="https://raw.githubusercontent.com/kubernetes/ingress-nginx/refs/tags/controller-v1.12.1/deploy/static/provider/kind/deploy.yaml"
 name=kubestellar
 port=9443
 wait=true


### PR DESCRIPTION
## Summary

Upgrade NGINX ingress to v1.12.1 to patch vulnerabilities CVE-2025-24513, CVE-2025-24514, CVE-2025-1097, CVE-2025-1098, and CVE-2025-1974.

See https://thehackernews.com/2025/03/critical-ingress-nginx-controller.html

## Related issue(s)

Fixes #
