### PR TITLE
✨  Update self-references for regular release 0.28.0

### DIFF
--- a/core-chart/values.yaml
+++ b/core-chart/values.yaml
@@ -7,7 +7,7 @@
 # please do not change them unless you know what you are doing.
 HELM_VERSION: "3.16.4"
 KUBECTL_VERSION: "1.30.12"
-KUBESTELLAR_VERSION: "0.28.0-rc.1"
+KUBESTELLAR_VERSION: "0.28.0"
 # TRANSPORT_VERSION: e.g., "0.24.0"; defaults to KUBESTELLAR_VERSION value, if not defined
 CLUSTERADM_VERSION: "0.10.1"
 OCM_STATUS_ADDON_VERSION: "0.2.0-rc15"

--- a/docs/content/direct/release-notes.md
+++ b/docs/content/direct/release-notes.md
@@ -4,6 +4,13 @@ The following sections list the known issues for each release. The issue list is
 
 ## 0.28.0
 
+Helm chart, the name of the subobject for ArgoCD has changed from
+`argo-cd` to `argocd`.
+
+There have been minor fixups, including to the website.
+
+We have advanced the version of the kube-rbac-proxy image used, from 0.18.0 (which is based on Kubernetes 1.30) to 0.19.1 (which is based on Kubernetes 1.31). Depending on a later minor release of Kubernetes is generally risky, but expected to work OK in this case.
+
 ### 0.28.0-rc.1
 
 There is one breaking change for users: in the "values" for the core

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -13,8 +13,8 @@ repo_raw_url: https://raw.githubusercontent.com/kubestellar/kubestellar
 edit_uri: edit/main/docs/content
 ks_branch: 'main'
 ks_tag: 'latest'
-ks_latest_regular_release: '0.27.2'
-ks_latest_release: '0.28.0-rc.1'
+ks_latest_regular_release: '0.28.0'
+ks_latest_release: '0.28.0'
 
 ks_kind_port_num: '1119'
 

--- a/scripts/check_pre_req.sh
+++ b/scripts/check_pre_req.sh
@@ -17,7 +17,7 @@
 # NOTE WELL: Two copies of this file exist, one in kubestellar/hack/
 # and one in kubestellar/scripts/ . Keep them both up-to-date.
 BASE_URL="https://docs.kubestellar.io"
-VERSION="release-0.28.0-rc.1"
+VERSION="release-0.28.0"
 INSTALLATION_ERROR_URL="${BASE_URL}/${VERSION}/direct/installation-errors#pod-errors-due-to-too-many-open-files"
 
 set -e # exit on error

--- a/scripts/create-kubestellar-demo-env.sh
+++ b/scripts/create-kubestellar-demo-env.sh
@@ -68,7 +68,7 @@ if ! dunsel=$(docker ps 2>&1); then
 fi
 echo "Container runtime is running."
 
-kubestellar_version=0.28.0-rc.1
+kubestellar_version=0.28.0
 echo -e "KubeStellar Version: ${kubestellar_version}"
 
 echo -e "Checking that pre-req softwares are installed..."


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
This PR updates the self-references in preparation for release 0.28.0.

## Related issue(s)

Fixes #


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated release notes to reflect changes in version 0.28.0, including Helm chart naming, minor fixes, website updates, and kube-rbac-proxy image version upgrade.
  - Updated documentation configuration to reference the latest stable release.

- **Chores**
  - Updated version references from "0.28.0-rc.1" (release candidate) to "0.28.0" (stable release) across configuration files and scripts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->