### PR TITLE
🐛  ci now uses commitsha over tag

### DIFF
--- a/.github/.reversemap.yml
+++ b/.github/.reversemap.yml
@@ -1,0 +1,51 @@
+actions/checkout:
+  commit-sha: 11bd71901bbe5b1630ceea73d27597364c9af683
+  tag: v4
+actions/add-to-project:
+  tag: v1.0.2
+  commit-sha: 244f685bbc3b7adfa8466e08b698b5577571133e
+titoportas/update-project-fields:
+  tag: v0.1.0
+  commit-sha: 421a54430b3cdc9eefd8f14f9ce0142ab7678751
+ScholliYT/Broken-Links-Crawler-Action:
+  commit-sha: a074e6a0c83f29560300752af773c7356041ceb4
+  tag: fix-http-redirects
+JasonEtco/create-an-issue:
+  commit-sha: 1b14a70e4d8dc185e5cc76d3bec9eab20257b2c5
+  tag: v2
+actions/setup-python:
+  commit-sha: a26af69be951a213d495a4c3e4e4022e16d87065
+  tag: v5
+actions/setup-go:
+  commit-sha: 0aaccfd150d50ccaeb58ebd88d36e91967a5f35b
+  tag: v5
+anchore/sbom-action/download-syft:
+  commit-sha: 9f7302141466aa6482940f15371237e9d9f4c34a
+  tag: v0.19.0
+goreleaser/goreleaser-action:
+  commit-sha: 9c156ee8a17a598857849441385a2041ef570552
+  tag: v6
+azure/setup-helm:
+  commit-sha: 37dd2562cae2f186a3dc13f2bb5d4abe08dbfec4
+  tag: v4
+docker/login-action:
+  commit-sha: 74a5d142397b4f367a81961eba4e8cd7edddf772
+  tag: v3
+actions/first-interaction:
+  commit-sha: fb2402657b4a28582200150d0a145671d0e50597
+  tag: v1
+azure/setup-kubectl:
+  commit-sha: 3e0aec4d80787158d308d7b364cb1b702e7feb7f
+  tag: v4
+ko-build/setup-ko:
+  commit-sha: d006021bd0c28d1ce33a07e7943d48b079944c8d
+  tag: v0.9
+technote-space/assign-author:
+  commit-sha: 9558557c5c4816f38bd06176fbc324ba14bb3160
+  tag: v1.6.2
+rojopolis/spellcheck-github-actions:
+  commit-sha: 23dc186319866e1de224f94fe1d31b72797aeec7
+  tag: 0.48.0
+actions/upload-artifact:
+  commit-sha: ea165f8d65b6e75b540449e92b4886f43607fa02
+  tag: v4

--- a/.github/workflows/add-to-project.yml
+++ b/.github/workflows/add-to-project.yml
@@ -19,18 +19,18 @@ jobs:
         id: date
         run: echo "date=$(date +'%Y-%m-%d')" >> $GITHUB_OUTPUT
         
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
         with:
           token: ${{ secrets.GH_ALL_PROJECT_TOKEN }}
           persist-credentials: 'false'
       
-      - uses: actions/add-to-project@v1.0.2 # This adds the issue to the project
+      - uses: actions/add-to-project@244f685bbc3b7adfa8466e08b698b5577571133e # This adds the issue to the project
         with:
           project-url: https://github.com/orgs/kubestellar/projects/5
           github-token: ${{ secrets.GH_ALL_PROJECT_TOKEN }}
         id: add-project
       
-      - uses: titoportas/update-project-fields@v0.1.0
+      - uses: titoportas/update-project-fields@421a54430b3cdc9eefd8f14f9ce0142ab7678751
         with:
           project-url: https://github.com/orgs/kubestellar/projects/5
           github-token: ${{ secrets.GH_ALL_PROJECT_TOKEN }}

--- a/.github/workflows/broken-links-crawler.yml
+++ b/.github/workflows/broken-links-crawler.yml
@@ -68,7 +68,7 @@ jobs:
             echo workflow_dispatch - running on version ${{ steps.extract_branch.outputs.version }}
         if: github.event_name != 'pull_request' && github.event_name != 'push'
 
