### PR TITLE
📖 Fix the broken link for Galaxy repository in galaxy.md file

### DIFF
--- a/docs/content/direct/galaxy-intro.md
+++ b/docs/content/direct/galaxy-intro.md
@@ -28,5 +28,5 @@ and Argo Workflows + KubeStellar integration.
 
 # Learn More
 
-To learn more [visit the repository at https://github.com/kubestellar/galaxy](https://github.com/kubestellar/gala)
+To learn more [visit the repository at https://github.com/kubestellar/galaxy](https://github.com/kubestellar/galaxy)
 **_Note that all the code in the galaxy repo is experimental and is available on an as-is basis **


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Don't forget to first look for overlapping PRs. Remember, open source
is a collaborative rather than competitive activity.

If this PR includes changes to the source files for the website
(docs/content/** or a file included from there) then include a preview
of the modified website; see
docs/content/contribution-guidelines/operations/document-management.md.

Please put one of the following icons at the start of your PR title,
to indicate the type of your PR. You could use copy-and-paste from
here; alternatively, the indicated code is recognized by most browsers
as a way to input that icon.

✨ - code :sparkles:, type feature
🐛 - code :bug:, type bug fix
📖 - code :book:, type docs
📝 - code :memo:, type proposal
⚠️ - code :warning:, type breaking change
🌱 - code :seedling:, type other/misc
❓ - code :question:, type requires manual review/categorization

-->
## Summary
Found a broken link in this [documentation page](https://docs.kubestellar.io/release-0.28.0/direct/galaxy-intro/#learn-more) while exploring Kubestellar.

This PR fixes a broken link in [docs/content/direct/galaxy-intro.md](https://github.com/kubestellar/kubestellar/blob/main/docs/content/direct/galaxy-intro.md?plain=1#L31). 
There was a typo in underlying reference that was causing 404 error. The issue was discovered while exploring the docs.

Preview at https://greninja517.github.io/kubestellar/direct/galaxy-intro/#learn-more


