### PR TITLE
📖  Add the Contributor Ladder to website

### DIFF
--- a/docs/content/contribution-guidelines/contributor_ladder.md
+++ b/docs/content/contribution-guidelines/contributor_ladder.md
@@ -1,0 +1,107 @@
+# Maintainer Pathway – KubeStellar
+
+This document outlines the process by which contributors to the [KubeStellar](https://github.com/kubestellar/kubestellar) open source project can progress toward becoming maintainers, and defines a transparent, merit-based path that rewards consistent engagement and community contribution.
+
+---
+
+## Purpose
+
+To provide contributors with a clear understanding of how to grow within the KubeStellar community — from first-time contributors to trusted maintainers — based on mentorship, impact, and measurable contributions.
+
+---
+
+## Contributor Journey
+
+Each level reflects a growing commitment to the project, increased responsibilities, and expanded leadership opportunities.
+
+---
+
+### 1.  Contributor -> Unpaid Intern
+
+**Requirements:**
+- Minimum of **3 contributions** (e.g., bug reports, documentation PRs, or code PRs)
+- Display enthusiasm and interest in long-term participation
+- Be active on GitHub and Slack
+- Informal application or nomination to join the intern program
+
+---
+
+### 2. Unpaid Intern -> Paid Intern
+
+**Timeframe:** 12-week internship  
+**Quantitative Requirements (within 12 weeks):**
+- Open at least **6 “help wanted” issues**
+- **Merge at least 20 PRs**
+  - Of those, at least **8 PRs must be merged within the first 6 weeks**
+- Attend weekly team meetings or submit summaries asynchronously
+- Work collaboratively with mentors
+
+Promotion to paid intern requires completion of the above plus:
+- A mentor’s recommendation
+- Strong communication and follow-through
+
+---
+
+### 3. Paid Intern -> Mentor
+
+**Requirements:**
+- Successfully complete at least one 12-week paid internship cycle
+- Help onboard and support at least one new intern or contributor
+- Submit:
+  - ≥ **3 PR reviews**
+  - ≥ **5 helpful comments** on PRs or issues
+- Present or co-present at a community call
+
+---
+
+### 4. Mentor -> Maintainer
+
+**Requirements:**
+- Demonstrate technical leadership in one or more key areas
+- Maintain consistent contribution activity
+- Engage with the community in GitHub and Slack
+- Approved by core maintainers following a public review process
+
+---
+
+## Maintainer Activity Requirements
+
+Maintainers are expected to remain active by meeting the following **bi-monthly (every 2 months)** contribution minimums:
+
+| Metric                                | Requirement (Per 2 Months) |
+|---------------------------------------|----------------------------|
+| “Help Wanted” Issues                  | ≥ 2                        |
+| **PRs Merged**                        | ≥ 3                        |
+| PR Reviews or Constructive Comments   | ≥ 8                        |
+| Community Meeting Attendance          | ≥ 3                        |
+
+All maintainers will be listed in a shared Google Sheet where these metrics are tracked publicly.
+
+---
+
+## Evaluation and Status
+
+- Evaluations occur every 6 weeks for interns and every 8 weeks for maintainers
+- Interns who do not meet the required output may be removed from the program
+- Maintainers who fail to meet activity thresholds for 2 consecutive cycles will be reviewed for possible status change
+- Contributors may re-enter or regain status based on future contributions
+
+---
+
+## Metric Tracking
+
+Contribution metrics will be gathered via GitHub API and updated to a public Google Sheet (link TBD). Contributions across the following repos count toward intern and maintainer totals:
+
+- [`kubestellar/kubestellar`](https://github.com/kubestellar/kubestellar)
+- [`kubestellar/kubeflex`](https://github.com/kubestellar/kubeflex)
+- [`kubestellar/ui`](https://github.com/kubestellar/ui)
+
+---
+
+## Join the Pathway
+
+If you’re interested in becoming an intern or nominating someone, please attend a [KubeStellar Community Meeting](https://github.com/kubestellar/community), or open an issue with the label `maintainer-pathway`.
+
+---
+
+*Maintained by the KubeStellar team. Last updated: July 2025.*

--- a/docs/content/direct/contribute.md
+++ b/docs/content/direct/contribute.md
@@ -35,6 +35,7 @@ Read the resources to gain a better understanding of the contribution processes.
 
 - **[Code of Conduct](../contribution-guidelines/coc-inc.md)** The CNCF code of conduct for the KubeStellar community
 - **[Contribution Guidelines](../contribution-guidelines/contributing-inc.md)** General Guidelines for our Github processes
+- **[Contributor Ladder](../contribution-guidelines/contributor_ladder.md)** Path for becoming a KubeStellar maintainer by contributing
 - **[License](../contribution-guidelines/license-inc.md)** The Apache 2.0 license under which KubeStellar is published
 - **[Governance](../contribution-guidelines/governance-inc.md)** The protocols under which the KubeStellar project is run
 - **[Onboarding](../contribution-guidelines/onboarding-inc.md)** The procedures for adding/removing members of our Github organization

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -82,6 +82,7 @@ nav:
       - Overview (How to join in): direct/contribute.md
       - Code of Conduct: contribution-guidelines/coc-inc.md
       - Guidelines: contribution-guidelines/contributing-inc.md
+      - Contributor Ladder: contribution-guidelines/contributor_ladder.md
       - License: contribution-guidelines/license-inc.md
       - Governance: contribution-guidelines/governance-inc.md
       - Onboarding: contribution-guidelines/onboarding-inc.md


### PR DESCRIPTION
## Summary
Preview at https://kproche.github.io/kubestellar/doc-addladder
Most notably ladder can be previewed at https://kproche.github.io/kubestellar/doc-addladder/contribution-guidelines/cont_ladder/
and is linked from https://kproche.github.io/kubestellar/doc-addladder/direct/contribute/

Based on the discussion in UI issue 1432, created a contributor ladder page in the website docs, with a referring file stub in the repository root

**NOTE** I removed the emojis from the original MD file; planned future website automations may choke on them
## Related issue(s)
https://github.com/kubestellar/ui/issues/1432

Fixes #
