### PR TITLE
🐛 bug: remove variable double definition in WDS CP (fixes #3124)

### DIFF
--- a/core-chart/templates/controlplanes/wds.yaml
+++ b/core-chart/templates/controlplanes/wds.yaml
@@ -11,7 +11,6 @@ spec:
     - hookName: kubestellar-controller
       vars:
         APIGroups: "{{ .APIGroups | default "" }}"
-        ITSName: "{{ .ITSName | default "" }}"
     - hookName: transport-controller
   globalVars:
     ControlPlaneName: {{ .name }}


### PR DESCRIPTION
## Summary

Removed the double definition of ITSName in the wds.yaml file, it now uses the one defined in the globalVars.

## Related issue(s)

Fixes #3124 
