### PR TITLE
🐛 Add 'v' prefix to Helm version for consistent comparison of wantver and getver in check prerequisites script

### DIFF
--- a/scripts/check_pre_req.sh
+++ b/scripts/check_pre_req.sh
@@ -124,7 +124,7 @@ is_installed_helm() {
     is_installed 'Helm' \
         'helm' \
         'helm version' \
-        'helm version --template={{.Version}}' \
+        'echo "v$(helm version --template={{.Version}})"' \
         'https://helm.sh/docs/intro/install/' \
         'v3'
     if log=$(helm show chart oci://ghcr.io/kubestellar/kubestellar/core-chart 2>&1)


### PR DESCRIPTION

<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Don't forget to first look for overlapping PRs. Remember, open source
is a collaborative rather than competitive activity.

If this PR includes changes to the source files for the website
(docs/content/** or a file included from there) then include a preview
of the modified website; see
docs/content/contribution-guidelines/operations/document-management.md.

Please put one of the following icons at the start of your PR title,
to indicate the type of your PR. You could use copy-and-paste from
here; alternatively, the indicated code is recognized by most browsers
as a way to input that icon.

✨ - code :sparkles:, type feature
🐛 - code :bug:, type bug fix
📖 - code :book:, type docs
📝 - code :memo:, type proposal
⚠️ - code :warning:, type breaking change
🌱 - code :seedling:, type other/misc
❓ - code :question:, type requires manual review/categorization

-->
## Summary
The [is_installed](https://github.com/kubestellar/kubestellar/blob/main/scripts/check_pre_req.sh#L29) function compares structured versions using lexical comparison, and expects both `gotver` and `wantver` to be similarly formatted. And, Helm returns version prefixed without `v` e.g. (`3.18.1`), but the `wantver` is prefixed  with 'v' e.g. (`v3`), causing incorrect comparisons and script run failure.

So, Added `'v'` prefix to the output of `gotver` by wrapping it inside [is_installed_helm()](https://github.com/kubestellar/kubestellar/blob/main/scripts/check_pre_req.sh#L122) function, ensuring both `gotver` and `wantver` are formatted as `vX.Y.Z`.
## Related issue(s)

Fixes #
