### PR TITLE
📖 finalize observability page with protocol and port clarifications

### DIFF
--- a/docs/content/direct/observability.md
+++ b/docs/content/direct/observability.md
@@ -12,13 +12,13 @@ KubeStellar controllers expose Prometheus-compatible metrics endpoints. These en
 | Controller                    | Protocol | Port  | Path     | AuthN/AuthZ | Notes |
 |-------------------------------|----------|-------|----------|-------------|-------|
 | kubestellar-controller-manager | HTTPS    | 8443  | /metrics | Kubernetes client authentication required when using the Service | Service: `kubestellar-controller-manager-metrics-service` (default port, configurable via Helm values). |
-| kubestellar-controller-manager | HTTPS    | 8443  | /metrics | Kubernetes client authentication required even for Pod access | Access via Pod port 8443; HTTPS and authentication are always required. Default port, configurable via Helm values. |
+| kubestellar-controller-manager | HTTPS    | 8443  | /metrics | Kubernetes client authentication and authorization required even for Pod access | Access via Pod port 8443; HTTPS and authentication are always required. Default port, configurable via Helm values. |
 | kubestellar-controller-manager | HTTP     | 8080  | /metrics | None (direct pod access) | Debug endpoint access without auth; typically disabled in production. |
 | ks-transport-controller       | HTTP     | 8090  | /metrics | None (in-cluster) | Default port, configurable via Helm values. |
 | status-addon-controller       | HTTP     | 9280  | /metrics | None (in-cluster) | Default port, configurable via Helm values. |
-| status-agent-controller       | HTTP     | 8080  | /metrics | None (in-cluster) | Default port, configurable via Helm values. |
+| status-addon-agent            | HTTP     | 8080  | /metrics | None (in-cluster) | Default port, configurable via Helm values. |
 
