### PR TITLE
🐛 implementation of the script as CLI to solve Supply Chain security on CI

### DIFF
--- a/.gha-reversemap.yml
+++ b/.gha-reversemap.yml
@@ -1,0 +1,85 @@
+actions/checkout:
+  sha: 11bd71901bbe5b1630ceea73d27597364c9af683
+  sha-url: https://github.com/actions/checkout/commit/11bd71901bbe5b1630ceea73d27597364c9af683
+  tag: v4.2.2
+  tag-url: https://github.com/actions/checkout/tree/v4.2.2
+actions/add-to-project:
+  sha: 244f685bbc3b7adfa8466e08b698b5577571133e
+  sha-url: https://github.com/actions/add-to-project/commit/244f685bbc3b7adfa8466e08b698b5577571133e
+  tag: v1.0.2
+  tag-url: https://github.com/actions/add-to-project/tree/v1.0.2
+titoportas/update-project-fields:
+  sha: 421a54430b3cdc9eefd8f14f9ce0142ab7678751
+  sha-url: https://github.com/titoportas/update-project-fields/commit/421a54430b3cdc9eefd8f14f9ce0142ab7678751
+  tag: v0.1.0
+  tag-url: https://github.com/titoportas/update-project-fields/tree/v0.1.0
+ScholliYT/Broken-Links-Crawler-Action:
+  sha: b3fb123879e5a6a854d6fda5c33df2d94d41092c
+  sha-url: https://github.com/ScholliYT/Broken-Links-Crawler-Action/commit/b3fb123879e5a6a854d6fda5c33df2d94d41092c
+  tag: v3.3.1
+  tag-url: https://github.com/ScholliYT/Broken-Links-Crawler-Action/tree/v3.3.1
+JasonEtco/create-an-issue:
+  sha: 1b14a70e4d8dc185e5cc76d3bec9eab20257b2c5
+  sha-url: https://github.com/JasonEtco/create-an-issue/commit/1b14a70e4d8dc185e5cc76d3bec9eab20257b2c5
+  tag: v2
+  tag-url: https://github.com/JasonEtco/create-an-issue/tree/v2
+actions/setup-python:
+  sha: a26af69be951a213d495a4c3e4e4022e16d87065
+  sha-url: https://github.com/actions/setup-python/commit/a26af69be951a213d495a4c3e4e4022e16d87065
+  tag: v5
+  tag-url: https://github.com/actions/setup-python/tree/v5
+actions/setup-go:
+  sha: 0aaccfd150d50ccaeb58ebd88d36e91967a5f35b
+  sha-url: https://github.com/actions/setup-go/commit/0aaccfd150d50ccaeb58ebd88d36e91967a5f35b
+  tag: v5
+  tag-url: https://github.com/actions/setup-go/tree/v5
+anchore/sbom-action/download-syft:
+  sha: 9f7302141466aa6482940f15371237e9d9f4c34a
+  sha-url: https://github.com/anchore/sbom-action/commit/9f7302141466aa6482940f15371237e9d9f4c34a
+  tag: v0.19.0
+  tag-url: https://github.com/anchore/sbom-action/tree/v0.19.0
+goreleaser/goreleaser-action:
+  sha: 9c156ee8a17a598857849441385a2041ef570552
+  sha-url: https://github.com/goreleaser/goreleaser-action/commit/9c156ee8a17a598857849441385a2041ef570552
+  tag: v6
+  tag-url: https://github.com/goreleaser/goreleaser-action/tree/v6
+azure/setup-helm:
+  sha: 29960d0f5f19214b88e1d9ba750a9914ab0f1a2f
+  sha-url: https://github.com/azure/setup-helm/commit/29960d0f5f19214b88e1d9ba750a9914ab0f1a2f
+  tag: v4
+  tag-url: https://github.com/azure/setup-helm/tree/v4
+docker/login-action:
+  sha: 74a5d142397b4f367a81961eba4e8cd7edddf772
+  sha-url: https://github.com/docker/login-action/commit/74a5d142397b4f367a81961eba4e8cd7edddf772
+  tag: v3
+  tag-url: https://github.com/docker/login-action/tree/v3
+actions/first-interaction:
+  sha: 3c71ce730280171fd1cfb57c00c774f8998586f7
+  sha-url: https://github.com/actions/first-interaction/commit/3c71ce730280171fd1cfb57c00c774f8998586f7
+  tag: v1
+  tag-url: https://github.com/actions/first-interaction/tree/v1
+azure/setup-kubectl:
+  sha: 3e0aec4d80787158d308d7b364cb1b702e7feb7f
+  sha-url: https://github.com/azure/setup-kubectl/commit/3e0aec4d80787158d308d7b364cb1b702e7feb7f
+  tag: v4
+  tag-url: https://github.com/azure/setup-kubectl/tree/v4
+ko-build/setup-ko:
+  sha: d006021bd0c28d1ce33a07e7943d48b079944c8d
+  sha-url: https://github.com/ko-build/setup-ko/commit/d006021bd0c28d1ce33a07e7943d48b079944c8d
+  tag: v0.9
+  tag-url: https://github.com/ko-build/setup-ko/tree/v0.9
+technote-space/assign-author:
+  sha: 9558557c5c4816f38bd06176fbc324ba14bb3160
+  sha-url: https://github.com/technote-space/assign-author/commit/9558557c5c4816f38bd06176fbc324ba14bb3160
+  tag: v1.6.2
+  tag-url: https://github.com/technote-space/assign-author/tree/v1.6.2
+rojopolis/spellcheck-github-actions:
+  sha: 23dc186319866e1de224f94fe1d31b72797aeec7
+  sha-url: https://github.com/rojopolis/spellcheck-github-actions/commit/23dc186319866e1de224f94fe1d31b72797aeec7
+  tag: 0.48.0
+  tag-url: https://github.com/rojopolis/spellcheck-github-actions/tree/0.48.0
+actions/upload-artifact:
+  sha: ea165f8d65b6e75b540449e92b4886f43607fa02
+  sha-url: https://github.com/actions/upload-artifact/commit/ea165f8d65b6e75b540449e92b4886f43607fa02
+  tag: v4
+  tag-url: https://github.com/actions/upload-artifact/tree/v4

