### PR TITLE
✨  Prep for patch release 0.27.2

### DIFF
--- a/core-chart/values.yaml
+++ b/core-chart/values.yaml
@@ -7,7 +7,7 @@
 # please do not change them unless you know what you are doing.
 HELM_VERSION: "3.16.1"
 KUBECTL_VERSION: "1.31.0"
-KUBESTELLAR_VERSION: "0.27.1"
+KUBESTELLAR_VERSION: "0.27.2"
 # TRANSPORT_VERSION: e.g., "0.24.0"; defaults to KUBESTELLAR_VERSION value, if not defined
 CLUSTERADM_VERSION: "0.10.1"
 OCM_STATUS_ADDON_VERSION: "0.2.0-rc14"

--- a/docs/content/direct/release-notes.md
+++ b/docs/content/direct/release-notes.md
@@ -2,11 +2,17 @@
 
 The following sections list the known issues for each release. The issue list is not differential (i.e., compared to previous releases) but a full list representing the overall state of the specific release. 
 
+## 0.27.2
+
+Fixes `scripts/check_pre_req.sh` so that when it objects to the version of `clusteradm`, this is more obvious (restores the RED X that was inadvertently removed in the previous patch release).
+
+Also some doc improvements, and bumps to some build-time dependencies.
+
 ## 0.27.1
 
 Bumps version of ingrex-nginx used to 0.12.1, to avoid recently disclosed vulnerabilities in older versions.
 
-Avoids use of release 0.11 of clusteradm, which introduced an incompatible change in the name of a ServiceAccount.
+Avoids use of release 0.11 of clusteradm, **which introduced an incompatible change in the name of a ServiceAccount**.
 
 ## 0.27.0 and its RCs
 

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -13,8 +13,8 @@ repo_raw_url: https://raw.githubusercontent.com/kubestellar/kubestellar
 edit_uri: edit/main/docs/content
 ks_branch: 'main'
 ks_tag: 'latest'
-ks_latest_regular_release: '0.27.0'
-ks_latest_release: '0.27.0'
+ks_latest_regular_release: '0.27.2'
+ks_latest_release: '0.27.2'
 
 ks_kind_port_num: '1119'
 

--- a/scripts/check_pre_req.sh
+++ b/scripts/check_pre_req.sh
@@ -17,7 +17,7 @@
 # NOTE WELL: Two copies of this file exist, one in kubestellar/hack/
 # and one in kubestellar/scripts/ . Keep them both up-to-date.
 BASE_URL="https://docs.kubestellar.io"
-VERSION="release-0.27.1"
+VERSION="release-0.27.2"
 INSTALLATION_ERROR_URL="${BASE_URL}/${VERSION}/direct/installation-errors#pod-errors-due-to-too-many-open-files"
 
 set -e # exit on error

--- a/scripts/create-kubestellar-demo-env.sh
+++ b/scripts/create-kubestellar-demo-env.sh
@@ -68,7 +68,7 @@ if ! dunsel=$(docker ps 2>&1); then
 fi
 echo "Container runtime is running."
 
-kubestellar_version=0.27.1
+kubestellar_version=0.27.2
 echo -e "KubeStellar Version: ${kubestellar_version}"
 
 echo -e "Checking that pre-req softwares are installed..."


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
This PR updates the self-references in preparation for the patch release 0.27.2.

This PR also undoes the inadvertent release reversion to `docs/mkdocs.ysml` in #2861 .

Website preview at https://mikespreitzer.github.io/kcp-edge-mc/doc-prep4-0272/readme/

## Related issue(s)

Fixes #
