### PR TITLE
✨  Bump kube-rbac-proxy from 0.18.0 to 0.19.1

### DIFF
--- a/core-chart/templates/postcreatehooks/wds.yaml
+++ b/core-chart/templates/postcreatehooks/wds.yaml
@@ -371,7 +371,7 @@ spec:
                 - --upstream=http://127.0.0.1:8080/
                 - --logtostderr=true
                 - --v=0
-              image: quay.io/brancz/kube-rbac-proxy:v0.18.0
+              image: quay.io/brancz/kube-rbac-proxy:v0.19.1
               name: kube-rbac-proxy
               ports:
                 - containerPort: 8443

--- a/scripts/create-kubestellar-demo-env.sh
+++ b/scripts/create-kubestellar-demo-env.sh
@@ -191,7 +191,7 @@ kubectl config use-context $k8s_platform-kubeflex
 echo -e "\nPulling container images local..."
 images=("ghcr.io/loft-sh/vcluster:0.16.4"
         "rancher/k3s:v1.27.2-k3s1"
-        "quay.io/open-cluster-management/registration-operator:v0.14.0"
+        "quay.io/open-cluster-management/registration-operator:v0.15.2"
         "quay.io/kubestellar/postgresql:16.0.0-debian-11-r13")
 
 for image in "${images[@]}"; do

--- a/test/e2e/common/setup-kubestellar.sh
+++ b/test/e2e/common/setup-kubestellar.sh
@@ -127,9 +127,9 @@ else
 popd
 
 : Waiting for OCM hub to be ready...
-kubectl wait controlplane.tenancy.kflex.kubestellar.org/its1 --for 'jsonpath={.status.postCreateHooks.its-with-clusteradm}=true' --timeout 200s
-kubectl wait -n its1-system job.batch/its-with-clusteradm --for condition=Complete --timeout 300s
-kubectl wait -n its1-system job.batch/update-cluster-info --for condition=Complete --timeout 90s
+kubectl wait controlplane.tenancy.kflex.kubestellar.org/its1 --for 'jsonpath={.status.postCreateHooks.its-with-clusteradm}=true' --timeout 400s
+kubectl wait -n its1-system job.batch/its-with-clusteradm --for condition=Complete --timeout 400s
+kubectl wait -n its1-system job.batch/update-cluster-info --for condition=Complete --timeout 200s
 
 wait-for-cmd "(kubectl --context '$HOSTING_CONTEXT' -n wds1-system wait --for=condition=Ready pod/\$(kubectl --context '$HOSTING_CONTEXT' -n wds1-system get pods -l name=transport-controller -o jsonpath='{.items[0].metadata.name}'))"
 
@@ -163,8 +163,8 @@ function add_wec() {
 
 "${SRC_DIR}/../../../scripts/check_pre_req.sh" --assert --verbose ocm
 
-kubectl --context $HOSTING_CONTEXT wait controlplane.tenancy.kflex.kubestellar.org/its1 --for 'jsonpath={.status.postCreateHooks.its-with-clusteradm}=true' --timeout 90s
-kubectl --context $HOSTING_CONTEXT wait -n its1-system job.batch/its-with-clusteradm --for condition=Complete --timeout 150s
+kubectl --context $HOSTING_CONTEXT wait controlplane.tenancy.kflex.kubestellar.org/its1 --for 'jsonpath={.status.postCreateHooks.its-with-clusteradm}=true' --timeout 200s
+kubectl --context $HOSTING_CONTEXT wait -n its1-system job.batch/its-with-clusteradm --for condition=Complete --timeout 400s
 
 add_wec cluster1
 add_wec cluster2


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
This PR bumps the version of the quay.io/brancz/kube-rbac-proxy image used in the kubestellar-controller-manager Deployment from v0.18.0 to v0.19.1. The benefit is fewer security vulnerabilities. The downside is that v0.19.1 is built on Kubernetes 1.31, while the rest of KubeStellar uses Kubernetes 1.30. I suspect that this inconsistency will not be problematic because of the narrow job of this particular image.

## Related issue(s)

Fixes #
