### PR TITLE
📖  Cross-link the two readmes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
-<!--readme-for-root-start-->
-<!--prow test 8-->
+<!-- Note that this repo has two readme files, with content that is as nearly identical as is practical: `/README.md` and `/docs/content/readme.md` -->
 
 <img alt="" width="500px" align="left" src="KubeStellar-with-Logo.png" />
 
@@ -105,4 +104,3 @@ Instantly get access to our documents and meeting invites at http://kubestellar.
 <br>Kubernetes and the Kubernetes logo are registered trademarks of The Linux Foundation® (TLF).
 <br>The Linux Foundation has registered trademarks and uses trademarks. For a list of trademarks of The Linux Foundation, please see our <a href="https://www.linuxfoundation.org/legal/trademark-usage">Trademark Usage page</a>.
 <br>© 2022-2025. The KubeStellar Authors.
-<!--readme-for-root-end-->

--- a/docs/content/readme.md
+++ b/docs/content/readme.md
@@ -1,4 +1,4 @@
-<!--readme-for-root-start-->
+<!-- Note that this repo has two readme files, with content that is as nearly identical as is practical: `/README.md` and `/docs/content/readme.md` -->
 
 <img alt="" width="500px" align="left" src="../KubeStellar-with-Logo.png" />
 
@@ -110,4 +110,3 @@ Thanks go to these wonderful people:
 <!-- prettier-ignore-end -->
 
 <!-- ALL-CONTRIBUTORS-LIST:END -->
-<!--readme-for-root-end-->


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Don't forget to first look for overlapping PRs. Remember, open source
is a collaborative rather than competitive activity.

If this PR includes changes to the source files for the website
(docs/content/** or a file included from there) then include a preview
of the modified website; see
docs/content/contribution-guidelines/operations/document-management.md.

Please put one of the following icons at the start of your PR title,
to indicate the type of your PR. You could use copy-and-paste from
here; alternatively, the indicated code is recognized by most browsers
as a way to input that icon.

✨ - code :sparkles:, type feature
🐛 - code :bug:, type bug fix
📖 - code :book:, type docs
📝 - code :memo:, type proposal
⚠️ - code :warning:, type breaking change
🌱 - code :seedling:, type other/misc
❓ - code :question:, type requires manual review/categorization

-->
## Summary
This PR makes each of the two readmes point to both of them and assert that they are as nearly identical as is practical.

This PR also removes some obsolete HTML comments.

Preview at https://github.com/MikeSpreitzer/kcp-edge-mc/blob/doc-readme-twins/README.md and https://mikespreitzer.github.io/kcp-edge-mc/doc-readme-twins/readme/

## Related issue(s)

Fixes #
