### PR TITLE
🌱  Make building helm 3.16 get good dependencies

### DIFF
--- a/hack/build-helm-image.sh
+++ b/hack/build-helm-image.sh
@@ -77,7 +77,7 @@ cd "$helm_folder"
 
 case "$helm_version" in
     (3.16.*)
-	go get golang.org/x/net@v0.38.0 github.com/containerd/containerd@v1.7.27
+	go get golang.org/x/net@v0.38.0 github.com/containerd/containerd@v1.7.27 golang.org/x/oauth2@v0.30.0
 	go mod tidy;;
 esac
 

--- a/hack/build-helm-image.sh
+++ b/hack/build-helm-image.sh
@@ -75,6 +75,12 @@ git clone -b "v$helm_version" --depth 1 https://github.com/helm/helm.git "$helm_
 
 cd "$helm_folder"
 
+case "$helm_version" in
+    (3.16.*)
+	go get golang.org/x/net@v0.38.0 github.com/containerd/containerd@v1.7.27
+	go mod tidy;;
+esac
+
 export KO_DOCKER_REPO=$registry
 
 ko build -B ./cmd/helm -t $helm_version --sbom=none --platform $platform

--- a/hack/build-helm-image.sh
+++ b/hack/build-helm-image.sh
@@ -76,7 +76,7 @@ git clone -b "v$helm_version" --depth 1 https://github.com/helm/helm.git "$helm_
 cd "$helm_folder"
 
 case "$helm_version" in
-    (3.16.*)
+    (3.1[56].*)
 	go get golang.org/x/net@v0.38.0 github.com/containerd/containerd@v1.7.27 golang.org/x/oauth2@v0.30.0
 	go mod tidy;;
 esac


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
This PR updates the `hack/build-helm-image.sh` script so that when invoked on version 3.16.anything of Helm it will pick up more recent dependencies. This is good because it will remove all the vulnerabilities that https://artifacthub.io/packages/helm/kubestellar/core-chart note for the `quay.io/kubestellar/helm:3.16.1` container image.

This is a copy of #2891, which got wedged during the Prow migration.

## Related issue(s)

Fixes #
