### PR TITLE
📖  Doc install right clusteradm

### DIFF
--- a/docs/content/direct/get-started.md
+++ b/docs/content/direct/get-started.md
@@ -53,6 +53,18 @@ The following command will check for the prerequisites that you will need for th
 bash <(curl https://raw.githubusercontent.com/kubestellar/kubestellar/v{{ config.ks_latest_release }}/scripts/check_pre_req.sh) kflex ocm helm kubectl docker kind
 ```
 
+If that script complains then take it seriously! For example, the following indicates that you have a version of clusteradm that KubeStellar cannot use.
+
+```console
+$ bash <(curl https://raw.githubusercontent.com/kubestellar/kubestellar/v0.27.1/scripts/check_pre_req.sh) kflex ocm helm kubectl docker kind
+  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
+                                 Dload  Upload   Total   Spent    Left  Speed
+100  9278  100  9278    0     0   135k      0 --:--:-- --:--:-- --:--:--  137k
+✔ KubeFlex (Kubeflex version: v0.8.2.5fd5f9c 2025-03-10T14:58:02Z)
+✔ OCM CLI (:v0.11.0-0-g73281f6)
+  structured version ':v0.11.0-0-g73281f6' is less than required minimum ':v0.7' or ':v0.10' but less than ':v0.11'
+```
+
 This setup recipe uses [kind](https://kind.sigs.k8s.io/) to create three Kubernetes clusters on your machine.
 Note that `kind` does not support three or more concurrent clusters unless you raise some limits as described in this `kind` "known issue": [Pod errors due to “too many open files”](https://kind.sigs.k8s.io/docs/user/known-issues/#pod-errors-due-to-too-many-open-files).
 

--- a/docs/content/direct/pre-reqs.md
+++ b/docs/content/direct/pre-reqs.md
@@ -25,11 +25,11 @@ Our documentation has remarks about using the following sorts of clusters:
     To install kubeflex go to [https://github.com/kubestellar/kubeflex/blob/main/docs/users.md#installation](https://github.com/kubestellar/kubeflex/blob/main/docs/users.md#installation). To upgrade from an existing installation,
 follow [these instructions](https://github.com/kubestellar/kubeflex/blob/main/docs/users.md#upgrading-kubeflex). At the end of the install make sure that the kubeflex CLI, kflex, is in your `$PATH`.
 
-- **OCM CLI (clusteradm)** 0.7 <= version < 0.11.
-    To install OCM CLI use:
+- **OCM CLI (clusteradm)** 0.7 <= version **< 0.11**.
+    To install the latest acceptable version of the OCM CLI use:
 
     ```shell
-    curl -L https://raw.githubusercontent.com/open-cluster-management-io/clusteradm/main/install.sh | bash
+    bash <(curl -L https://raw.githubusercontent.com/open-cluster-management-io/clusteradm/main/install.sh) 0.10.1
     ```
 
     Note that the default installation of clusteradm will install in /usr/local/bin which will require root access. If you prefer to avoid root, you can specify an alternative installation location using the INSTALL_DIR environment variable, as follows:
@@ -37,7 +37,7 @@ follow [these instructions](https://github.com/kubestellar/kubeflex/blob/main/do
     ```shell
     mkdir -p ocm
     export INSTALL_DIR="$PWD/ocm"
-    curl -L https://raw.githubusercontent.com/open-cluster-management-io/clusteradm/main/install.sh | bash
+    bash <(curl -L https://raw.githubusercontent.com/open-cluster-management-io/clusteradm/main/install.sh) 0.10.1
     export PATH=$PWD/ocm:$PATH
     ```
 

--- a/scripts/check_pre_req.sh
+++ b/scripts/check_pre_req.sh
@@ -46,7 +46,7 @@ is_installed() {
             if ! [[ "$gotver" < "$wantver" ]]; then : OK, easy case
             elif [ -n "$exclver" ] && [[ "$gotver" < "$exclver" ]] && ! [[ "$gotver" < "$addlver" ]]; then : OK, hard case
             else
-                echo "  structured version '$gotver' is less than required minimum '$wantver'" $([ -z "$addlver" ] || echo or "'$addlver' but less than '$exclver'") >&2
+                echo -e "\033[0;31mX\033[0m  structured version '$gotver' is less than required minimum '$wantver'" $([ -z "$addlver" ] || echo or "'$addlver' but less than '$exclver'") >&2
                 exit 2
             fi
         else

--- a/scripts/check_pre_req.sh
+++ b/scripts/check_pre_req.sh
@@ -216,7 +216,7 @@ is_installed_ocm() {
         'clusteradm' \
         'clusteradm version 2> /dev/null | grep ^client' \
         "clusteradm version 2> /dev/null | grep ^client | awk '"'{ print $3 }'"'" \
-        'curl -L https://raw.githubusercontent.com/open-cluster-management-io/clusteradm/main/install.sh | bash' \
+        'bash <(curl -L https://raw.githubusercontent.com/open-cluster-management-io/clusteradm/main/install.sh) 0.10.1' \
         :v0.7 \
         :v0.10 \
         :v0.11


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
This PR updates the instructions to install the latest **usable** version of clusteradm and to emphasize that check_pre_req.sh has to succeed, and restores the RED X that appears when version checking on clusteradm fails.

Website preview at https://mikespreitzer.github.io/kcp-edge-mc/doc-install-right-clusteradm/direct/pre-reqs/#software-prerequisites-for-using-kubestellar

## Related issue(s)

Fixes #