--- a/.github/workflows/add-to-project.yml
+++ b/.github/workflows/add-to-project.yml
@@ -19,18 +19,18 @@ jobs:
         id: date
         run: echo "date=$(date +'%Y-%m-%d')" >> $GITHUB_OUTPUT
         
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 
         with:
           token: ${{ secrets.GH_ALL_PROJECT_TOKEN }}
           persist-credentials: 'false'
       
-      - uses: actions/add-to-project@v1.0.2 # This adds the issue to the project
+      - uses: actions/add-to-project@244f685bbc3b7adfa8466e08b698b5577571133e # This adds the issue to the project
         with:
           project-url: https://github.com/orgs/kubestellar/projects/5
           github-token: ${{ secrets.GH_ALL_PROJECT_TOKEN }}
         id: add-project
       
-      - uses: titoportas/update-project-fields@v0.1.0
+      - uses: titoportas/update-project-fields@421a54430b3cdc9eefd8f14f9ce0142ab7678751 
         with:
           project-url: https://github.com/orgs/kubestellar/projects/5
           github-token: ${{ secrets.GH_ALL_PROJECT_TOKEN }}

--- a/.github/workflows/broken-links-crawler.yml
+++ b/.github/workflows/broken-links-crawler.yml
@@ -68,7 +68,7 @@ jobs:
             echo workflow_dispatch - running on version ${{ steps.extract_branch.outputs.version }}
         if: github.event_name != 'pull_request' && github.event_name != 'push'
 