-      - uses: ScholliYT/Broken-Links-Crawler-Action@fix-http-redirects
+      - uses: ScholliYT/Broken-Links-Crawler-Action@a074e6a0c83f29560300752af773c7356041ceb4
         with:
           website_url: https://${{ steps.extract_branch.outputs.site }}/${{ steps.extract_branch.outputs.version }}
           include_url_prefix: https://${{ steps.extract_branch.outputs.site }}/${{ steps.extract_branch.outputs.version }}
@@ -86,7 +86,7 @@ jobs:
         if: github.event_name == 'pull_request' 
 #         $GITHUB_BASE_REF
 
-      - uses: ScholliYT/Broken-Links-Crawler-Action@fix-http-redirects
+      - uses: ScholliYT/Broken-Links-Crawler-Action@a074e6a0c83f29560300752af773c7356041ceb4
         with:
           website_url: https://docs.kubestellar.io/${{ github.event.pull_request.base.ref }}
           include_url_prefix: https://docs.kubestellar.io/${{ github.event.pull_request.base.ref }}
@@ -103,7 +103,7 @@ jobs:
         run: echo push - running on branch ${{ github.event.push.base.ref }}
         if: github.event_name == 'push' 
 
-      - uses: ScholliYT/Broken-Links-Crawler-Action@fix-http-redirects
+      - uses: ScholliYT/Broken-Links-Crawler-Action@a074e6a0c83f29560300752af773c7356041ceb4
         with:
           website_url: https://docs.kubestellar.io/${{ github.event.push.base.ref }}
           include_url_prefix: https://docs.kubestellar.io/${{ github.event.push.base.ref }}

--- a/.github/workflows/create-our-meeting-bi-weekly.yml
+++ b/.github/workflows/create-our-meeting-bi-weekly.yml
@@ -24,12 +24,12 @@ jobs:
             echo "run_workflow=false" >> $GITHUB_OUTPUT
           fi
           
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
         with:
           token: ${{ secrets.GH_ALL_PROJECT_TOKEN }}
           persist-credentials: 'false'
           
-      - uses: JasonEtco/create-an-issue@v2
+      - uses: JasonEtco/create-an-issue@1b14a70e4d8dc185e5cc76d3bec9eab20257b2c5
         if: steps.check_condition.outputs.run_workflow == 'true'
         env:
           GITHUB_TOKEN: ${{ secrets.GH_ALL_PROJECT_TOKEN }}

--- a/.github/workflows/docs-gen-and-push.yml
+++ b/.github/workflows/docs-gen-and-push.yml
@@ -42,14 +42,14 @@ jobs:
     name: Generate and push docs
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
         with:
           token: ${{ github.repository_owner == 'kubestellar' && secrets.GH_ALL_PROJECT_TOKEN || github.token }}
           persist-credentials: 'true'
   
       - run: git fetch origin gh-pages
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
         with:
           python-version: '3.10'
           cache: 'pip'

--- a/.github/workflows/elapsed-time-collector.yml
+++ b/.github/workflows/elapsed-time-collector.yml
@@ -45,7 +45,7 @@ jobs:
       - run: echo "${{ github.event_name }}"
         
       - name: echo fetching push or pull_request branch
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
         with:
           token: ${{ secrets.GH_ALL_PROJECT_TOKEN }}
           persist-credentials: 'false'
@@ -54,7 +54,7 @@ jobs:
     #     if: github.event_name == 'push' || github.event_name == 'pull_request'
 
     #   - name: echo fetching workflow_dispatch branch
-    #     uses: actions/checkout@v3
+    #     uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
     #     with:
     #         ref: ${GITHUB_REF##*/} 
     #     if: github.event_name == 'workflow_dispatch'
@@ -68,7 +68,7 @@ jobs:
           echo "$EOF" >> "$GITHUB_ENV"
         id: run_make
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
         with:
           token: ${{ secrets.GH_ALL_PROJECT_TOKEN }}
           persist-credentials: 'false'

