### PR TITLE
🌱  Rename and tweak PR title checking workflow

### DIFF
--- a/.github/workflows/pr-verify-title.yaml
+++ b/.github/workflows/pr-verify-title.yaml
@@ -29,19 +29,18 @@ jobs:
 
           # Define allowed emoji prefixes using a safe regular expression match
           if ! printf '%s' "$TITLE" | grep -qE '^(⚠|✨|🐛|📖|🚀|🌱)'; then
-            echo "❌ Error: PR title has invalid format."
-            echo "Your PR title must start with one of the following indicators:"
-            echo "- ⚠  Breaking change"
-            echo "- ✨  Non-breaking feature"
-            echo "- 🐛  Patch fix"
-            echo "- 📖  Documentation"
-            echo "- 🚀  Release"
-            echo "- 🌱  Infra/Tests/Other"
-            echo "The failed title is '${TITLE}'"
-            echo -n The first character is, in hex:
+            printf "❌ required indicator not found at the start of title: %q\n" "$TITLE"
+            echo "Your PR title must start with one of the following special characters:"
+            echo "⚠ (indicates Breaking change)"
+            echo "✨ (indicates Non-breaking feature)"
+            echo "🐛 (indicates Patch fix)"
+            echo "📖 (indicates Documentation)"
+            echo "🚀 (indicates Release)"
+            echo "🌱 (indicates Infra/Tests/Other)"
+            echo -n "Your title's first character is, in hex: "
             python3 -c "import os; print('%x' % ord(os.environ['TITLE'][0]))"
             exit 1
           fi
 
           # Safely print the title without allowing code execution
-          printf "✅ PR title is valid: %q\n" "$TITLE"
+          printf "✅ PR title is valid: '%q'\n" "$TITLE"


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Don't forget to first look for overlapping PRs. Remember, open source
is a collaborative rather than competitive activity.

If this PR includes changes to the source files for the website
(docs/content/** or a file included from there) then include a preview
of the modified website; see
docs/content/contribution-guidelines/operations/document-management.md.

Please put one of the following icons at the start of your PR title,
to indicate the type of your PR. You could use copy-and-paste from
here; alternatively, the indicated code is recognized by most browsers
as a way to input that icon.

✨ - code :sparkles:, type feature
🐛 - code :bug:, type bug fix
📖 - code :book:, type docs
📝 - code :memo:, type proposal
⚠️ - code :warning:, type breaking change
🌱 - code :seedling:, type other/misc
❓ - code :question:, type requires manual review/categorization

-->
## Summary
This PR rewords the error message from the PR title verifier, trying to make it more utterly clear that the title should begin with the emoji rather than the code for it.

This PR also makes the workflow display the offending title when it fails.

This PR also renames the workflow file to a slightly more informative name.

## Related issue(s)

Fixes #
