### PR TITLE
✨Dependency policy fix for CLOMonitor

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -5,3 +5,32 @@ updates:
   directory: "/"
   schedule:
     interval: "daily"
+# Maintain dependencies for Go modules
+- package-ecosystem: "gomod"
+  directory: "/"
+  schedule:
+    interval: "weekly"
+# Maintain dependencies for Python requirements (docs)
+- package-ecosystem: "pip"
+  directory: "/docs/"
+  schedule:
+    interval: "weekly"
+# Maintain dependencies for Python requirements (performance tests)
+- package-ecosystem: "pip"
+  directory: "/test/performance/common/"
+  schedule:
+    interval: "weekly"
+# Maintain dependencies for Dockerfiles
+- package-ecosystem: "docker"
+  directory: "/"
+  schedule:
+    interval: "weekly"
+- package-ecosystem: "docker"
+  directory: "/hack/"
+  schedule:
+    interval: "weekly"
+# Maintain dependencies for Helm charts
+- package-ecosystem: "helm"
+  directory: "/core-chart/"
+  schedule:
+    interval: "weekly"

--- a/SECURITY-INSIGHTS.yml
+++ b/SECURITY-INSIGHTS.yml
@@ -52,6 +52,6 @@ dependencies:
   dependencies-lists:
   - https://github.com/kubestellar/kubestellar/blob/main/SECURITY.md
   env-dependencies-policy:
-    policy-url: https://github.com/kubestellar/kubestellar/blob/main/SECURITY.md
+    policy-url: https://github.com/kubestellar/kubestellar/blob/main/SECURITY.md#dependencies-policy
     comment: |
       KubeStellar uses Dependabot for automated dependency updates and follows the policy described in SECURITY.md.

--- a/SECURITY-INSIGHTS.yml
+++ b/SECURITY-INSIGHTS.yml
@@ -51,4 +51,7 @@ dependencies:
   third-party-packages: true
   dependencies-lists:
   - https://github.com/kubestellar/kubestellar/blob/main/SECURITY.md
-  env-dependencies-policy: https://github.com/kubestellar/kubestellar/blob/main/SECURITY.md
+  env-dependencies-policy:
+    policy-url: https://github.com/kubestellar/kubestellar/blob/main/SECURITY.md
+    comment: |
+      KubeStellar uses Dependabot for automated dependency updates and follows the policy described in SECURITY.md.

--- a/SECURITY-INSIGHTS.yml
+++ b/SECURITY-INSIGHTS.yml
@@ -51,3 +51,4 @@ dependencies:
   third-party-packages: true
   dependencies-lists:
   - https://github.com/kubestellar/kubestellar/blob/main/SECURITY.md
+  env-dependencies-policy: https://github.com/kubestellar/kubestellar/blob/main/SECURITY.md#dependencies-policy

--- a/SECURITY-INSIGHTS.yml
+++ b/SECURITY-INSIGHTS.yml
@@ -51,4 +51,4 @@ dependencies:
   third-party-packages: true
   dependencies-lists:
   - https://github.com/kubestellar/kubestellar/blob/main/SECURITY.md
-  env-dependencies-policy: https://github.com/kubestellar/kubestellar/blob/main/SECURITY.md#dependencies-policy
+  env-dependencies-policy: https://github.com/kubestellar/kubestellar/blob/main/SECURITY.md

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -3,6 +3,15 @@
 
 Join the [kubestellar-security-announce](https://groups.google.com/u/1/g/kubestellar-security-announce) group for emails about security and major API announcements.
 
+## Dependencies Policy
+
+KubeStellar manages its dependencies with the following policy:
+
+- **Automated Updates:** We use [Dependabot](https://github.com/dependabot) to automatically check for and propose updates to dependencies in Go modules, Python requirements, Dockerfiles, and Helm charts. Dependabot PRs are reviewed and merged by maintainers.
+- **Review Process:** All dependency update pull requests are subject to the same review process as other code changes. Maintainers verify that updates do not introduce breaking changes or known vulnerabilities before merging.
+- **Security Best Practices:** We avoid using unmaintained or deprecated dependencies, and monitor for security advisories affecting our dependencies. Vulnerabilities in dependencies are prioritized for prompt remediation.
+- **Documentation:** The dependency update process is documented in the repository's README and CONTRIBUTING guidelines.
+
 ## Report a Vulnerability
 
 We're extremely grateful for security researchers and users that report vulnerabilities to the KubeStellar Open Source Community. All reports are thoroughly investigated by a set of community volunteers.


### PR DESCRIPTION
### Problem
The dependency policy check was not passing in CLOMonitor earlier which could have caused some security vulnerabilities.

### Solution
After making the required changes by reading the documentation, I ran the CLOMonitor tests against my local branch and it passed the dependency policy check.
![CleanShot 2025-07-01 at 23 34 27@2x](https://github.com/user-attachments/assets/cdfaa446-8d88-4349-8992-1cdd092fd77d)