--- a/.github/workflows/full-broken-links-crawler.yml
+++ b/.github/workflows/full-broken-links-crawler.yml
@@ -51,7 +51,7 @@ jobs:
             echo workflow_dispatch - running on branch ${{ steps.extract_branch.outputs.branch }}
             echo workflow_dispatch - running on version ${{ steps.extract_branch.outputs.version }}
 
-      - uses: ScholliYT/Broken-Links-Crawler-Action@fix-http-redirects
+      - uses: ScholliYT/Broken-Links-Crawler-Action@a074e6a0c83f29560300752af773c7356041ceb4
         with:
           website_url: https://${{ steps.extract_branch.outputs.site }}/${{ steps.extract_branch.outputs.version }}
           include_url_prefix: "https:"

--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -18,11 +18,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
       with:
         fetch-depth: 0
 
-    - uses: actions/setup-go@v5
+    - uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b
       with:
         go-version: v1.22
          
@@ -33,10 +33,10 @@ jobs:
       run: echo LDFLAGS="$(make ldflags)" >> $GITHUB_ENV
 
     - name: Install syft binary executable
-      uses: anchore/sbom-action/download-syft@v0.19.0
+      uses: anchore/sbom-action/download-syft@9f7302141466aa6482940f15371237e9d9f4c34a
 
     - name: Run GoReleaser on tag
-      uses: goreleaser/goreleaser-action@v6
+      uses: goreleaser/goreleaser-action@9c156ee8a17a598857849441385a2041ef570552
       with:
         distribution: goreleaser
         version: latest
@@ -47,12 +47,12 @@ jobs:
         EMAIL: ${{ github.actor}}@users.noreply.github.com
 
     - name: Set up Helm
-      uses: azure/setup-helm@v4
+      uses: azure/setup-helm@37dd2562cae2f186a3dc13f2bb5d4abe08dbfec4
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Login to registry
-      uses: docker/login-action@v3
+      uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772
       with:
         registry: ${{ env.REGISTRY }}
         username: ${{ github.actor }}

--- a/.github/workflows/greetings.yml
+++ b/.github/workflows/greetings.yml
@@ -15,7 +15,7 @@ jobs:
       issues: write
       pull-requests: write
     steps:
-    - uses: actions/first-interaction@v1
+    - uses: actions/first-interaction@fb2402657b4a28582200150d0a145671d0e50597
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
         issue-message: "Thank you for contributing your first Issue to KubeStellar. We are delighted to have you in our Universe!"

--- a/.github/workflows/ocp-self-runner.yml
+++ b/.github/workflows/ocp-self-runner.yml
@@ -10,20 +10,20 @@ jobs:
     name: ginkgo tests
     runs-on: self-hosted
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b
         with:
           go-version: v1.22
           cache: true
 
       - name: Set up Helm
-        uses: azure/setup-helm@v4
+        uses: azure/setup-helm@37dd2562cae2f186a3dc13f2bb5d4abe08dbfec4
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install kubectl
-        uses: azure/setup-kubectl@v4
+        uses: azure/setup-kubectl@3e0aec4d80787158d308d7b364cb1b702e7feb7f
         id: install
 
       - name: Install dependencies
@@ -62,20 +62,20 @@ jobs:
     name: bash script tests
     runs-on: self-hosted
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b
         with:
           go-version: v1.22
           cache: true
 
       - name: Set up Helm
-        uses: azure/setup-helm@v4
+        uses: azure/setup-helm@37dd2562cae2f186a3dc13f2bb5d4abe08dbfec4
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install kubectl
-        uses: azure/setup-kubectl@v4
+        uses: azure/setup-kubectl@3e0aec4d80787158d308d7b364cb1b702e7feb7f
         id: install
 
       - name: Install dependencies

--- a/.github/workflows/pr-test-e2e.yml
+++ b/.github/workflows/pr-test-e2e.yml
@@ -6,45 +6,45 @@ on:
   workflow_dispatch:
     inputs:
       testFlags:
-        description: 'Command line flags for run-test.sh'
+        description: "Command line flags for run-test.sh"
         required: false
-        default: ''
+        default: ""
         type: choice
         options:
-        - ''
-        - '--released'
+          - ""
+          - "--released"
   pull_request:
     branches:
       - main
     paths-ignore:
