### PR TITLE
🌱  List more files that should not trigger e2e/integration tests

### DIFF
--- a/.github/workflows/pr-test-e2e.yml
+++ b/.github/workflows/pr-test-e2e.yml
@@ -22,6 +22,10 @@ on:
       - ".github/workflows/**"
       - "!.github/workflows/pr-test-e2e.yml"
       - "**/*.md"
+      - ".gha-reversemap.yml"
+      - "hack/verify-*"
+      - "hack/boilerplate/*"
+      - "hack/gha-reversemap.sh"
   push:
     branches:
       - main
@@ -33,6 +37,10 @@ on:
       - ".github/workflows/**"
       - "!.github/workflows/pr-test-e2e.yml"
       - "**/*.md"
+      - ".gha-reversemap.yml"
+      - "hack/verify-*"
+      - "hack/boilerplate/*"
+      - "hack/gha-reversemap.sh"
 
 permissions:
   contents: read

--- a/.github/workflows/pr-test-integration.yml
+++ b/.github/workflows/pr-test-integration.yml
@@ -11,6 +11,10 @@ on:
       - ".github/workflows/**"
       - "!.github/workflows/pr-test-e2e.yml"
       - "**/*.md"
+      - ".gha-reversemap.yml"
+      - "hack/verify-*"
+      - "hack/boilerplate/*"
+      - "hack/gha-reversemap.sh"
   push:
     paths-ignore:
       - "docs/**"
@@ -18,6 +22,10 @@ on:
       - ".github/workflows/**"
       - "!.github/workflows/pr-test-e2e.yml"
       - "**/*.md"
+      - ".gha-reversemap.yml"
+      - "hack/verify-*"
+      - "hack/boilerplate/*"
+      - "hack/gha-reversemap.sh"
 
 permissions:
   contents: read


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Don't forget to first look for overlapping PRs. Remember, open source
is a collaborative rather than competitive activity.

If this PR includes changes to the source files for the website
(docs/content/** or a file included from there) then include a preview
of the modified website; see
docs/content/contribution-guidelines/operations/document-management.md.

Please put one of the following icons at the start of your PR title,
to indicate the type of your PR. You could use copy-and-paste from
here; alternatively, the indicated code is recognized by most browsers
as a way to input that icon.

✨ - code :sparkles:, type feature
🐛 - code :bug:, type bug fix
📖 - code :book:, type docs
📝 - code :memo:, type proposal
⚠️ - code :warning:, type breaking change
🌱 - code :seedling:, type other/misc
❓ - code :question:, type requires manual review/categorization

-->
## Summary
This PR expands the list of files that should not trigger the E2E and integration test workflows. This is good because it wastes less of our human time and github workflow run capacity.

## Related issue(s)

Fixes #
