### PR TITLE
✨  Improve action hash script and bump two actions

### DIFF
--- a/.gha-reversemap.yml
+++ b/.gha-reversemap.yml
@@ -34,10 +34,10 @@ actions/setup-go:
   tag: v5
   tag-url: https://github.com/actions/setup-go/tree/v5
 anchore/sbom-action/download-syft:
-  sha: e11c554f704a0b820cbf8c51673f6945e0731532
-  sha-url: https://github.com/anchore/sbom-action/commit/e11c554f704a0b820cbf8c51673f6945e0731532
-  tag: v0.20.0
-  tag-url: https://github.com/anchore/sbom-action/tree/v0.20.0
+  sha: 9246b90769f852b3a8921f330c59e0b3f439d6e9
+  sha-url: https://github.com/anchore/sbom-action/commit/9246b90769f852b3a8921f330c59e0b3f439d6e9
+  tag: v0.20.1
+  tag-url: https://github.com/anchore/sbom-action/tree/v0.20.1
 goreleaser/goreleaser-action:
   sha: 9c156ee8a17a598857849441385a2041ef570552
   sha-url: https://github.com/goreleaser/goreleaser-action/commit/9c156ee8a17a598857849441385a2041ef570552
@@ -74,10 +74,10 @@ technote-space/assign-author:
   tag: v1.6.2
   tag-url: https://github.com/technote-space/assign-author/tree/v1.6.2
 rojopolis/spellcheck-github-actions:
-  sha: 584b2ae95998967a53af7fbfb7f5b15352c38748
-  sha-url: https://github.com/rojopolis/spellcheck-github-actions/commit/584b2ae95998967a53af7fbfb7f5b15352c38748
-  tag: 0.49.0
-  tag-url: https://github.com/rojopolis/spellcheck-github-actions/tree/0.49.0
+  sha: 63aba9473ee34d681dd48dee26b3d43ea0bbc462
+  sha-url: https://github.com/rojopolis/spellcheck-github-actions/commit/63aba9473ee34d681dd48dee26b3d43ea0bbc462
+  tag: 0.50.0
+  tag-url: https://github.com/rojopolis/spellcheck-github-actions/tree/0.50.0
 actions/upload-artifact:
   sha: ea165f8d65b6e75b540449e92b4886f43607fa02
   sha-url: https://github.com/actions/upload-artifact/commit/ea165f8d65b6e75b540449e92b4886f43607fa02

--- a/.github/workflows/add-to-project.yml
+++ b/.github/workflows/add-to-project.yml
@@ -19,7 +19,7 @@ jobs:
         id: date
         run: echo "date=$(date +'%Y-%m-%d')" >> $GITHUB_OUTPUT
         
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
         with:
           token: ${{ secrets.GH_ALL_PROJECT_TOKEN }}
           persist-credentials: 'false'
@@ -30,7 +30,7 @@ jobs:
           github-token: ${{ secrets.GH_ALL_PROJECT_TOKEN }}
         id: add-project
       
-      - uses: titoportas/update-project-fields@421a54430b3cdc9eefd8f14f9ce0142ab7678751 
+      - uses: titoportas/update-project-fields@421a54430b3cdc9eefd8f14f9ce0142ab7678751
         with:
           project-url: https://github.com/orgs/kubestellar/projects/5
           github-token: ${{ secrets.GH_ALL_PROJECT_TOKEN }}

--- a/.github/workflows/broken-links-crawler.yml
+++ b/.github/workflows/broken-links-crawler.yml
@@ -68,7 +68,7 @@ jobs:
             echo workflow_dispatch - running on version ${{ steps.extract_branch.outputs.version }}
         if: github.event_name != 'pull_request' && github.event_name != 'push'
 
-      - uses: ScholliYT/Broken-Links-Crawler-Action@b3fb123879e5a6a854d6fda5c33df2d94d41092c 
+      - uses: ScholliYT/Broken-Links-Crawler-Action@b3fb123879e5a6a854d6fda5c33df2d94d41092c
         with:
           website_url: https://${{ steps.extract_branch.outputs.site }}/${{ steps.extract_branch.outputs.version }}
           include_url_prefix: https://${{ steps.extract_branch.outputs.site }}/${{ steps.extract_branch.outputs.version }}
