### PR TITLE
fix: update Helm command syntax in documentation

### DIFF
--- a/docs/content/direct/core-chart.md
+++ b/docs/content/direct/core-chart.md
@@ -181,9 +181,9 @@ User defined control planes can be added using additional value files of `--set`
 A KubeStellar Core installation that is consistent with [Getting Started](get-started.md) and and supports [the example scenarios](./example-scenarios.md) could be achieved with the following command:
 
 ```shell
-helm upgrade --install ks-core oci://ghcr.io/kubestellar/kubestellar/core-chart --version $KUBESTELLAR_VERSION \
-  --set-json='ITSes=[{"name":"its1"}]' \
-  --set-json='WDSes=[{"name":"wds1"}]'
+helm upgrade --install ks-core oci://ghcr.io/kubestellar/kubestellar/core-chart --version "$KUBESTELLAR_VERSION" \
+  --set-json ITSes='[{"name":"its1"}]' \
+  --set-json WDSes='[{"name":"wds1"}]'
 ```
 
 The core chart also supports the use of a pre-existing cluster (or any space, really) as an ITS. A specific application is to connect to existing OCM clusters. As an example, create a first local kind cluster with OCM installed in it:

--- a/docs/content/direct/get-started.md
+++ b/docs/content/direct/get-started.md
@@ -104,10 +104,10 @@ bash <(curl -s https://raw.githubusercontent.com/kubestellar/kubestellar/v{{ con
 
 ```shell
 helm upgrade --install ks-core oci://ghcr.io/kubestellar/kubestellar/core-chart \
-    --version $kubestellar_version \
-    --set-json='ITSes=[{"name":"its1"}]' \
-    --set-json='WDSes=[{"name":"wds1"},{"name":"wds2", "type":"host"}]' \
-    --set-json='verbosity.default=5' # so we can debug your problem reports
+    --version "$kubestellar_version" \
+    --set-json ITSes='[{"name":"its1"}]' \
+    --set-json WDSes='[{"name":"wds1"},{"name":"wds2","type":"host"}]' \
+    --set verbosity.default=5  # so we can debug your problem reports
 ```
 
 That command will print some notes about how to get kubeconfig "contexts" named "its1", "wds1", and "wds2" defined. Do that, because those contexts are used in the steps that follow.


### PR DESCRIPTION
:book: 📖 docs: Fix Helm command syntax in documentation

## Summary

This PR updates the Helm command syntax in the KubeStellar documentation to use the correct format for `--set-json` flags. The changes make the commands more reliable across different shell environments, particularly on Ubuntu 24.04.

### Changes Made:
1. Updated `--set-json='KEY=VALUE'` to `--set-json KEY='VALUE'` for better shell compatibility
2. Added proper quoting around shell variables (e.g., `"$KUBESTELLAR_VERSION"`)
3. Changed `--set-json='verbosity.default=5'` to `--set verbosity.default=5` for consistency

### Why This Change is Important:
- Fixes potential command failures on Ubuntu 24.04 and other Linux distributions
- Follows Helm's recommended usage patterns
- Makes the documentation more reliable for new users

## Related Issue(s)

Fixes # (add issue number if applicable)
I have not raised an issue for it.

## Testing Done
- Verified the commands work on Ubuntu 24.04
- Confirmed the syntax is valid according to Helm's documentation
- Ensured all examples in the documentation are consistent

##Screenshots

![image](https://github.com/user-attachments/assets/7b669add-709b-42a8-b3c5-5b9cd43d8c5f)

![image](https://github.com/user-attachments/assets/d1c4b839-a88c-4d7a-9ea7-4ef8e60b6bab)
