### PR TITLE
🐛 Fix the Warning message from kubeflex to display actual kubeflex version

### DIFF
--- a/scripts/check_pre_req.sh
+++ b/scripts/check_pre_req.sh
@@ -159,8 +159,8 @@ is_installed_kcp() {
 is_installed_kflex() {
     is_installed 'KubeFlex' \
         'kflex' \
-        'kflex version | head -1' \
-        'kflex version | head -1' \
+        'kflex version | grep "^Kubeflex version:"' \
+        'kflex version | grep "^Kubeflex version:"' \
         'https://github.com/kubestellar/kubeflex' \
         'Kubeflex version: v0.8.0'
 }


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Don't forget to first look for overlapping PRs. Remember, open source
is a collaborative rather than competitive activity.

If this PR includes changes to the source files for the website
(docs/content/** or a file included from there) then include a preview
of the modified website; see
docs/content/contribution-guidelines/operations/document-management.md.

Please put one of the following icons at the start of your PR title,
to indicate the type of your PR. You could use copy-and-paste from
here; alternatively, the indicated code is recognized by most browsers
as a way to input that icon.

✨ - code :sparkles:, type feature
🐛 - code :bug:, type bug fix
📖 - code :book:, type docs
📝 - code :memo:, type proposal
⚠️ - code :warning:, type breaking change
🌱 - code :seedling:, type other/misc
❓ - code :question:, type requires manual review/categorization

-->
## Summary
This PR fixes the Warning Message display by `kubeflex` new version ( `0.9.0` ) while running _/scripts/check_pre_req.sh_  script to show the actual version of `kubeflex`.

### Before:
<img width="2704" height="262" alt="image" src="https://github.com/user-attachments/assets/a5725f6c-c572-4e0e-b9cf-9c00067bd552" />

### After:
<img width="2704" height="262" alt="image" src="https://github.com/user-attachments/assets/68fc8489-ae35-4cec-941a-e2c4e536f263" />


## Related issue(s)

Fixes #3078