@@ -86,7 +86,7 @@ jobs:
         if: github.event_name == 'pull_request' 
 #         $GITHUB_BASE_REF
 
-      - uses: ScholliYT/Broken-Links-Crawler-Action@b3fb123879e5a6a854d6fda5c33df2d94d41092c 
+      - uses: ScholliYT/Broken-Links-Crawler-Action@b3fb123879e5a6a854d6fda5c33df2d94d41092c
         with:
           website_url: https://docs.kubestellar.io/${{ github.event.pull_request.base.ref }}
           include_url_prefix: https://docs.kubestellar.io/${{ github.event.pull_request.base.ref }}
@@ -103,7 +103,7 @@ jobs:
         run: echo push - running on branch ${{ github.event.push.base.ref }}
         if: github.event_name == 'push' 
 
-      - uses: ScholliYT/Broken-Links-Crawler-Action@b3fb123879e5a6a854d6fda5c33df2d94d41092c 
+      - uses: ScholliYT/Broken-Links-Crawler-Action@b3fb123879e5a6a854d6fda5c33df2d94d41092c
         with:
           website_url: https://docs.kubestellar.io/${{ github.event.push.base.ref }}
           include_url_prefix: https://docs.kubestellar.io/${{ github.event.push.base.ref }}

--- a/.github/workflows/create-our-meeting-bi-weekly.yml
+++ b/.github/workflows/create-our-meeting-bi-weekly.yml
@@ -24,12 +24,12 @@ jobs:
             echo "run_workflow=false" >> $GITHUB_OUTPUT
           fi
           
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
         with:
           token: ${{ secrets.GH_ALL_PROJECT_TOKEN }}
           persist-credentials: 'false'
           
-      - uses: JasonEtco/create-an-issue@1b14a70e4d8dc185e5cc76d3bec9eab20257b2c5 
+      - uses: JasonEtco/create-an-issue@1b14a70e4d8dc185e5cc76d3bec9eab20257b2c5
         if: steps.check_condition.outputs.run_workflow == 'true'
         env:
           GITHUB_TOKEN: ${{ secrets.GH_ALL_PROJECT_TOKEN }}

--- a/.github/workflows/docs-gen-and-push.yml
+++ b/.github/workflows/docs-gen-and-push.yml
@@ -42,14 +42,14 @@ jobs:
     name: Generate and push docs
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
         with:
           token: ${{ github.repository_owner == 'kubestellar' && secrets.GH_ALL_PROJECT_TOKEN || github.token }}
           persist-credentials: 'true'
   
       - run: git fetch origin gh-pages
 
-      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
         with:
           python-version: '3.10'
           cache: 'pip'

--- a/.github/workflows/elapsed-time-collector.yml
+++ b/.github/workflows/elapsed-time-collector.yml
@@ -45,7 +45,7 @@ jobs:
       - run: echo "${{ github.event_name }}"
         
       - name: echo fetching push or pull_request branch
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
         with:
           token: ${{ secrets.GH_ALL_PROJECT_TOKEN }}
           persist-credentials: 'false'
@@ -54,7 +54,7 @@ jobs:
     #     if: github.event_name == 'push' || github.event_name == 'pull_request'
 
     #   - name: echo fetching workflow_dispatch branch
-    #     uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 
+    #     uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
     #     with:
     #         ref: ${GITHUB_REF##*/} 
     #     if: github.event_name == 'workflow_dispatch'
@@ -68,7 +68,7 @@ jobs:
           echo "$EOF" >> "$GITHUB_ENV"
         id: run_make
 
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
         with:
           token: ${{ secrets.GH_ALL_PROJECT_TOKEN }}
           persist-credentials: 'false'

--- a/.github/workflows/full-broken-links-crawler.yml
+++ b/.github/workflows/full-broken-links-crawler.yml
@@ -51,7 +51,7 @@ jobs:
             echo workflow_dispatch - running on branch ${{ steps.extract_branch.outputs.branch }}
             echo workflow_dispatch - running on version ${{ steps.extract_branch.outputs.version }}
 
