### PR TITLE
✨Update container images to resolve critical vulnerabilities

### DIFF
--- a/config/default/manager_auth_proxy_patch.yaml
+++ b/config/default/manager_auth_proxy_patch.yaml
@@ -30,7 +30,7 @@ spec:
           capabilities:
             drop:
               - "ALL"
-        image: quay.io/brancz/kube-rbac-proxy:v0.17.1
+        image: quay.io/brancz/kube-rbac-proxy:v0.19.1
         args:
         - "--secure-listen-address=0.0.0.0:8443"
         - "--upstream=http://127.0.0.1:8080/"

--- a/core-chart/Chart.yaml
+++ b/core-chart/Chart.yaml
@@ -29,7 +29,7 @@ icon: https://raw.githubusercontent.com/kubestellar/kubestellar/main/docs/favico
 # List dependencies
 dependencies:
 - name: kubeflex-operator
-  version: v0.8.3
+  version: v0.8.4
   repository: oci://ghcr.io/kubestellar/kubeflex/chart
   condition: kubeflex-operator.install
 - name: argo-cd

--- a/core-chart/templates/postcreatehooks/wds.yaml
+++ b/core-chart/templates/postcreatehooks/wds.yaml
@@ -371,7 +371,7 @@ spec:
                 - --upstream=http://127.0.0.1:8080/
                 - --logtostderr=true
                 - --v=0
-              image: quay.io/brancz/kube-rbac-proxy:v0.17.1
+              image: quay.io/brancz/kube-rbac-proxy:v{{ .Values.RBAC_PROXY_VERSION }}
               name: kube-rbac-proxy
               ports:
                 - containerPort: 8443

--- a/core-chart/values.yaml
+++ b/core-chart/values.yaml
@@ -5,12 +5,13 @@
 
 # Container/chart image versions. These values are set during the chart release process,
 # please do not change them unless you know what you are doing.
-HELM_VERSION: "3.16.1"
-KUBECTL_VERSION: "1.31.0"
+HELM_VERSION: "3.17.3"
+KUBECTL_VERSION: "1.31.8"
 KUBESTELLAR_VERSION: "0.27.2"
 # TRANSPORT_VERSION: e.g., "0.24.0"; defaults to KUBESTELLAR_VERSION value, if not defined
 CLUSTERADM_VERSION: "0.10.1"
 OCM_STATUS_ADDON_VERSION: "0.2.0-rc15"
+RBAC_PROXY_VERSION: "0.19.1"
 
 
 # Control controller log verbosity

--- a/hack/build-kubectl-image.sh
+++ b/hack/build-kubectl-image.sh
@@ -26,7 +26,7 @@ registry=quay.io/kubestellar
 platform=linux/amd64,linux/arm64,linux/ppc64le
 
 get_latest_version() {
-    curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt
+    curl -sL https://dl.k8s.io/release/stable.txt
 }
 
 while (( $# > 0 )); do

--- a/scripts/deploy-transport-controller.sh
+++ b/scripts/deploy-transport-controller.sh
@@ -117,7 +117,7 @@ spec:
       serviceAccountName: kubestellar-controller-manager
       initContainers:
       - name: setup-wds-kubeconfig
-        image: quay.io/kubestellar/kubectl:1.27.8
+        image: quay.io/kubestellar/kubectl:1.31.8
         imagePullPolicy: Always
         command: [ "bin/sh", "-c", "sh /mnt/config/get-kubeconfig.sh ${WDS_NAME} true | base64 -d > /mnt/shared/wds-kubeconfig"]
         volumeMounts:
@@ -126,7 +126,7 @@ spec:
         - name: shared-volume
           mountPath: /mnt/shared
       - name: setup-its-kubeconfig
-        image: quay.io/kubestellar/kubectl:1.27.8
+        image: quay.io/kubestellar/kubectl:1.31.8
         imagePullPolicy: Always
         command: [ "bin/sh", "-c", "sh /mnt/config/get-kubeconfig.sh ${ITS_NAME} true | base64 -d > /mnt/shared/transport-kubeconfig"]
         volumeMounts:


### PR DESCRIPTION
## Summary

Update container images to resolve critical [vulnerabilities](https://artifacthub.io/packages/helm/kubestellar/core-chart?modal=security-report):
- kubeflex v0.8.3 --> v0.8.4
- helm v3.16.1 --> v3.17.3
- kubectl v1.31.0 --> v1.31.8
- kube-rbac-proxy v0.17.1 --> v0.19.1

## Related issue(s)

Fixes #
