### PR TITLE
🐛 bug: unable to downsync storage class objects to a WEC #2915

### DIFF
--- a/docs/content/direct/known-issues.md
+++ b/docs/content/direct/known-issues.md
@@ -27,3 +27,12 @@ This can arise when using `kind` inside a virtual machine (e.g., when using Dock
 ## Insufficient CPU for your clusters
 
 This can happen when you are using a docker-in-docker technique. The symptom is that setup stops making progress at some point. See [Insufficient CPU for your clusters](knownissue-cpu-insufficient-fort-its1.md)
+
+## StorageClass resources fail to sync to WEC clusters
+
+The symptom is StorageClass resources defined in a KubeStellar WDS failing to sync to Workload Edge Clusters (WECs) with an error like:
+```
+Failed to apply manifest: storageclasses.storage.k8s.io "local-storage" is forbidden: User "system:serviceaccount:open-cluster-management-agent:klusterlet-work-sa" cannot get resource "storageclasses" in API group "storage.k8s.io" at the cluster scope
+```
+
+This happens because the OCM agent service account (`klusterlet-work-sa`) doesn't have permission to manage StorageClass resources by default. See [StorageClass Permissions Issue](knownissue-storage-class-permissions.md) for details and solution.

--- a/docs/content/direct/knownissue-storage-class-permissions.md
+++ b/docs/content/direct/knownissue-storage-class-permissions.md
@@ -1,0 +1,56 @@
+# StorageClass Permissions Issue in WEC Clusters
+
+## Issue
+
+When attempting to deploy cluster-scoped resources like `StorageClass` objects from a WDS to a Workload Edge Cluster (WEC), the synchronization fails with permission errors like:
+
+```yaml
+Failed to apply manifest: storageclasses.storage.k8s.io "local-storage" is forbidden: User "system:serviceaccount:open-cluster-management-agent:klusterlet-work-sa" cannot get resource "storageclasses" in API group "storage.k8s.io" at the cluster scope
+```
+
+## Root Cause
+
+In the Open Cluster Management (OCM) setup that KubeStellar uses for resource distribution, the agent running on each managed cluster (WEC) uses a service account called `klusterlet-work-sa` in the `open-cluster-management-agent` namespace. By default, this service account doesn't have sufficient RBAC permissions to interact with certain cluster-scoped resources, including `StorageClass`.
+
+## Solution
+
+You need to apply additional RBAC permissions to grant the `klusterlet-work-sa` service account access to manage `StorageClass` resources. We provide a helper script that applies these permissions:
+
+```bash
+# Apply to a specific WEC cluster context
+scripts/apply-ocm-storage-permissions.sh --context <your-wec-context>
+```
+
+If you're setting up a new environment using the standard setup script, these permissions are now applied automatically.
+
+## Manual Fix
+
+If you prefer to apply the permissions manually or want to understand what's being done, here are the RBAC resources that need to be applied to each WEC:
+
+```yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: klusterlet-work-sa-storage
+rules:
+- apiGroups: ["storage.k8s.io"]
+  resources: ["storageclasses"]
+  verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: klusterlet-work-sa-storage
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: klusterlet-work-sa-storage
+subjects:
+- kind: ServiceAccount
+  name: klusterlet-work-sa
+  namespace: open-cluster-management-agent
+```
+
+## Other Cluster-Scoped Resources
+
+If you encounter similar permission issues with other cluster-scoped resources, you may need to expand the ClusterRole to include those resource types. The same pattern applies - add the relevant API group and resources to the ClusterRole's rules section.

--- a/scripts/apply-ocm-storage-permission.sh
+++ b/scripts/apply-ocm-storage-permission.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+# Copyright 2024 The KubeStellar Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This script applies the necessary RBAC permissions to enable StorageClass management
+# by the OCM klusterlet-work-sa service account in a WEC cluster.
+
+set -e
+
+# Default to no specific context
+CONTEXT=""
+
+function print_usage() {
+  echo "Usage: $0 [--context CLUSTER_CONTEXT]"
+  echo "Apply OCM storage permissions to enable StorageClass management in WECs"
+  echo ""
+  echo "Options:"
+  echo "  --context CLUSTER_CONTEXT  Kubernetes context to apply permissions to"
+  echo "  -h, --help                 Display this help message"
+}
+
+# Parse command line arguments
+while [[ $# -gt 0 ]]; do
+  key="$1"
+  case $key in
+    --context)
+      CONTEXT="$2"
+      shift
+      shift
+      ;;
+    -h|--help)
+      print_usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown option: $1"
+      print_usage
+      exit 1
+      ;;
+  esac
+done
+
+CONTEXT_ARG=""
+if [[ -n "${CONTEXT}" ]]; then
+  CONTEXT_ARG="--context ${CONTEXT}"
+  echo "Applying permissions to context: ${CONTEXT}"
+fi
+
+# Apply the ClusterRole and ClusterRoleBinding
+kubectl ${CONTEXT_ARG} apply -f - <<EOF
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: klusterlet-work-sa-storage
+rules:
+- apiGroups: ["storage.k8s.io"]
+  resources: ["storageclasses"]
+  verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: klusterlet-work-sa-storage
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: klusterlet-work-sa-storage
+subjects:
+- kind: ServiceAccount
+  name: klusterlet-work-sa
+  namespace: open-cluster-management-agent
+EOF
+
+echo "Successfully applied StorageClass permissions for klusterlet-work-sa"

--- a/test/e2e/common/setup-kubestellar.sh
+++ b/test/e2e/common/setup-kubestellar.sh
@@ -181,6 +181,10 @@ kubectl --context its1 create cm -n customization-properties cluster1 --from-lit
 kubectl --context its1 label managedcluster cluster2 location-group=edge name=cluster2 region=west
 kubectl --context its1 create cm -n customization-properties cluster2 --from-literal clusterURL=https://my.clusters/2002-cdef
 
+# Apply necessary storage permissions to WECs to enable StorageClass management
+"${SRC_DIR}/../../../scripts/apply-ocm-storage-permission.sh" --context cluster1
+"${SRC_DIR}/../../../scripts/apply-ocm-storage-permission.sh" --context cluster2
+
 :
 : -------------------------------------------------------------------------
 : Get all deployments and statefulsets running in the hosting cluster.


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

The fix addresses the root cause by granting the `klusterlet-work-sa` service account the necessary permissions to manage `StorageClass` resources in the `WEC clusters`. The permissions are granted through a `ClusterRole` and `ClusterRoleBinding` that specifically target S`torageClass` resources in the `storage.k8s.io API` group. 

This fix properly resolves issue #2915 and ensures that StorageClass resources can be successfully synced from a WDS to WEC clusters.

More has been discussed in the attached issue discussion which I have added in this PR as well. 

## Related issue(s)

Fixes #2915
