### PR TITLE
🐛  Make doc preview check not crash

### DIFF
--- a/.github/workflows/check-docs-pr-preview.yml
+++ b/.github/workflows/check-docs-pr-preview.yml
@@ -34,30 +34,27 @@ jobs:
           OWNER=$(gh pr view "$PR_NUMBER" --json headRepositoryOwner -q '.headRepositoryOwner.login')
           REPO_NAME=$(gh pr view "$PR_NUMBER" --json headRepository -q '.headRepository.name')
           GITHUB_PAGES_URL="https://${OWNER}.github.io/${REPO_NAME}/${BRANCH}"
-          PREVIEW_LINE=$(echo "$BODY" | grep -iE '^\s*Preview.*https?://')
-          GREEN='\033[0;32m'
-          RED='\033[0;31m'
-          YELLOW='\033[1;33m'
-          NC='\033[0m' # No Color
+          GREEN=$'\033[0;32m'
+          RED=$'\033[0;31m'
+          YELLOW=$'\033[1;33m'
+          NC=$'\033[0m' # No Color
 
-          if [ -n "$PREVIEW_LINE" ]; then
-            PREVIEW_URL=$(echo "$PREVIEW_LINE" | grep -oE 'https?://[^ ]*')
-
-            if [[ "$PREVIEW_LINE" == *"$GITHUB_PAGES_URL"* ]]; then
-              if [[ "$BRANCH" =~ $DOC_BRANCH_REGEX ]]; then
-                echo -e "${GREEN}[OK] Docs PR: doc- branch and preview link format matches expected GitHub Pages URL.${NC}"
-              else
-                echo -e "${YELLOW}[WARN] Docs PR: Preview link format is good, but branch does not start with doc-. Consider renaming to enable automatic previews.${NC}"
-              fi
-            else
-              echo -e "${YELLOW}[WARN] Docs PR: Preview link found, but it does not match the expected GitHub Pages URL."
-              echo -e "Expected: ${GITHUB_PAGES_URL}"
-              echo -e "Found:    ${PREVIEW_URL}${NC}"
-            fi
-          else
-            echo -e "${RED}[ERROR] Docs PR: No preview link found. Please include a line starting with 'Preview' and a valid GitHub Pages URL for your changes.${NC}"
+          if ! PREVIEW_LINE=$(echo "$BODY" | grep -iE '^\s*Preview.*https?://') ; then
+            echo "${RED}[ERROR] Docs PR: No preview link found. Please include a line starting with 'Preview' and a valid GitHub Pages URL for your changes.${NC}"
             echo
             exit 1
+          else
+            if [[ "$PREVIEW_LINE" == *"$GITHUB_PAGES_URL"* ]]; then
+              if [[ "$BRANCH" =~ $DOC_BRANCH_REGEX ]]; then
+                echo "${GREEN}[OK] Docs PR: doc- branch and preview link format matches expected GitHub Pages URL.${NC}"
+              else
+                echo "${YELLOW}[WARN] Docs PR: Preview link format is good, but branch does not start with doc-. Consider renaming to enable automatic previews.${NC}"
+              fi
+            else
+              echo "${YELLOW}[WARN] Docs PR: Preview link found, but it does not match the expected GitHub Pages URL."
+              PREVIEW_URL=$(echo "$PREVIEW_LINE" | grep -oE 'https?://[^ ]*' || true)
+              echo "Expected: ${GITHUB_PAGES_URL}"
+              echo "Found:    ${PREVIEW_URL}${NC}"
+            fi
           fi
           echo
-          


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Don't forget to first look for overlapping PRs. Remember, open source
is a collaborative rather than competitive activity.

If this PR includes changes to the source files for the website
(docs/content/** or a file included from there) then include a preview
of the modified website; see
docs/content/contribution-guidelines/operations/document-management.md.

Please put one of the following icons at the start of your PR title,
to indicate the type of your PR. You could use copy-and-paste from
here; alternatively, the indicated code is recognized by most browsers
as a way to input that icon.

✨ - code :sparkles:, type feature
🐛 - code :bug:, type bug fix
📖 - code :book:, type docs
📝 - code :memo:, type proposal
⚠️ - code :warning:, type breaking change
🌱 - code :seedling:, type other/misc
❓ - code :question:, type requires manual review/categorization

-->
## Summary
This PR fixes a couple of bugs in the GitHub Actions workflow that checks whether a PR that modifies the website includes a link to a preview.

- Fixes the script so that it does not crash when there is no preview link.
- Removes metacharacter injection vulnerability by removing use of `echo -e`


## Related issue(s)

Fixes #
