### PR TITLE
🐛  Fix: Ignore invisible HTML content in spellchecker (Fixes #2507)

### DIFF
--- a/.github/spellcheck/.spellcheck.yml
+++ b/.github/spellcheck/.spellcheck.yml
@@ -11,8 +11,16 @@ matrix:
   - pyspelling.filters.html:
       comments: false
       ignores:
-      - code
-      - pre
+        - code
+        - pre
+        - style
+        - script
+        - head
+        - noscript
+      ignore_classes:
+        - hidden
+        - sr-only
+        - copy-button
   sources:
   - '**/*.md'
   default_encoding: utf-8


### PR DESCRIPTION
## Summary
This PR updates the `spellcheck.yml` configuration to fix issues related to HTML tags being incorrectly checked by the spellchecker. 
- Adjusted `pyspelling.filters.html` to properly ignore HTML elements like `code`, `pre`, `style`, and `script`.
- Updated the configuration to handle hidden and invisible HTML content more accurately.

## Related issue(s)
Fixes #2507
