### PR TITLE
docs: add Windows setup instructions

### DIFF
--- a/.github/workflows/docs-gen-and-push.yml
+++ b/.github/workflows/docs-gen-and-push.yml
@@ -10,6 +10,7 @@ on:
       - "release-*"
       - "doc-*"
       - main
+      - windows-setup-guide
     paths:
       - "docs/**"
       - "*.md"

--- a/README.md
+++ b/README.md
@@ -51,6 +51,10 @@ We ❤️ our contributors! If you're interested in helping us out, please head 
 
 This community has a [Code of Conduct](./CODE_OF_CONDUCT.md). Please make sure to follow it.
 
+## Windows Installation
+- [Windows Setup Instructions](docs/setup-windows.md)
+
+
 ## Our Roadmap
 Have a look at what we are working on next, see our [Roadmap](docs/content/direct/roadmap.md) 
 

--- a/docs/content/direct/windows-setup-guide.md
+++ b/docs/content/direct/windows-setup-guide.md
@@ -1,0 +1,134 @@
+
+##  KubeStellar Installation Guide for Windows (PowerShell/CMD)
+
+## Work in Progress -- More steps coming soon!!!!!!
+
+### Prerequisites
+
+You need to install the following tools:
+
+1. [Git for Windows](https://git-scm.com/)
+2. [Docker Desktop](https://www.docker.com/products/docker-desktop/)
+3. [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl-windows/)
+4. [kind](https://kind.sigs.k8s.io/docs/user/quick-start/#installation)
+5. [Helm](https://helm.sh/docs/intro/install/)
+6. [OCM CLI (`clusteradm`)](https://open-cluster-management.io/)
+7. [kubeflex CLI (`kflex`)](https://github.com/kubestellar/kubeflex)
+
+
+
+###  Step-by-Step Windows Installation
+
+### Invoke-WebRequest -> This is a built-in PowerShell command used to download files or access web pages. It's similar to curl or wget in Linux/macOS
+
+### -Uri -> This specifies the URL you want to request/download from
+
+### -OutFile -> This specifies where to save the downloaded file on your computer
+
+### "$env:USERPROFILE\kind.exe"  -> This uses an environment variable $env:USERPROFILE to refer to your Windows user folder (like C:\Users\YourName), and saves the file there as kind.exe
+
+
+
+#### 1. Install kubectl
+
+```powershell
+Invoke-WebRequest -Uri "https://dl.k8s.io/release/v1.32.2/bin/windows/amd64/kubectl.exe" -OutFile "$env:USERPROFILE\kubectl.exe"
+```
+
+* Add to `PATH`:
+
+  * Press `Win + R` → `SystemPropertiesAdvanced` → Environment Variables
+  * Add: `C:\Users\<YourUsername>\` to `Path`
+
+* Test:
+```powershell
+kubectl version --client
+```
+
+---
+
+#### 2. Install kind
+
+```powershell
+Invoke-WebRequest -Uri https://kind.sigs.k8s.io/dl/v0.22.0/kind-windows-amd64 -OutFile "$env:USERPROFILE\kind.exe"
+```
+
+* Rename and move (optional):
+
+```powershell
+Rename-Item "$env:USERPROFILE\kind.exe" "kind.exe"
+Move-Item "$env:USERPROFILE\kind.exe" "C:\Program Files\kind.exe"
+```
+
+* Add to PATH or run directly from folder
+
+* Test:
+```powershell
+kind version
+```
+
+---
+
+#### 3. Install Helm
+
+```powershell
+Invoke-WebRequest -Uri https://get.helm.sh/helm-v3.14.0-windows-amd64.zip -OutFile helm.zip
+Expand-Archive .\helm.zip -DestinationPath .\
+Move-Item .\windows-amd64\helm.exe "$env:USERPROFILE\helm.exe"
+```
+
+* Add to PATH and test:
+
+```powershell
+helm version
+```
+
+---
+
+#### 4. Install `clusteradm` (OCM CLI)
+
+```powershell
+Invoke-WebRequest -Uri https://github.com/open-cluster-management-io/clusteradm/releases/download/v0.10.1/clusteradm-windows-amd64.exe -OutFile "$env:USERPROFILE\clusteradm.exe"
+```
+
+* Add to PATH and test:
+
+```powershell
+clusteradm version
+```
+
+---
+
+#### 5. Install `kflex` (kubeflex CLI)
+
+```powershell
+Invoke-WebRequest -Uri https://github.com/kubestellar/kubeflex/releases/download/v0.8.9/kflex-windows-amd64.exe -OutFile "$env:USERPROFILE\kflex.exe"
+```
+
+* Rename to `kflex.exe`, add to PATH and test:
+
+```powershell
+kflex version
+```
+
+---
+
+###  Final Sanity Check
+
+You can verify all prerequisites using:
+
+```powershell
+curl -s https://raw.githubusercontent.com/kubestellar/kubestellar/main/scripts/check_pre_req.sh | bash
+```
+
+ This one still needs **Git Bash or WSL** due to Unix-style shebangs. You can skip this if you’ve manually confirmed all binaries.
+
+
+
+### Optional: Create a kind cluster
+
+```powershell
+kind create cluster --name kubestellar
+kubectl cluster-info --context kind-kubestellar
+```
+---

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -44,6 +44,7 @@ nav:
           - Overview: direct/setup-overview.md
           - Setup limitations: direct/setup-limitations.md
           - Prerequisites: direct/pre-reqs.md
+          - Windows Setup Guide: direct/windows-setup-guide.md 
           - KubeFlex Hosting cluster:
             - Acquire cluster for KubeFlex Hosting: direct/acquire-hosting-cluster.md
             - Initialize KubeFlex Hosting cluster: direct/init-hosting-cluster.md
@@ -54,7 +55,7 @@ nav:
           - Argo CD integration with Core Helm chart: direct/core-chart-argocd.md
           - Workload Execution Clusters:
             - About Workload Execution Clusters: direct/wec.md
-            - Register a Workload Execution Cluster: direct/wec-registration.md
+            - Register a Workload Execution Cluster: direct/wec-registration.md  
       - Usage:
           - Usage limitations: direct/usage-limitations.md
           - KubeStellar API:
@@ -74,8 +75,7 @@ nav:
               - Authorization failure while fetching Helm chart from ghcr.io: direct/knownissue-helm-ghcr.md
               - Missing results in a CombinedStatus object: direct/knownissue-collector-miss.md
               - Kind host not configured for more than two clusters: direct/installation-errors.md
-              - Insufficient CPU for your clusters: direct/knownissue-cpu-insufficient-for-its1.md
-          - Windows Setup Guide: windows-setup-guide.md    
+              - Insufficient CPU for your clusters: direct/knownissue-cpu-insufficient-for-its1.md   
       - UI (User Interface): ui-docs/ui-overview.md
       - Teardown: direct/teardown.md 
   - Contributing:

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -76,8 +76,8 @@ nav:
               - Kind host not configured for more than two clusters: direct/installation-errors.md
               - Insufficient CPU for your clusters: direct/knownissue-cpu-insufficient-for-its1.md
       - UI (User Interface): ui-docs/ui-overview.md
-      - Teardown: direct/teardown.md
-  - Windows Setup Guide: windows-setup-guide.md 
+      - Windows Setup Guide: windows-setup-guide.md
+      - Teardown: direct/teardown.md 
   - Contributing:
       - Overview (How to join in): direct/contribute.md
       - Code of Conduct: contribution-guidelines/coc-inc.md

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -77,6 +77,7 @@ nav:
               - Insufficient CPU for your clusters: direct/knownissue-cpu-insufficient-for-its1.md
       - UI (User Interface): ui-docs/ui-overview.md
       - Teardown: direct/teardown.md
+  - Windows Setup Guide: windows-setup-guide.md 
   - Contributing:
       - Overview (How to join in): direct/contribute.md
       - Code of Conduct: contribution-guidelines/coc-inc.md

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -75,8 +75,8 @@ nav:
               - Missing results in a CombinedStatus object: direct/knownissue-collector-miss.md
               - Kind host not configured for more than two clusters: direct/installation-errors.md
               - Insufficient CPU for your clusters: direct/knownissue-cpu-insufficient-for-its1.md
+          - Windows Setup Guide: windows-setup-guide.md    
       - UI (User Interface): ui-docs/ui-overview.md
-      - Windows Setup Guide: windows-setup-guide.md
       - Teardown: direct/teardown.md 
   - Contributing:
       - Overview (How to join in): direct/contribute.md

--- a/docs/setup-windows.md
+++ b/docs/setup-windows.md
@@ -1,0 +1,134 @@
+
+##  KubeStellar Installation Guide for Windows (PowerShell/CMD)
+
+## Work in Progress -- More steps coming soon!!!!!!
+
+### Prerequisites
+
+You need to install the following tools:
+
+1. [Git for Windows](https://git-scm.com/)
+2. [Docker Desktop](https://www.docker.com/products/docker-desktop/)
+3. [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl-windows/)
+4. [kind](https://kind.sigs.k8s.io/docs/user/quick-start/#installation)
+5. [Helm](https://helm.sh/docs/intro/install/)
+6. [OCM CLI (`clusteradm`)](https://open-cluster-management.io/)
+7. [kubeflex CLI (`kflex`)](https://github.com/kubestellar/kubeflex)
+
+
+
+###  Step-by-Step Windows Installation
+
+### Invoke-WebRequest -> This is a built-in PowerShell command used to download files or access web pages. It's similar to curl or wget in Linux/macOS
+
+### -Uri -> This specifies the URL you want to request/download from
+
+### -OutFile -> This specifies where to save the downloaded file on your computer
+
+### "$env:USERPROFILE\kind.exe"  -> This uses an environment variable $env:USERPROFILE to refer to your Windows user folder (like C:\Users\YourName), and saves the file there as kind.exe
+
+
+
+#### 1. Install kubectl
+
+```powershell
+Invoke-WebRequest -Uri "https://dl.k8s.io/release/v1.32.2/bin/windows/amd64/kubectl.exe" -OutFile "$env:USERPROFILE\kubectl.exe"
+```
+
+* Add to `PATH`:
+
+  * Press `Win + R` → `SystemPropertiesAdvanced` → Environment Variables
+  * Add: `C:\Users\<YourUsername>\` to `Path`
+
+* Test:
+```powershell
+kubectl version --client
+```
+
+---
+
+#### 2. Install kind
+
+```powershell
+Invoke-WebRequest -Uri https://kind.sigs.k8s.io/dl/v0.22.0/kind-windows-amd64 -OutFile "$env:USERPROFILE\kind.exe"
+```
+
+* Rename and move (optional):
+
+```powershell
+Rename-Item "$env:USERPROFILE\kind.exe" "kind.exe"
+Move-Item "$env:USERPROFILE\kind.exe" "C:\Program Files\kind.exe"
+```
+
+* Add to PATH or run directly from folder
+
+* Test:
+```powershell
+kind version
+```
+
+---
+
+#### 3. Install Helm
+
+```powershell
+Invoke-WebRequest -Uri https://get.helm.sh/helm-v3.14.0-windows-amd64.zip -OutFile helm.zip
+Expand-Archive .\helm.zip -DestinationPath .\
+Move-Item .\windows-amd64\helm.exe "$env:USERPROFILE\helm.exe"
+```
+
+* Add to PATH and test:
+
+```powershell
+helm version
+```
+
+---
+
+#### 4. Install `clusteradm` (OCM CLI)
+
+```powershell
+Invoke-WebRequest -Uri https://github.com/open-cluster-management-io/clusteradm/releases/download/v0.10.1/clusteradm-windows-amd64.exe -OutFile "$env:USERPROFILE\clusteradm.exe"
+```
+
+* Add to PATH and test:
+
+```powershell
+clusteradm version
+```
+
+---
+
+#### 5. Install `kflex` (kubeflex CLI)
+
+```powershell
+Invoke-WebRequest -Uri https://github.com/kubestellar/kubeflex/releases/download/v0.8.9/kflex-windows-amd64.exe -OutFile "$env:USERPROFILE\kflex.exe"
+```
+
+* Rename to `kflex.exe`, add to PATH and test:
+
+```powershell
+kflex version
+```
+
+---
+
+###  Final Sanity Check
+
+You can verify all prerequisites using:
+
+```powershell
+curl -s https://raw.githubusercontent.com/kubestellar/kubestellar/main/scripts/check_pre_req.sh | bash
+```
+
+ This one still needs **Git Bash or WSL** due to Unix-style shebangs. You can skip this if you’ve manually confirmed all binaries.
+
+
+
+### Optional: Create a kind cluster
+
+```powershell
+kind create cluster --name kubestellar
+kubectl cluster-info --context kind-kubestellar
+```
+---

--- a/docs/windows-setup-guide.md
+++ b/docs/windows-setup-guide.md
@@ -1,0 +1,134 @@
+
+##  KubeStellar Installation Guide for Windows (PowerShell/CMD)
+
+## Work in Progress -- More steps coming soon!!!!!!
+
+### Prerequisites
+
+You need to install the following tools:
+
+1. [Git for Windows](https://git-scm.com/)
+2. [Docker Desktop](https://www.docker.com/products/docker-desktop/)
+3. [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl-windows/)
+4. [kind](https://kind.sigs.k8s.io/docs/user/quick-start/#installation)
+5. [Helm](https://helm.sh/docs/intro/install/)
+6. [OCM CLI (`clusteradm`)](https://open-cluster-management.io/)
+7. [kubeflex CLI (`kflex`)](https://github.com/kubestellar/kubeflex)
+
+
+
+###  Step-by-Step Windows Installation
+
+### Invoke-WebRequest -> This is a built-in PowerShell command used to download files or access web pages. It's similar to curl or wget in Linux/macOS
+
+### -Uri -> This specifies the URL you want to request/download from
+
+### -OutFile -> This specifies where to save the downloaded file on your computer
+
+### "$env:USERPROFILE\kind.exe"  -> This uses an environment variable $env:USERPROFILE to refer to your Windows user folder (like C:\Users\YourName), and saves the file there as kind.exe
+
+
+
+#### 1. Install kubectl
+
+```powershell
+Invoke-WebRequest -Uri "https://dl.k8s.io/release/v1.32.2/bin/windows/amd64/kubectl.exe" -OutFile "$env:USERPROFILE\kubectl.exe"
+```
+
+* Add to `PATH`:
+
+  * Press `Win + R` → `SystemPropertiesAdvanced` → Environment Variables
+  * Add: `C:\Users\<YourUsername>\` to `Path`
+
+* Test:
+```powershell
+kubectl version --client
+```
+
+---
+
+#### 2. Install kind
+
+```powershell
+Invoke-WebRequest -Uri https://kind.sigs.k8s.io/dl/v0.22.0/kind-windows-amd64 -OutFile "$env:USERPROFILE\kind.exe"
+```
+
+* Rename and move (optional):
+
+```powershell
+Rename-Item "$env:USERPROFILE\kind.exe" "kind.exe"
+Move-Item "$env:USERPROFILE\kind.exe" "C:\Program Files\kind.exe"
+```
+
+* Add to PATH or run directly from folder
+
+* Test:
+```powershell
+kind version
+```
+
+---
+
+#### 3. Install Helm
+
+```powershell
+Invoke-WebRequest -Uri https://get.helm.sh/helm-v3.14.0-windows-amd64.zip -OutFile helm.zip
+Expand-Archive .\helm.zip -DestinationPath .\
+Move-Item .\windows-amd64\helm.exe "$env:USERPROFILE\helm.exe"
+```
+
+* Add to PATH and test:
+
+```powershell
+helm version
+```
+
+---
+
+#### 4. Install `clusteradm` (OCM CLI)
+
+```powershell
+Invoke-WebRequest -Uri https://github.com/open-cluster-management-io/clusteradm/releases/download/v0.10.1/clusteradm-windows-amd64.exe -OutFile "$env:USERPROFILE\clusteradm.exe"
+```
+
+* Add to PATH and test:
+
+```powershell
+clusteradm version
+```
+
+---
+
+#### 5. Install `kflex` (kubeflex CLI)
+
+```powershell
+Invoke-WebRequest -Uri https://github.com/kubestellar/kubeflex/releases/download/v0.8.9/kflex-windows-amd64.exe -OutFile "$env:USERPROFILE\kflex.exe"
+```
+
+* Rename to `kflex.exe`, add to PATH and test:
+
+```powershell
+kflex version
+```
+
+---
+
+###  Final Sanity Check
+
+You can verify all prerequisites using:
+
+```powershell
+curl -s https://raw.githubusercontent.com/kubestellar/kubestellar/main/scripts/check_pre_req.sh | bash
+```
+
+ This one still needs **Git Bash or WSL** due to Unix-style shebangs. You can skip this if you’ve manually confirmed all binaries.
+
+
+
+### Optional: Create a kind cluster
+
+```powershell
+kind create cluster --name kubestellar
+kubectl cluster-info --context kind-kubestellar
+```
+---


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:
Add Windows setup instructions

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
📖 Adds Windows-native setup instructions to the documentation for users who cannot use WSL, as described in #2304.

This includes:
- Using PowerShell and CMD to install prerequisites
- Docker Desktop notes
- Instructions for `kubectl`, `kind`, and `kflex`

## Related issue(s)

Fixes #2304