-      - uses: ScholliYT/Broken-Links-Crawler-Action@fix-http-redirects
+      - uses: ScholliYT/Broken-Links-Crawler-Action@b3fb123879e5a6a854d6fda5c33df2d94d41092c 
         with:
           website_url: https://${{ steps.extract_branch.outputs.site }}/${{ steps.extract_branch.outputs.version }}
           include_url_prefix: https://${{ steps.extract_branch.outputs.site }}/${{ steps.extract_branch.outputs.version }}
@@ -86,7 +86,7 @@ jobs:
         if: github.event_name == 'pull_request' 
 #         $GITHUB_BASE_REF
 
-      - uses: ScholliYT/Broken-Links-Crawler-Action@fix-http-redirects
+      - uses: ScholliYT/Broken-Links-Crawler-Action@b3fb123879e5a6a854d6fda5c33df2d94d41092c 
         with:
           website_url: https://docs.kubestellar.io/${{ github.event.pull_request.base.ref }}
           include_url_prefix: https://docs.kubestellar.io/${{ github.event.pull_request.base.ref }}
@@ -103,7 +103,7 @@ jobs:
         run: echo push - running on branch ${{ github.event.push.base.ref }}
         if: github.event_name == 'push' 
 
-      - uses: ScholliYT/Broken-Links-Crawler-Action@fix-http-redirects
+      - uses: ScholliYT/Broken-Links-Crawler-Action@b3fb123879e5a6a854d6fda5c33df2d94d41092c 
         with:
           website_url: https://docs.kubestellar.io/${{ github.event.push.base.ref }}
           include_url_prefix: https://docs.kubestellar.io/${{ github.event.push.base.ref }}

--- a/.github/workflows/create-our-meeting-bi-weekly.yml
+++ b/.github/workflows/create-our-meeting-bi-weekly.yml
@@ -24,12 +24,12 @@ jobs:
             echo "run_workflow=false" >> $GITHUB_OUTPUT
           fi
           
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 
         with:
           token: ${{ secrets.GH_ALL_PROJECT_TOKEN }}
           persist-credentials: 'false'
           
-      - uses: JasonEtco/create-an-issue@v2
+      - uses: JasonEtco/create-an-issue@1b14a70e4d8dc185e5cc76d3bec9eab20257b2c5 
         if: steps.check_condition.outputs.run_workflow == 'true'
         env:
           GITHUB_TOKEN: ${{ secrets.GH_ALL_PROJECT_TOKEN }}

--- a/.github/workflows/docs-gen-and-push.yml
+++ b/.github/workflows/docs-gen-and-push.yml
@@ -42,14 +42,14 @@ jobs:
     name: Generate and push docs
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 
         with:
           token: ${{ github.repository_owner == 'kubestellar' && secrets.GH_ALL_PROJECT_TOKEN || github.token }}
           persist-credentials: 'true'
   
       - run: git fetch origin gh-pages
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 
         with:
           python-version: '3.10'
           cache: 'pip'

--- a/.github/workflows/elapsed-time-collector.yml
+++ b/.github/workflows/elapsed-time-collector.yml
@@ -45,7 +45,7 @@ jobs:
       - run: echo "${{ github.event_name }}"
         
       - name: echo fetching push or pull_request branch
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 
         with:
           token: ${{ secrets.GH_ALL_PROJECT_TOKEN }}
           persist-credentials: 'false'
@@ -54,7 +54,7 @@ jobs:
     #     if: github.event_name == 'push' || github.event_name == 'pull_request'
 
     #   - name: echo fetching workflow_dispatch branch
-    #     uses: actions/checkout@v3
+    #     uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 
     #     with:
     #         ref: ${GITHUB_REF##*/} 
     #     if: github.event_name == 'workflow_dispatch'
@@ -68,7 +68,7 @@ jobs:
           echo "$EOF" >> "$GITHUB_ENV"
         id: run_make
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 
         with:
           token: ${{ secrets.GH_ALL_PROJECT_TOKEN }}
           persist-credentials: 'false'

