### PR TITLE
🌱 other/misc: add log for better understanding of docker context error!

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -179,17 +179,23 @@ run: manifests generate fmt vet ## Run a controller from your host.
 
 .PHONY: ko-build-controller-manager-local
 ko-build-controller-manager-local: ## Build local controller manager container image with ko
-	$(shell (docker version | { ! grep -qi podman; } ) || echo "DOCKER_HOST=unix://$$HOME/.local/share/containers/podman/machine/qemu/podman.sock ") KO_DOCKER_REPO=ko.local ko build -B ./cmd/${CONTROLLER_MANAGER_CMD_NAME} -t ${IMAGE_TAG} --platform linux/${ARCH}
-	@if docker image inspect ko.local/${CONTROLLER_MANAGER_CMD_NAME}:${IMAGE_TAG} > /dev/null 2>&1; then \
-		docker tag ko.local/${CONTROLLER_MANAGER_CMD_NAME}:${IMAGE_TAG} ${CONTROLLER_MANAGER_IMAGE}; \
-	else \
-		echo "[WARN] Failed to tag image. This might be due to a Docker context mismatch or missing tag '${IMAGE_TAG}'. Try setting: export DOCKER_HOST=unix:///home/$(shell whoami)/.docker/desktop/docker.sock"; \
+	@if ! docker images &> /dev/null; then \
+		echo "Error: docker command is not working. Please ensure you have a working docker setup."; \
+		echo "For podman users, you may need to set up docker compatibility or configure DOCKER_HOST."; \
+		exit 1; \
 	fi
+	KO_DOCKER_REPO=ko.local ko build -B ./cmd/${CONTROLLER_MANAGER_CMD_NAME} -t ${IMAGE_TAG} --platform linux/${ARCH}
+	docker tag ko.local/${CONTROLLER_MANAGER_CMD_NAME}:${IMAGE_TAG} ${CONTROLLER_MANAGER_IMAGE}
 
 
 .PHONY: ko-build-transport-local
 ko-build-transport-local: ## Build local transport container image with `ko`.
-	$(shell (docker version | { ! grep -qi podman; } ) || echo "DOCKER_HOST=unix://$$HOME/.local/share/containers/podman/machine/qemu/podman.sock ") KO_DOCKER_REPO=ko.local ko build -B ./pkg/transport/${TRANSPORT_CMD_NAME} -t ${IMAGE_TAG} --platform linux/${ARCH}
+	@if ! docker images &> /dev/null; then \
+		echo "Error: docker command is not working. Please ensure you have a working docker setup."; \
+		echo "For podman users, you may need to set up docker compatibility or configure DOCKER_HOST."; \
+		exit 1; \
+	fi
+	KO_DOCKER_REPO=ko.local ko build -B ./pkg/transport/${TRANSPORT_CMD_NAME} -t ${IMAGE_TAG} --platform linux/${ARCH}
 	docker tag ko.local/${TRANSPORT_CMD_NAME}:${IMAGE_TAG} ${TRANSPORT_IMAGE}
 
 # this is used for local testing

--- a/Makefile
+++ b/Makefile
@@ -178,12 +178,35 @@ run: manifests generate fmt vet ## Run a controller from your host.
 	go run ./cmd/controller-manager/main.go $(ARGS)
 
 .PHONY: ko-build-controller-manager-local
-ko-build-controller-manager-local:
-	@KO_DOCKER_REPO=ko.local ko build -B ./cmd/${CONTROLLER_MANAGER_CMD_NAME} -t ${IMAGE_TAG} --platform linux/${ARCH}
+ko-build-controller-manager-local: ## Build local controller manager container image with ko
+	@echo "Building controller manager image..."
+	@# Try standard ko build first (case 1: simple Docker setup)
+	@if KO_DOCKER_REPO=ko.local ko build -B ./cmd/${CONTROLLER_MANAGER_CMD_NAME} -t ${IMAGE_TAG} --platform linux/${ARCH} > /dev/null 2>&1; then \
+		echo "Build successful with standard Docker setup"; \
+	elif docker version 2>/dev/null | grep -qi podman; then \
+		echo "Podman detected, retrying with Podman socket..."; \
+		if DOCKER_HOST=unix://$$HOME/.local/share/containers/podman/machine/qemu/podman.sock KO_DOCKER_REPO=ko.local ko build -B ./cmd/${CONTROLLER_MANAGER_CMD_NAME} -t ${IMAGE_TAG} --platform linux/${ARCH} > /dev/null 2>&1; then \
+			echo "Build successful with Podman setup"; \
+		else \
+			echo "[ERROR] Ko build failed even with Podman configuration"; \
+			exit 1; \
+		fi; \
+	else \
+		echo "[ERROR] Ko build failed with standard Docker setup"; \
+		echo "[WARN] This might be due to a Docker context mismatch. Try one of:"; \
+		echo "  - export DOCKER_HOST=unix:///home/$$(whoami)/.docker/desktop/docker.sock"; \
+		echo "  - docker context list (to see available contexts)"; \
+		echo "  - docker context use <context-name>"; \
+		exit 1; \
+	fi
+	@# Tag the image if it exists
 	@if docker image inspect ko.local/${CONTROLLER_MANAGER_CMD_NAME}:${IMAGE_TAG} > /dev/null 2>&1; then \
 		docker tag ko.local/${CONTROLLER_MANAGER_CMD_NAME}:${IMAGE_TAG} ${CONTROLLER_MANAGER_IMAGE}; \
+		echo "Successfully tagged image as ${CONTROLLER_MANAGER_IMAGE}"; \
 	else \
