### PR TITLE
📖 CNCF Slack Update: Update all Slack URLs to point to new CNCF Slack Channel across the repo and docs

### DIFF
--- a/ONBOARDING.md
+++ b/ONBOARDING.md
@@ -20,7 +20,7 @@ The purpose of this policy is to ensure a smooth on-boarding and off-boarding pr
 - Upon approval, the member will receive an invitation to join the KubeStellar GitHub organization.
 
 2.3. Getting Help:
-- The organization's maintainers are here to help contributors be efficient and confident in their collaboration effort. If you need help you can reach out to the maintainers on slack at the [KubeStellar-dev channel](https://kubernetes.slack.com/archives/C058SUSL5AA).
+- The organization's maintainers are here to help contributors be efficient and confident in their collaboration effort. If you need help you can reach out to the maintainers on slack at the [KubeStellar-dev channel](https://cloud-native.slack.com/archives/C097094RZ3M).
 - Be sure to join the [KubeStellar-dev Google Group](https://groups.google.com/g/kubestellar-dev) to get access to important artifacts like proposals, diagrams, and meeting invitations.
 
 2.4. Orientation:

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 [![](https://www.bestpractices.dev/projects/8266/badge)](https://www.bestpractices.dev/projects/8266)
 [![](https://api.scorecard.dev/projects/github.com/kubestellar/kubestellar/badge)](https://scorecard.dev/viewer/?uri=github.com/kubestellar/kubestellar)
 [![](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/kubestellar)](https://artifacthub.io/packages/search?repo=kubestellar)
-<a href="https://kubernetes.slack.com/archives/C058SUSL5AA"> 
+<a href="https://cloud-native.slack.com/archives/C097094RZ3M"> 
     <img alt="Join Slack" src="https://img.shields.io/badge/KubeStellar-Join%20Slack-blue?logo=slack">
   </a>
 
@@ -59,7 +59,7 @@ There are several ways to communicate with us:
 
 Instantly get access to our documents and meeting invites at http://kubestellar.io/joinus
 
-- The [`#kubestellar-dev` channel](https://kubernetes.slack.com/archives/C058SUSL5AA) in the [Kubernetes Slack workspace](https://slack.k8s.io)
+- The [`#kubestellar-dev` channel](https://cloud-native.slack.com/archives/C097094RZ3M) in the [CNCF Slack workspace](https://communityinviter.com/apps/cloud-native/cncf)
 - Our mailing lists:
     - [kubestellar-dev](https://groups.google.com/g/kubestellar-dev) for development discussions
     - [kubestellar-users](https://groups.google.com/g/kubestellar-users) for discussions among users and potential users

--- a/docs/content/Community/_index.md
+++ b/docs/content/Community/_index.md
@@ -15,7 +15,7 @@
 #### If you want to get more involved by contributing to KubeStellar, join us here:
 
 - [GitHub]({{ config.repo_url }}): Development takes place here!
-- [#kubestellar-dev Slack channel](https://kubernetes.slack.com/archives/C058SUSL5AA) in the [Kubernetes slack workspace](https://slack.k8s.io/): Chat with other project developers
+- [#kubestellar-dev Slack channel](https://cloud-native.slack.com/archives/C097094RZ3M) in the [CNCF slack workspace](https://communityinviter.com/apps/cloud-native/cncf): Chat with other project developers
 - [Developer mailing list](https://groups.google.com/g/kubestellar-dev): Discuss development issues around the project
 - You can find out how to contribute to KubeStellar in our [Contribution Guidelines](../contribution-guidelines/contributing-inc.md)
 

--- a/docs/content/Community/partners/fluxcd.md
+++ b/docs/content/Community/partners/fluxcd.md
@@ -4,4 +4,4 @@
    end="<!--coming-soon-end-->"
 %}
 
-[Work with us](https://kubernetes.slack.com/archives/C058SUSL5AA) to create this document
+[Work with us](https://cloud-native.slack.com/archives/C097094RZ3M) to create this document

--- a/docs/content/Community/partners/kyverno.md
+++ b/docs/content/Community/partners/kyverno.md
@@ -19,7 +19,7 @@ Medium - [Syncing Objects from one Kubernetes cluster to another Kubernetes clus
 </p>
 
 ### How do I get this working with my KubeStellar instance?
-[Work with us](https://kubernetes.slack.com/archives/C058SUSL5AA) to create this document
+[Work with us](https://cloud-native.slack.com/archives/C097094RZ3M) to create this document
 
 <style type="text/css">
 .centerImage

--- a/docs/content/Community/partners/mvi.md
+++ b/docs/content/Community/partners/mvi.md
@@ -10,7 +10,7 @@ Medium - [Deployment and configuration of MVI-Edge using KubeStellar](https://me
 </p>
 
 ### How do I get this working with my KubeStellar instance?
-[Work with us](https://kubernetes.slack.com/archives/C058SUSL5AA) to create this document
+[Work with us](https://cloud-native.slack.com/archives/C097094RZ3M) to create this document
 
 ### MVI and KubeStellar in the news
 <p align=center>

--- a/docs/content/contribution-guidelines/contributing-inc.md
+++ b/docs/content/contribution-guidelines/contributing-inc.md
@@ -2,12 +2,12 @@
 
 Greetings! We are grateful for your interest in joining the KubeStellar community and making a positive impact. Whether you're raising issues, enhancing documentation, fixing bugs, or developing new features, your contributions are essential to our success.
 
-To get started, kindly read through this document and familiarize yourself with our code of conduct. If you have any inquiries, please feel free to reach out to us on [Slack](https://kubernetes.slack.com/archives/C058SUSL5AA).
+To get started, kindly read through this document and familiarize yourself with our code of conduct. If you have any inquiries, please feel free to reach out to us on [Slack](https://cloud-native.slack.com/archives/C097094RZ3M).
 
 We can't wait to collaborate with you!
 
 
-This document describes our policies, procedures and best practices for working on KubeStellar via the project and repository on GitHub. Much of this interaction (issues, pull requests, discussions) is meant to be viewed directly at the [KubeStellar repository webpage on GitHub](https://github.com/kubestellar/kubestellar/). Other community discussions and questions are available via our slack channel. If you have any inquiries, please feel free to reach out to us on the [KubeStellar-dev Slack channel](https://kubernetes.slack.com/archives/C058SUSL5AA/).
+This document describes our policies, procedures and best practices for working on KubeStellar via the project and repository on GitHub. Much of this interaction (issues, pull requests, discussions) is meant to be viewed directly at the [KubeStellar repository webpage on GitHub](https://github.com/kubestellar/kubestellar/). Other community discussions and questions are available via our slack channel. If you have any inquiries, please feel free to reach out to us on the [KubeStellar-dev Slack channel](https://cloud-native.slack.com/archives/C097094RZ3M/).
 
 Please read the following guidelines if you're interested in contributing to KubeStellar.
 
@@ -122,7 +122,7 @@ Reviewers will review your PR within a business day. A PR requires both an `/lgt
 
 _Congratulations! Your pull request has been successfully merged!_ 👏
 
-If you have any questions about contributing, don't hesitate to reach out to us on the KubeStellar-dev [Slack channel](https://kubernetes.slack.com/archives/C058SUSL5AA/).
+If you have any questions about contributing, don't hesitate to reach out to us on the KubeStellar-dev [Slack channel](https://cloud-native.slack.com/archives/C097094RZ3M/).
 
 
 

--- a/docs/content/direct/contribute.md
+++ b/docs/content/direct/contribute.md
@@ -1,7 +1,7 @@
 # Contributing to KubeStellar
 Welcome to the KubeStellar Contribution Guide! We are excited to have you here. 
 
-You can join the community via our [Slack channel](https://kubernetes.slack.com/archives/C058SUSL5AA/).
+You can join the community via our [Slack channel](https://cloud-native.slack.com/archives/C097094RZ3M/).
 
 This section provides information on the Code of Conduct, guidelines, terms, and conditions that define the KubeStellar contribution processes. By contributing, you are enabling the success of KubeStellar users, and that goes a long way to make everyone happier, including you. We welcome individuals who are new to open-source contributions.
 

--- a/docs/content/direct/user-guide-intro.md
+++ b/docs/content/direct/user-guide-intro.md
@@ -3,7 +3,7 @@
 This document is an overview of the User Guide.
 See the KubeStellar [overview](../readme.md) for architecture and other information.
 
-This user guide is an ongoing project. If you find errors, please point them out in our [Slack channel](https://kubernetes.slack.com/archives/C058SUSL5AA/) or open an issue in our [github repository](https://github.com/kubestellar/kubestellar)!
+This user guide is an ongoing project. If you find errors, please point them out in our [Slack channel](https://cloud-native.slack.com/archives/C097094RZ3M/) or open an issue in our [github repository](https://github.com/kubestellar/kubestellar)!
 
 ## Simple Examples
 

--- a/docs/content/readme.md
+++ b/docs/content/readme.md
@@ -15,7 +15,7 @@
 [![](https://www.bestpractices.dev/projects/8266/badge)](https://www.bestpractices.dev/projects/8266)
 [![](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/kubestellar)](https://artifacthub.io/packages/search?repo=kubestellar)
 [![](https://api.scorecard.dev/projects/github.com/kubestellar/kubestellar/badge)](https://scorecard.dev/viewer/?uri=github.com/kubestellar/kubestellar)
-<a href="https://kubernetes.slack.com/archives/C058SUSL5AA"> 
+<a href="https://cloud-native.slack.com/archives/C097094RZ3M"> 
     <img alt="Join Slack" src="https://img.shields.io/badge/KubeStellar-Join%20Slack-blue?logo=slack">
   </a>
 
@@ -56,7 +56,7 @@ There are several ways to communicate with us:
 
 Instantly get access to our documents and meeting invites [http://kubestellar.io/joinus](http://kubestellar.io/joinus)
 
-- The [`#kubestellar-dev` channel](https://kubernetes.slack.com/archives/C058SUSL5AA) in the [Kubernetes Slack workspace](https://slack.k8s.io)
+- The [`#kubestellar-dev` channel](https://cloud-native.slack.com/archives/C097094RZ3M) in the [CNCF Slack workspace](https://communityinviter.com/apps/cloud-native/cncf)
 - Our mailing lists:
     - [kubestellar-dev](https://groups.google.com/g/kubestellar-dev) for development discussions
     - [kubestellar-users](https://groups.google.com/g/kubestellar-users) for discussions among users and potential users

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -182,7 +182,7 @@ extra:
   #     link: 'https://www.youtube.com/@kubestellar'
   #     name: KubeStellar on YouTube
   #   - icon: fontawesome/brands/slack
-  #     link: 'https://kubernetes.slack.com/archives/C058SUSL5AA'
+  #     link: 'https://cloud-native.slack.com/archives/C097094RZ3M'
   #     name: KubeStellar on Slack
   #   - icon: fontawesome/solid/paper-plane
   #     link: mailto:kubestellar-dev@google.groups.com


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Don't forget to first look for overlapping PRs. Remember, open source
is a collaborative rather than competitive activity.

If this PR includes changes to the source files for the website
(docs/content/** or a file included from there) then include a preview
of the modified website; see
docs/content/contribution-guidelines/operations/document-management.md.

Please put one of the following icons at the start of your PR title,
to indicate the type of your PR. You could use copy-and-paste from
here; alternatively, the indicated code is recognized by most browsers
as a way to input that icon.

✨ - code :sparkles:, type feature
🐛 - code :bug:, type bug fix
📖 - code :book:, type docs
📝 - code :memo:, type proposal
⚠️ - code :warning:, type breaking change
🌱 - code :seedling:, type other/misc
❓ - code :question:, type requires manual review/categorization

-->
## Summary
This PR updates all the references of  `kubestellar-dev` slack channel that was previously under Kubernetes workspace to point to new slack channel under CNCF workspace as described in the issue #3122 in the entire repo and docs. Community Inviter URL for the new CNCF workspace has also been updated in the relevant files. 

Shortcut URL `https://kubestellar.io/slack` is still pointing to old Kubernetes Slack channel which needs to be updated by the maintainers who are managing the domain names.

Preview at: https://greninja517.github.io/kubestellar/doc-cncf-slack-update/

## Related issue(s)

Fixes #3122
