### PR TITLE
🌱 Refactor: Improve the wait logic for CSR approval of WECs in demo-env file

### DIFF
--- a/scripts/create-kubestellar-demo-env.sh
+++ b/scripts/create-kubestellar-demo-env.sh
@@ -104,33 +104,28 @@ context_clean_up() {
 }
 
 checking_cluster() {
-    found=false
+    local timeout_duration="100s"
 
-    while true; do
+    while IFS= read -r line; do
+        # Check for the cluster name and "Pending" status
+        if echo "$line" | grep -q "$1" && echo "$line" | grep -q "Pending"; then
+            echo "Pending CSR for $1 has been found, approving..."
+            clusteradm --context its1 accept --clusters "$1"
 
-        output=$(kubectl --context its1 get csr)
-
-        while IFS= read -r line; do
-
-            if echo "$line" | grep -q $1; then
-                echo "$1 has been found, approving CSR"
-                clusteradm --context its1 accept --clusters "$1"
-                found=true
-                break
+            if [ $? -eq 0 ]; then
+                echo -e "\033[33m✔\033[0m CSR Approved for $1."
+                return 0
+            else
+                echo -e "\033[0;31mX\033[0m Failed to approve CSR for $1."
+                return 1
             fi
-
-        done <<< "$output"
-
-        if [ "$found" = true ]; then
-            break
-
-        else
-            echo "CSR for $1 not found. Trying again..."
-            sleep 20
         fi
+    done < <(timeout ${timeout_duration} kubectl --context its1 get csr --watch) 
 
-    done
+    echo "Timed out. CSR for $1 was not found within ${timeout_duration}."
+    return 1
 }
+
 
 echo -e "\nStarting environment clean up..."
 echo -e "Starting cluster clean up..."


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Don't forget to first look for overlapping PRs. Remember, open source
is a collaborative rather than competitive activity.

If this PR includes changes to the source files for the website
(docs/content/** or a file included from there) then include a preview
of the modified website; see
docs/content/contribution-guidelines/operations/document-management.md.

Please put one of the following icons at the start of your PR title,
to indicate the type of your PR. You could use copy-and-paste from
here; alternatively, the indicated code is recognized by most browsers
as a way to input that icon.

✨ - code :sparkles:, type feature
🐛 - code :bug:, type bug fix
📖 - code :book:, type docs
📝 - code :memo:, type proposal
⚠️ - code :warning:, type breaking change
🌱 - code :seedling:, type other/misc
❓ - code :question:, type requires manual review/categorization

-->
## Summary
This PR refactors the CSR approval function to be more efficient by switching from an inefficient polling loop with `sleep` to an event-driven `kubectl --watch`. Additionally, `timeout` has been added to prevent script from indefinite hangout.


## Related issue(s) #3075 

Fixes #
