### PR TITLE
🐛  bug: fixed insufficient default rbac for syncing cluster scoped resources 

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -29,3 +29,15 @@ rules:
   - get
   - patch
   - update
+- apiGroups:
+  - "storage.k8s.io"
+  resources:
+  - storageclasses
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete

--- a/config/rbac/role_binding.yaml
+++ b/config/rbac/role_binding.yaml
@@ -15,5 +15,5 @@ roleRef:
   name: manager-role
 subjects:
 - kind: ServiceAccount
-  name: default
+  name: controller-manager
   namespace: '{{"{{.Namespace}}"}}'


### PR DESCRIPTION

<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

- Updated manager-role `ClusterRole` to grant full access to `storageclasses` in the `storage.k8s.io API group`.
- Updated the `ClusterRoleBinding` to bind manager-role to the controller-manager service account (not default).

The root cause for this issue according to me was missing RBAC rules for cluster-scoped resources. The solution was to update the ClusterRole to include those resources and ensure the correct service account is bound to that role, so the controller/agent can manage cluster-scoped resources like StorageClass without manual RBAC intervention.


## Related issue(s)

Fixes #2947 
