### PR TITLE
 📖  Fix: Contribution Guide Link Not Opening from Documentation

### DIFF
--- a/docs/content/readme.md
+++ b/docs/content/readme.md
@@ -48,7 +48,7 @@ See the [Getting Started setup guide](direct/get-started.md) for getting started
 ## Contributing
 
 
-We ❤️ our contributors! If you're interested in helping us out, please head over to our [Contributing](/direct/contribute) guide.
+We ❤️ our contributors! If you're interested in helping us out, please head over to our [Contributing](contribution-guidelines/contributing-inc.md) guide.
 
 ## Getting in touch
 

--- a/docs/content/readme.md
+++ b/docs/content/readme.md
@@ -47,7 +47,8 @@ See the [Getting Started setup guide](direct/get-started.md) for getting started
 
 ## Contributing
 
-We ❤️ our contributors! If you're interested in helping us out, please head over to our [Contributing](Contribution%20guidelines/CONTRIBUTING.md) guide.
+
+We ❤️ our contributors! If you're interested in helping us out, please head over to our [Contributing](/direct/contribute) guide.
 
 ## Getting in touch
 


### PR DESCRIPTION
Previously, when clicking on "Contributing guide" in the documentation, the link incorrectly opened:

https://docs.kubestellar.io/release-0.27.2/readme/Contribution%20guidelines/CONTRIBUTING.md
which resulted in a broken or not found page.

The expected behavior was to open the proper contribution guide at:
/direct/contribute/
This PR fixes the link so that clicking "Contributing guide" now correctly navigates to the /direct/contribute/ page, improving user experience and eliminating the broken link issue.
i fixed it and tested , now the link open correctly on clicking Contributing