-		echo "[WARN] Failed to tag image. This might be due to a Docker context mismatch or missing tag '${IMAGE_TAG}'. Try setting: export DOCKER_HOST=unix:///home/$(shell whoami)/.docker/desktop/docker.sock"; \
+		echo "[WARN] Built image not found for tagging. Image may have been created with different tag."; \
+		echo "Available images:"; \
+		docker images | grep -E "(ko\.local|${CONTROLLER_MANAGER_CMD_NAME})" || echo "No matching images found"; \
 	fi
 
 

--- a/Makefile
+++ b/Makefile
@@ -180,7 +180,8 @@ run: manifests generate fmt vet ## Run a controller from your host.
 .PHONY: ko-build-controller-manager-local
 ko-build-controller-manager-local: ## Build local controller manager container image with ko
 	$(shell (docker version | { ! grep -qi podman; } ) || echo "DOCKER_HOST=unix://$$HOME/.local/share/containers/podman/machine/qemu/podman.sock ") KO_DOCKER_REPO=ko.local ko build -B ./cmd/${CONTROLLER_MANAGER_CMD_NAME} -t ${IMAGE_TAG} --platform linux/${ARCH}
-	docker tag ko.local/${CONTROLLER_MANAGER_CMD_NAME}:${IMAGE_TAG} ${CONTROLLER_MANAGER_IMAGE}
+	docker tag ko.local/${CONTROLLER_MANAGER_CMD_NAME}:${IMAGE_TAG} ${CONTROLLER_MANAGER_IMAGE} || \
+ 		echo "[WARN] Failed to tag image. This might be due to a Docker context mismatch or missing tag '${IMAGE_TAG}'. Try setting: export DOCKER_HOST=unix:///home/$(shell whoami)/.docker/desktop/docker.sock"
 
 .PHONY: ko-build-transport-local
 ko-build-transport-local: ## Build local transport container image with `ko`.

--- a/Makefile
+++ b/Makefile
@@ -178,10 +178,14 @@ run: manifests generate fmt vet ## Run a controller from your host.
 	go run ./cmd/controller-manager/main.go $(ARGS)
 
 .PHONY: ko-build-controller-manager-local
-ko-build-controller-manager-local: ## Build local controller manager container image with ko
-	$(shell (docker version | { ! grep -qi podman; } ) || echo "DOCKER_HOST=unix://$$HOME/.local/share/containers/podman/machine/qemu/podman.sock ") KO_DOCKER_REPO=ko.local ko build -B ./cmd/${CONTROLLER_MANAGER_CMD_NAME} -t ${IMAGE_TAG} --platform linux/${ARCH}
-	docker tag ko.local/${CONTROLLER_MANAGER_CMD_NAME}:${IMAGE_TAG} ${CONTROLLER_MANAGER_IMAGE} || \
- 		echo "[WARN] Failed to tag image. This might be due to a Docker context mismatch or missing tag '${IMAGE_TAG}'. Try setting: export DOCKER_HOST=unix:///home/$(shell whoami)/.docker/desktop/docker.sock"
+ko-build-controller-manager-local:
+	@KO_DOCKER_REPO=ko.local ko build -B ./cmd/${CONTROLLER_MANAGER_CMD_NAME} -t ${IMAGE_TAG} --platform linux/${ARCH}
+	@if docker image inspect ko.local/${CONTROLLER_MANAGER_CMD_NAME}:${IMAGE_TAG} > /dev/null 2>&1; then \
+		docker tag ko.local/${CONTROLLER_MANAGER_CMD_NAME}:${IMAGE_TAG} ${CONTROLLER_MANAGER_IMAGE}; \
+	else \
+		echo "[WARN] Failed to tag image. This might be due to a Docker context mismatch or missing tag '${IMAGE_TAG}'. Try setting: export DOCKER_HOST=unix:///home/$(shell whoami)/.docker/desktop/docker.sock"; \
+	fi
+
 
 .PHONY: ko-build-transport-local
 ko-build-transport-local: ## Build local transport container image with `ko`.


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
```
KO_DOCKER_REPO=ko.local ko build -B ./cmd/controller-manager -t c0f945577 --platform linux/amd64
2025/06/13 12:15:21 Using base cgr.dev/chainguard/static:latest@sha256:797e62f43d04d792e9f930913e7d9f5a63e92bd19ca5e7e5139a692decee2dbc for github.com/kubestellar/kubestellar/cmd/controller-manager
2025/06/13 12:15:22 Building github.com/kubestellar/kubestellar/cmd/controller-manager for linux/amd64
2025/06/13 12:15:45 Loading ko.local/controller-manager:35529aa9721bd8be3f09f3daaa2d6185ef93d83b71190e9432d5de1ef31d4ef3
2025/06/13 12:15:46 Loaded ko.local/controller-manager:35529aa9721bd8be3f09f3daaa2d6185ef93d83b71190e9432d5de1ef31d4ef3
2025/06/13 12:15:46 Adding tag c0f945577
2025/06/13 12:15:46 Added tag c0f945577
ko.local/controller-manager:35529aa9721bd8be3f09f3daaa2d6185ef93d83b71190e9432d5de1ef31d4ef3
docker tag ko.local/controller-manager:c0f945577 ghcr.io/kubestellar/kubestellar/controller-manager:c0f945577
Error response from daemon: No such image: ko.local/controller-manager:c0f945577
make: *** [Makefile:183: ko-build-controller-manager-local] Error 1

```

this error is not common and not every one face so, i have added a log if any one face that understand the error and solve that !
## Related issue(s)

Fixes #