--- a/.github/workflows/full-broken-links-crawler.yml
+++ b/.github/workflows/full-broken-links-crawler.yml
@@ -51,7 +51,7 @@ jobs:
             echo workflow_dispatch - running on branch ${{ steps.extract_branch.outputs.branch }}
             echo workflow_dispatch - running on version ${{ steps.extract_branch.outputs.version }}
 
-      - uses: ScholliYT/Broken-Links-Crawler-Action@fix-http-redirects
+      - uses: ScholliYT/Broken-Links-Crawler-Action@b3fb123879e5a6a854d6fda5c33df2d94d41092c 
         with:
           website_url: https://${{ steps.extract_branch.outputs.site }}/${{ steps.extract_branch.outputs.version }}
           include_url_prefix: "https:"

--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -18,11 +18,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 
       with:
         fetch-depth: 0
 
-    - uses: actions/setup-go@v5
+    - uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b 
       with:
         go-version: v1.22
          
@@ -33,10 +33,10 @@ jobs:
       run: echo LDFLAGS="$(make ldflags)" >> $GITHUB_ENV
 
     - name: Install syft binary executable
-      uses: anchore/sbom-action/download-syft@v0.19.0
+      uses: anchore/sbom-action/download-syft@9f7302141466aa6482940f15371237e9d9f4c34a 
 
     - name: Run GoReleaser on tag
-      uses: goreleaser/goreleaser-action@v6
+      uses: goreleaser/goreleaser-action@9c156ee8a17a598857849441385a2041ef570552 
       with:
         distribution: goreleaser
         version: latest
@@ -47,12 +47,12 @@ jobs:
         EMAIL: ${{ github.actor}}@users.noreply.github.com
 
     - name: Set up Helm
-      uses: azure/setup-helm@v4
+      uses: azure/setup-helm@37dd2562cae2f186a3dc13f2bb5d4abe08dbfec4 
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Login to registry
-      uses: docker/login-action@v3
+      uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 
       with:
         registry: ${{ env.REGISTRY }}
         username: ${{ github.actor }}

--- a/.github/workflows/greetings.yml
+++ b/.github/workflows/greetings.yml
@@ -15,7 +15,7 @@ jobs:
       issues: write
       pull-requests: write
     steps:
-    - uses: actions/first-interaction@v1
+    - uses: actions/first-interaction@3c71ce730280171fd1cfb57c00c774f8998586f7 
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
         issue-message: "Thank you for contributing your first Issue to KubeStellar. We are delighted to have you in our Universe!"

--- a/.github/workflows/ocp-self-runner.yml
+++ b/.github/workflows/ocp-self-runner.yml
@@ -10,20 +10,20 @@ jobs:
     name: ginkgo tests
     runs-on: self-hosted
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b 
         with:
           go-version: v1.22
           cache: true
 
       - name: Set up Helm
-        uses: azure/setup-helm@v4
+        uses: azure/setup-helm@37dd2562cae2f186a3dc13f2bb5d4abe08dbfec4 
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install kubectl
-        uses: azure/setup-kubectl@v4
+        uses: azure/setup-kubectl@3e0aec4d80787158d308d7b364cb1b702e7feb7f 
         id: install
 
       - name: Install dependencies
@@ -62,20 +62,20 @@ jobs:
     name: bash script tests
     runs-on: self-hosted
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b 
         with:
           go-version: v1.22
           cache: true
 
       - name: Set up Helm
-        uses: azure/setup-helm@v4
+        uses: azure/setup-helm@37dd2562cae2f186a3dc13f2bb5d4abe08dbfec4 
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install kubectl
-        uses: azure/setup-kubectl@v4
+        uses: azure/setup-kubectl@3e0aec4d80787158d308d7b364cb1b702e7feb7f 
         id: install
 
       - name: Install dependencies

