### PR TITLE
✨ Liberalize yq version check, bump setup-go to 5.5.0

### DIFF
--- a/.gha-reversemap.yml
+++ b/.gha-reversemap.yml
@@ -29,8 +29,8 @@ actions/setup-python:
   tag: v5
   tag-url: https://github.com/actions/setup-python/tree/v5
 actions/setup-go:
-  sha: 0aaccfd150d50ccaeb58ebd88d36e91967a5f35b
-  sha-url: https://github.com/actions/setup-go/commit/0aaccfd150d50ccaeb58ebd88d36e91967a5f35b
+  sha: d35c59abb061a4a6fb18e82ac0862c26744d6ab5
+  sha-url: https://github.com/actions/setup-go/commit/d35c59abb061a4a6fb18e82ac0862c26744d6ab5
   tag: v5
   tag-url: https://github.com/actions/setup-go/tree/v5
 anchore/sbom-action/download-syft:

--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -22,7 +22,7 @@ jobs:
       with:
         fetch-depth: 0
 
-    - uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b 
+    - uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 
       with:
         go-version: v1.22
          

--- a/.github/workflows/ocp-self-runner.yml
+++ b/.github/workflows/ocp-self-runner.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 
 
-      - uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b 
+      - uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 
         with:
           go-version: v1.22
           cache: true
@@ -64,7 +64,7 @@ jobs:
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 
 
-      - uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b 
+      - uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 
         with:
           go-version: v1.22
           cache: true

--- a/.github/workflows/pr-test-e2e.yml
+++ b/.github/workflows/pr-test-e2e.yml
@@ -35,7 +35,7 @@ jobs:
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 
 
-      - uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b 
+      - uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 
         with:
           go-version: v1.22
           cache: true
@@ -166,7 +166,7 @@ jobs:
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 
 
-      - uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b 
+      - uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 
         with:
           go-version: v1.22
           cache: true

--- a/.github/workflows/pr-test-integration.yml
+++ b/.github/workflows/pr-test-integration.yml
@@ -20,7 +20,7 @@ jobs:
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 
 
-      - uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b 
+      - uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 
         with:
           go-version: v1.22
           cache: true

--- a/.github/workflows/test-latest-release.yml
+++ b/.github/workflows/test-latest-release.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 
 
-      - uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b 
+      - uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 
         with:
           go-version: v1.22
           cache: true
@@ -93,7 +93,7 @@ jobs:
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 
 
-      - uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b 
+      - uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 
         with:
           go-version: v1.22
           cache: true

--- a/hack/gha-reversemap.sh
+++ b/hack/gha-reversemap.sh
@@ -25,7 +25,7 @@ set -e
 
 GITHUB_WORKFLOWS_PATH="./.github/workflows"
 REVERSEMAP_FILE=".gha-reversemap.yml"
-YQ_REQUIRED_VERSION="v4.45.1"
+YQ_REQUIRED_VERSION="v4.45"
 GIT_COMMITSHA_LENGTH=40
 TMP_OUTPUT="/tmp/$(date -u -Iseconds | cut -d '+' -f1).json"
 


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
This PR makes two changes. One is to liberalize the check that the `hack/gha-reversemap.sh` script makes on the version of yq, so that any v4.45.X is accepted. This is good because 4.45.2 was recently released.

The other change is to pick up the latest release of the setup-go action.

This will supersede #2902 

## Related issue(s)

Fixes #