-      - uses: ScholliYT/Broken-Links-Crawler-Action@b3fb123879e5a6a854d6fda5c33df2d94d41092c 
+      - uses: ScholliYT/Broken-Links-Crawler-Action@b3fb123879e5a6a854d6fda5c33df2d94d41092c
         with:
           website_url: https://${{ steps.extract_branch.outputs.site }}/${{ steps.extract_branch.outputs.version }}
           include_url_prefix: "https:"

--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -18,11 +18,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout
-      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
       with:
         fetch-depth: 0
 
-    - uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 
+    - uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5
       with:
         go-version: 1.24
          
@@ -33,10 +33,10 @@ jobs:
       run: echo LDFLAGS="$(make ldflags)" >> $GITHUB_ENV
 
     - name: Install syft binary executable
-      uses: anchore/sbom-action/download-syft@9246b90769f852b3a8921f330c59e0b3f439d6e9 
+      uses: anchore/sbom-action/download-syft@9246b90769f852b3a8921f330c59e0b3f439d6e9
 
     - name: Run GoReleaser on tag
-      uses: goreleaser/goreleaser-action@9c156ee8a17a598857849441385a2041ef570552 
+      uses: goreleaser/goreleaser-action@9c156ee8a17a598857849441385a2041ef570552
       with:
         distribution: goreleaser
         version: latest
@@ -47,12 +47,12 @@ jobs:
         EMAIL: ${{ github.actor}}@users.noreply.github.com
 
     - name: Set up Helm
-      uses: azure/setup-helm@b9e51907a09c216f16ebe8536097933489208112 
+      uses: azure/setup-helm@b9e51907a09c216f16ebe8536097933489208112
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Login to registry
-      uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 
+      uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772
       with:
         registry: ${{ env.REGISTRY }}
         username: ${{ github.actor }}

--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -33,7 +33,7 @@ jobs:
       run: echo LDFLAGS="$(make ldflags)" >> $GITHUB_ENV
 
     - name: Install syft binary executable
-      uses: anchore/sbom-action/download-syft@e11c554f704a0b820cbf8c51673f6945e0731532 
+      uses: anchore/sbom-action/download-syft@9246b90769f852b3a8921f330c59e0b3f439d6e9 
 
     - name: Run GoReleaser on tag
       uses: goreleaser/goreleaser-action@9c156ee8a17a598857849441385a2041ef570552 

--- a/.github/workflows/greetings.yml
+++ b/.github/workflows/greetings.yml
@@ -15,7 +15,7 @@ jobs:
       issues: write
       pull-requests: write
     steps:
-    - uses: actions/first-interaction@3c71ce730280171fd1cfb57c00c774f8998586f7 
+    - uses: actions/first-interaction@3c71ce730280171fd1cfb57c00c774f8998586f7
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
         issue-message: "Thank you for contributing your first Issue to KubeStellar. We are delighted to have you in our Universe!"

--- a/.github/workflows/ocp-self-runner.yml
+++ b/.github/workflows/ocp-self-runner.yml
@@ -10,20 +10,20 @@ jobs:
     name: ginkgo tests
     runs-on: self-hosted
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
 
-      - uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 
+      - uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5
         with:
           go-version: 1.24
           cache: true
 
       - name: Set up Helm
-        uses: azure/setup-helm@b9e51907a09c216f16ebe8536097933489208112 
+        uses: azure/setup-helm@b9e51907a09c216f16ebe8536097933489208112
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install kubectl
-        uses: azure/setup-kubectl@3e0aec4d80787158d308d7b364cb1b702e7feb7f 
+        uses: azure/setup-kubectl@3e0aec4d80787158d308d7b364cb1b702e7feb7f
         id: install
 
       - name: Install dependencies
@@ -62,20 +62,20 @@ jobs:
     name: bash script tests
     runs-on: self-hosted
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
 
-      - uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 
+      - uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5
         with:
           go-version: 1.24
           cache: true
 
       - name: Set up Helm