--- a/.github/workflows/pr-test-e2e.yml
+++ b/.github/workflows/pr-test-e2e.yml
@@ -33,18 +33,18 @@ jobs:
     name: Tests in ginkgo
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b 
         with:
           go-version: v1.22
           cache: true
 
       - name: Install kubectl
-        uses: azure/setup-kubectl@v4
+        uses: azure/setup-kubectl@3e0aec4d80787158d308d7b364cb1b702e7feb7f 
         id: install
 
-      - uses: ko-build/setup-ko@v0.9
+      - uses: ko-build/setup-ko@d006021bd0c28d1ce33a07e7943d48b079944c8d 
 
       - name: Install dependencies
         run: |
@@ -164,18 +164,18 @@ jobs:
     name: Test in bash
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b 
         with:
           go-version: v1.22
           cache: true
 
       - name: Install kubectl
-        uses: azure/setup-kubectl@v4
+        uses: azure/setup-kubectl@3e0aec4d80787158d308d7b364cb1b702e7feb7f 
         id: install
 
-      - uses: ko-build/setup-ko@v0.9
+      - uses: ko-build/setup-ko@d006021bd0c28d1ce33a07e7943d48b079944c8d 
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/pr-test-integration.yml
+++ b/.github/workflows/pr-test-integration.yml
@@ -18,18 +18,18 @@ jobs:
     name: Test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b 
         with:
           go-version: v1.22
           cache: true
 
       - name: Install kubectl
-        uses: azure/setup-kubectl@v4
+        uses: azure/setup-kubectl@3e0aec4d80787158d308d7b364cb1b702e7feb7f 
         id: install
 
-      - uses: ko-build/setup-ko@v0.9
+      - uses: ko-build/setup-ko@d006021bd0c28d1ce33a07e7943d48b079944c8d 
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Assign author to PR
-        uses: technote-space/assign-author@v1.6.2
+        uses: technote-space/assign-author@9558557c5c4816f38bd06176fbc324ba14bb3160 
         
       # - name: Get current date
       #   id: date

--- a/.github/workflows/spellcheck_action.yml
+++ b/.github/workflows/spellcheck_action.yml
@@ -30,16 +30,16 @@ jobs:
     name: Spellcheck
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 
 
-    - uses: rojopolis/spellcheck-github-actions@0.48.0
+    - uses: rojopolis/spellcheck-github-actions@23dc186319866e1de224f94fe1d31b72797aeec7 
       name: Spellcheck
       with:
         config_path: .github/spellcheck/.spellcheck.yml
         output_file: spellcheck-output.txt
 #         source_files: "docs/content/*"
         
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 
       if: success() || failure()
       with:
         name: Spellcheck Output

--- a/.github/workflows/test-latest-release.yml
+++ b/.github/workflows/test-latest-release.yml
@@ -16,18 +16,18 @@ jobs:
     name: Tests in ginkgo
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b 
         with:
           go-version: v1.22
           cache: true
 
       - name: Install kubectl
-        uses: azure/setup-kubectl@v4
+        uses: azure/setup-kubectl@3e0aec4d80787158d308d7b364cb1b702e7feb7f 
         id: install
 
-      - uses: ko-build/setup-ko@v0.9
+      - uses: ko-build/setup-ko@d006021bd0c28d1ce33a07e7943d48b079944c8d 
 
       - name: Install dependencies
         run: |
@@ -91,18 +91,18 @@ jobs:
     name: Test in bash
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b 
         with:
           go-version: v1.22
           cache: true
 
       - name: Install kubectl
-        uses: azure/setup-kubectl@v4
+        uses: azure/setup-kubectl@3e0aec4d80787158d308d7b364cb1b702e7feb7f 
         id: install
 
-      - uses: ko-build/setup-ko@v0.9
+      - uses: ko-build/setup-ko@d006021bd0c28d1ce33a07e7943d48b079944c8d 
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -10,7 +10,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 
 
       - name: Validate PR Title Format
         run: |

