### PR TITLE
make changes with lookup so that no duplicate pch installed

### DIFF
--- a/core-chart/templates/postcreatehooks/its-with-clusteradm.yaml
+++ b/core-chart/templates/postcreatehooks/its-with-clusteradm.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.InstallPCHs }}
+{{- if (not (lookup "tenancy.kflex.kubestellar.org/v1alpha1" "PostCreateHook" "" "its-with-clusteradm")) }}
 apiVersion: tenancy.kflex.kubestellar.org/v1alpha1
 kind: PostCreateHook
 metadata:

--- a/core-chart/templates/postcreatehooks/its-without-clusteradm.yaml
+++ b/core-chart/templates/postcreatehooks/its-without-clusteradm.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.InstallPCHs }}
+{{- if (not (lookup "tenancy.kflex.kubestellar.org/v1alpha1" "PostCreateHook" "" "its-without-clusteradm")) }}
 apiVersion: tenancy.kflex.kubestellar.org/v1alpha1
 kind: PostCreateHook
 metadata:

--- a/core-chart/templates/postcreatehooks/wds.yaml
+++ b/core-chart/templates/postcreatehooks/wds.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.InstallPCHs }}
+{{- if (not (lookup "tenancy.kflex.kubestellar.org/v1alpha1" "PostCreateHook" "" "wds")) }}
 apiVersion: tenancy.kflex.kubestellar.org/v1alpha1
 kind: PostCreateHook
 metadata:

--- a/core-chart/values.yaml
+++ b/core-chart/values.yaml
@@ -93,10 +93,6 @@ transport_controller:
   max_size_wrapped: 512000
 
 
-# Determine if the Post Create Hooks should be installed by the chart
-InstallPCHs: true
-
-
 # List the Inventory and Transport Spaces (ITSes) to be created by the chart
 # Each ITS consists of:
 # - a mandatory unique name


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

## Related issue(s)

Fixes #

Previous Implementation: 
```
helm install ks-core ./core-chart \
  --namespace kubeflex-system \
  --set "kubeflex-operator.hostContainer=kubeflex-control-plane" \
  --set "kubeflex-operator.externalPort=9443" \
  --set-json='ITSes=[{"name":"its1"}]' \
  --set-json='WDSes=[{"name":"wds1","ITSName":"its1"}]'
```
output: 
```
NAME: ks-core
LAST DEPLOYED: Thu May 22 22:06:49 2025
NAMESPACE: kubeflex-system
STATUS: deployed
REVISION: 1
TEST SUITE: None
```
but 
```
helm install ks-core-2 ./core-chart --namespace kubeflex-system \
  --set "kubeflex-operator.install=false" \
  --set "kubeflex-operator.hostContainer=kubeflex-control-plane" \
  --set "kubeflex-operator.externalPort=9443" \
  --set-json='ITSes=[{"name":"its2"}]' \
  --set-json='WDSes=[{"name":"wds2","ITSName":"its2"}]'
```
Error: INSTALLATION FAILED: Unable to continue with install: PostCreateHook "its-with-clusteradm" in namespace "" exists and cannot be imported into the current release: invalid ownership metadata; annotation validation error: key "meta.helm.sh/release-name" must equal "ks-core-2": current value is "ks-core"
you got this error !

```
ks-core-2 ./core-chart --namespace kubeflex-system \
  --set "InstallPCHs=false" \
  --set "kubeflex-operator.install=false" \
  --set "kubeflex-operator.hostContainer=kubeflex-control-plane" \
  --set "kubeflex-operator.externalPort=9443" \
  --set-json='ITSes=[{"name":"its2"}]' \
  --set-json='WDSes=[{"name":"wds2","ITSName":"its2"}]'
```
as we set manually  ` --set "InstallPCHs=false" \` you can see this is working fine! 
```
NAME: ks-core-2
LAST DEPLOYED: Thu May 22 22:12:38 2025
NAMESPACE: kubeflex-system
STATUS: deployed
REVISION: 1
TEST SUITE: None
```
current Implementation: 

```
helm install ks-core ./core-chart \
  --namespace kubeflex-system \
  --set "kubeflex-operator.hostContainer=kubeflex-control-plane" \
  --set "kubeflex-operator.externalPort=9443" \
  --set-json='ITSes=[{"name":"its1"}]' \
  --set-json='WDSes=[{"name":"wds1","ITSName":"its1"}]'
```

Output of kubectl get postcreatehook:
```
NAME                     SYNCED   READY   TYPE   AGE
its-with-clusteradm                              2m18s
its-without-clusteradm                           2m18s
openshift-crds                                   46m
wds                                                      2m18s
```


Output of kubectl get controlplanes:
```
NAME   SYNCED   READY   TYPE       AGE
its1   True     True    vcluster   2m1s
wds1   True     True    k8s        2m1s
```


helm install ks-core-2 ./core-chart --namespace kubeflex-system \
  --set "kubeflex-operator.install=false" \
  --set "kubeflex-operator.hostContainer=kubeflex-control-plane" \
  --set "kubeflex-operator.externalPort=9443" \
  --set-json='ITSes=[{"name":"its2"}]' \
  --set-json='WDSes=[{"name":"wds2","ITSName":"its2"}]'
  
```
Output showed successful deployment:
NAME: ks-core-2
LAST DEPLOYED: Thu May 22 21:48:38 2025
NAMESPACE: kubeflex-system
STATUS: deployed
REVISION: 1
TEST SUITE: None
```

no need to manually set this ` --set "InstallPCHs=false" \` 