### PR TITLE
✨  Add LatencyCollector controller to collect end-to-end metrics across clusters

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -53,6 +53,7 @@ require (
 	github.com/fsnotify/fsnotify v1.7.0 // indirect
 	github.com/go-errors/errors v1.4.2 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
+	github.com/go-logr/zapr v1.3.0 // indirect
 	github.com/go-openapi/jsonpointer v0.21.0 // indirect
 	github.com/go-openapi/jsonreference v0.20.2 // indirect
 	github.com/go-openapi/swag v0.23.0 // indirect

--- a/test/performance/latency-controller/README.md
+++ b/test/performance/latency-controller/README.md
@@ -1,0 +1,242 @@
+# kubestellar-latency-collector
+
+> A Kubernetes controller to measure and expose latency metrics for KubeStellar’s downsync and upsync operations.
+
+---
+
+## 🚀 Demo Setup
+
+Create a KubeStellar demo environment using Kind:
+
+```bash
+bash <(curl -s https://raw.githubusercontent.com/kubestellar/kubestellar/refs/tags/v0.27.2/scripts/create-kubestellar-demo-env.sh) --platform kind
+```
+
+Set up your environment:
+
+```bash
+export host_context=kind-kubeflex
+export its_cp=its1
+export its_context=its1
+export wds_cp=wds1
+export wds_context=wds1
+export wec1_name=cluster1
+export wec2_name=cluster2
+export wec1_context=cluster1
+export wec2_context=cluster2
+export label_query_both="location-group=edge"
+export label_query_one="name=cluster1"
+```
+
+## 📦 Deploy Example Workloads
+
+Binding Policy
+
+```bash
+kubectl --context "$wds_context" apply -f - <<EOF
+apiVersion: control.kubestellar.io/v1alpha1
+kind: BindingPolicy
+metadata:
+  name: nginx-singleton-bpolicy
+spec:
+  clusterSelectors:
+  - matchLabels: {"name":"cluster1"}
+  downsync:
+  - objectSelectors:
+    - matchLabels: {"app.kubernetes.io/name":"nginx-singleton"}
+    wantSingletonReportedState: true
+EOF
+```
+
+### Deployments
+
+Apply deployments to generate observable latency metrics:
+
+```bash
+# Deployment 1
+kubectl --context "$wds_context" apply -f - <<EOF
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx-singleton-deployment
+  namespace: default
+  labels:
+    app.kubernetes.io/name: nginx-singleton
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: nginx
+  template:
+    metadata:
+      labels:
+        app: nginx
+    spec:
+      containers:
+      - name: nginx
+        image: nginx:alpine
+        ports:
+        - containerPort: 80
+        readinessProbe:
+          httpGet:
+            path: /
+            port: 80
+          initialDelaySeconds: 5
+          periodSeconds: 5
+EOF
+```
+
+```bash
+# Deployment 2 (variation)
+kubectl --context "$wds_context" apply -f - <<EOF
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx-test-deployment
+  namespace: default
+  labels:
+    app.kubernetes.io/name: nginx-singleton
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: nginx
+  template:
+    metadata:
+      labels:
+        app: nginx
+    spec:
+      containers:
+      - name: nginx
+        image: nginx:alpine
+        ports:
+        - containerPort: 80
+        readinessProbe:
+          httpGet:
+            path: /
+            port: 80
+          initialDelaySeconds: 5
+          periodSeconds: 5
+EOF
+```
+
+### Pods
+
+Apply pods to generate observable latency metrics:
+
+```bash
+# Pod 1
+kubectl --context "$wds_context" apply -f - <<EOF
+apiVersion: v1
+kind: Pod
+metadata:
+  name: nginx-pod
+  namespace: default
+  labels:
+    app.kubernetes.io/name: nginx-singleton
+spec:
+  containers:
+  - name: nginx
+    image: nginx:alpine
+    ports:
+    - containerPort: 80
+    readinessProbe:
+      httpGet:
+        path: /
+        port: 80
+      initialDelaySeconds: 5
+      periodSeconds: 5
+EOF
+```
+
+```bash
+# Pod 2 (variation)
+kubectl --context "$wds_context" apply -f - <<EOF
+apiVersion: v1
+kind: Pod
+metadata:
+  name: nginx-pod-2
+  namespace: default
+  labels:
+    app.kubernetes.io/name: nginx-singleton
+spec:
+  containers:
+  - name: nginx
+    image: nginx:alpine
+    ports:
+    - containerPort: 80
+    readinessProbe:
+      httpGet:
+        path: /
+        port: 80
+      initialDelaySeconds: 5
+      periodSeconds: 5
+EOF
+```
+
+## 🛠️ Build & Run
+
+Run
+
+```bash
+go build -o bin/latency-controller ./test/performance/latency-controller
+
+./bin/latency-controller
+```
+
+## 📊 Monitoring Setup
+
+### Another Terminal (Prometheus)
+
+```bash
+# Download and extract
+wget https://github.com/prometheus/prometheus/releases/download/v2.51.0/prometheus-2.51.0.linux-amd64.tar.gz
+tar -xzf prometheus-2.51.0.linux-amd64.tar.gz
+cd prometheus-2.51.0.linux-amd64
+```
+
+Create `prometheus.yml`:
+
+```bash
+global:
+  scrape_interval: 15s
+  evaluation_interval: 15s
+
+scrape_configs:
+  - job_name: 'kubestellar-latency'
+    static_configs:
+      - targets: ['localhost:2222']
+    metrics_path: '/metrics'
+```
+
+Run Prometheus:
+
+```bash
+./prometheus \
+  --config.file=prometheus.yml \
+  --storage.tsdb.path=./data \
+  --web.listen-address=0.0.0.0:9090
+```
+
+### Again In Another Terminal (Grafana)
+
+```bash
+# Download and extract
+wget https://dl.grafana.com/oss/release/grafana-10.4.1.linux-amd64.tar.gz
+tar -xzf grafana-10.4.1.linux-amd64.tar.gz
+cd grafana-10.4.1
+```
+
+Start Grafana
+
+```bash
+./bin/grafana-server web
+```
+
+Access Grafana at http://localhost:3000
+(Default credentials: admin / admin)
+
+## Import Dashboard
+
+- Navigate to Dashboards > Import
+- Upload the file: ./kubestellar-dashboard.json

--- a/test/performance/latency-controller/internal/controller/controller.go
+++ b/test/performance/latency-controller/internal/controller/controller.go
@@ -1,0 +1,725 @@
+/*
+Copyright 2023 The KubeStellar Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/kubernetes"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/metrics"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+)
+
+const (
+	workStatusSuffixFmt = "%s-%s-%s-%s"
+)
+
+// ClusterData holds timestamps for a specific cluster
+type ClusterData struct {
+	manifestWorkName           string
+	manifestWorkCreated        time.Time
+	appliedManifestWorkCreated time.Time
+	wecObjectCreated           time.Time
+	wecObjectStatusTime        time.Time
+	workStatusTime             time.Time
+}
+
+// PerWorkloadCache holds all observed timestamps for one workload
+type PerWorkloadCache struct {
+	wdsObjectCreated    time.Time
+	wdsObjectStatusTime time.Time
+	clusterData         map[string]*ClusterData
+	gvr                 schema.GroupVersionResource
+	gvk                 schema.GroupVersionKind
+	name                string
+	namespace           string
+}
+
+// GenericLatencyCollectorReconciler collects end-to-end latencies across all workloads
+type GenericLatencyCollectorReconciler struct {
+	client.Client
+	Scheme *runtime.Scheme
+
+	// Clients for each cluster
+	WdsClient   kubernetes.Interface
+	WecClients  map[string]kubernetes.Interface
+	WdsDynamic  dynamic.Interface
+	ItsDynamic  dynamic.Interface
+	WecDynamics map[string]dynamic.Interface
+
+	// Configuration
+	MonitoredNamespace  string
+	BindingPolicy       string
+	DiscoveredResources []schema.GroupVersionKind
+	gvkToGVR            map[schema.GroupVersionKind]schema.GroupVersionResource
+	bindingCreated      time.Time
+
+	cache    map[string]*PerWorkloadCache
+	cacheMux sync.Mutex
+
+	// Histogram metrics for each stage
+	totalPackagingHistogram               *prometheus.HistogramVec
+	totalDeliveryHistogram                *prometheus.HistogramVec
+	totalActivationHistogram              *prometheus.HistogramVec
+	totalDownsyncHistogram                *prometheus.HistogramVec
+	totalStatusPropagationReportHistogram *prometheus.HistogramVec
+	totalStatusPropagationFinalHistogram  *prometheus.HistogramVec
+	totalStatusPropagationHistogram       *prometheus.HistogramVec
+	totalE2EHistogram                     *prometheus.HistogramVec
+	workloadCountGauge                    *prometheus.GaugeVec
+}
+
+//+kubebuilder:rbac:groups=*,resources=*,verbs=get;list;watch
+//+kubebuilder:rbac:groups=control.kubestellar.io,resources=bindingpolicies;workstatuses,verbs=get;list
+//+kubebuilder:rbac:groups=work.open-cluster-management.io,resources=manifestworks;appliedmanifestworks,verbs=get;list
+
+func (r *GenericLatencyCollectorReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	r.cache = make(map[string]*PerWorkloadCache)
+
+	// Precompute GVK to GVR mappings
+	mapper := mgr.GetRESTMapper()
+	r.gvkToGVR = make(map[schema.GroupVersionKind]schema.GroupVersionResource)
+	for _, gvk := range r.DiscoveredResources {
+		mapping, err := mapper.RESTMapping(gvk.GroupKind(), gvk.Version)
+		if err == nil {
+			r.gvkToGVR[gvk] = mapping.Resource
+		}
+	}
+
+	preds := predicate.Funcs{
+		CreateFunc: func(e event.CreateEvent) bool {
+			if obj, ok := e.Object.(*unstructured.Unstructured); ok {
+				gvk := obj.GetObjectKind().GroupVersionKind()
+				if gvk.Kind == "" {
+					for _, discoveredGVK := range r.DiscoveredResources {
+						if discoveredGVK.Kind == obj.GetKind() {
+							obj.SetGroupVersionKind(discoveredGVK)
+							break
+						}
+					}
+				}
+				return obj.GetObjectKind().GroupVersionKind().Kind != ""
+			}
+			return e.Object.GetObjectKind().GroupVersionKind().Kind != ""
+		},
+		UpdateFunc: func(e event.UpdateEvent) bool {
+			if obj, ok := e.ObjectNew.(*unstructured.Unstructured); ok {
+				gvk := obj.GetObjectKind().GroupVersionKind()
+				if gvk.Kind == "" {
+					for _, discoveredGVK := range r.DiscoveredResources {
+						if discoveredGVK.Kind == obj.GetKind() {
+							obj.SetGroupVersionKind(discoveredGVK)
+							break
+						}
+					}
+				}
+				return obj.GetObjectKind().GroupVersionKind().Kind != ""
+			}
+			return e.ObjectNew.GetObjectKind().GroupVersionKind().Kind != ""
+		},
+		DeleteFunc: func(e event.DeleteEvent) bool {
+			return false
+		},
+		GenericFunc: func(e event.GenericEvent) bool {
+			return false
+		},
+	}
+
+	controllerBuilder := ctrl.NewControllerManagedBy(mgr).
+		Named("generic-latency-collector").
+		WithEventFilter(preds)
+
+	for _, gvk := range r.DiscoveredResources {
+		if _, found := r.gvkToGVR[gvk]; !found {
+			continue
+		}
+		obj := &unstructured.Unstructured{}
+		obj.SetGroupVersionKind(gvk)
+		controllerBuilder = controllerBuilder.Watches(
+			obj,
+			&handler.EnqueueRequestForObject{},
+		)
+	}
+
+	return controllerBuilder.Complete(r)
+}
+
+func (r *GenericLatencyCollectorReconciler) RegisterMetrics() {
+	r.totalPackagingHistogram = prometheus.NewHistogramVec(prometheus.HistogramOpts{
+		Name:    "kubestellar_downsync_packaging_duration_seconds",
+		Help:    "Histogram of WDS object → ManifestWork creation durations",
+		Buckets: prometheus.ExponentialBuckets(0.1, 2, 15),
+	}, []string{"workload", "cluster", "kind", "apiVersion", "namespace", "bindingpolicy"})
+
+	r.totalDeliveryHistogram = prometheus.NewHistogramVec(prometheus.HistogramOpts{
+		Name:    "kubestellar_downsync_delivery_duration_seconds",
+		Help:    "Histogram of ManifestWork → AppliedManifestWork creation durations",
+		Buckets: prometheus.ExponentialBuckets(0.1, 2, 15),
+	}, []string{"workload", "cluster", "kind", "apiVersion", "namespace", "bindingpolicy"})
+
+	r.totalActivationHistogram = prometheus.NewHistogramVec(prometheus.HistogramOpts{
+		Name:    "kubestellar_downsync_activation_duration_seconds",
+		Help:    "Histogram of AppliedManifestWork → WEC object creation durations",
+		Buckets: prometheus.ExponentialBuckets(0.1, 2, 15),
+	}, []string{"workload", "cluster", "kind", "apiVersion", "namespace", "bindingpolicy"})
+
+	r.totalDownsyncHistogram = prometheus.NewHistogramVec(prometheus.HistogramOpts{
+		Name:    "kubestellar_downsync_duration_seconds",
+		Help:    "Histogram of WDS object → WEC object creation durations",
+		Buckets: prometheus.ExponentialBuckets(0.1, 2, 15),
+	}, []string{"workload", "cluster", "kind", "apiVersion", "namespace", "bindingpolicy"})
+
+	r.totalStatusPropagationReportHistogram = prometheus.NewHistogramVec(prometheus.HistogramOpts{
+		Name:    "kubestellar_statusPropagation_report_duration_seconds",
+		Help:    "Histogram of WEC object → WorkStatus report durations",
+		Buckets: prometheus.ExponentialBuckets(0.1, 2, 15),
+	}, []string{"workload", "cluster", "kind", "apiVersion", "namespace", "bindingpolicy"})
+
+	r.totalStatusPropagationFinalHistogram = prometheus.NewHistogramVec(prometheus.HistogramOpts{
+		Name:    "kubestellar_statusPropagation_finalization_duration_seconds",
+		Help:    "Histogram of WorkStatus → WDS object status durations",
+		Buckets: prometheus.ExponentialBuckets(0.1, 2, 15),
+	}, []string{"workload", "cluster", "kind", "apiVersion", "namespace", "bindingpolicy"})
+
+	r.totalStatusPropagationHistogram = prometheus.NewHistogramVec(prometheus.HistogramOpts{
+		Name:    "kubestellar_statusPropagation_duration_seconds",
+		Help:    "Histogram of WEC object → WDS object status durations",
+		Buckets: prometheus.ExponentialBuckets(0.1, 2, 15),
+	}, []string{"workload", "cluster", "kind", "apiVersion", "namespace", "bindingpolicy"})
+
+	r.totalE2EHistogram = prometheus.NewHistogramVec(prometheus.HistogramOpts{
+		Name:    "kubestellar_e2e_latency_duration_seconds",
+		Help:    "Histogram of total binding → WDS status durations",
+		Buckets: prometheus.ExponentialBuckets(0.1, 2, 15),
+	}, []string{"workload", "cluster", "kind", "apiVersion", "namespace", "bindingpolicy"})
+
+	r.workloadCountGauge = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "kubestellar_workload_count",
+		Help: "Number of workload objects deployed in clusters",
+	}, []string{"cluster", "kind", "apiVersion", "namespace", "bindingpolicy"})
+
+	metrics.Registry.MustRegister(
+		r.totalPackagingHistogram,
+		r.totalDeliveryHistogram,
+		r.totalActivationHistogram,
+		r.totalDownsyncHistogram,
+		r.totalStatusPropagationReportHistogram,
+		r.totalStatusPropagationFinalHistogram,
+		r.totalStatusPropagationHistogram,
+		r.totalE2EHistogram,
+		r.workloadCountGauge,
+	)
+}
+
+func (r *GenericLatencyCollectorReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	if req.NamespacedName.Namespace != r.MonitoredNamespace {
+		return ctrl.Result{}, nil
+	}
+
+	obj := &unstructured.Unstructured{}
+	var targetGVK schema.GroupVersionKind
+
+	// Try all discovered GVKs to find the object
+	for _, gvk := range r.DiscoveredResources {
+		obj.SetGroupVersionKind(gvk)
+		if err := r.Get(ctx, req.NamespacedName, obj); err == nil {
+			targetGVK = gvk
+			break
+		}
+	}
+
+	if targetGVK.Kind == "" {
+		return ctrl.Result{}, nil
+	}
+
+	// Process the generic object
+	r.processGenericObject(ctx, obj)
+
+	return ctrl.Result{RequeueAfter: 10 * time.Second}, nil
+}
+
+func (r *GenericLatencyCollectorReconciler) getGenericStatusTime(obj *unstructured.Unstructured) time.Time {
+	if managedFieldsTime := getStatusTime(obj); !managedFieldsTime.IsZero() {
+		return managedFieldsTime
+	}
+	var latest time.Time
+	conds, found, err := unstructured.NestedSlice(obj.Object, "status", "conditions")
+	if err == nil && found {
+		for _, cond := range conds {
+			if condMap, ok := cond.(map[string]interface{}); ok {
+				fields := []string{"lastUpdateTime", "lastTransitionTime"}
+				for _, field := range fields {
+					if timeStr, ok, _ := unstructured.NestedString(condMap, field); ok {
+						if ts, err := time.Parse(time.RFC3339, timeStr); err == nil && ts.After(latest) {
+							latest = ts
+						}
+					}
+				}
+			}
+		}
+	}
+	return latest
+}
+
+func (r *GenericLatencyCollectorReconciler) lookupManifestWorkForCluster(ctx context.Context, key, clusterName string, entry *PerWorkloadCache) {
+	logger := log.FromContext(ctx).WithValues("workload", key, "cluster", clusterName, "function", "lookupManifestWorkForCluster")
+	clusterData := entry.clusterData[clusterName]
+	if clusterData == nil {
+		clusterData = &ClusterData{}
+		entry.clusterData[clusterName] = clusterData
+	}
+
+	gvr := schema.GroupVersionResource{Group: "work.open-cluster-management.io", Version: "v1", Resource: "manifestworks"}
+	selector := fmt.Sprintf("transport.kubestellar.io/originOwnerReferenceBindingKey=%s", r.BindingPolicy)
+	list, err := r.ItsDynamic.Resource(gvr).Namespace(clusterName).List(ctx, metav1.ListOptions{LabelSelector: selector})
+	if err != nil {
+		logger.Error(err, "Failed to list ManifestWorks in cluster namespace")
+		return
+	}
+
+	logger.Info("Processing ManifestWorks matching binding key", "selector", selector, "count", len(list.Items))
+	var chosenMW *unstructured.Unstructured
+	var chosenTime time.Time
+
+	for _, mw := range list.Items {
+		manifests, found, err := unstructured.NestedSlice(mw.Object, "spec", "workload", "manifests")
+		if err != nil || !found {
+			continue
+		}
+		for _, m := range manifests {
+			if mMap, ok := m.(map[string]interface{}); ok {
+				name, nFound, _ := unstructured.NestedString(mMap, "metadata", "name")
+				namespace, nsFound, _ := unstructured.NestedString(mMap, "metadata", "namespace")
+				_, kFound, _ := unstructured.NestedString(mMap, "kind")
+				if nFound && nsFound && kFound && name == entry.name && namespace == entry.namespace {
+					ts := mw.GetCreationTimestamp().Time
+					if chosenMW == nil || ts.Before(chosenTime) {
+						chosenMW = &mw
+						chosenTime = ts
+					}
+					break
+				}
+			}
+		}
+	}
+
+	if chosenMW != nil {
+		if clusterData.manifestWorkCreated.IsZero() {
+			clusterData.manifestWorkName = chosenMW.GetName()
+			clusterData.manifestWorkCreated = chosenTime
+			logger.Info("📦 ManifestWork creation timestamp recorded",
+				"manifestWork", clusterData.manifestWorkName, "timestamp", clusterData.manifestWorkCreated)
+		}
+	} else {
+		logger.Info("No matching ManifestWork found for workload", "workload", entry.name)
+	}
+}
+
+func (r *GenericLatencyCollectorReconciler) lookupAppliedManifestWork(ctx context.Context, key, clusterName string, entry *PerWorkloadCache) {
+	logger := log.FromContext(ctx).WithValues("workload", key, "cluster", clusterName, "function", "lookupAppliedManifestWork")
+	clusterData := entry.clusterData[clusterName]
+	if clusterData == nil || clusterData.manifestWorkName == "" {
+		logger.Info("Skipping AppliedManifestWork lookup - ManifestWork name unknown")
+		return
+	}
+
+	dynClient, exists := r.WecDynamics[clusterName]
+	if !exists {
+		logger.Error(nil, "WEC dynamic client not found for cluster")
+		return
+	}
+
+	gvr := schema.GroupVersionResource{Group: "work.open-cluster-management.io", Version: "v1", Resource: "appliedmanifestworks"}
+	list, err := dynClient.Resource(gvr).List(ctx, metav1.ListOptions{})
+	if err != nil {
+		logger.Error(err, "Failed to list AppliedManifestWorks")
+		return
+	}
+
+	logger.Info("Processing AppliedManifestWorks", "count", len(list.Items))
+	for _, aw := range list.Items {
+		parts := strings.SplitN(aw.GetName(), "-", 2)
+		if len(parts) == 2 && parts[1] == clusterData.manifestWorkName {
+			ts := aw.GetCreationTimestamp().Time
+			if clusterData.appliedManifestWorkCreated.IsZero() {
+				clusterData.appliedManifestWorkCreated = ts
+				logger.Info("📬 AppliedManifestWork creation timestamp recorded",
+					"appliedManifestWork", aw.GetName(), "timestamp", ts)
+			}
+			return
+		}
+	}
+
+	logger.Info("No matching AppliedManifestWork found",
+		"manifestWork", clusterData.manifestWorkName)
+}
+
+func (r *GenericLatencyCollectorReconciler) lookupWorkStatus(ctx context.Context, key, clusterName string, entry *PerWorkloadCache) {
+	logger := log.FromContext(ctx).WithValues("workload", key, "cluster", clusterName, "function", "lookupWorkStatus")
+	clusterData := entry.clusterData[clusterName]
+	if clusterData == nil {
+		return
+	}
+
+	gvr := schema.GroupVersionResource{Group: "control.kubestellar.io", Version: "v1alpha1", Resource: "workstatuses"}
+	list, err := r.ItsDynamic.Resource(gvr).List(ctx, metav1.ListOptions{})
+	if err != nil {
+		logger.Error(err, "Failed to list WorkStatuses")
+		return
+	}
+
+	suffix := fmt.Sprintf(workStatusSuffixFmt,
+		normalizedGroupVersion(entry.gvk),
+		strings.ToLower(entry.gvk.Kind),
+		entry.namespace,
+		entry.name)
+
+	for _, ws := range list.Items {
+		if strings.HasSuffix(ws.GetName(), suffix) {
+			ts := getStatusTime(&ws)
+			if ts.IsZero() {
+				continue
+			}
+			if clusterData.workStatusTime.IsZero() || ts.After(clusterData.workStatusTime) {
+				clusterData.workStatusTime = ts
+				logger.Info("📝 WorkStatus timestamp recorded",
+					"workStatus", ws.GetName(), "timestamp", ts)
+			}
+			return
+		}
+	}
+	logger.Info("No matching WorkStatus found", "suffix", suffix)
+}
+
+func (r *GenericLatencyCollectorReconciler) lookupWECObject(ctx context.Context, key, clusterName string, entry *PerWorkloadCache) {
+	logger := log.FromContext(ctx).WithValues("workload", key, "cluster", clusterName, "function", "lookupWECObject")
+	dynClient, exists := r.WecDynamics[clusterName]
+	if !exists {
+		logger.Error(nil, "WEC dynamic client not found for cluster")
+		return
+	}
+
+	obj, err := dynClient.Resource(entry.gvr).Namespace(entry.namespace).Get(ctx, entry.name, metav1.GetOptions{})
+	if err != nil {
+		if errors.IsNotFound(err) {
+			logger.Info("WEC object not yet created", "kind", entry.gvk.Kind)
+		} else {
+			logger.Error(err, "Error fetching WEC object", "kind", entry.gvk.Kind)
+		}
+		return
+	}
+
+	clusterData := entry.clusterData[clusterName]
+	if clusterData == nil {
+		clusterData = &ClusterData{}
+		entry.clusterData[clusterName] = clusterData
+	}
+
+	createdTime := obj.GetCreationTimestamp().Time
+	if clusterData.wecObjectCreated.IsZero() {
+		clusterData.wecObjectCreated = createdTime
+		logger.Info("🏭 WEC object creation timestamp recorded", "kind", entry.gvk.Kind, "timestamp", createdTime)
+	}
+
+	statusTime := r.getGenericStatusTime(obj)
+	if !statusTime.IsZero() {
+		if clusterData.wecObjectStatusTime.IsZero() || statusTime.After(clusterData.wecObjectStatusTime) {
+			clusterData.wecObjectStatusTime = statusTime
+			logger.Info("✅ WEC object status timestamp recorded", "kind", entry.gvk.Kind, "timestamp", statusTime)
+		}
+	} else {
+		logger.Info("⚠️ No valid status conditions found for WEC object", "kind", entry.gvk.Kind)
+	}
+}
+
+func (r *GenericLatencyCollectorReconciler) processGenericObject(ctx context.Context, obj *unstructured.Unstructured) {
+	logger := log.FromContext(ctx).WithValues("object", obj.GetName())
+	gvk := obj.GetObjectKind().GroupVersionKind()
+	if gvk.Kind == "" {
+		if kind, found, _ := unstructured.NestedString(obj.Object, "kind"); found {
+			if apiVersion, found, _ := unstructured.NestedString(obj.Object, "apiVersion"); found {
+				if gv, err := schema.ParseGroupVersion(apiVersion); err == nil {
+					gvk = schema.GroupVersionKind{Group: gv.Group, Version: gv.Version, Kind: kind}
+					obj.SetGroupVersionKind(gvk)
+				}
+			}
+		}
+		if gvk.Kind == "" {
+			logger.Error(nil, "Unable to determine GVK for object", "object", obj.Object)
+			return
+		}
+	}
+
+	gvr, found := r.gvkToGVR[gvk]
+	if !found {
+		logger.Info("Skipping object: no GVR mapping found", "gvk", gvk)
+		return
+	}
+	logger.Info("Processing generic object", "namespace", obj.GetNamespace(), "name", obj.GetName(), "kind", gvk.Kind)
+
+	key := fmt.Sprintf("%s/%s/%s", strings.ToLower(gvk.Kind), obj.GetNamespace(), obj.GetName())
+	r.cacheMux.Lock()
+	defer r.cacheMux.Unlock()
+	entry, exists := r.cache[key]
+	hasStatusField := r.objectHasStatusField(gvk.Kind)
+
+	if !exists {
+		entry = &PerWorkloadCache{
+			gvr:         gvr,
+			gvk:         gvk,
+			name:        obj.GetName(),
+			namespace:   obj.GetNamespace(),
+			clusterData: make(map[string]*ClusterData),
+		}
+		r.cache[key] = entry
+
+		entry.wdsObjectCreated = obj.GetCreationTimestamp().Time
+		logger.Info("🟢 WDS object creation timestamp recorded",
+			"object", obj.GetName(),
+			"namespace", obj.GetNamespace(),
+			"kind", gvk.Kind,
+			"timestamp", entry.wdsObjectCreated)
+
+		if hasStatusField {
+			entry.wdsObjectStatusTime = r.getGenericStatusTime(obj)
+			if !entry.wdsObjectStatusTime.IsZero() {
+				logger.Info("📌 WDS object status timestamp recorded",
+					"object", obj.GetName(),
+					"namespace", obj.GetNamespace(),
+					"kind", gvk.Kind,
+					"timestamp", entry.wdsObjectStatusTime)
+			}
+		}
+
+		shouldRemove := r.processClusters(ctx, entry, key, true)
+		if shouldRemove || !hasStatusField {
+			delete(r.cache, key)
+			logger.Info("Creation event processed: cache entry purged", "key", key, "hasStatus", hasStatusField)
+		} else {
+			logger.Info("Creation event processed: cache entry retained for status updates", "key", key)
+		}
+		return
+	}
+
+	if hasStatusField {
+		oldStatus := entry.wdsObjectStatusTime
+		newStatus := r.getGenericStatusTime(obj)
+		if !newStatus.IsZero() && newStatus.After(oldStatus) {
+			entry.wdsObjectStatusTime = newStatus
+			logger.Info("🔄 WDS object status timestamp updated",
+				"object", obj.GetName(),
+				"namespace", obj.GetNamespace(),
+				"kind", gvk.Kind,
+				"old", oldStatus,
+				"new", newStatus)
+
+			shouldRemove := r.processClusters(ctx, entry, key, false)
+			if shouldRemove {
+				delete(r.cache, key)
+				logger.Info("Status update event processed: cache entry purged", "key", key)
+			}
+			return
+		}
+	}
+	logger.Info("No significant changes detected for workload", "key", key)
+}
+
+func (r *GenericLatencyCollectorReconciler) objectHasStatusField(kind string) bool {
+	noStatusObjects := map[string]bool{
+		"ConfigMap":          true,
+		"Secret":             true,
+		"ServiceAccount":     true,
+		"Role":               true,
+		"ClusterRole":        true,
+		"RoleBinding":        true,
+		"ClusterRoleBinding": true,
+		"LimitRange":         true,
+		"ResourceQuota":      true,
+		"NetworkPolicy":      true,
+		"StorageClass":       true,
+		"Endpoints":          true,
+		"EndpointSlice":      true,
+	}
+	return !noStatusObjects[kind]
+}
+
+func (r *GenericLatencyCollectorReconciler) processClusters(ctx context.Context, entry *PerWorkloadCache, key string, isCreationEvent bool) bool {
+	logger := log.FromContext(ctx)
+	logger.Info("Processing clusters for workload", "name", entry.name, "kind", entry.gvk.Kind, "isCreation", isCreationEvent)
+	if entry.wdsObjectCreated.IsZero() {
+		logger.Info("Skipping metrics: WDS object creation time not recorded")
+		return false
+	}
+	hasE2ELatency := false
+
+	apiVersion := entry.gvk.GroupVersion().String()
+	labels := prometheus.Labels{
+		"workload":      entry.name,
+		"cluster":       "",
+		"kind":          entry.gvk.Kind,
+		"apiVersion":    apiVersion,
+		"namespace":     entry.namespace,
+		"bindingpolicy": r.BindingPolicy,
+	}
+
+	for clusterName := range r.WecClients {
+		if entry.clusterData[clusterName] == nil {
+			entry.clusterData[clusterName] = &ClusterData{}
+		}
+		clusterData := entry.clusterData[clusterName]
+		labels["cluster"] = clusterName
+
+		if isCreationEvent {
+			r.lookupManifestWorkForCluster(ctx, key, clusterName, entry)
+			if clusterData.manifestWorkName != "" {
+				r.lookupAppliedManifestWork(ctx, key, clusterName, entry)
+				r.lookupWorkStatus(ctx, key, clusterName, entry)
+				r.lookupWECObject(ctx, key, clusterName, entry)
+			}
+		} else {
+			if clusterData.manifestWorkName != "" {
+				r.lookupWorkStatus(ctx, key, clusterName, entry)
+				r.lookupWECObject(ctx, key, clusterName, entry)
+			}
+		}
+
+		if isCreationEvent && !clusterData.manifestWorkCreated.IsZero() {
+			pkg := clusterData.manifestWorkCreated.Sub(entry.wdsObjectCreated).Seconds()
+			if pkg < 0 {
+				pkg = 0
+			}
+			r.totalPackagingHistogram.With(labels).Observe(pkg)
+		}
+		if isCreationEvent && !clusterData.manifestWorkCreated.IsZero() && !clusterData.appliedManifestWorkCreated.IsZero() {
+			delivery := clusterData.appliedManifestWorkCreated.Sub(clusterData.manifestWorkCreated).Seconds()
+			if delivery < 0 {
+				delivery = 0
+			}
+			r.totalDeliveryHistogram.With(labels).Observe(delivery)
+		}
+		if isCreationEvent && !clusterData.appliedManifestWorkCreated.IsZero() && !clusterData.wecObjectCreated.IsZero() {
+			activation := clusterData.wecObjectCreated.Sub(clusterData.appliedManifestWorkCreated).Seconds()
+			if activation < 0 {
+				activation = 0
+			}
+			r.totalActivationHistogram.With(labels).Observe(activation)
+		}
+		if isCreationEvent && !clusterData.wecObjectCreated.IsZero() {
+			downsync := clusterData.wecObjectCreated.Sub(entry.wdsObjectCreated).Seconds()
+			if downsync < 0 {
+				downsync = 0
+			}
+			r.totalDownsyncHistogram.With(labels).Observe(downsync)
+		}
+		if !clusterData.wecObjectStatusTime.IsZero() && !clusterData.workStatusTime.IsZero() {
+			report := clusterData.workStatusTime.Sub(clusterData.wecObjectStatusTime).Seconds()
+			if report < 0 {
+				report = 0
+			}
+			r.totalStatusPropagationReportHistogram.With(labels).Observe(report)
+		}
+		if !clusterData.workStatusTime.IsZero() && !entry.wdsObjectStatusTime.IsZero() {
+			final := entry.wdsObjectStatusTime.Sub(clusterData.workStatusTime).Seconds()
+			if final < 0 {
+				final = 0
+			}
+			r.totalStatusPropagationFinalHistogram.With(labels).Observe(final)
+		}
+		if !clusterData.wecObjectStatusTime.IsZero() && !entry.wdsObjectStatusTime.IsZero() {
+			total := entry.wdsObjectStatusTime.Sub(clusterData.wecObjectStatusTime).Seconds()
+			if total < 0 {
+				total = 0
+			}
+			r.totalStatusPropagationHistogram.With(labels).Observe(total)
+		}
+		if !entry.wdsObjectStatusTime.IsZero() {
+			e2e := entry.wdsObjectStatusTime.Sub(entry.wdsObjectCreated).Seconds()
+			if e2e < 0 {
+				e2e = 0
+			}
+			r.totalE2EHistogram.With(labels).Observe(e2e)
+			hasE2ELatency = true
+		}
+	}
+
+	if isCreationEvent {
+		for clusterName, dynClient := range r.WecDynamics {
+			labels := []string{
+				clusterName,
+				entry.gvk.Kind,
+				entry.gvk.GroupVersion().String(),
+				entry.namespace,
+				r.BindingPolicy,
+			}
+			if list, err := dynClient.Resource(entry.gvr).Namespace(r.MonitoredNamespace).List(ctx, metav1.ListOptions{}); err == nil {
+				r.workloadCountGauge.WithLabelValues(labels...).Set(float64(len(list.Items)))
+			}
+		}
+	}
+	return hasE2ELatency
+}
+
+func normalizedGroupVersion(gvk schema.GroupVersionKind) string {
+	if gvk.Group == "" && gvk.Version == "v1" {
+		return "v1"
+	}
+	if gvk.Group == "apps" && gvk.Version == "v1" {
+		return "appsv1"
+	}
+	return strings.ToLower(gvk.GroupVersion().String())
+}
+
+func getStatusTime(obj metav1.Object) time.Time {
+	preferred := map[string]bool{
+		"controller-manager":    true,
+		"ocm-status-addon":      true,
+		"kubelet":               true,
+		"Status":                true,
+		"Go-http-client":        true,
+		"registration-operator": true,
+		"transport-controller":  true,
+	}
+	var latest time.Time
+	for _, mf := range obj.GetManagedFields() {
+		if mf.Operation == metav1.ManagedFieldsOperationUpdate && mf.Subresource == "status" {
+			if mf.Manager != "" && preferred[mf.Manager] {
+				if mf.Time != nil && mf.Time.Time.After(latest) {
+					latest = mf.Time.Time
+					break
+				}
+			}
+		}
+	}
+	return latest
+}

--- a/test/performance/latency-controller/kubestellar-dashboard.json
+++ b/test/performance/latency-controller/kubestellar-dashboard.json
@@ -1,0 +1,1333 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "target": {
+          "limit": 100,
+          "matchAny": false,
+          "tags": [],
+          "type": "dashboard"
+        },
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "gnetId": null,
+  "graphTooltip": 1,
+  "id": 2,
+  "links": [],
+  "liveNow": false,
+  "panels": [
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "End-to-End latency percentiles over time, computed per cluster",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 15,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.99, sum by (le, cluster) (rate(kubestellar_e2e_latency_duration_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", bindingpolicy=~\"$bindingpolicy\"}[5m])))",
+          "legendFormat": "99th %ile - {{cluster}}",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.75, sum by (le, cluster) (rate(kubestellar_e2e_latency_duration_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", bindingpolicy=~\"$bindingpolicy\"}[5m])))",
+          "legendFormat": "75th %ile - {{cluster}}",
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.50, sum by (le, cluster) (rate(kubestellar_e2e_latency_duration_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", bindingpolicy=~\"$bindingpolicy\"}[5m])))",
+          "legendFormat": "50th %ile - {{cluster}}",
+          "refId": "C"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.25, sum by (le, cluster) (rate(kubestellar_e2e_latency_duration_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", bindingpolicy=~\"$bindingpolicy\"}[5m])))",
+          "legendFormat": "25th %ile - {{cluster}}",
+          "refId": "D"
+        }
+      ],
+      "title": "End-to-End Latency Percentiles by Cluster",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 8
+      },
+      "id": 11,
+      "panels": [],
+      "title": "Downsync Process Breakdown",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "Packaging latency percentiles over time",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 0,
+        "y": 9
+      },
+      "id": 2,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.99, sum by (le, cluster) (rate(kubestellar_downsync_packaging_duration_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", bindingpolicy=~\"$bindingpolicy\"}[5m])))",
+          "legendFormat": "99th %ile - {{cluster}}",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.75, sum by (le, cluster) (rate(kubestellar_downsync_packaging_duration_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", bindingpolicy=~\"$bindingpolicy\"}[5m])))",
+          "legendFormat": "75th %ile - {{cluster}}",
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.50, sum by (le, cluster) (rate(kubestellar_downsync_packaging_duration_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", bindingpolicy=~\"$bindingpolicy\"}[5m])))",
+          "legendFormat": "50th %ile - {{cluster}}",
+          "refId": "C"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.25, sum by (le, cluster) (rate(kubestellar_downsync_packaging_duration_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", bindingpolicy=~\"$bindingpolicy\"}[5m])))",
+          "legendFormat": "25th %ile - {{cluster}}",
+          "refId": "D"
+        }
+      ],
+      "title": "Packaging Latency (WDS → ManifestWork) Percentiles",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "Delivery latency percentiles over time",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 8,
+        "y": 9
+      },
+      "id": 3,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.99, sum by (le, cluster) (rate(kubestellar_downsync_delivery_duration_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", bindingpolicy=~\"$bindingpolicy\"}[5m])))",
+          "legendFormat": "99th %ile - {{cluster}}",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.75, sum by (le, cluster) (rate(kubestellar_downsync_delivery_duration_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", bindingpolicy=~\"$bindingpolicy\"}[5m])))",
+          "legendFormat": "75th %ile - {{cluster}}",
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.50, sum by (le, cluster) (rate(kubestellar_downsync_delivery_duration_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", bindingpolicy=~\"$bindingpolicy\"}[5m])))",
+          "legendFormat": "50th %ile - {{cluster}}",
+          "refId": "C"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.25, sum by (le, cluster) (rate(kubestellar_downsync_delivery_duration_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", bindingpolicy=~\"$bindingpolicy\"}[5m])))",
+          "legendFormat": "25th %ile - {{cluster}}",
+          "refId": "D"
+        }
+      ],
+      "title": "Delivery Latency (ManifestWork → AppliedManifestWork) Percentiles",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "Activation latency percentiles over time",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 9
+      },
+      "id": 5,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.99, sum by (le, cluster) (rate(kubestellar_downsync_activation_duration_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", bindingpolicy=~\"$bindingpolicy\"}[5m])))",
+          "legendFormat": "99th %ile - {{cluster}}",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.75, sum by (le, cluster) (rate(kubestellar_downsync_activation_duration_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", bindingpolicy=~\"$bindingpolicy\"}[5m])))",
+          "legendFormat": "75th %ile - {{cluster}}",
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.50, sum by (le, cluster) (rate(kubestellar_downsync_activation_duration_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", bindingpolicy=~\"$bindingpolicy\"}[5m])))",
+          "legendFormat": "50th %ile - {{cluster}}",
+          "refId": "C"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.25, sum by (le, cluster) (rate(kubestellar_downsync_activation_duration_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", bindingpolicy=~\"$bindingpolicy\"}[5m])))",
+          "legendFormat": "25th %ile - {{cluster}}",
+          "refId": "D"
+        }
+      ],
+      "title": "Activation Latency (AppliedManifestWork → WEC Deployment) Percentiles",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 17
+      },
+      "id": 12,
+      "panels": [],
+      "title": "Status Propagation Process Breakdown",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "Status report latency percentiles over time",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 18
+      },
+      "id": 6,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.99, sum by (le, cluster) (rate(kubestellar_statusPropagation_report_duration_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", bindingpolicy=~\"$bindingpolicy\"}[5m])))",
+          "legendFormat": "99th %ile - {{cluster}}",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.75, sum by (le, cluster) (rate(kubestellar_statusPropagation_report_duration_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", bindingpolicy=~\"$bindingpolicy\"}[5m])))",
+          "legendFormat": "75th %ile - {{cluster}}",
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.50, sum by (le, cluster) (rate(kubestellar_statusPropagation_report_duration_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", bindingpolicy=~\"$bindingpolicy\"}[5m])))",
+          "legendFormat": "50th %ile - {{cluster}}",
+          "refId": "C"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.25, sum by (le, cluster) (rate(kubestellar_statusPropagation_report_duration_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", bindingpolicy=~\"$bindingpolicy\"}[5m])))",
+          "legendFormat": "25th %ile - {{cluster}}",
+          "refId": "D"
+        }
+      ],
+      "title": "Status Report Latency (WEC Deployment → WorkStatus) Percentiles",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "Status finalization latency percentiles over time",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 18
+      },
+      "id": 7,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.99, sum by (le, cluster) (rate(kubestellar_statusPropagation_finalization_duration_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", bindingpolicy=~\"$bindingpolicy\"}[5m])))",
+          "legendFormat": "99th %ile - {{cluster}}",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.75, sum by (le, cluster) (rate(kubestellar_statusPropagation_finalization_duration_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", bindingpolicy=~\"$bindingpolicy\"}[5m])))",
+          "legendFormat": "75th %ile - {{cluster}}",
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.50, sum by (le, cluster) (rate(kubestellar_statusPropagation_finalization_duration_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", bindingpolicy=~\"$bindingpolicy\"}[5m])))",
+          "legendFormat": "50th %ile - {{cluster}}",
+          "refId": "C"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.25, sum by (le, cluster) (rate(kubestellar_statusPropagation_finalization_duration_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", bindingpolicy=~\"$bindingpolicy\"}[5m])))",
+          "legendFormat": "25th %ile - {{cluster}}",
+          "refId": "D"
+        }
+      ],
+      "title": "Status Finalization Latency (WorkStatus → WDS Status) Percentiles",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 26
+      },
+      "id": 13,
+      "panels": [],
+      "title": "Total Latency Summaries",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "Total Downsync latency percentiles over time",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 27
+      },
+      "id": 20,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.99, sum by (le, cluster) (rate(kubestellar_downsync_duration_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", bindingpolicy=~\"$bindingpolicy\"}[5m])))",
+          "legendFormat": "99th %ile - {{cluster}}",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.75, sum by (le, cluster) (rate(kubestellar_downsync_duration_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", bindingpolicy=~\"$bindingpolicy\"}[5m])))",
+          "legendFormat": "75th %ile - {{cluster}}",
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.50, sum by (le, cluster) (rate(kubestellar_downsync_duration_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", bindingpolicy=~\"$bindingpolicy\"}[5m])))",
+          "legendFormat": "50th %ile - {{cluster}}",
+          "refId": "C"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.25, sum by (le, cluster) (rate(kubestellar_downsync_duration_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", bindingpolicy=~\"$bindingpolicy\"}[5m])))",
+          "legendFormat": "25th %ile - {{cluster}}",
+          "refId": "D"
+        }
+      ],
+      "title": "Total Downsync Percentiles",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "Total Status Propagation latency percentiles over time",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 27
+      },
+      "id": 21,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.99, sum by (le, cluster) (rate(kubestellar_statusPropagation_duration_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", bindingpolicy=~\"$bindingpolicy\"}[5m])))",
+          "legendFormat": "99th %ile - {{cluster}}",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.75, sum by (le, cluster) (rate(kubestellar_statusPropagation_duration_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", bindingpolicy=~\"$bindingpolicy\"}[5m])))",
+          "legendFormat": "75th %ile - {{cluster}}",
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.50, sum by (le, cluster) (rate(kubestellar_statusPropagation_duration_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", bindingpolicy=~\"$bindingpolicy\"}[5m])))",
+          "legendFormat": "50th %ile - {{cluster}}",
+          "refId": "C"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.25, sum by (le, cluster) (rate(kubestellar_statusPropagation_duration_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", bindingpolicy=~\"$bindingpolicy\"}[5m])))",
+          "legendFormat": "25th %ile - {{cluster}}",
+          "refId": "D"
+        }
+      ],
+      "title": "Total Status Propagation Percentiles",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 35
+      },
+      "id": 22,
+      "panels": [],
+      "title": "Workload Deployment Metrics",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "Cumulative count of workload objects deployed in clusters over time",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 36
+      },
+      "id": 23,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "sum by (cluster) (kubestellar_workload_count{cluster=~\"$cluster\", namespace=~\"$namespace\", bindingpolicy=~\"$bindingpolicy\"})",
+          "legendFormat": "{{cluster}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Cumulative Workload Deployment Count",
+      "type": "timeseries"
+    }
+  ],
+  "refresh": "10s",
+  "schemaVersion": 39,
+  "style": "dark",
+  "tags": [
+    "kubestellar",
+    "latency",
+    "observability",
+    "osm",
+    "openshift"
+  ],
+  "templating": {
+    "list": [
+      {
+        "current": {
+          "selected": false,
+          "text": "prometheus",
+          "value": "prometheus"
+        },
+        "hide": 0,
+        "includeAll": false,
+        "multi": false,
+        "name": "DS_PROMETHEUS",
+        "options": [],
+        "query": "prometheus",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "type": "datasource"
+      },
+      {
+        "name": "namespace",
+        "label": "Namespace",
+        "type": "query",
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${DS_PROMETHEUS}"
+        },
+        "query": {
+          "query": "label_values(kubestellar_downsync_packaging_duration_seconds_count, namespace)",
+          "refId": "StandardVariableQuery"
+        },
+        "refresh": 1,
+        "regex": "",
+        "multi": true,
+        "includeAll": true,
+        "skipUrlSync": false,
+        "current": {
+          "selected": true,
+          "text": "All",
+          "value": "$__all"
+        }
+      },
+      {
+        "name": "bindingpolicy",
+        "label": "Binding Policy",
+        "type": "query",
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${DS_PROMETHEUS}"
+        },
+        "query": {
+          "query": "label_values(kubestellar_downsync_packaging_duration_seconds_count, bindingpolicy)",
+          "refId": "StandardVariableQuery"
+        },
+        "refresh": 1,
+        "regex": "",
+        "multi": true,
+        "includeAll": true,
+        "skipUrlSync": false,
+        "current": {
+          "selected": true,
+          "text": "All",
+          "value": "$__all"
+        }
+      },
+      {
+        "allValue": null,
+        "current": {
+          "selected": true,
+          "text": [
+            "All"
+          ],
+          "value": [
+            "$__all"
+          ]
+        },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${DS_PROMETHEUS}"
+        },
+        "definition": "label_values(kubestellar_downsync_packaging_duration_seconds_count, cluster)",
+        "hide": 0,
+        "includeAll": true,
+        "multi": true,
+        "name": "cluster",
+        "options": [],
+        "query": {
+          "query": "label_values(kubestellar_downsync_packaging_duration_seconds_count, cluster)",
+          "refId": "StandardVariableQuery"
+        },
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 0,
+        "type": "query"
+      },
+      {
+        "name": "object_type",
+        "label": "Object Type",
+        "type": "custom",
+        "query": "Deployment",
+        "hide": 0,
+        "includeAll": false,
+        "multi": false,
+        "allValue": null,
+        "current": {
+          "selected": true,
+          "text": "Deployment",
+          "value": "Deployment"
+        },
+        "options": [
+          {
+            "text": "Deployment",
+            "value": "Deployment",
+            "selected": true
+          }
+        ],
+        "skipUrlSync": false
+      }
+    ]
+  },
+  "time": {
+    "from": "now-1h",
+    "to": "now"
+  },
+  "timepicker": {
+    "refresh_intervals": [
+      "5s",
+      "10s",
+      "30s",
+      "1m",
+      "5m",
+      "15m",
+      "30m",
+      "1h",
+      "2h",
+      "1d"
+    ],
+    "time_options": [
+      "5m",
+      "15m",
+      "1h",
+      "6h",
+      "12h",
+      "24h",
+      "2d",
+      "7d",
+      "30d"
+    ]
+  },
+  "timezone": "browser",
+  "title": "KubeStellar Multi-Cluster Latency Dashboard",
+  "version": 2,
+  "weekStart": ""
+}

--- a/test/performance/latency-controller/main.go
+++ b/test/performance/latency-controller/main.go
@@ -1,0 +1,364 @@
+/*
+Copyright 2023 The KubeStellar Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"flag"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/spf13/pflag"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/kubernetes"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/healthz"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
+	"sigs.k8s.io/controller-runtime/pkg/webhook"
+
+	"github.com/kubestellar/kubestellar/test/performance/latency-controller/internal/controller"
+)
+
+var (
+	scheme   = runtime.NewScheme()
+	setupLog = ctrl.Log.WithName("setup")
+)
+
+var excludedGroups = map[string]bool{
+	"flowcontrol.apiserver.k8s.io": true,
+	"discovery.k8s.io":             true,
+	"apiregistration.k8s.io":       true,
+	"coordination.k8s.io":          true,
+	"control.kubestellar.io":       true,
+}
+
+var excludedResourceNames = map[string]bool{
+	"events":               true,
+	"nodes":                true,
+	"csistoragecapacities": true,
+	"csinodes":             true,
+	"endpoints":            true,
+	"workstatuses":         true,
+}
+
+func init() {
+	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
+	gv := schema.GroupVersion{Group: "", Version: "v1"}
+	scheme.AddKnownTypes(gv,
+		&unstructured.Unstructured{},
+		&unstructured.UnstructuredList{},
+	)
+}
+
+func main() {
+	var (
+		metricsAddr          string
+		enableLeaderElection bool
+		probeAddr            string
+		secureMetrics        bool
+		enableHTTP2          bool
+
+		// Context flags
+		wdsContext         string
+		itsContext         string
+		wecContexts        string
+		kubeconfigPath     string
+		wdsKubeconfigPath  string
+		itsKubeconfigPath  string
+		wecKubeconfigPaths string
+		monitoredNamespace string
+		bindingPolicy      string
+		excludedResources  string
+		includedGroups     string
+	)
+
+	// Flags
+	pflag.StringVar(&wdsContext, "wds-context", "wds1", "Context name for WDS cluster in kubeconfig")
+	pflag.StringVar(&itsContext, "its-context", "its1", "Context name for ITS cluster in kubeconfig")
+	pflag.StringVar(&wecContexts, "wec-contexts", "cluster1", "Comma-separated WEC contexts")
+	pflag.StringVar(&kubeconfigPath, "kubeconfig", "~/.kube/config", "Path to kubeconfig file for external use")
+	pflag.StringVar(&wdsKubeconfigPath, "wds-kubeconfig", "", "Path to WDS kubeconfig (empty = detect automatically)")
+	pflag.StringVar(&itsKubeconfigPath, "its-kubeconfig", "", "Path to ITS kubeconfig (empty = detect automatically)")
+	pflag.StringVar(&wecKubeconfigPaths, "wec-kubeconfigs", "", "Comma-separated paths to WEC kubeconfigs")
+	pflag.StringVar(&monitoredNamespace, "monitored-namespace", "default", "Namespace to monitor")
+	pflag.StringVar(&bindingPolicy, "binding-name", "nginx-singleton-bpolicy", "Binding policy name")
+	pflag.StringVar(&excludedResources, "excluded-resources", "events,nodes,componentstatuses,endpoints,persistentvolumes,clusterroles,clusterrolebindings", "Resources to exclude")
+	pflag.StringVar(&includedGroups, "included-groups", "", "API groups to include (empty=all)")
+
+	pflag.StringVar(&metricsAddr, "metrics-bind-address", ":2222", "Address for metrics endpoint")
+	pflag.StringVar(&probeAddr, "health-probe-bind-address", ":8081", "Address for health probes")
+	pflag.BoolVar(&enableLeaderElection, "leader-elect", false, "Enable leader election")
+	pflag.BoolVar(&secureMetrics, "metrics-secure", false, "Serve metrics securely")
+	pflag.BoolVar(&enableHTTP2, "enable-http2", false, "Enable HTTP2 for servers")
+
+	opts := zap.Options{Development: true}
+	opts.BindFlags(flag.CommandLine)
+	pflag.Parse()
+	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&opts)))
+
+	// Build manager config from WDS cluster
+	// Automatic detection: use explicit path > in-cluster > default kubeconfig
+	mgrCfg := resolveConfig(wdsKubeconfigPath, kubeconfigPath, wdsContext)
+	mgr, err := ctrl.NewManager(mgrCfg, ctrl.Options{
+		Scheme:                 scheme,
+		Metrics:                metricsserver.Options{BindAddress: metricsAddr, SecureServing: secureMetrics},
+		WebhookServer:          webhook.NewServer(webhook.Options{}),
+		HealthProbeBindAddress: probeAddr,
+		LeaderElection:         enableLeaderElection,
+		LeaderElectionID:       "34020a28.kubestellar.io",
+		Client:                 client.Options{Cache: &client.CacheOptions{Unstructured: true}},
+	})
+	if err != nil {
+		setupLog.Error(err, "unable to start manager")
+		os.Exit(1)
+	}
+
+	// Discover resources
+	discovered, err := discoverResources(mgrCfg, excludedResources, includedGroups)
+	if err != nil {
+		setupLog.Error(err, "unable to discover resources")
+		os.Exit(1)
+	}
+
+	// Prepare per-cluster configs
+	wdsCfg := resolveConfig(wdsKubeconfigPath, kubeconfigPath, wdsContext)
+	itsCfg := resolveConfig(itsKubeconfigPath, kubeconfigPath, itsContext)
+
+	// Build WEC clients
+	wecContextList := strings.Split(wecContexts, ",")
+	wecClients := make(map[string]kubernetes.Interface)
+	wecDynamics := make(map[string]dynamic.Interface)
+	if wecKubeconfigPaths != "" {
+		paths := strings.Split(wecKubeconfigPaths, ",")
+		for i, ctx := range wecContextList {
+			path := kubeconfigPath
+			if i < len(paths) && paths[i] != "" {
+				path = paths[i]
+			}
+			cfg := resolveConfig(path, kubeconfigPath, ctx)
+			cs, err := kubernetes.NewForConfig(cfg)
+			utilruntime.Must(err)
+			dc, err := dynamic.NewForConfig(cfg)
+			utilruntime.Must(err)
+			wecClients[ctx], wecDynamics[ctx] = cs, dc
+		}
+	} else {
+		for _, ctx := range wecContextList {
+			cfg := resolveConfig(kubeconfigPath, kubeconfigPath, ctx)
+			cs, err := kubernetes.NewForConfig(cfg)
+			utilruntime.Must(err)
+			dc, err := dynamic.NewForConfig(cfg)
+			utilruntime.Must(err)
+			wecClients[ctx], wecDynamics[ctx] = cs, dc
+		}
+	}
+
+	// Build core clients
+	wdsClientset, err := kubernetes.NewForConfig(wdsCfg)
+	utilruntime.Must(err)
+	wdsClient := wdsClientset
+	wdsDynamic, err := dynamic.NewForConfig(wdsCfg)
+	utilruntime.Must(err)
+	itsDynamic, err := dynamic.NewForConfig(itsCfg)
+	utilruntime.Must(err)
+
+	// Setup controller
+	r := &controller.GenericLatencyCollectorReconciler{
+		Client:              mgr.GetClient(),
+		Scheme:              mgr.GetScheme(),
+		WdsClient:           wdsClient,
+		WecClients:          wecClients,
+		WdsDynamic:          wdsDynamic,
+		ItsDynamic:          itsDynamic,
+		WecDynamics:         wecDynamics,
+		MonitoredNamespace:  monitoredNamespace,
+		BindingPolicy:       bindingPolicy,
+		DiscoveredResources: discovered,
+	}
+	r.RegisterMetrics()
+	if err := r.SetupWithManager(mgr); err != nil {
+		setupLog.Error(err, "unable to create controller")
+		os.Exit(1)
+	}
+
+	// Health checks
+	mgr.AddHealthzCheck("healthz", healthz.Ping)
+	mgr.AddReadyzCheck("readyz", healthz.Ping)
+
+	setupLog.Info("starting manager")
+	if err := mgr.Start(ctrl.SetupSignalHandler()); err != nil {
+		setupLog.Error(err, "problem running manager")
+		os.Exit(1)
+	}
+}
+
+// resolveConfig picks explicit path > in-cluster > default kubeconfig
+func resolveConfig(explicit, defaultPath, context string) *rest.Config {
+	// explicit flag
+	if explicit != "" {
+		return buildClusterConfig(explicit, context)
+	}
+	// in-cluster if env present
+	if os.Getenv("KUBERNETES_SERVICE_HOST") != "" {
+		cfg, err := rest.InClusterConfig()
+		if err == nil {
+			return cfg
+		}
+	}
+	// fallback to default kubeconfig
+	return buildClusterConfig(defaultPath, context)
+}
+
+// Update the discoverResources function to return GVK instead of GVR
+func discoverResources(config *rest.Config, excludedResources, includedGroups string) ([]schema.GroupVersionKind, error) {
+	clientset, err := kubernetes.NewForConfig(config)
+	if err != nil {
+		return nil, err
+	}
+
+	discoveryClient := clientset.Discovery()
+
+	// Get all API resources
+	serverResources, err := discoveryClient.ServerPreferredResources()
+	if err != nil {
+		return nil, err
+	}
+
+	var resources []schema.GroupVersionKind
+	excludedSet := make(map[string]bool)
+	includedGroupsSet := make(map[string]bool)
+
+	// Parse excluded resources
+	if excludedResources != "" {
+		for _, res := range strings.Split(excludedResources, ",") {
+			excludedSet[strings.TrimSpace(res)] = true
+		}
+	}
+
+	// Parse included groups
+	if includedGroups != "" {
+		for _, group := range strings.Split(includedGroups, ",") {
+			includedGroupsSet[strings.TrimSpace(group)] = true
+		}
+	}
+
+	for _, group := range serverResources {
+		gv, err := schema.ParseGroupVersion(group.GroupVersion)
+		if err != nil {
+			continue
+		}
+		if excludedGroups[gv.Group] {
+			continue
+		}
+		for _, resource := range group.APIResources {
+			// Skip subresources
+			if strings.Contains(resource.Name, "/") {
+				continue
+			}
+
+			// Skip by resource-name exclusion
+			if excludedResourceNames[resource.Name] {
+				continue
+			}
+
+			// Skip excluded resources
+			if excludedSet[resource.Name] {
+				continue
+			}
+
+			// Parse group and version
+			gv, err := schema.ParseGroupVersion(group.GroupVersion)
+			if err != nil {
+				continue
+			}
+
+			// Filter by included groups if specified
+			if len(includedGroupsSet) > 0 && !includedGroupsSet[gv.Group] {
+				continue
+			}
+
+			// Only include namespaced resources that support list and watch
+			if resource.Namespaced && containsVerb(resource.Verbs, "list") && containsVerb(resource.Verbs, "watch") {
+				kind := resource.Kind
+				gvk := schema.GroupVersionKind{
+					Group:   gv.Group,
+					Version: gv.Version,
+					Kind:    kind,
+				}
+				resources = append(resources, gvk)
+			}
+		}
+	}
+
+	setupLog.Info("Discovered resources", "count", len(resources))
+	return resources, nil
+}
+
+func containsVerb(verbs []string, verb string) bool {
+	for _, v := range verbs {
+		if v == verb {
+			return true
+		}
+	}
+	return false
+}
+
+func buildClusterConfig(kubeconfigPath, context string) *rest.Config {
+	if kubeconfigPath == "" {
+		config, err := rest.InClusterConfig()
+		if err != nil {
+			setupLog.Error(err, "unable to load in-cluster config")
+			os.Exit(1)
+		}
+		return config
+	}
+
+	if strings.HasPrefix(kubeconfigPath, "~/") {
+		home, err := os.UserHomeDir()
+		if err == nil {
+			kubeconfigPath = strings.Replace(kubeconfigPath, "~", home, 1)
+		}
+	}
+
+	loadingRules := clientcmd.NewDefaultClientConfigLoadingRules()
+	loadingRules.ExplicitPath = kubeconfigPath
+
+	overrides := &clientcmd.ConfigOverrides{}
+	if context != "" {
+		overrides.CurrentContext = context
+	}
+
+	config, err := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(
+		loadingRules, overrides).ClientConfig()
+	if err != nil {
+		setupLog.Error(err, "unable to load kubeconfig", "context", context)
+		os.Exit(1)
+	}
+
+	config.Timeout = 15 * time.Second
+	return config
+}


### PR DESCRIPTION
## Summary

This PR introduces a new `GenericLatencyCollectorReconciler` controller responsible for observing and collecting end-to-end latency metrics across the Kubernetes multi-cluster landscape using KubeStellar.

The controller tracks:
- Downsync durations: from WDS Deployment to WEC Deployment
- Upsync durations: from WEC Deployment status back to WDS status
- Individual lifecycle stages such as:
  - Packaging
  - Delivery
  - Activation
  - WorkStatus reporting

The metrics are exposed as Prometheus histogram metrics and a workload count gauge, registered under `kubestellar_*` prefixed metric names.

A Grafana dashboard can consume these Prometheus metrics to visualize latency trends.

> 📊 **See the screenshots below for a sample Grafana dashboard visualization.**

![Screenshot 2025-06-26 204702](https://github.com/user-attachments/assets/ea4651df-addc-490d-8d1d-02156ed756a5)
![Screenshot 2025-06-26 204718](https://github.com/user-attachments/assets/3c8abc75-2dcb-49a8-8c98-26f6baa48f90)
![Screenshot 2025-06-26 204731](https://github.com/user-attachments/assets/3a5a7e52-491c-49d3-9639-e44d19bbf30e)



## Notes

- Go to the `README.md` file for detailed **testing and setup instructions**, including:
  - Metrics exposure steps
  - Prometheus + Grafana configuration
  - Sample dashboard JSON
