### PR TITLE
📖 Update get-started documentation

### DIFF
--- a/docs/content/direct/get-started.md
+++ b/docs/content/direct/get-started.md
@@ -12,7 +12,7 @@ The two ways to create this simple configuration are as follows.
 
 ### Note for Windows users
 
-For some users on WSL, use of the setup procedure on this page and/or the demo environment creation script may require running as the user `root` in Linux. There is a [known issue about this](knownissue-wsl-ghcr-helm.md).
+For some users on WSL, use of the setup procedure on this page and/or the demo environment creation script may require running as the user `root` in Linux. There is a [known issue about this](knownissue-helm-ghcr.md).
 
 ### Important: Shell Variables for Example Scenarios
 


### PR DESCRIPTION
## Summary
Fixed broken link in get-started documentation as reported in issue #3137.

## Problem
The get-started documentation had a broken link in the "Note for Windows users" section that was referencing a non-existent file `docs/content/direct/knownissue-wsl-ghcr-helm.md`.

## Solution
- Fixed the broken link reference
- Updated the link to point to the correct file `docs/content/direct/knownissue-helm-ghcr.md`
- Ensured the documentation flows correctly for Windows users

## Related Issue
Fixes #3137

## Changes Made
- Updated broken link in `docs/content/direct/get-started.md`
- Verified the target file exists and contains relevant information