### PR TITLE
🐛 Split ambiguous cr-validation test into two focused cases

### DIFF
--- a/test/integration/controller-manager/cr-validation_test.go
+++ b/test/integration/controller-manager/cr-validation_test.go
@@ -89,12 +89,12 @@ func TestBindingPolicyValidation(t *testing.T) {
 		specJSON string
 		expectOK bool
 	}{
-		{name: "junk-field-in-spec", specJSON: `{"junk": 1}`, expectOK: false},
+		{name: "junk-field-in-spec", specJSON: `{"junk": 1}`},
 		{name: "junk-field-in-policy", specJSON: `{"downsync": [{"junq": true}]}`},
 		// Test: empty ObjectTest (no selector fields, valid fields only)
-		{name: "empty-object-test", specJSON: `{"downsync": [{"createOnly": true}]}`, expectOK: false},
+		{name: "empty-object-test", specJSON: `{"downsync": [{"createOnly": true}]}`},
 		// Test: use of now-invalid 'statusCollection' field (should fail OpenAPI validation)
-		{name: "invalid-statusCollection-field", specJSON: `{"downsync": [{"createOnly": true, "statusCollection": {"statusCollectors": ["phred"]}}]}`, expectOK: false},
+		{name: "invalid-statusCollection-field", specJSON: `{"downsync": [{"statusCollection": {"statusCollectors": ["phred"]}}]}`},
 		{name: "match-all-resources", specJSON: `{"downsync": [{"resources": ["*"]}]}`, expectOK: true},
 	} {
 		t.Run(testCase.name, func(t *testing.T) {


### PR DESCRIPTION
Description:
Split the ambiguous no-test-in-policy test into two separate cases: one for empty ObjectTest rejection, and one for the invalid statusCollection field. Each test now checks a single validation error as intended.

fixes #2673 