### PR TITLE
 Fix: Contribution Guide Link Not Opening from Documentation

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -324,8 +324,8 @@ nav:
   - Home: index.md
   - QuickStart: Getting-Started/quickstart.md
   - Contributing: 
-      - Guidelines: Contribution guidelines/CONTRIBUTING.md
-```
+      - Guidelines: contribution-guidelines/contributing-inc.md
+
 ````
 <b>as seen by reader:</b>
 ```yaml
@@ -333,7 +333,8 @@ nav:
   - Home: index.md
   - QuickStart: Getting-Started/quickstart.md
   - Contributing: 
-      - Guidelines: Contribution guidelines/CONTRIBUTING.md
+     - Guidelines: contribution-guidelines/contributing-inc.md
+
 ```
 <br/>
 

--- a/docs/content/contribution-guidelines/contributing-inc.md
+++ b/docs/content/contribution-guidelines/contributing-inc.md
@@ -1,7 +1,7 @@
 # Contributing to KubeStellar
 
 {%
-    include "../../../CONTRIBUTING.md"
+    include "./contributing-inc.md"
     start="<!--guidelines-start-->"
     end="<!--end-first-include-->"
 %}
@@ -9,16 +9,15 @@
 Please make sure that your environment has all the necessary versions as spelled out in the prerequisites section of our [user guide](../direct/pre-reqs.md)
 
 {%
-    include "../../../CONTRIBUTING.md"
+    include "./contributing-inc.md"
     start="<!--start-second-include-->"
     end="<!--end-second-include-->"
 %}
 
 See [Git Commit Signoff and Signing](../direct/pr-signoff.md) for more information on how to do that.
 
-
 {%
-    include "../../../CONTRIBUTING.md"
+    include "./contributing-inc.md"
     start="<!--start-third-include-->"
     end="<!--end-third-include-->"
 %}
@@ -29,7 +28,7 @@ To set up and test a development system, please refer to the _test/e2e/README.md
 After running any of those e2e (end to end) tests you will be left with a running system that can be exercised further.
 
 {%
-    include "../../../CONTRIBUTING.md"
+    include "./contributing-inc.md"
     start="<!--start-fourth-include-->"
     end="<!--end-fourth-include-->"
 %}
@@ -37,7 +36,7 @@ After running any of those e2e (end to end) tests you will be left with a runnin
 If you are interested in modifying the Helm chart itself, look at the User Guide page on the [Core Helm chart](../direct/core-chart.md) for more information on its many options before you begin, notably on how to specify using a local version of the script.
 
 {%
-    include "../../../CONTRIBUTING.md"
+    include "./contributing-inc.md"
     start="<!--start-fifth-include-->"
     end="<!--end-fifth-include-->"
 %}
@@ -45,8 +44,8 @@ If you are interested in modifying the Helm chart itself, look at the User Guide
 KubeStellar is [Apache 2.0 licensed](./license-inc.md) and we accept contributions via GitHub pull requests.
 
 {%
-    include "../../../CONTRIBUTING.md"
+    include "./contributing-inc.md"
     start="<!--start-sixth-include-->"
 %}
 
-_Note: this file "contribute-github.md" is a wrapper that includes the CONTRIBUTING.md file found in the root of the KubeStellar repository, adding website relative links while eliding relative navigation links that are specific to the repository folder structure_
+_Note: this file "contribute-github.md" is a wrapper that includes the file found in the root of the KubeStellar repository, adding website relative links while eliding relative navigation links that are specific to the repository folder structure_

--- a/docs/content/readme.md
+++ b/docs/content/readme.md
@@ -47,7 +47,7 @@ See the [Getting Started setup guide](direct/get-started.md) for getting started
 
 ## Contributing
 
-We ❤️ our contributors! If you're interested in helping us out, please head over to our [Contributing](contribution-guidelines/contributing-inc.md) guide.
+We ❤️ our contributors! If you're interested in helping us out, please head over to our [Contributing](/direct/contribute) guide.
 
 ## Getting in touch
 

--- a/docs/content/readme.md
+++ b/docs/content/readme.md
@@ -47,7 +47,7 @@ See the [Getting Started setup guide](direct/get-started.md) for getting started
 
 ## Contributing
 
-We ❤️ our contributors! If you're interested in helping us out, please head over to our [Contributing](Contribution%20guidelines/CONTRIBUTING.md) guide.
+We ❤️ our contributors! If you're interested in helping us out, please head over to our [Contributing](contribution-guidelines/contributing-inc.md) guide.
 
 ## Getting in touch
 


### PR DESCRIPTION
Previously, when clicking on "Contributing guide" in the documentation, the link incorrectly opened as mentioned in #2922: 

https://docs.kubestellar.io/release-0.27.2/readme/Contribution%20guidelines/CONTRIBUTING.md
which resulted in a broken or not found page.

The expected behavior was to open the proper contribution guide at:
/direct/contribute/
This PR fixes the link so that clicking "Contributing guide" now correctly navigates to the /direct/contribute/ page, improving user experience and eliminating the broken link issue.
i fixed it and tested , now the link open correctly on clicking Contributing