### PR TITLE
✨feat: add docs preview enforcement workflow and PR template 

### DIFF
--- a/.github/workflows/check-docs-pr-preview.yml
+++ b/.github/workflows/check-docs-pr-preview.yml
@@ -1,0 +1,63 @@
+# This workflow checks that PRs modifying website docs include a preview link in the PR description.
+# It enforces KubeStellar's documentation PR best practices.
+
+name: Check Docs PR Preview Link
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize]
+    paths:
+      - 'docs/content/**'
+      - 'docs/README.md'
+      - 'docs/mkdocs.yml'
+      - 'docs/overrides/**'
+      - 'docs/scripts/**'
+      - 'docs/requirements.txt'
+      - 'docs/main.py'
+
+jobs:
+  check-preview-link:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+      - name: Check for Preview Link in PR Description (bash)
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+          BRANCH: ${{ github.head_ref }}
+        run: |
+          set -e
+          BODY=$(gh pr view "$PR_NUMBER" --json body -q '.body')
+          DOC_BRANCH_REGEX='^doc-'
+          OWNER=$(gh pr view "$PR_NUMBER" --json headRepositoryOwner -q '.headRepositoryOwner.login')
+          REPO_NAME=$(gh pr view "$PR_NUMBER" --json headRepository -q '.headRepository.name')
+          GITHUB_PAGES_URL="https://${OWNER}.github.io/${REPO_NAME}/${BRANCH}"
+          PREVIEW_LINE=$(echo "$BODY" | grep -iE '^\s*Preview.*https?://')
+          GREEN='\033[0;32m'
+          RED='\033[0;31m'
+          YELLOW='\033[1;33m'
+          NC='\033[0m' # No Color
+
+          if [ -n "$PREVIEW_LINE" ]; then
+            PREVIEW_URL=$(echo "$PREVIEW_LINE" | grep -oE 'https?://[^ ]*')
+
+            if [[ "$PREVIEW_LINE" == *"$GITHUB_PAGES_URL"* ]]; then
+              if [[ "$BRANCH" =~ $DOC_BRANCH_REGEX ]]; then
+                echo -e "${GREEN}[OK] Docs PR: doc- branch and preview link format matches expected GitHub Pages URL.${NC}"
+              else
+                echo -e "${YELLOW}[WARN] Docs PR: Preview link format is good, but branch does not start with doc-. Consider renaming to enable automatic previews.${NC}"
+              fi
+            else
+              echo -e "${YELLOW}[WARN] Docs PR: Preview link found, but it does not match the expected GitHub Pages URL."
+              echo -e "Expected: ${GITHUB_PAGES_URL}"
+              echo -e "Found:    ${PREVIEW_URL}${NC}"
+            fi
+          else
+            echo -e "${RED}[ERROR] Docs PR: No preview link found. Please include a line starting with 'Preview' and a valid GitHub Pages URL for your changes.${NC}"
+            echo
+            exit 1
+          fi
+          echo
+          


### PR DESCRIPTION
This PR adds a GitHub Actions workflow and a supporting PR template to enforce documentation PR best practices in KubeStellar.

### 📋 What's Included

- **Workflow**: Automatically checks PRs that modify documentation files.
  - If docs are changed, the PR must include a `Preview:` line with a valid GitHub Pages URL.
  - Warns if the branch name doesn't start with `doc-`, as automatic previews rely on that.
  - Fails the check if no preview link is provided.

- **PR Template**: Adds a clear instruction block to guide contributors to include the correct preview format.

### 📎 Motivation

Ensures that all documentation PRs are previewable, consistent, and easier to review. Reduces back-and-forth and improves contributor experience.

### 🔗 Related Issue

Fixes #3001