--- a/hack/gha-reversemap.sh
+++ b/hack/gha-reversemap.sh
@@ -1,0 +1,257 @@
+#!/usr/bin/env bash
+
+# Copyright 2025 The KubeStellar Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Purpose: Harmonise '$GITHUB_WORKFLOWS_PATH' and the reversemap '$REVERSEMAP_FILE'
+
+# Usage: see help function
+# Working directory must be the project root
+
+# Define the required version of yq
+# GITHUB_TOKEN=
+set -e
+
+GITHUB_WORKFLOWS_PATH="./.github/workflows"
+REVERSEMAP_FILE=".gha-reversemap.yml"
+YQ_REQUIRED_VERSION="v4.45.1"
+GIT_COMMITSHA_LENGTH=40
+TMP_OUTPUT="/tmp/$(date -u -Iseconds | cut -d '+' -f1).json"
+
+ERR_YQ_DOWNLOAD_FAILED=50
+ERR_YQ_NOT_INSTALLED=60
+ERR_GITHUB_TOKEN_INVALID=70
+ERR_ARCH_UNSUPPORTED=80
+
+help() {
+    cat <<EOF
+Harmonise '$GITHUB_WORKFLOWS_PATH' and the reversemap '$REVERSEMAP_FILE'
+
+Usage:
+    $0  <operation> [ARGUMENTS]
+
+Example:
+    # Update actions/checkout to its latest release
+    $0  update actions/checkout
+
+Operations:
+    apply-reversemap        [WORKFLOW_FILE...]          -   Update the given workflow files with the information in the reversemap
+                                                            file; if no workflow files are given then all are updated
+
+    update-action-version   ACTION_REF...               -   Update the version of the given action reference within the reversemap
+                                                            (sha, tag, urls) to its latest regular release tag
+
+    update-reversemap       [WORKFLOW_FILE...]          -   Update the reverse map values (sha, tag, urls) with the information 
+                                                            in the github workflow; if no workflow files are specified then 
+                                                            all workflows are used
+
+EOF
+}
+
+# Log information
+_loginfo() {
+    echo -e "$(date -Iseconds);INFO;$1"
+}
+
+# Exit with an error
+_exit_with_error() {
+    echo -e "$(date -Iseconds);ERROR;$2" >&2
+    exit "$1"
+}
+
+# Internal - indicates proper return of value within a function
+_return() {
+    echo "$1"
+}
+
+# Function to check if yq is installed and has the required version
+_check_yq_version() {
+    if command -v yq >/dev/null 2>&1; then
+        INSTALLED_VERSION=$(yq --version 2>/dev/null)
+        if ! [[ "$INSTALLED_VERSION" =~ $YQ_REQUIRED_VERSION ]]; then
+            _exit_with_error $ERR_YQ_NOT_INSTALLED "yq is installed but the version is $INSTALLED_VERSION. Required version is $YQ_REQUIRED_VERSION."
+        fi
+    else
+        _exit_with_error $ERR_YQ_NOT_INSTALLED "yq is not installed."
+    fi
+}
+
+# Check github token
+_check_github_token(){
+    if [[ -z $GITHUB_TOKEN ]]; then
+        _exit_with_error $ERR_GITHUB_TOKEN_INVALID "environment variable GITHUB_TOKEN is not set."
+    fi
+}
+
+# Get commitsha from an action ref upstream
+_fetch_sha_from_upstream_ref() {
+    action_ref=$1
+    tag_or_branch=$2
+    action_ref_safe=$(echo "$action_ref" | cut -d '/' -f 1,2)
+    API_GITHUB_BRANCH="https://api.github.com/repos/${action_ref_safe}/git/refs/heads/${tag_or_branch}"
+    API_GITHUB_TAG="https://api.github.com/repos/${action_ref_safe}/git/refs/tags/${tag_or_branch}"
+    HTTP_STATUS=$(curl -o "$TMP_OUTPUT" -s -w "%{http_code}" -H "Authorization: Bearer $GITHUB_TOKEN" "$API_GITHUB_TAG")
+    if [[ $HTTP_STATUS -ge 200 && $HTTP_STATUS -lt 300 ]]; then
+        commit_sha=$(jq -r '.object.sha' $TMP_OUTPUT)
+        # _loginfo "tag api $commit_sha"
+    else
+        commit_sha=$(curl -s -H "Authorization: Bearer $GITHUB_TOKEN" "$API_GITHUB_BRANCH" | jq -r '.object.sha')
+        # _loginfo "branch api $commit_sha"
+    fi
+    _return "$commit_sha"
+}
+
+# Update reverse map KV using yq
+_yq_update_reversemap() {
+    action_ref=$1
+    action_tag=$2
+    action_sha=$3
+    action_ref_safe=$(echo "$action_ref" | cut -d '/' -f 1,2) # In case the action is a sub-action of a repo (ie. user/action/subaction@v1)
+    yq ".${action_ref}.sha = \"${action_sha}\"" -i $REVERSEMAP_FILE
+    yq ".${action_ref}.sha-url = \"https://github.com/${action_ref_safe}/commit/${action_sha}\"" -i $REVERSEMAP_FILE
+    yq ".${action_ref}.tag = \"${action_tag}\"" -i $REVERSEMAP_FILE
+    yq ".${action_ref}.tag-url = \"https://github.com/${action_ref_safe}/tree/${action_tag}\"" -i $REVERSEMAP_FILE
+}
+
+# Update the reverse map values with an action full ref (ie. actions/checkout@v4.2.0)
+_update_reversemap_with() {
+    filename=$1
+    for action_fullref in $(yq '.jobs[].steps[] | select(has("uses")) | .uses ' "$filename"); do
+        action_ref=$(echo "$action_fullref" | cut -d '@' -f 1)
+        action_tag=$(echo "$action_fullref" | cut -d '@' -f 2)
+        length=${#action_tag}
+        _loginfo "ref=$action_ref and tag=$action_tag len=$length"
+        if [[ $length -ne $GIT_COMMITSHA_LENGTH ]]; then
+            action_sha=$(_fetch_sha_from_upstream_ref "$action_ref" "$action_tag")
+            _loginfo "taking commit of action=${action_ref} tag=${action_tag} sha=${action_sha}"
+            _yq_update_reversemap "$action_ref" "$action_tag" "$action_sha"
+        fi
+    done
+}
+
+# Fetch latest release tag of an action upstream
+_fetch_latest_tag() {
+    action_ref=$1
+    API_GITHUB_LATEST_RELEASE=https://api.github.com/repos/$action_ref/releases/latest
+    _return "$(curl -s -H "Authorization: Bearer $GITHUB_TOKEN" "$API_GITHUB_LATEST_RELEASE" | jq -r '.tag_name')"
+}
+
+# Update action version within a file
+_update_action_version_infile() {
+    file=$1
+    action_ref=$2
+    action_sha=$3
+    sed_replace_expr="s;(uses:) $action_ref@[a-zA-Z0-9 \._\-]+;\1 $action_ref@$action_sha ;g"
+    if [[ "$(uname -s)" = "Darwin" ]]; then
+        # MacOS sed usage of -i option differs from Linux version.
+        sed -E -i '' "$sed_replace_expr" "$file"
+    else
+        sed -E -i "$sed_replace_expr" "$file"
+    fi
+}
+
+# Get commit sha of an action ref stored in the reverse map
+_get_sha_from_reversemap() {
+    action_ref=$1
+    query=$(yq ".\"$action_ref\".sha" $REVERSEMAP_FILE)
+    if [[ $? -ne 0 ]]; then
+        _exit_with_error "no sha has been found for $action_ref in $REVERSEMAP_FILE"
+    fi
+    _return "$query"
+}
+
+# Apply the commit sha of every action listed in the reversemap as the version to use in all github workflows
+run_apply_reversemap() {
+    files=$@
+    for file in $files; do
+        _loginfo "applying '$REVERSEMAP_FILE' commit sha to be used in '$file' ..."
+        action_fullrefs=$(yq '.jobs[].steps[] | select(.uses) | .uses' "$file")
+        for action_fullref in $action_fullrefs; do
+            action_ref=$(echo "$action_fullref" | cut -d "@" -f 1)
+            action_sha=$(_get_sha_from_reversemap "$action_ref")
+            _loginfo "found '$action_ref' in reversemap with sha=$action_sha"
+            _update_action_version_infile "$file" "$action_ref" "$action_sha"
+        done
+    done
+}
+
+# Update the version of the given action references within the reverse map (sha, tag, urls) to its latest regular release tag
+run_update_action_version() {
+    action_refs=$@
+    for action_ref in $action_refs; do
+        _loginfo "updating dependency '$action_ref' tag to latest version available inside reverse map '$REVERSEMAP_FILE'"
+        latest_tag=$(_fetch_latest_tag "$action_ref")
+        action_sha=$(_fetch_sha_from_upstream_ref "$action_ref" "$latest_tag")
+        _yq_update_reversemap "$action_ref" "$latest_tag" "$action_sha"
+    done
+}
+
+# Update the reverse map values (sha, tag, urls) from the actions used in given github workflows
+run_update_reversemap() {
+    files=$@
+    for file in $files; do
+        _loginfo "updating $REVERSEMAP_FILE with actions from '$file' ..."
+        _update_reversemap_with "$file"
+    done
+}
+
+# Run the CLI with its operations
+run_cli() {
+    operation_arg=$1
+    case $operation_arg in
+    "help")
+        help
+        ;;
+    "apply-reversemap")
+        shift
+        _check_yq_version
+        files=$@
+        if [[ "$#" -eq 0 ]]; then
+            files="$GITHUB_WORKFLOWS_PATH/*.yml"
+        fi
+        _loginfo "running $operation_arg on $files"
+        run_apply_reversemap $files
+        ;;
+    "update-action-version")
+        shift
+        _check_github_token
+        _check_yq_version
+        action_refs=$@
+        if [[ "$#" -eq 0 ]]; then
+            _exit_with_error 1 "missing action ref to update. Format must be '{gh_owner}/{gh_repo}'"
+        fi
+        _loginfo "running $operation_arg on $action_refs"
+        run_update_action_version $action_refs
+        ;;
+    "update-reversemap")
+        shift
+        _check_github_token
+        _check_yq_version
+        files=$@
+        if [[ "$#" -eq 0 ]]; then
+            files="$GITHUB_WORKFLOWS_PATH/*.yml"
+        fi
+        _loginfo "running $operation_arg on $files"
+        run_update_reversemap $files
+        ;;
+    *)
+        help
+        exit 1
+        ;;
+    esac
+
+}
+
+# Execute the main program
+run_cli $@


### PR DESCRIPTION
## Summary

As per of [the following discussion](https://github.com/kubestellar/kubestellar/pull/2883#issuecomment-2848030049), a rework has been done to enhance the functionnality of the reverse map and its script.

**Goal**: move away of tag/branch as actions' version. Usage of commit sha instead to avoid supply chain attack.

Update includes:
- Usage of the script as a CLI with `update/reversemap`, `update-action-version` and `apply-reversemap` operations.
- Reverse map contains `sha`, `tag`, `url-sha` and `url-tag` as a KV for each actions

### Enhancement proposal (new issue)

Make use of this hack script as part of CI to:
- test to ensure that no actions has been used with a tag or branch as version. 
- update on approval an action version in its reverse map and workflows right from GitHub.

If part of the CI, perhaps creating `.github/scripts/` would be idiomatic as GitHub recognises this directory as scripts for CI.

## Related issue(s)

Fixes #2844 
