### PR TITLE
📖  [release-0.27.1] Fix docs about clusteradm and helm and troubleshooting

### DIFF
--- a/docs/content/direct/get-started.md
+++ b/docs/content/direct/get-started.md
@@ -53,6 +53,18 @@ The following command will check for the prerequisites that you will need for th
 bash <(curl https://raw.githubusercontent.com/kubestellar/kubestellar/v{{ config.ks_latest_release }}/scripts/check_pre_req.sh) kflex ocm helm kubectl docker kind
 ```
 
+If that script complains then take it seriously! For example, the following indicates that you have a version of clusteradm that KubeStellar cannot use.
+
+```console
+$ bash <(curl https://raw.githubusercontent.com/kubestellar/kubestellar/v0.27.1/scripts/check_pre_req.sh) kflex ocm helm kubectl docker kind
+  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
+                                 Dload  Upload   Total   Spent    Left  Speed
+100  9278  100  9278    0     0   135k      0 --:--:-- --:--:-- --:--:--  137k
+✔ KubeFlex (Kubeflex version: v0.8.2.5fd5f9c 2025-03-10T14:58:02Z)
+✔ OCM CLI (:v0.11.0-0-g73281f6)
+  structured version ':v0.11.0-0-g73281f6' is less than required minimum ':v0.7' or ':v0.10' but less than ':v0.11'
+```
+
 This setup recipe uses [kind](https://kind.sigs.k8s.io/) to create three Kubernetes clusters on your machine.
 Note that `kind` does not support three or more concurrent clusters unless you raise some limits as described in this `kind` "known issue": [Pod errors due to “too many open files”](https://kind.sigs.k8s.io/docs/user/known-issues/#pod-errors-due-to-too-many-open-files).
 

--- a/docs/content/direct/pre-reqs.md
+++ b/docs/content/direct/pre-reqs.md
@@ -25,11 +25,11 @@ Our documentation has remarks about using the following sorts of clusters:
     To install kubeflex go to [https://github.com/kubestellar/kubeflex/blob/main/docs/users.md#installation](https://github.com/kubestellar/kubeflex/blob/main/docs/users.md#installation). To upgrade from an existing installation,
 follow [these instructions](https://github.com/kubestellar/kubeflex/blob/main/docs/users.md#upgrading-kubeflex). At the end of the install make sure that the kubeflex CLI, kflex, is in your `$PATH`.
 
-- **OCM CLI (clusteradm)** 0.7 <= version < 0.11.
-    To install OCM CLI use:
+- **OCM CLI (clusteradm)** 0.7 <= version **< 0.11**.
+    To install the latest acceptable version of the OCM CLI use:
 
     ```shell
-    curl -L https://raw.githubusercontent.com/open-cluster-management-io/clusteradm/main/install.sh | bash
+    bash <(curl -L https://raw.githubusercontent.com/open-cluster-management-io/clusteradm/main/install.sh) 0.10.1
     ```
 
     Note that the default installation of clusteradm will install in /usr/local/bin which will require root access. If you prefer to avoid root, you can specify an alternative installation location using the INSTALL_DIR environment variable, as follows:
@@ -37,7 +37,7 @@ follow [these instructions](https://github.com/kubestellar/kubeflex/blob/main/do
     ```shell
     mkdir -p ocm
     export INSTALL_DIR="$PWD/ocm"
-    curl -L https://raw.githubusercontent.com/open-cluster-management-io/clusteradm/main/install.sh | bash
+    bash <(curl -L https://raw.githubusercontent.com/open-cluster-management-io/clusteradm/main/install.sh) 0.10.1
     export PATH=$PWD/ocm:$PATH
     ```
 

--- a/docs/content/direct/pre-reqs.md
+++ b/docs/content/direct/pre-reqs.md
@@ -43,7 +43,7 @@ follow [these instructions](https://github.com/kubestellar/kubeflex/blob/main/do
 
     At the end of the install make sure that the OCM CLI, clusteradm, is in your `$PATH`.
 
-- **helm** version >= 3 - to deploy the Kubestellar and kubeflex charts. Your `helm` command must not be broken; see [](knownissue-helm-ghcr.md).
+- **helm** version >= 3. To deploy the Kubestellar and kubeflex charts. Your `helm` command must not be broken; see [the known issue](knownissue-helm-ghcr.md).
 - [**kubectl**](https://kubernetes.io/docs/tasks/tools/) version >= 1.27 - to access the kubernetes clusters
 
 ## Additional Software for the Getting Started setup

--- a/docs/content/direct/troubleshooting.md
+++ b/docs/content/direct/troubleshooting.md
@@ -30,6 +30,7 @@ verbosity (`-v`) of various controllers.
 
 ## Things to look at
 
+- Existence and version of dependencies. There is [a document](pre-reqs.md) and a checking script (`scripts/check_pre_req.sh`).
 - While double-checking your input is never bad, using `kubectl get -o yaml --show-managed-fields` to examine the live API objects adds some good stuff: confirmation that your input was received and parsed as expected, display of any error messages in your API objects, timestamps in the metadata (helpful for comparing with log messages), indication of what last wrote to each part of your API objects and when.
 - When basic stuff is not working, survey the Pod objects in the KubeFlex hosting cluster to look for ones that are damaged in some way. For example: you can get a summary with the command `kubectl --context kind-kubeflex get pods -A` --- adjust as necessary for the name of your kubeconfig context to use for the KubeFlex hosting cluster.
 - Remember that for each of your BindingPolicy objects, there is a corresponding Binding object that reports what is matching the policy object.
@@ -56,7 +57,8 @@ Do a simple clean demonstration of the problem, if possible.
 
 Show the particulars of something going wrong.
 
-- Show a shell session, starting from scratch
+- Show a shell session, starting from scratch.
+- Show a run of `scripts/check_pre_req.sh`.
 - Report timestamps of when salient changes happened. Make it clear which timezone is involved in each one. Particularly interesting times are when KubeStellar did the wrong thing or failed to do anything at all in response to something.
 - Show the relevant API objects. When the problem is behavior over time, show the objects contents from before and after the misbehavior.
     - In the WDS: the workload objects involved; any `BidingPolicy` involved, and the corresponding `Binding` for each; any `CustomTransform`, `StatusCollector`, or `CombinedStatus` involved.
@@ -76,7 +78,7 @@ Show the particulars of something going wrong.
 ### Use the snapshot script
 
 There is a script that is intended to capture a lot of relevant state;
-using it can help make a good trouble report.
+using it can **help** make a good trouble report (but remember all of the ideas above).
 
 You can use a command like the following to invoke the script.
 


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
This PR updates the `release-0.27.1` version of the website, fixing botches about clusteradm and helm and enhancing troubleshooting. I had made earlier PRs intended to update this version of the website but botched them, they actually got opened against `main`.

Website preview at https://mikespreitzer.github.io/kcp-edge-mc/doc-rel0271-triplefix/direct/pre-reqs/

## Related issue(s)

Fixes #