-**Note:** The listed ports are defaults. Currently, only the `ks-transport-controller` and `status-agent-controller` ports are configurable via Helm values (see issue #2158). When using the Service for `kubestellar-controller-manager`, protocol is HTTPS and Kubernetes client authentication is required. Direct pod access may use HTTP.
+**Note:** The listed ports are defaults. Currently, only the `ks-transport-controller` and `status-addon-agent` ports are configurable via Helm values (see [issue #2158](https://github.com/kubestellar/kubestellar/issues/2158)). When using the Service for `kubestellar-controller-manager`, protocol is HTTPS and Kubernetes client authentication is required. Direct pod access may use HTTP.
 
 ## Debug/Profiling Endpoints
 
@@ -31,12 +31,14 @@ Some KubeStellar components expose Go's built-in pprof debug endpoints for profi
 | kubestellar-controller-manager   | HTTP     | 8082  | /debug/pprof/   | None        |  |
 | ks-transport-controller         | HTTP     | 8092  | /debug/pprof/   | None        |  |
 | status-addon-controller         | HTTP     | 9282  | /debug/pprof/   | None        |  |
-| status-agent-controller         | HTTP     | 8083  | /debug/pprof/   | None        |  |
+| status-addon-agent              | HTTP     | 8082  | /debug/pprof/   | None        |  |
+
+**Note:** The listed ports are defaults. Currently, only the `ks-transport-controller` and `status-addon-agent` pprof ports are configurable via Helm values.
 
 ## Example: Accessing KubeStellar Controller Metrics and Debug Endpoints
 
 
-**Note:** The following example assumes you have a running KubeStellar controller-manager pod (not any other controller) and access to the appropriate Kubernetes context and namespace. The Deployment name is always `kubestellar-controller-manager`, but you may need to adjust the context and namespace for your environment.
+**Note:** The following example assumes you have a running KubeStellar controller-manager pod and access to the appropriate Kubernetes context and namespace. The Deployment name is always `kubestellar-controller-manager`, but you may need to adjust the context and namespace for your environment.
 
 
 ```sh

--- a/docs/content/direct/observability.md
+++ b/docs/content/direct/observability.md
@@ -12,12 +12,13 @@ KubeStellar controllers expose Prometheus-compatible metrics endpoints. These en
 | Controller                    | Protocol | Port  | Path     | AuthN/AuthZ | Notes |
 |-------------------------------|----------|-------|----------|-------------|-------|
 | kubestellar-controller-manager | HTTPS    | 8443  | /metrics | Kubernetes client authentication required when using the Service | Service: `kubestellar-controller-manager-metrics-service` (default port, configurable via Helm values). |
-| kubestellar-controller-manager | HTTPS    | 8443  | /metrics | None (direct pod access) | Access via Pod port 8443 (default, configurable via Helm values). |
+| kubestellar-controller-manager | HTTPS    | 8443  | /metrics | Kubernetes client authentication required even for Pod access | Access via Pod port 8443; HTTPS and authentication are always required. Default port, configurable via Helm values. |
+| kubestellar-controller-manager | HTTP     | 8080  | /metrics | None (direct pod access) | Debug endpoint access without auth; typically disabled in production. |
 | ks-transport-controller       | HTTP     | 8090  | /metrics | None (in-cluster) | Default port, configurable via Helm values. |
 | status-addon-controller       | HTTP     | 9280  | /metrics | None (in-cluster) | Default port, configurable via Helm values. |
 | status-agent-controller       | HTTP     | 8080  | /metrics | None (in-cluster) | Default port, configurable via Helm values. |
 
-**Note:** The ports listed above are defaults. In the core Helm chart, the ports to use are configured in the chart's values. When using the Service for `kubestellar-controller-manager`, protocol is HTTPS and Kubernetes client authentication is required. Direct pod access may use HTTP.
+**Note:** The listed ports are defaults. Currently, only the `ks-transport-controller` and `status-agent-controller` ports are configurable via Helm values (see issue #2158). When using the Service for `kubestellar-controller-manager`, protocol is HTTPS and Kubernetes client authentication is required. Direct pod access may use HTTP.
 
 ## Debug/Profiling Endpoints
 
@@ -30,12 +31,12 @@ Some KubeStellar components expose Go's built-in pprof debug endpoints for profi
 | kubestellar-controller-manager   | HTTP     | 8082  | /debug/pprof/   | None        |  |
 | ks-transport-controller         | HTTP     | 8092  | /debug/pprof/   | None        |  |
 | status-addon-controller         | HTTP     | 9282  | /debug/pprof/   | None        |  |
-| status-agent-controller         | HTTP     | 8082  | /debug/pprof/   | None        |  |
+| status-agent-controller         | HTTP     | 8083  | /debug/pprof/   | None        |  |
 
-## Example: Accessing Metrics and Debug Endpoints
+## Example: Accessing KubeStellar Controller Metrics and Debug Endpoints
 
 
-**Note:** The following example assumes you have a running KubeStellar controller-manager pod and access to the appropriate Kubernetes context and namespace. The Deployment name is always `kubestellar-controller-manager`, but you may need to adjust the context and namespace for your environment.
+**Note:** The following example assumes you have a running KubeStellar controller-manager pod (not any other controller) and access to the appropriate Kubernetes context and namespace. The Deployment name is always `kubestellar-controller-manager`, but you may need to adjust the context and namespace for your environment.
 
 
 ```sh

--- a/docs/content/direct/observability.md
+++ b/docs/content/direct/observability.md
@@ -4,21 +4,19 @@ KubeStellar provides endpoints and integrations for observability and monitoring
 
 ## Metrics Endpoints
 
-
 KubeStellar controllers expose Prometheus-compatible metrics endpoints. These endpoints respond to HTTP requests for metrics and can be queried by any monitoring system; KubeStellar does not mandate how metrics are collected or scraped. For an example of collecting both metrics and debug endpoint data using Prometheus, see the [monitoring](https://github.com/kubestellar/kubestellar/tree/main/monitoring/) directory. This is just one possible approach; KubeStellar does not require or mandate any specific monitoring tool or method.
 
 ### Metrics Endpoint Table
 
-| Controller                    | Protocol | Port  | Path     | AuthN/AuthZ | Notes |
-|-------------------------------|----------|-------|----------|-------------|-------|
-| kubestellar-controller-manager | HTTPS    | 8443  | /metrics | Kubernetes client authentication required when using the Service | Service: `kubestellar-controller-manager-metrics-service` (default port, configurable via Helm values). |
-| kubestellar-controller-manager | HTTPS    | 8443  | /metrics | Kubernetes client authentication and authorization required even for Pod access | Access via Pod port 8443; HTTPS and authentication are always required. Default port, configurable via Helm values. |
-| kubestellar-controller-manager | HTTP     | 8080  | /metrics | None (direct pod access) | Debug endpoint access without auth; typically disabled in production. |
-| ks-transport-controller       | HTTP     | 8090  | /metrics | None (in-cluster) | Default port, configurable via Helm values. |
-| status-addon-controller       | HTTP     | 9280  | /metrics | None (in-cluster) | Default port, configurable via Helm values. |
-| status-addon-agent            | HTTP     | 8080  | /metrics | None (in-cluster) | Default port, configurable via Helm values. |
+| Controller                     | Protocol | Port  | Path     | AuthN/AuthZ                                               | Notes                                                         |
+|-------------------------------|----------|-------|----------|-----------------------------------------------------------|---------------------------------------------------------------|
+| kubestellar-controller-manager | HTTPS    | 8443  | /metrics | Kubernetes client authentication required (Service or Pod) | Service: `kubestellar-controller-manager-metrics-service`.    |
+| kubestellar-controller-manager | HTTP     | 8080  | /metrics | None (debug; not recommended for production)               | Debug endpoint; typically disabled in production.              |
+| ks-transport-controller        | HTTP     | 8090  | /metrics | None (in-cluster)                                          | Port configurable via Helm values.                            |
+| status-addon-controller        | HTTP     | 9280  | /metrics | None (in-cluster)                                          |                                                               |
+| status-addon-agent             | HTTP     | 8080  | /metrics | None (in-cluster)                                          | Port configurable via Helm values.                            |
 
-**Note:** The listed ports are defaults. Currently, only the `ks-transport-controller` and `status-addon-agent` ports are configurable via Helm values (see [issue #2158](https://github.com/kubestellar/kubestellar/issues/2158)). When using the Service for `kubestellar-controller-manager`, protocol is HTTPS and Kubernetes client authentication is required. Direct pod access may use HTTP.
+**Note:** The listed ports are defaults. Only the `ks-transport-controller` and `status-addon-agent` metrics ports are configurable via Helm values (see [issue #2158](https://github.com/kubestellar/kubestellar/issues/2158)).
 
 ## Debug/Profiling Endpoints
 
@@ -29,17 +27,15 @@ Some KubeStellar components expose Go's built-in pprof debug endpoints for profi
 | Controller                      | Protocol | Port  | Path            | AuthN/AuthZ | Notes |
 |----------------------------------|----------|-------|-----------------|-------------|-------|
 | kubestellar-controller-manager   | HTTP     | 8082  | /debug/pprof/   | None        |  |
-| ks-transport-controller         | HTTP     | 8092  | /debug/pprof/   | None        |  |
+| ks-transport-controller         | HTTP     | 8092  | /debug/pprof/   | None        | Port configurable via Helm values. |
 | status-addon-controller         | HTTP     | 9282  | /debug/pprof/   | None        |  |
-| status-addon-agent              | HTTP     | 8082  | /debug/pprof/   | None        |  |
+| status-addon-agent              | HTTP     | 8082  | /debug/pprof/   | None        | Port configurable via Helm values. |
 
-**Note:** The listed ports are defaults. Currently, only the `ks-transport-controller` and `status-addon-agent` pprof ports are configurable via Helm values.
+**Note:** The listed ports are defaults. Only the `ks-transport-controller` and `status-addon-agent` pprof ports are configurable via Helm values.
 
 ## Example: Accessing KubeStellar Controller Metrics and Debug Endpoints
 
-
 **Note:** The following example assumes you have a running KubeStellar controller-manager pod and access to the appropriate Kubernetes context and namespace. The Deployment name is always `kubestellar-controller-manager`, but you may need to adjust the context and namespace for your environment.
-
 
 ```sh
 kubectl --context kind-kubeflex port-forward -n wds1-system deployment/kubestellar-controller-manager 8443:8443 8082:8082
@@ -53,7 +49,6 @@ Access pprof: [http://localhost:8082/debug/pprof/](http://localhost:8082/debug/p
 
 - Example Grafana dashboards and configuration can be found in [`monitoring/grafana/`](https://github.com/kubestellar/kubestellar/tree/main/monitoring/grafana).
 - After deploying Prometheus and Grafana (or your preferred stack), you can import dashboards to visualize KubeStellar metrics.
-
 
 ## Additional Resources
 

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -87,6 +87,7 @@ nav:
       - Onboarding: contribution-guidelines/onboarding-inc.md
       - Website:
           - Docs Management Overview: contribution-guidelines/operations/document-management.md
+          - Testing website PRs: contribution-guidelines/operations/document-management.md#testing-website-prs
       - Security:
           - Policy: contribution-guidelines/security/security-inc.md
           - Contacts: contribution-guidelines/security/security_contacts-inc.md

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -87,7 +87,7 @@ nav:
       - Onboarding: contribution-guidelines/onboarding-inc.md
       - Website:
           - Docs Management Overview: contribution-guidelines/operations/document-management.md
-          - Testing website PRs: contribution-guidelines/operations/document-management.md#testing-website-prs
+          - Testing website PRs: contribution-guidelines/operations/testing-doc-prs.md
       - Security:
           - Policy: contribution-guidelines/security/security-inc.md
           - Contacts: contribution-guidelines/security/security_contacts-inc.md


### PR DESCRIPTION
📖 Summary

This PR refines the Observability documentation based on feedback from [PR #2992](https://github.com/kubestellar/kubestellar/pull/2992).
It clarifies and expands the details around controller metrics and profiling endpoints.

Key improvements:
	•	Added kubestellar-controller-manager entry for port 8080 (HTTP access without auth)
	•	Clarified when HTTPS and authentication are required — even for direct Pod access
	•	Corrected status-agent-controller debug endpoint port from 8082 → 8083
	•	Updated notes to reflect Helm configurability status (per [issue #2158](https://github.com/kubestellar/kubestellar/issues/2158))
	•	Improved section titles for accuracy (e.g., “Accessing KubeStellar Controller Metrics”)
	•	Fixed outdated mkdocs.yml link to point to #testing-website-prs directly

These changes improve accuracy, clarity, and ensure better onboarding for users setting up observability tooling.

🔗 Related Issue(s)

Follow-up to: #2992

🔍 Preview

 Preview : https://rishi-jat.github.io/kubestellar/doc-observability-fix/direct/observability/