### PR TITLE
🐛  Pin clusteradm to release 0.10.1

### DIFF
--- a/.github/workflows/ocp-self-runner.yml
+++ b/.github/workflows/ocp-self-runner.yml
@@ -31,7 +31,7 @@ jobs:
           export USE_SUDO=false
           mkdir clusteradm
           export INSTALL_DIR="$PWD/clusteradm"
-          curl -L https://raw.githubusercontent.com/open-cluster-management-io/clusteradm/main/install.sh | bash
+          bash <(curl -L https://raw.githubusercontent.com/open-cluster-management-io/clusteradm/refs/tags/v0.10.1/install.sh) 0.10.1
           curl -L https://github.com/kubestellar/kubeflex/releases/download/v0.8.2/kubeflex_0.8.2_linux_amd64.tar.gz --output kubeflex.tar.gz
           tar -xvf kubeflex.tar.gz bin/kflex
           go install github.com/onsi/ginkgo/v2/ginkgo
@@ -83,7 +83,7 @@ jobs:
           mkdir clusteradm
           export USE_SUDO=false
           export INSTALL_DIR="$PWD/clusteradm"
-          curl -L https://raw.githubusercontent.com/open-cluster-management-io/clusteradm/main/install.sh | bash
+          bash <(curl -L https://raw.githubusercontent.com/open-cluster-management-io/clusteradm/refs/tags/v0.10.1/install.sh) 0.10.1
           curl -L https://github.com/kubestellar/kubeflex/releases/download/v0.8.2/kubeflex_0.8.2_linux_amd64.tar.gz --output kubeflex.tar.gz
           tar -xvf kubeflex.tar.gz bin/kflex
           go install github.com/onsi/ginkgo/v2/ginkgo

--- a/.github/workflows/pr-test-e2e.yml
+++ b/.github/workflows/pr-test-e2e.yml
@@ -48,7 +48,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          curl -L https://raw.githubusercontent.com/open-cluster-management-io/clusteradm/main/install.sh | bash
+          bash <(curl -L https://raw.githubusercontent.com/open-cluster-management-io/clusteradm/refs/tags/v0.10.1/install.sh) 0.10.1
           wget https://github.com/kubestellar/kubeflex/releases/download/v0.8.2/kubeflex_0.8.2_linux_amd64.tar.gz
           tar -xvf kubeflex_0.8.2_linux_amd64.tar.gz bin/kflex
           mv bin/kflex /usr/local/bin
@@ -179,7 +179,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          curl -L https://raw.githubusercontent.com/open-cluster-management-io/clusteradm/main/install.sh | bash
+          bash <(curl -L https://raw.githubusercontent.com/open-cluster-management-io/clusteradm/refs/tags/v0.10.1/install.sh) 0.10.1
           wget https://github.com/kubestellar/kubeflex/releases/download/v0.8.2/kubeflex_0.8.2_linux_amd64.tar.gz
           tar -xvf kubeflex_0.8.2_linux_amd64.tar.gz bin/kflex
           mv bin/kflex /usr/local/bin
@@ -202,6 +202,12 @@ jobs:
           date
           kubectl --context kind-kubeflex get pods -A
           kubectl --context kind-kubeflex get pods -A | grep -vw Running | grep -vw Completed | grep -v NAME | while read ns name rest; do echo; kubectl --context kind-kubeflex describe pod -n $ns $name; echo; kubectl --context kind-kubeflex logs -p -n $ns $name || true; echo; kubectl --context kind-kubeflex logs -n $ns $name || true; done
+
+      - name: show previous logs in hosting cluster
+        if: always()
+        run: |
+          date
+          kubectl --context kind-kubeflex get pods -A | grep -v NAME | while read ns name ready status restarts rest; do if [ $restarts != 0 ]; then echo; echo For $ns/$name; kubectl --context kind-kubeflex logs -p -n $ns $name || true; fi; done;
 
       - name: show Deployment objects in hosting cluster
         if: always()

--- a/.github/workflows/pr-test-integration.yml
+++ b/.github/workflows/pr-test-integration.yml
@@ -33,7 +33,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          curl -L https://raw.githubusercontent.com/open-cluster-management-io/clusteradm/main/install.sh | bash
+          bash <(curl -L https://raw.githubusercontent.com/open-cluster-management-io/clusteradm/refs/tags/v0.10.1/install.sh) 0.10.1
           wget https://github.com/kubestellar/kubeflex/releases/download/v0.8.2/kubeflex_0.8.2_linux_amd64.tar.gz
           tar -xvf kubeflex_0.8.2_linux_amd64.tar.gz bin/kflex
           mv bin/kflex /usr/local/bin

--- a/.github/workflows/test-latest-release.yml
+++ b/.github/workflows/test-latest-release.yml
@@ -31,7 +31,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          curl -L https://raw.githubusercontent.com/open-cluster-management-io/clusteradm/main/install.sh | bash
+          bash <(curl -L https://raw.githubusercontent.com/open-cluster-management-io/clusteradm/refs/tags/v0.10.1/install.sh) 0.10.1
           wget https://github.com/kubestellar/kubeflex/releases/download/v0.8.2/kubeflex_0.8.2_linux_amd64.tar.gz
           tar -xvf kubeflex_0.8.2_linux_amd64.tar.gz bin/kflex
           mv bin/kflex /usr/local/bin
@@ -106,7 +106,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          curl -L https://raw.githubusercontent.com/open-cluster-management-io/clusteradm/main/install.sh | bash
+          bash <(curl -L https://raw.githubusercontent.com/open-cluster-management-io/clusteradm/refs/tags/v0.10.1/install.sh) 0.10.1
           wget https://github.com/kubestellar/kubeflex/releases/download/v0.8.2/kubeflex_0.8.2_linux_amd64.tar.gz
           tar -xvf kubeflex_0.8.2_linux_amd64.tar.gz bin/kflex
           mv bin/kflex /usr/local/bin


### PR DESCRIPTION


<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
This PR pins the version of clusteradm used in CI to 0.10.1, because 0.11.0 changes a ServiceAccount name and breaks our scripting.

<img width="521" alt="image" src="https://github.com/user-attachments/assets/2c097fe0-d5de-4731-bb43-c825a451717a" />

## Related issue(s)

Fixes #
