### PR TITLE
🐛 Undo bugs introduced in split of ITS PCH into two

### DIFF
--- a/core-chart/templates/postcreatehooks/install-status-addon.yaml
+++ b/core-chart/templates/postcreatehooks/install-status-addon.yaml
@@ -21,12 +21,15 @@ spec:
               - sh
               - -c
               - |
-                echo "Waiting for kubeconfig file /etc/kube/{{.ITSkubeconfig}} to exist and be non-empty..."
-                until [ -s /etc/kube/{{.ITSkubeconfig}} ]; do
+                echo "Waiting for kubeconfig file '$KUBECONFIG' to exist and be non-empty..."
+                until [ -s "$KUBECONFIG" ]; do
                   echo "Kubeconfig file not ready yet, waiting..."
                   sleep 2
                 done
                 echo "Kubeconfig file is ready"
+            env:
+            - name: KUBECONFIG
+              value: "{{"/etc/kube/{{.ITSkubeconfig}}"}}"
             volumeMounts:
             - name: kubeconfig
               mountPath: "/etc/kube"

--- a/core-chart/templates/postcreatehooks/its-hub-init.yaml
+++ b/core-chart/templates/postcreatehooks/its-hub-init.yaml
@@ -22,12 +22,15 @@ spec:
               - sh
               - -c
               - |
-                echo "Waiting for kubeconfig file /etc/kube/{{.ITSkubeconfig}} to exist and be non-empty..."
-                until [ -s /etc/kube/{{.ITSkubeconfig}} ]; do
+                echo "Waiting for kubeconfig file '$KUBECONFIG' to exist and be non-empty..."
+                until [ -s "$KUBECONFIG" ]; do
                   echo "Kubeconfig file not ready yet, waiting..."
                   sleep 2
                 done
                 echo "Kubeconfig file is ready"
+            env:
+            - name: KUBECONFIG
+              value: "{{"/etc/kube/{{.ITSkubeconfig}}"}}"
             volumeMounts:
             - name: kubeconfig
               mountPath: "/etc/kube"

--- a/docs/content/direct/get-started.md
+++ b/docs/content/direct/get-started.md
@@ -141,10 +141,8 @@ kflex ctx --overwrite-existing-context its1
 The Helm chart above has a Job that initializes the ITS as an OCM "hub" cluster. Helm does not have a way to wait for that initialization to finish. So you have to do the wait yourself. The following commands will do that.
 
 ```shell
-kubectl --context kind-kubeflex wait controlplane.tenancy.kflex.kubestellar.org/its1 --for 'jsonpath={.status.postCreateHooks.install-status-addon}=true' --timeout 90s
-kubectl --context kind-kubeflex wait -n its1-system job.batch/install-status-addon --for condition=Complete --timeout 150s
-kubectl --context kind-kubeflex wait controlplane.tenancy.kflex.kubestellar.org/its1 --for 'jsonpath={.status.postCreateHooks.its-hub-init}=true' --timeout 90s
-kubectl --context kind-kubeflex wait -n its1-system job.batch/its-hub-init --for condition=Complete --timeout 150s
+kubectl --context kind-kubeflex wait controlplane.tenancy.kflex.kubestellar.org/its1 --for 'jsonpath={.status.postCreateHooks.its-with-clusteradm}=true' --timeout 90s
+kubectl --context kind-kubeflex wait -n its1-system job.batch/its-with-clusteradm --for condition=Complete --timeout 150s
 ```
 
 *To learn more about the Core Helm Chart, refer to the [Core Helm Chart documentation](./core-chart.md)*

--- a/scripts/create-kubestellar-demo-env.sh
+++ b/scripts/create-kubestellar-demo-env.sh
@@ -217,10 +217,8 @@ kflex ctx --overwrite-existing-context wds2
 kflex ctx --overwrite-existing-context its1
 
 echo -e "\nWaiting for OCM cluster manager to be ready..."
-kubectl --context $k8s_platform-kubeflex wait controlplane.tenancy.kflex.kubestellar.org/its1 --for 'jsonpath={.status.postCreateHooks.install-status-addon}=true' --timeout 24h
-kubectl --context $k8s_platform-kubeflex wait -n its1-system job.batch/install-status-addon --for condition=Complete --timeout 24h
-kubectl --context $k8s_platform-kubeflex wait controlplane.tenancy.kflex.kubestellar.org/its1 --for 'jsonpath={.status.postCreateHooks.its-hub-init}=true' --timeout 24h
-kubectl --context $k8s_platform-kubeflex wait -n its1-system job.batch/its-hub-init --for condition=Complete --timeout 24h
+kubectl --context $k8s_platform-kubeflex wait controlplane.tenancy.kflex.kubestellar.org/its1 --for 'jsonpath={.status.postCreateHooks.its-with-clusteradm}=true' --timeout 24h
+kubectl --context $k8s_platform-kubeflex wait -n its1-system job.batch/its-with-clusteradm --for condition=Complete --timeout 24h
 echo -e "\nWaiting for OCM hub cluster-info to be updated..."
 kubectl --context $k8s_platform-kubeflex wait -n its1-system job.batch/update-cluster-info --for condition=Complete --timeout 24h
 echo -e "\033[33m✔\033[0m OCM hub is ready"


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Don't forget to first look for overlapping PRs. Remember, open source
is a collaborative rather than competitive activity.

If this PR includes changes to the source files for the website
(docs/content/** or a file included from there) then include a preview
of the modified website; see
docs/content/contribution-guidelines/operations/document-management.md.

Please put one of the following icons at the start of your PR title,
to indicate the type of your PR. You could use copy-and-paste from
here; alternatively, the indicated code is recognized by most browsers
as a way to input that icon.

✨ - code :sparkles:, type feature
🐛 - code :bug:, type bug fix
📖 - code :book:, type docs
📝 - code :memo:, type proposal
⚠️ - code :warning:, type breaking change
🌱 - code :seedling:, type other/misc
❓ - code :question:, type requires manual review/categorization

-->
## Summary
This PR fixes the bugs introduced in #3121:

- usage of the released Helm chart is followed by commands that apply to the latest version in `main` rather than the last release;
- a quoting problem caused premature completion of waiting for the kubeconfig file to appear.

This PR also removes an unnecessary copy of a block of waiting commands.

Preview at https://mikespreitzer.github.io/kcp-edge-mc/doc-pullback-its-split/direct/get-started/#wait-for-its-to-be-fully-initialized

## Related issue(s)

Fixes #