-        uses: azure/setup-helm@b9e51907a09c216f16ebe8536097933489208112 
+        uses: azure/setup-helm@b9e51907a09c216f16ebe8536097933489208112
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install kubectl
-        uses: azure/setup-kubectl@3e0aec4d80787158d308d7b364cb1b702e7feb7f 
+        uses: azure/setup-kubectl@3e0aec4d80787158d308d7b364cb1b702e7feb7f
         id: install
 
       - name: Install dependencies

--- a/.github/workflows/pr-test-e2e.yml
+++ b/.github/workflows/pr-test-e2e.yml
@@ -33,18 +33,18 @@ jobs:
     name: Tests in ginkgo
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
 
-      - uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 
+      - uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5
         with:
           go-version: 1.24
           cache: true
 
       - name: Install kubectl
-        uses: azure/setup-kubectl@3e0aec4d80787158d308d7b364cb1b702e7feb7f 
+        uses: azure/setup-kubectl@3e0aec4d80787158d308d7b364cb1b702e7feb7f
         id: install
 
-      - uses: ko-build/setup-ko@d006021bd0c28d1ce33a07e7943d48b079944c8d 
+      - uses: ko-build/setup-ko@d006021bd0c28d1ce33a07e7943d48b079944c8d
 
       - name: Install dependencies
         run: |
@@ -164,18 +164,18 @@ jobs:
     name: Test in bash
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
 
-      - uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 
+      - uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5
         with:
           go-version: 1.24
           cache: true
 
       - name: Install kubectl
-        uses: azure/setup-kubectl@3e0aec4d80787158d308d7b364cb1b702e7feb7f 
+        uses: azure/setup-kubectl@3e0aec4d80787158d308d7b364cb1b702e7feb7f
         id: install
 
-      - uses: ko-build/setup-ko@d006021bd0c28d1ce33a07e7943d48b079944c8d 
+      - uses: ko-build/setup-ko@d006021bd0c28d1ce33a07e7943d48b079944c8d
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/pr-test-integration.yml
+++ b/.github/workflows/pr-test-integration.yml
@@ -18,18 +18,18 @@ jobs:
     name: Test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
 
-      - uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 
+      - uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5
         with:
           go-version: 1.24
           cache: true
 
       - name: Install kubectl
-        uses: azure/setup-kubectl@3e0aec4d80787158d308d7b364cb1b702e7feb7f 
+        uses: azure/setup-kubectl@3e0aec4d80787158d308d7b364cb1b702e7feb7f
         id: install
 
-      - uses: ko-build/setup-ko@d006021bd0c28d1ce33a07e7943d48b079944c8d 
+      - uses: ko-build/setup-ko@d006021bd0c28d1ce33a07e7943d48b079944c8d
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Assign author to PR
-        uses: technote-space/assign-author@9558557c5c4816f38bd06176fbc324ba14bb3160 
+        uses: technote-space/assign-author@9558557c5c4816f38bd06176fbc324ba14bb3160
         
       # - name: Get current date
       #   id: date

--- a/.github/workflows/spellcheck_action.yml
+++ b/.github/workflows/spellcheck_action.yml
@@ -30,16 +30,16 @@ jobs:
     name: Spellcheck
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
 
-    - uses: rojopolis/spellcheck-github-actions@63aba9473ee34d681dd48dee26b3d43ea0bbc462 
+    - uses: rojopolis/spellcheck-github-actions@63aba9473ee34d681dd48dee26b3d43ea0bbc462
       name: Spellcheck
       with:
         config_path: .github/spellcheck/.spellcheck.yml
         output_file: spellcheck-output.txt
 #         source_files: "docs/content/*"
         
-    - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 
+    - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
       if: success() || failure()
       with:
         name: Spellcheck Output

--- a/.github/workflows/spellcheck_action.yml
+++ b/.github/workflows/spellcheck_action.yml
@@ -32,7 +32,7 @@ jobs:
     steps:
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 
 
-    - uses: rojopolis/spellcheck-github-actions@584b2ae95998967a53af7fbfb7f5b15352c38748 
+    - uses: rojopolis/spellcheck-github-actions@63aba9473ee34d681dd48dee26b3d43ea0bbc462 
       name: Spellcheck
       with:
         config_path: .github/spellcheck/.spellcheck.yml

