### PR TITLE
🌱 chore: update checkout action version in PR title verifier workflow

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -10,7 +10,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 
 
       - name: Validate PR Title Format
         env:


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow in `.github/workflows/verify.yml` to use a specific commit hash for the `actions/checkout` action instead of a version tag. This change ensures a more stable and secure workflow by pinning the action to a known commit.

* [`.github/workflows/verify.yml`](diffhunk://#diff-b32b798d8ec577b859922a84b90dfe871b19fad404cc6fa7a6fe163f079fbcbfL13-R13): Updated the `uses` field for the `actions/checkout` step to reference the specific commit `11bd71901bbe5b1630ceea73d27597364c9af683` instead of the `v4` version tag



Fixes #2910
