### PR TITLE
📖  Note branch name restriction and fork repair

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -55,7 +55,7 @@ You may preview possible changes to the website either
 ### Serving up documents globally from a fork of the repository via GitHub
 You can take advantage of [the "Generate and Push Docs" GitHub Actions workflow](https://github.com/kubestellar/kubestellar/blob/v{{ config.ks_latest_release }}/.github/workflows/docs-gen-and-push.yml)---invoked either explicitly in the GitHub web UI or implicitly by a branch naming convention---to create an online, shareable rendering of the website.
 This is particularly useful for documentation PRs, as it allows you to share a preview of your proposed changes directly via a URL to a working website.
-To take advantage of this action, you must ensure that you have forked the repository properly. This entails two things: having a version of the branch named `gh-pages`, and configuring GitHub to publish a website based on that branch.
+To take advantage of this action, you must (a) limit the character set used in the name of your branch and (b) ensure that your fork is properly set up for using [GitHub Pages](https://pages.github.com/). Your branch name should consist only of alphanumerics and dashes and dots. Fork setup for GitHub Pages entails two things: having a version of the branch named `gh-pages`, and configuring GitHub to publish a website based on that branch.
 
 The name of your branch equals the "version" of the website where the rendering appears.
 
@@ -66,6 +66,8 @@ commit changes to a branch whose name begins with `doc-`
 (e.g. `doc-myversion`).  If you have [prepared your fork for GitHub
 Pages
 rendering](#creating-a-fork-that-can-use-the-generate-and-push-docs-action)
+and restricted the name of your branch as described
+[above](#serving-up-documents-globally-from-a-fork-of-the-repository-via-github)
 then the workflow will succeed to create/update a website rendering in
 the GitHub Pages of your fork. For example: if you name your branch
 `doc-holliday` then the GitHub pages for your fork will get a website
@@ -90,7 +92,18 @@ in your PR.
 
 5. Go to the Settings tab of your fork, select "Pages" in the navigation panel on the left, and make sure that you have told GitHub to publish your site based on the contents of the `gh-pages` branch in your fork. It will look something like the following
     ![Configure publishing your GitHub pages](content/direct/images/github-pages-config-example.png)
- 
+
+#### Enabling GitHub pages for a fork that already exists
+
+1. Using the Git command line, and assuming that you have a "remote" named "origin" that points to your fork and a remote named "upstream" that points to https://github.com/kubestellar/kubestellar, do the following commands.
+
+    ```shell
+    git checkout upstream/gh-pages
+    git push -f origin gh-pages
+    ```
+
+2. Adjust the Settings of your fork as described in the section [above](#creating-a-fork-that-can-use-the-generate-and-push-docs-action).
+
 #### Manually generating a website rendered from a branch of your fork
 1. Work on the documents in a branch of your fork of the repository, and commit the changes
 2. (If you have been working on a local copy of the files, push the changes to the fork, then log into the GitHub webpage for your fork)


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Don't forget to first look for overlapping PRs. Remember, open source
is a collaborative rather than competitive activity.

If this PR includes changes to the source files for the website
(docs/content/** or a file included from there) then include a preview
of the modified website; see
docs/content/contribution-guidelines/operations/document-management.md.

Please put one of the following icons at the start of your PR title,
to indicate the type of your PR. You could use copy-and-paste from
here; alternatively, the indicated code is recognized by most browsers
as a way to input that icon.

✨ - code :sparkles:, type feature
🐛 - code :bug:, type bug fix
📖 - code :book:, type docs
📝 - code :memo:, type proposal
⚠️ - code :warning:, type breaking change
🌱 - code :seedling:, type other/misc
❓ - code :question:, type requires manual review/categorization

-->
## Summary
This PR updates the documentation regarding rendering of the website by GitHub, in two ways.
1. Note the restriction on branch name.
2. Explain how to enable GitHub Pages on a pre-existing fork.

Preview at https://mikespreitzer.github.io/kcp-edge-mc/doc-rendering-more/contribution-guidelines/operations/document-management/#serving-up-documents-globally-from-a-fork-of-the-repository-via-github and https://mikespreitzer.github.io/kcp-edge-mc/doc-rendering-more/contribution-guidelines/operations/document-management/#enabling-github-pages-for-a-fork-that-already-exists

Unfortunately, this PR overlaps with #3033. Ordinarily I would try to avoid such a conflict, but I think this PR may be urgent because it adds critical information for preparing successful PRs.

## Related issue(s)

Fixes #
