### PR TITLE
🌱 Test : Fix  command injection vulnerability in PR title validation

### DIFF
--- a/.github/workflows/pr-verifier.yaml
+++ b/.github/workflows/pr-verifier.yaml
@@ -13,24 +13,29 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Validate PR Title Format
+        env:
+          TITLE: ${{ github.event.pull_request.title }}
         run: |
-          TITLE="${{ github.event.pull_request.title }}"
+          set -euo pipefail
           
-          if [[ -z "$TITLE" ]]; then
-            echo "Error: PR title cannot be empty."
+          # Safely access the PR title
+          if [ -z "${TITLE}" ]; then
+            echo "❌ Error: PR title cannot be empty."
             exit 1
           fi
           
-          if ! [[ "$TITLE" =~ ^($'\u26A0'|$'\u2728'|$'\U0001F41B'|$'\U0001F4D6'|$'\U0001F680'|$'\U0001F331') ]]; then
-            echo "Error: Invalid PR title format."
+          # Define allowed emoji prefixes using a safe regular expression match
+          if ! printf '%s' "$TITLE" | grep -qE '^(⚠|✨|🐛|📖|🚀|🌱)'; then
+            echo "❌ Error: Invalid PR title format."
             echo "Your PR title must start with one of the following indicators:"
-            echo "- Breaking change: ⚠ (U+26A0)"
-            echo "- Non-breaking feature: ✨ (U+2728)"
-            echo "- Patch fix: 🐛 (U+1F41B)"
-            echo "- Docs: 📖 (U+1F4D6)"
-            echo "- Release: 🚀 (U+1F680)"
-            echo "- Infra/Tests/Other: 🌱 (U+1F331)"
+            echo "- ⚠  Breaking change"
+            echo "- ✨  Non-breaking feature"
+            echo "- 🐛  Patch fix"
+            echo "- 📖  Documentation"
+            echo "- 🚀  Release"
+            echo "- 🌱  Infra/Tests/Other"
             exit 1
           fi
-          
-          echo "PR title is valid: '$TITLE'"
+
+          # Safely print the title without allowing code execution
+          printf "✅ PR title is valid: %q\n" "$TITLE"


### PR DESCRIPTION
### Problem:
The current `pr-verifier.yaml` workflow is vulnerable to command injection when processing PR titles. Unescaped characters or injected commands can be executed in the shell during the GitHub Actions run.

### Solution:
- Secure the PR title handling by escaping characters properly using `printf %q`.
- Prevent command injection by avoiding direct evaluation of untrusted input in the shell.
- Add `set -euo pipefail` for shell safety.
- Use `grep -qE` for secure matching of allowed emojis in the PR title.

### Changes:
- Updated `pr-verifier.yaml` to:
  - Add safe shell practices.
  - Properly handle and escape PR title.
  - Ensure the PR title is validated securely without running injected commands.

### Impact:
This change prevents arbitrary command execution via PR titles, improving the security of the GitHub Actions workflow.

Please review the changes and merge if acceptable. Let me know if any further modifications are needed.

Fixes #2908