### PR TITLE
🐛bug: improve e2e ginkgo test logging for setup debugging

### DIFF
--- a/test/util/util.go
+++ b/test/util/util.go
@@ -17,7 +17,6 @@ limitations under the License.
 package util
 
 import (
-	"bytes"
 	"context"
 	goerrors "errors"
 	"fmt"
@@ -112,21 +111,15 @@ func CreateNS(ctx context.Context, client *kubernetes.Clientset, name string) {
 
 func Cleanup(ctx context.Context) {
 	ginkgo.GinkgoHelper()
-	var e, o bytes.Buffer
 	cmd := exec.CommandContext(ctx, "../common/cleanup.sh")
-	cmd.Stderr = &e
-	cmd.Stdout = &o
+	cmd.Stderr = ginkgo.GinkgoWriter
+	cmd.Stdout = ginkgo.GinkgoWriter
 	err := cmd.Run()
-	if err != nil {
-		fmt.Fprintf(ginkgo.GinkgoWriter, "%s", o.String())
-		fmt.Fprintf(ginkgo.GinkgoWriter, "%s", e.String())
-	}
 	gomega.Expect(err).To(gomega.Succeed())
 }
 
 func SetupKubestellar(ctx context.Context, releasedFlag bool, otherFlags ...string) {
 	ginkgo.GinkgoHelper()
-	var e, o bytes.Buffer
 	var args []string
 	if releasedFlag {
 		args = []string{"--released"}
@@ -135,13 +128,9 @@ func SetupKubestellar(ctx context.Context, releasedFlag bool, otherFlags ...stri
 	commandName := "../common/setup-kubestellar.sh"
 	ginkgo.By(fmt.Sprintf("Execing command %#v", append([]string{commandName}, args...)))
 	cmd := exec.CommandContext(ctx, commandName, args...)
-	cmd.Stderr = &e
-	cmd.Stdout = &o
+	cmd.Stderr = ginkgo.GinkgoWriter
+	cmd.Stdout = ginkgo.GinkgoWriter
 	err := cmd.Run()
-	if err != nil {
-		fmt.Fprintf(ginkgo.GinkgoWriter, "%s", o.String())
-		fmt.Fprintf(ginkgo.GinkgoWriter, "%s", e.String())
-	}
 	gomega.Expect(err).To(gomega.Succeed())
 }
 


### PR DESCRIPTION
## Summary
Improve E2E test logging to show detailed output during setup failures.

## Problem
The Ginkgo E2E tests were failing with timeouts but provided no indication of where in the `setup-kubestellar.sh` script the timeout occurred, making debugging very difficult.

## Solution
Modified `test/util/util.go` to stream output from the setup script in real-time, providing complete visibility into the setup process and exact failure points.

## Changes
- Updated `SetupKubestellar()` function to show live output from `setup-kubestellar.sh`
- Now displays detailed kind cluster creation, kubeadm init process, and API server startup logs
- Enables precise identification of where setup failures occur

Fixes #2200