### PR TITLE
🐛 Hide version info banner on scroll for small screens

### DIFF
--- a/docs/overrides/main.html
+++ b/docs/overrides/main.html
@@ -41,14 +41,40 @@
 {% endblock %}
 
 {% block header %}
-       {{ super() }}
-       <header class='md-header' data-md-component='header' style="z-index:-10;">
-	       <div class='md-header__inner md-grid' data-md-component='container'>
-	       <p class='md_container' style="font-size:larger"> 
-	       KubeStellar has multiple documentation versions to match its multiple releases.<br />
-	       Please make sure you are viewing the docs version which matches the release version of the code you are using!
-	       </p>
-	       </div>
-       </header>
+  {{ super() }}
+  <header id="ks-info-banner" class="md-header" data-md-component="header" style="z-index:-10;">
+    <div class="md-header__inner md-grid" data-md-component="container">
+      <p class="md_container" style="font-size:larger"> 
+        KubeStellar has multiple documentation versions to match its multiple releases.<br />
+        Please make sure you are viewing the docs version which matches the release version of the code you are using!
+      </p>
+    </div>
+  </header>
 
-{% endblock %}
+  <script>
+    document.addEventListener("DOMContentLoaded", function () {
+      const banner = document.getElementById("ks-info-banner");
+      let lastScroll = window.scrollY;
+  
+      function handleScroll() {
+        const currentScroll = window.scrollY;
+        const isMobile = window.innerWidth <= 768;
+  
+        if (!isMobile) {
+          banner.style.transform = "none";
+          return;
+        }
+  
+        if (currentScroll > lastScroll) {
+          banner.style.transform = "translateY(-100%)";
+        } else {
+          banner.style.transform = "translateY(0)";
+        }
+        lastScroll = currentScroll;
+      }
+  
+      banner.style.transition = "transform 0.3s ease";
+      window.addEventListener("scroll", handleScroll);
+    });
+  </script>
+{% endblock %}  


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs



:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization
-->



## Summary

Hide the KubeStellar documentation version info banner on scroll for small screens. This improves usability by freeing up screen space when reading docs on mobile or smaller viewports.  
The banner reappears when scrolling up.  
JavaScript is added inline to avoid extra files and keep integration simple.


https://github.com/user-attachments/assets/8b81dbaf-d2e3-4497-8bd6-93c04879ff53


## Related issue(s)

Fixes #2764