-      - 'docs/**'
-      - '**/*.md'
+      - "docs/**"
+      - "**/*.md"
   push:
     branches:
       - main
     tags:
-      - 'v*'
+      - "v*"
     paths-ignore:
-      - 'docs/**'
-      - '**/*.md'
+      - "docs/**"
+      - "**/*.md"
 
 jobs:
   ginkgo-test:
     name: Tests in ginkgo
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b
         with:
           go-version: v1.22
           cache: true
 
       - name: Install kubectl
-        uses: azure/setup-kubectl@v4
+        uses: azure/setup-kubectl@3e0aec4d80787158d308d7b364cb1b702e7feb7f
         id: install
 
-      - uses: ko-build/setup-ko@v0.9
+      - uses: ko-build/setup-ko@d006021bd0c28d1ce33a07e7943d48b079944c8d
 
       - name: Install dependencies
         run: |
@@ -164,18 +164,18 @@ jobs:
     name: Test in bash
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b
         with:
           go-version: v1.22
           cache: true
 
       - name: Install kubectl
-        uses: azure/setup-kubectl@v4
+        uses: azure/setup-kubectl@3e0aec4d80787158d308d7b364cb1b702e7feb7f
         id: install
 
-      - uses: ko-build/setup-ko@v0.9
+      - uses: ko-build/setup-ko@d006021bd0c28d1ce33a07e7943d48b079944c8d
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/pr-test-integration.yml
+++ b/.github/workflows/pr-test-integration.yml
@@ -20,16 +20,16 @@ jobs:
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b
         with:
           go-version: v1.22
           cache: true
 
       - name: Install kubectl
-        uses: azure/setup-kubectl@v4
+        uses: azure/setup-kubectl@3e0aec4d80787158d308d7b364cb1b702e7feb7f
         id: install
 
-      - uses: ko-build/setup-ko@v0.9
+      - uses: ko-build/setup-ko@d006021bd0c28d1ce33a07e7943d48b079944c8d
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/pr-verifier.yaml
+++ b/.github/workflows/pr-verifier.yaml
@@ -10,7 +10,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
 
       - name: Validate PR Title Format
         run: |

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -14,24 +14,24 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Assign author to PR
-        uses: technote-space/assign-author@v1.6.2
+        uses: technote-space/assign-author@9558557c5c4816f38bd06176fbc324ba14bb3160
         
       # - name: Get current date
       #   id: date
       #   run: echo "date=$(date +'%Y-%m-%d')" >> $GITHUB_OUTPUT
 
-      # - uses: actions/checkout@v4.1.1
+      # - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683.1.1
       #   with:
       #     token: ${{ secrets.GH_ALL_PROJECT_TOKEN }}
       #     persist-credentials: 'false'
 
-      # - uses: actions/add-to-project@v1.0.2 # This adds the issue to the project
+      # - uses: actions/add-to-project@244f685bbc3b7adfa8466e08b698b5577571133e # This adds the issue to the project
       #   with:
       #     project-url: https://github.com/orgs/kubestellar/projects/5
       #     github-token: ${{ secrets.GH_ALL_PROJECT_TOKEN }}
       #   id: add-project
 
-      # - uses: titoportas/update-project-fields@v0.1.0
+      # - uses: titoportas/update-project-fields@421a54430b3cdc9eefd8f14f9ce0142ab7678751
       #   with:
       #     project-url: https://github.com/orgs/kubestellar/projects/5
       #     github-token: ${{ secrets.GH_ALL_PROJECT_TOKEN }}

--- a/.github/workflows/spellcheck_action.yml
+++ b/.github/workflows/spellcheck_action.yml
@@ -30,16 +30,16 @@ jobs:
     name: Spellcheck
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
 
-    - uses: rojopolis/spellcheck-github-actions@0.48.0
+    - uses: rojopolis/spellcheck-github-actions@23dc186319866e1de224f94fe1d31b72797aeec7
       name: Spellcheck
       with:
         config_path: .github/spellcheck/.spellcheck.yml
         output_file: spellcheck-output.txt
 #         source_files: "docs/content/*"
         
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
       if: success() || failure()
       with:
         name: Spellcheck Output

