### PR TITLE
✨ Enhance Transport Controller WDS Kubeconfig Resolution

### DIFF
--- a/pkg/transport/generic/cmd/kubeconfig-resolver.go
+++ b/pkg/transport/generic/cmd/kubeconfig-resolver.go
@@ -1,0 +1,60 @@
+/*
+Copyright 2025 The KubeStellar Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cmd
+
+import (
+	"fmt"
+
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
+	"k8s.io/klog/v2"
+
+	"github.com/kubestellar/kubestellar/pkg/ctrlutil"
+)
+
+// resolveWDSKubeconfig resolves WDS kubeconfig using priority order
+// Priority 1: Direct kubeconfig file path (--wds-kubeconfig)
+// Priority 2: Cluster-based discovery using WDS name (--wds-name) - same as kubestellar controller
+func resolveWDSKubeconfig(options *TransportOptions, logger klog.Logger) (*rest.Config, string, error) {
+	// Priority 1: Direct kubeconfig file path (highest priority)
+	if options.WdsKubeconfigPath != "" {
+		logger.Info("Using WDS kubeconfig from file", "path", options.WdsKubeconfigPath)
+		config, err := loadKubeconfigFromPath(options.WdsKubeconfigPath)
+		if err != nil {
+			return nil, "", fmt.Errorf("failed to load WDS kubeconfig from path %s: %w", options.WdsKubeconfigPath, err)
+		}
+		return config, "", nil
+	}
+
+	// Priority 2: Cluster-based discovery using WDS name (same as kubestellar controller-manager)
+	if options.WdsName != "" {
+		logger.Info("Getting WDS kubeconfig from cluster", "wdsName", options.WdsName)
+		// Use the SAME function that kubestellar controller-manager uses
+		return ctrlutil.GetWDSKubeconfig(logger, options.WdsName)
+	}
+
+	return nil, "", fmt.Errorf("no WDS configuration provided: specify either --wds-kubeconfig or --wds-name")
+}
+
+// loadKubeconfigFromPath loads kubeconfig from file path
+func loadKubeconfigFromPath(kubeconfigPath string) (*rest.Config, error) {
+	config, err := clientcmd.BuildConfigFromFlags("", kubeconfigPath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to build config from kubeconfig file: %w", err)
+	}
+	return config, nil
+}

--- a/pkg/transport/generic/cmd/kubeconfig-resolver_test.go
+++ b/pkg/transport/generic/cmd/kubeconfig-resolver_test.go
@@ -1,0 +1,170 @@
+/*
+Copyright 2025 The KubeStellar Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"k8s.io/klog/v2"
+)
+
+func TestResolveWDSKubeconfig(t *testing.T) {
+	logger := klog.Background()
+
+	t.Run("✅ Test Direct File Path Priority", func(t *testing.T) {
+		// Create a temporary kubeconfig file
+		tempDir := t.TempDir()
+		kubeconfigPath := filepath.Join(tempDir, "test-kubeconfig")
+
+		// Create a simple kubeconfig content
+		kubeconfigContent := `
+apiVersion: v1
+kind: Config
+clusters:
+- cluster:
+    server: https://test-server:6443
+  name: test-cluster
+contexts:
+- context:
+    cluster: test-cluster
+    user: test-user
+  name: test-context
+current-context: test-context
+users:
+- name: test-user
+  user:
+    token: test-token
+`
+		err := os.WriteFile(kubeconfigPath, []byte(kubeconfigContent), 0644)
+		if err != nil {
+			t.Fatalf("failed to create test kubeconfig: %v", err)
+		}
+
+		options := &TransportOptions{
+			WdsKubeconfigPath: kubeconfigPath,
+			WdsName:           "should-be-ignored", // This should be ignored due to priority
+		}
+
+		config, name, err := resolveWDSKubeconfig(options, logger)
+		if err != nil {
+			t.Fatalf("resolveWDSKubeconfig failed: %v", err)
+		}
+
+		if config == nil {
+			t.Fatal("expected config to be non-nil")
+		}
+
+		if config.Host != "https://test-server:6443" {
+			t.Errorf("expected host to be 'https://test-server:6443', got '%s'", config.Host)
+		}
+
+		t.Logf("✅ PASS: Direct file path test passed: %s", name)
+	})
+
+	t.Run("⏭️  Skip WDS Name Test (Requires Real Cluster)", func(t *testing.T) {
+		t.Skip("Skipping cluster-based test - would hang waiting for real control plane")
+	})
+
+	t.Run("✅ Test No Configuration Error", func(t *testing.T) {
+		options := &TransportOptions{
+			WdsKubeconfigPath: "", // No file path
+			WdsName:           "", // No WDS name
+		}
+
+		_, _, err := resolveWDSKubeconfig(options, logger)
+		if err == nil {
+			t.Fatal("expected error when no configuration provided")
+		}
+
+		expectedError := "no WDS configuration provided: specify either --wds-kubeconfig or --wds-name"
+		if err.Error() != expectedError {
+			t.Errorf("expected error '%s', got '%s'", expectedError, err.Error())
+		}
+
+		t.Logf("✅ PASS: No configuration error test: %v", err)
+	})
+}
+
+func TestLoadKubeconfigFromPath(t *testing.T) {
+	t.Run("✅ Test Valid Kubeconfig File", func(t *testing.T) {
+		tempDir := t.TempDir()
+		kubeconfigPath := filepath.Join(tempDir, "valid-kubeconfig")
+
+		kubeconfigContent := `
+apiVersion: v1
+kind: Config
+clusters:
+- cluster:
+    server: https://valid-server:6443
+  name: valid-cluster
+contexts:
+- context:
+    cluster: valid-cluster
+    user: valid-user
+  name: valid-context
+current-context: valid-context
+users:
+- name: valid-user
+  user:
+    token: valid-token
+`
+		err := os.WriteFile(kubeconfigPath, []byte(kubeconfigContent), 0644)
+		if err != nil {
+			t.Fatalf("failed to create test kubeconfig: %v", err)
+		}
+
+		config, err := loadKubeconfigFromPath(kubeconfigPath)
+		if err != nil {
+			t.Fatalf("loadKubeconfigFromPath failed: %v", err)
+		}
+
+		if config.Host != "https://valid-server:6443" {
+			t.Errorf("expected host 'https://valid-server:6443', got '%s'", config.Host)
+		}
+
+		t.Log("✅ PASS: Valid kubeconfig file test")
+	})
+
+	t.Run("✅ Test Invalid Kubeconfig File", func(t *testing.T) {
+		tempDir := t.TempDir()
+		kubeconfigPath := filepath.Join(tempDir, "invalid-kubeconfig")
+
+		// Invalid YAML content
+		err := os.WriteFile(kubeconfigPath, []byte("invalid: yaml: content: ["), 0644)
+		if err != nil {
+			t.Fatalf("failed to create test kubeconfig: %v", err)
+		}
+
+		_, err = loadKubeconfigFromPath(kubeconfigPath)
+		if err == nil {
+			t.Fatal("expected error for invalid kubeconfig file")
+		}
+
+		t.Logf("✅ PASS: Invalid kubeconfig file test: %v", err)
+	})
+
+	t.Run("✅ Test Non-existent File", func(t *testing.T) {
+		_, err := loadKubeconfigFromPath("/non/existent/path")
+		if err == nil {
+			t.Fatal("expected error for non-existent file")
+		}
+
+		t.Logf("✅ PASS: Non-existent file test: %v", err)
+	})
+}

--- a/pkg/transport/generic/cmd/options.go
+++ b/pkg/transport/generic/cmd/options.go
@@ -33,6 +33,7 @@ type TransportOptions struct {
 	MaxSizeWrapped         int
 	MaxNumWrapped          int
 	WdsName                string
+	WdsKubeconfigPath      string
 	ksopts.ProcessOptions
 }
 
@@ -53,6 +54,9 @@ func NewTransportOptions() *TransportOptions {
 
 func (options *TransportOptions) AddFlags(fs *pflag.FlagSet) {
 	fs.IntVar(&options.Concurrency, "concurrency", options.Concurrency, "number of concurrent workers to run in parallel")
+
+	fs.StringVar(&options.WdsKubeconfigPath, "wds-kubeconfig", "", "Path to WDS kubeconfig file (takes priority over wds-name)")
+
 	options.WdsClientOptions.AddFlags(fs)
 	options.TransportClientOptions.AddFlags(fs)
 	fs.IntVar(&options.MaxSizeWrapped, "max-size-wrapped", options.MaxSizeWrapped, "Max size of the wrapped object in bytes")


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Don't forget to first look for overlapping PRs. Remember, open source
is a collaborative rather than competitive activity.

If this PR includes changes to the source files for the website
(docs/content/** or a file included from there) then include a preview
of the modified website; see
docs/content/contribution-guidelines/operations/document-management.md.

Please put one of the following icons at the start of your PR title,
to indicate the type of your PR. You could use copy-and-paste from
here; alternatively, the indicated code is recognized by most browsers
as a way to input that icon.

✨ - code :sparkles:, type feature
🐛 - code :bug:, type bug fix
📖 - code :book:, type docs
📝 - code :memo:, type proposal
⚠️ - code :warning:, type breaking change
🌱 - code :seedling:, type other/misc
❓ - code :question:, type requires manual review/categorization

-->
## Summary

## Related issue(s) #3146 (part1 wds)

Fixes #


BEFORE (Old Transport Controller):

```
Could only connect to WDS using complex client options (--wds-qps, --wds-burst, etc.)
No direct kubeconfig file support
No cluster discovery like KubeStellar controller
Had to use init containers + volume mounts (messy setup)
```

AFTER (Enhanced Transport Controller):

```
Can use direct kubeconfig files: --wds-kubeconfig=/path/to/file 🎯
Can do cluster discovery: --wds-name=my-wds (same as KubeStellar controller) 🎯
Smart priority: File path beats cluster discovery
No volume mounting needed - cleaner setup
```