### PR TITLE
🐛bug: fix controller-runtime logging warnings in transport unit tests

### DIFF
--- a/pkg/transport/generic/generic_transport_controller_test.go
+++ b/pkg/transport/generic/generic_transport_controller_test.go
@@ -46,7 +46,9 @@ import (
 	"k8s.io/component-base/metrics/legacyregistry"
 	"k8s.io/klog/v2"
 	"k8s.io/klog/v2/ktesting"
+	ctrl "sigs.k8s.io/controller-runtime"
 
+	"github.com/go-logr/logr"
 	ksapi "github.com/kubestellar/kubestellar/api/control/v1alpha1"
 	ksclientfake "github.com/kubestellar/kubestellar/pkg/generated/clientset/versioned/fake"
 	ksinformers "github.com/kubestellar/kubestellar/pkg/generated/informers/externalversions"
@@ -57,6 +59,8 @@ import (
 
 func TestMain(m *testing.M) {
 	klog.InitFlags(nil)
+	// Use a no-op logr logger to satisfy controller-runtime
+	ctrl.SetLogger(logr.Discard())
 	os.Exit(m.Run())
 }
 


### PR DESCRIPTION
### Summary
Fix unwanted controller-runtime logging warnings that appear when debugging transport package unit tests in VSCode.

### Problem
When debugging unit tests for `pkg/transport` (which doesn't intend to use controller-runtime), VSCode's debugger was triggering controller-runtime initialization producing the warning.

### Solution
Added controller-runtime logger initialization in the test's `TestMain` function to satisfy the logging system requirements and prevent unwanted warnings.

### Changes
- Added `ctrl.SetLogger(logr.Discard())` in `TestMain()` function of `generic_transport_controller_test.go`
- Imported necessary controller-runtime packages (`ctrl` and `logr`)
- Used a no-op logger (`logr.Discard()`) to satisfy controller-runtime without producing actual log output
- Maintains clean test output while preventing initialization warnings

### Testing
- Verified that tests pass normally without warnings
- Confirmed that VSCode debugging no longer produces controller-runtime logging complaints
- Ensured no impact on actual test functionality or performance

This fix ensures that the transport package unit tests can be debugged cleanly without irrelevant controller-runtime logging noise, while maintaining the intended separation between transport logic and controller-runtime dependencies.

Fixes #2193