### PR TITLE
📖  Add elementary style guide to website contribution section

### DIFF
--- a/docs/content/contribution-guidelines/operations/docs-styleguide.md
+++ b/docs/content/contribution-guidelines/operations/docs-styleguide.md
@@ -7,7 +7,7 @@ _This document is a just starting point for a much more complete style guide and
 For KubeStellar's website and other documentation to be useful and effective, the pages need to be readable and accessible to its audience. Given the cooperative nature of an open-source project, a Style Guide makes it easier for multiple contributors to write and maintain the documentation with a consistent and understandable format and authorial voice.
 
 An extended [Design System for KubeStellar's websites and UI is being developed](https://github.com/kubestellar/ui/blob/dev/docs/design-progress.md) during mid-2025. The resulting **Design Guide** will govern the visual language and components of KubeStellar UIs and docs.
-This **Style Guide** is intended to complement the Design Guide to govern the written language components of the KubeStellar, and will evolve alongside the Design System.
+This **Style Guide** is intended to complement the Design Guide to govern the _prose_ (written language/text) components of the KubeStellar ecosystem, and will evolve alongside the Design Guide.
 
 ## Basic Style Considerations
 
@@ -27,16 +27,16 @@ It should also be **clear**: terms should be defined and jargon explained when f
 
 Much of KubeStellar's existing documentation -- especially introductory and overview text -- is written with a slightly light and breezy tone. That is deliberate; it, however, does not mean that the texts should not be technically accurate.
 
-## Avoid Use of Emojis in Prose
+### Avoid Use of Emojis in Prose
 
 The **Design Guide** will include guidance on use and placement of iconography in KubeStellar docs and UIs.
 In textual documentation, however, emojis may interfere with rendering and navigation of the website documentation, _especially_ if they are used in headings or titles. They also may make the documenation inaccessible to visitors who must use screen reader technology.
 
-## Always include alt-text for images
+### Always include alt-text for images
 
 This is a basic requirement for accessibility. Images and diagrams should always have an appropriate alt-text attribute. In general, keep the [W3C Guidelines for Accessibility](https://www.w3.org/TR/WCAG21/) in mind when writing/illustrating KubeStellar documentation 
 
-## Use Care If Using Generative AI
+### Use Care If Using Generative AI
 
 The use of generative AI for writing assistance is becoming more common. Any text created via genAI should be **carefully** reviewed to make sure it is both coherent and accurate. It should also be checked to ensure it is not plagiarism, as some LLMs have been trained on copyrighted works.
 

--- a/docs/content/contribution-guidelines/operations/docs-styleguide.md
+++ b/docs/content/contribution-guidelines/operations/docs-styleguide.md
@@ -1,0 +1,45 @@
+# KubeStellar Documentation Style Guide
+
+_This document is a just starting point for a much more complete style guide and toolbox being developed as a CNCF LXF Mentorship project in 2025_
+
+## Why have a Style Guide?
+
+For KubeStellar's website and other documentation to be useful and effective, the pages need to be readable and accessible to its audience. Given the cooperative nature of an open-source project, a Style Guide makes it easier for multiple contributors to write and maintain the documentation with a consistent and understandable format and authorial voice.
+
+An extended [Design System for KubeStellar's websites and UI is being developed](https://github.com/kubestellar/ui/blob/dev/docs/design-progress.md) during mid-2025. The resulting **Design Guide** will govern the visual language and components of KubeStellar UIs and docs.
+This **Style Guide** is intended to complement the Design Guide to govern the written language components of the KubeStellar, and will evolve alongside the Design System.
+
+## Basic Style Considerations
+
+As a starting point, here are some very basic items to consider when working on documentation for KubeStellar and its components:
+
+-  [Use clear and concise prose](#use-clear-and-concise-prose)
+-  [Avoid use of emojis (especially in headings)](#avoid-use-of-emojis-in-prose)
+-  [Always include alt-text for images](#always-include-alt-text-for-images)
+-  [Use care if using generative AI](#use-care-if-using-generative-ai) for writing assistance. Review text carefully to make sure it is both coherent and accurate.
+-  [Always check spelling and grammar](#always-do-a-spelling-and-grammar-check) before committing docs changes
+
+### Use Clear and Concise Prose
+
+The goal of written documentation should be "just enough." Enough detail that the reader can find the information they need, but not so much detail that they must search incessantly to find the key points.
+
+It should also be **clear**: terms should be defined and jargon explained when first used. Long, convoluted explanations should be examined to see if they might be better broken up into smaller chunks.
+
+Much of KubeStellar's existing documentation -- especially introductory and overview text -- is written with a slightly light and breezy tone. That is deliberate; it, however, does not mean that the texts should not be technically accurate.
+
+## Avoid Use of Emojis in Prose
+
+The **Design Guide** will include guidance on use and placement of iconography in KubeStellar docs and UIs.
+In textual documentation, however, emojis may interfere with rendering and navigation of the website documentation, _especially_ if they are used in headings or titles. They also may make the documenation inaccessible to visitors who must use screen reader technology.
+
+## Always include alt-text for images
+
+This is a basic requirement for accessibility. Images and diagrams should always have an appropriate alt-text attribute. In general, keep the [W3C Guidelines for Accessibility](https://www.w3.org/TR/WCAG21/) in mind when writing/illustrating KubeStellar documentation 
+
+## Use Care If Using Generative AI
+
+The use of generative AI for writing assistance is becoming more common. Any text created via genAI should be **carefully** reviewed to make sure it is both coherent and accurate. It should also be checked to ensure it is not plagiarism, as some LLMs have been trained on copyrighted works.
+
+## Always Do a Spelling and Grammar Check
+
+Before committing and/or pushing new docs to the repository and creating a pull request, be sure to check your written content for spelling and grammar errors. This will a) prevent the need to do a secondary commit to correct any discovered during the PR review and b) avoid the risk that such an error will confuse or throw a reader out of the text when they are using the documentation.

--- a/docs/content/contribution-guidelines/operations/document-management.md
+++ b/docs/content/contribution-guidelines/operations/document-management.md
@@ -25,6 +25,10 @@ two views (for example: indenting with four spaces instead of
 three). When that is not possible, considerations for the website
 rendering take precedence.
 
+### Style Guide
+
+With more contributors writing pages for our documentation, we are implementing a [Style Guide](docs-styleguide.md) to help ensure more usable documenations with a consistent style and voice.
+
 ### GitHub pages
 
 Our documentation is powered by [mike](https://github.com/jimporter/mike) and [MkDocs](https://www.mkdocs.org/). MkDocs is powered by [Python-Markdown](https://pypi.org/project/Markdown/). These are immensely configurable and extensible. You can see our MkDocs configuration in `docs/mkdocs.yml`. Following are some of the choices we have made.

--- a/docs/content/direct/contribute.md
+++ b/docs/content/direct/contribute.md
@@ -41,6 +41,7 @@ Read the resources to gain a better understanding of the contribution processes.
 - **[Onboarding](../contribution-guidelines/onboarding-inc.md)** The procedures for adding/removing members of our Github organization
 - **Website**
     - **[Build Overview](../contribution-guidelines/operations/document-management.md)** How our website is built and how to collaboratively work on changes to it using Github staging
+    - **[Style Guide](../contribution-guidelines/operations/docs-styleguide.md)** Guidelines on writing the prose parts of our documentation/website
     - **[Testing website PRs](../contribution-guidelines/operations/testing-doc-prs.md)** how to test website changes using only your local workstation
 - **Security**
     - **[Policy](../contribution-guidelines/security/security-inc.md)** Security Policies

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -88,6 +88,7 @@ nav:
       - Onboarding: contribution-guidelines/onboarding-inc.md
       - Website:
           - Docs Management Overview: contribution-guidelines/operations/document-management.md
+          - Style Guide: contribution-guidelines/operations/docs-styleguide.md
           - Testing website PRs: contribution-guidelines/operations/testing-doc-prs.md
       - Security:
           - Policy: contribution-guidelines/security/security-inc.md


### PR DESCRIPTION
## Summary
As the number of contributors to the KubeStellar documentation (and docs PRs) has grown, the need for a Style Guide to aid in consistent documentation has become apparent. This is intended as a stepping-off point for that Guide, intended to be used in conjunction with the Design Guide being currently developed 

The Style Guide may be previewed at 
https://kproche.github.io/kubestellar/doc-add-styleguide/contribution-guidelines/operations/docs-styleguide/

## Related issue(s)

