### PR TITLE
🐛  Make clusteradm build get some later dependencies

### DIFF
--- a/hack/build-clusteradm-image.sh
+++ b/hack/build-clusteradm-image.sh
@@ -76,5 +76,29 @@ git clone -b "v$clusteradm_version" --depth 1 https://github.com/open-cluster-ma
 
 cd "$clusteradm_folder"
 
+case "$clusteradm_version" in
+    (0.10.*)
+        go get github.com/docker/docker@v25.0.10 \
+               github.com/containerd/containerd@v1.7.27 \
+               golang.org/x/crypto@v0.36.0 \
+               golang.org/x/net@v0.38.0 \
+               golang.org/x/oauth2@v0.30.0 \
+               helm.sh/helm/v3@v3.15.4
+        go mod tidy
+        go mod vendor
+        ;;
+    (0.11.0)
+        go get github.com/docker/docker@v27.5.1 \
+               github.com/containerd/containerd@v1.7.27 \
+               golang.org/x/crypto@v0.36.0 \
+               golang.org/x/net@v0.38.0 \
+               golang.org/x/oauth2@v0.30.0 \
+               helm.sh/helm/v3@v3.16.4
+        go mod tidy
+        go mod vendor
+        ;;
+esac
+
+
 export KO_DOCKER_REPO=$registry
 ko build -B ./cmd/clusteradm -t $clusteradm_version --sbom=none --platform $platform


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
This PR updates the script for building the clusteradm container image so that it gets later versions of some dependencies, picking up security fixes.

I have rebuilt quay.io/kubestellar/clusteradm:0.10.1 and quay.io/kubestellar/clusteradm:0.11.0 with the revised script.

## Related issue(s)

Fixes #
