### PR TITLE
📖  Elide reference to KubeFlex from ui-intro.md

### DIFF
--- a/docs/content/direct/ui-intro.md
+++ b/docs/content/direct/ui-intro.md
@@ -7,8 +7,3 @@ With its web-based interface, you can view and manage your Workload Definition S
 The Kubestellar UI has [its own section in our User Guide](../ui-docs/ui-overview.md)
 
 To explore more fully under the covers, [visit the UI repository at https://github.com/kubestellar/ui](https://github.com/kubestellar/ui)
-
-There is also a [introductory video about KubeFlex](https://youtu.be/vI2O0L5ijVU?si=p32OUaQU96JOs5iH) on the KubeStellar YouTube Channel
-
-
-


### PR DESCRIPTION
## Summary
There was an extraneous reference to a kubeflex demo video at the end of the ui-intro.md file, the result of a cut-and-paste error. 
It has been removed.

Preview at https://kproche.github.io/kubestellar/doc-fix_ui-intro/direct/ui-intro/

## Related issue(s)

Fixes #