--- a/.github/workflows/test-latest-release.yml
+++ b/.github/workflows/test-latest-release.yml
@@ -16,18 +16,18 @@ jobs:
     name: Tests in ginkgo
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b
         with:
           go-version: v1.22
           cache: true
 
       - name: Install kubectl
-        uses: azure/setup-kubectl@v4
+        uses: azure/setup-kubectl@3e0aec4d80787158d308d7b364cb1b702e7feb7f
         id: install
 
-      - uses: ko-build/setup-ko@v0.9
+      - uses: ko-build/setup-ko@d006021bd0c28d1ce33a07e7943d48b079944c8d
 
       - name: Install dependencies
         run: |
@@ -91,18 +91,18 @@ jobs:
     name: Test in bash
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b
         with:
           go-version: v1.22
           cache: true
 
       - name: Install kubectl
-        uses: azure/setup-kubectl@v4
+        uses: azure/setup-kubectl@3e0aec4d80787158d308d7b364cb1b702e7feb7f
         id: install
 
-      - uses: ko-build/setup-ko@v0.9
+      - uses: ko-build/setup-ko@d006021bd0c28d1ce33a07e7943d48b079944c8d
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -10,7 +10,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
 
       - name: Validate PR Title Format
         run: |

--- a/hack/ci-update-reversemap.sh
+++ b/hack/ci-update-reversemap.sh
@@ -1,0 +1,107 @@
+#!/bin/bash
+
+# author: @rxinui
+
+# Define the required version of yq
+GITHUB_PAT=
+GITHUB_WORKFLOWS_PATH="./.github/workflows/"
+REVERSEMAP_FILE="./.github/.reversemap.yml"
+YQ_REQUIRED_VERSION="v4.45.1"
+YQ_IS_INSTALLED=0
+GIT_COMMITSHA_LENGTH=40
+
+# Function to check if yq is installed and has the required version
+check_yq_version() {
+    if command -v yq >/dev/null 2>&1; then
+        INSTALLED_VERSION=$(yq --version 2>/dev/null)
+        if [[ "$INSTALLED_VERSION" =~ "$YQ_REQUIRED_VERSION" ]]; then
+            echo "yq $YQ_REQUIRED_VERSION is already installed."
+            YQ_IS_INSTALLED=1
+        else
+            echo "yq is installed but the version is $INSTALLED_VERSION. Required version is $YQ_REQUIRED_VERSION."
+        fi
+    else
+        echo "yq is not installed."
+    fi
+}
+
+# Function to download and install yq
+install_yq() {
+    OS=$(uname | tr '[:upper:]' '[:lower:]')
+    ARCH=$(uname -m)
+
+    if [[ "$ARCH" == "x86_64" ]]; then
+        ARCH="amd64"
+    elif [[ "$ARCH" == "aarch64" ]]; then
+        ARCH="arm64"
+    elif [[ "$ARCH" == "arm64" ]]; then
+        ARCH="arm64"
+    else
+        echo "Unsupported architecture: $ARCH"
+        exit 1
+    fi
+
+    YQ_BINARY="yq_${OS}_${ARCH}"
+    DOWNLOAD_URL="https://github.com/mikefarah/yq/releases/download/${YQ_REQUIRED_VERSION}/${YQ_BINARY}.tar.gz"
+
+    echo "Downloading yq $YQ_REQUIRED_VERSION for $OS/$ARCH..."
+    curl -L -o /tmp/${YQ_BINARY}.tar.gz "$DOWNLOAD_URL"
+
+    if [[ $? -ne 0 ]]; then
+        echo "Failed to download yq."
+        exit 1
+    fi
+
+    tar xzf /tmp/${YQ_BINARY}.tar.gz -C /tmp
+    sudo chmod +x /tmp/${YQ_BINARY}
+    sudo mv /tmp/${YQ_BINARY} /usr/local/bin/yq
+
+    echo "yq $YQ_REQUIRED_VERSION installed successfully."
+}
+
+# Get commitsha from an action ref
+_get_commitsha_from_ref() {
+    action_ref=$1
+    tag_or_branch=$2
+    API_GITHUB_BRANCH="https://api.github.com/repos/${action_ref}/git/refs/heads/${tag_or_branch}"
+    API_GITHUB_TAG="https://api.github.com/repos/${action_ref}/git/refs/tags/${tag_or_branch}"
+    HTTP_STATUS=$(curl -o /dev/null -s -w "%{http_code}\n" -H "Authorization: $GITHUB_PAT" "$API_GITHUB_TAG")
+    if [[ $HTTP_STATUS -ge 200 && $HTTP_STATUS -lt 300 ]]; then
+        commit_sha=$(curl -s -H "Authorization: $GITHUB_PAT" $API_GITHUB_TAG | jq -r '.object.sha')
+    else
+        commit_sha=$(curl -s -H "Authorization: $GITHUB_PAT" $API_GITHUB_BRANCH | jq -r '.object.sha')
+    fi
+    echo $commit_sha
+}
+
+# Extract actions tag and update reversemap with commit
+extract_actions_info() {
+    filename=$1
+    outfile=$2
+    for action_fullref in $(yq '.jobs[].steps[] | select(has("uses")) | .uses ' $filename); do
+        action_ref=$(echo $action_fullref | cut -d '@' -f 1)
+        action_tag=$(echo $action_fullref | cut -d '@' -f 2)
+        length=${#action_tag}
+        echo "debug: ref=$action_ref and tag=$action_tag len=$length"
+        if [[ $length -ne $GIT_COMMITSHA_LENGTH ]]; then
+            action_commitsha=$(_get_commitsha_from_ref $action_ref $action_tag)
+            echo "info: sha=$action_commitsha"
+            yq ".${action_ref}.commit-sha = \"${action_commitsha}\"" -i $2
+            yq ".${action_ref}.tag = \"${action_tag}\"" -i $2
+        fi
+    done
+}
+
+# Execute the main program
+main() {
+    check_yq_version
+    if [[ $YQ_IS_INSTALLED -eq 0 ]]; then
+        install_yq
+    fi
+    for file in $(ls $GITHUB_WORKFLOWS_PATH); do
+        echo "info: fetching $file..."
+        extract_actions_info "$GITHUB_WORKFLOWS_PATH/$file" $REVERSEMAP_FILE
+    done
+}
+
+main;

--- a/hack/ci-update-reversemap.sh
+++ b/hack/ci-update-reversemap.sh
@@ -1,9 +1,26 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
-# author: @rxinui
+# Copyright 2025 The KubeStellar Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Purpose: update the reverse map $REVERSEMAP_FILE from actions used in $GITHUB_WORKFLOWS_PATH
+
+# Usage: $0
+# Working directory does not matter.
 
 # Define the required version of yq
-GITHUB_PAT=
+GITHUB_PAT=                                                 # API GITHUB TOKEN
 GITHUB_WORKFLOWS_PATH="./.github/workflows/"
 REVERSEMAP_FILE="./.github/.reversemap.yml"
 YQ_REQUIRED_VERSION="v4.45.1"


### PR DESCRIPTION
## Summary

To avoid any [CI supply chain attack](https://www.wiz.io/blog/github-action-tj-actions-changed-files-supply-chain-attack-cve-2025-30066), all actions tag has been replaced by its commit sha.

To facilitate the process, as commit sha are humanly hard to read, a new file `.github/.reversemap.yaml` is added. Its purpose is informational and allows easy lookup on sha/tag locally to further develop the ci.

```yaml
actions/checkout:
  commit-sha: 11bd71901bbe5b1630ceea73d27597364c9af683
  tag: v4
actions/add-to-project:
  tag: v1.0.2
  commit-sha: 244f685bbc3b7adfa8466e08b698b5577571133e
```

For that, a `hack/ci-update-reversemap.sh` is added to automatically scan the `.github/workflows`. Whenever an action is used with a tag, launching the script will lookup for its commitsha and add both to the reversemap to keep track. 

ℹ️ _Note: this was useful to implement the fix, may no longer be from now on. Also, the script does not do in-replacement within workflows as of now._

## Related issue(s)

Fixes #2844 