--- a/.github/workflows/test-latest-release.yml
+++ b/.github/workflows/test-latest-release.yml
@@ -16,18 +16,18 @@ jobs:
     name: Tests in ginkgo
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
 
-      - uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 
+      - uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5
         with:
           go-version: 1.24
           cache: true
 
       - name: Install kubectl
-        uses: azure/setup-kubectl@3e0aec4d80787158d308d7b364cb1b702e7feb7f 
+        uses: azure/setup-kubectl@3e0aec4d80787158d308d7b364cb1b702e7feb7f
         id: install
 
-      - uses: ko-build/setup-ko@d006021bd0c28d1ce33a07e7943d48b079944c8d 
+      - uses: ko-build/setup-ko@d006021bd0c28d1ce33a07e7943d48b079944c8d
 
       - name: Install dependencies
         run: |
@@ -91,18 +91,18 @@ jobs:
     name: Test in bash
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
 
-      - uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 
+      - uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5
         with:
           go-version: 1.24
           cache: true
 
       - name: Install kubectl
-        uses: azure/setup-kubectl@3e0aec4d80787158d308d7b364cb1b702e7feb7f 
+        uses: azure/setup-kubectl@3e0aec4d80787158d308d7b364cb1b702e7feb7f
         id: install
 
-      - uses: ko-build/setup-ko@d006021bd0c28d1ce33a07e7943d48b079944c8d 
+      - uses: ko-build/setup-ko@d006021bd0c28d1ce33a07e7943d48b079944c8d
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -10,7 +10,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
 
       - name: Validate PR Title Format
         env:

--- a/hack/gha-reversemap.sh
+++ b/hack/gha-reversemap.sh
@@ -33,6 +33,8 @@ ERR_YQ_DOWNLOAD_FAILED=50
 ERR_YQ_NOT_INSTALLED=60
 ERR_GITHUB_TOKEN_INVALID=70
 ERR_ARCH_UNSUPPORTED=80
+ERR_NO_LATEST=86
+ERR_NO_TAG=87
 
 help() {
     cat <<EOF
@@ -142,9 +144,18 @@ _update_reversemap_with() {
 
 # Fetch latest release tag of an action upstream
 _fetch_latest_tag() {
+    local latest latest_json
     action_ref=$1
     API_GITHUB_LATEST_RELEASE=https://api.github.com/repos/$action_ref/releases/latest
-    _return "$(curl -s -H "Authorization: Bearer $GITHUB_TOKEN" "$API_GITHUB_LATEST_RELEASE" | jq -r '.tag_name')"
+    latest_json=$(curl -s -H "Authorization: Bearer $GITHUB_TOKEN" "$API_GITHUB_LATEST_RELEASE")
+    if [ -z "$latest_json" ]; then
+	_exit_with_error $ERR_NO_LATEST "GitHub returned empty response to query for latest"
+    fi
+    latest=$(jq -r .tag_name <<<"$latest_json")
+    if [ -z "$latest" ] || [ "$latest" = null ]; then
+        _exit_with_error $ERR_NO_TAG "Latest release information for ${action_ref} lacks tag_name: ${latest_json}"
+    fi
+    _return "$latest"
 }
 
 # Update action version within a file
@@ -152,7 +163,7 @@ _update_action_version_infile() {
     file=$1
     action_ref=$2
     action_sha=$3
-    sed_replace_expr="s;(uses:) $action_ref@[a-zA-Z0-9 \._\-]+;\1 $action_ref@$action_sha ;g"
+    sed_replace_expr="s;(uses:) $action_ref@[a-zA-Z0-9\._\-]+;\1 $action_ref@$action_sha;g"
     if [[ "$(uname -s)" = "Darwin" ]]; then
         # MacOS sed usage of -i option differs from Linux version.
         sed -E -i '' "$sed_replace_expr" "$file"


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
This PR does a few things:

1. Remove the spurious spaces at the end of "uses:" lines.
2. Fix the `hack/gha-reversemap.sh` script to not ensure a tailing space there.
3. Make that script report failures to fetch latest release info.
4. Bump rojopolis/spellcheck-github-actions from 0.49.0 to 0.50.0
5. Bump anchore/sbom-action from 0.20.0 to 0.20.1

## Related issue(s)

Fixes #
