### PR TITLE
🌱  Bump anchore/sbom-action/download-syft to 0.20.0

### DIFF
--- a/.gha-reversemap.yml
+++ b/.gha-reversemap.yml
@@ -34,10 +34,10 @@ actions/setup-go:
   tag: v5
   tag-url: https://github.com/actions/setup-go/tree/v5
 anchore/sbom-action/download-syft:
-  sha: 9f7302141466aa6482940f15371237e9d9f4c34a
-  sha-url: https://github.com/anchore/sbom-action/commit/9f7302141466aa6482940f15371237e9d9f4c34a
-  tag: v0.19.0
-  tag-url: https://github.com/anchore/sbom-action/tree/v0.19.0
+  sha: e11c554f704a0b820cbf8c51673f6945e0731532
+  sha-url: https://github.com/anchore/sbom-action/commit/e11c554f704a0b820cbf8c51673f6945e0731532
+  tag: v0.20.0
+  tag-url: https://github.com/anchore/sbom-action/tree/v0.20.0
 goreleaser/goreleaser-action:
   sha: 9c156ee8a17a598857849441385a2041ef570552
   sha-url: https://github.com/goreleaser/goreleaser-action/commit/9c156ee8a17a598857849441385a2041ef570552

--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -33,7 +33,7 @@ jobs:
       run: echo LDFLAGS="$(make ldflags)" >> $GITHUB_ENV
 
     - name: Install syft binary executable
-      uses: anchore/sbom-action/download-syft@9f7302141466aa6482940f15371237e9d9f4c34a 
+      uses: anchore/sbom-action/download-syft@e11c554f704a0b820cbf8c51673f6945e0731532 
 
     - name: Run GoReleaser on tag
       uses: goreleaser/goreleaser-action@9c156ee8a17a598857849441385a2041ef570552 


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
This PR bumps the workflow dependency on Action anchore/sbom-action/download-syft from release 0.19.0 to 0.20.0.

## Related issue(s)

Fixes #
