### PR TITLE
📖  Put one-shot tracking work in release process

### DIFF
--- a/docs/content/direct/release.md
+++ b/docs/content/direct/release.md
@@ -54,6 +54,12 @@ Making a new kubestellar release requires a contributor to do the following thin
 
 - Update the version in `scripts/create-kubestellar-demo-env.sh`. Note: merging this change will cause the script to be broken until the release is made.
 
+- Finish the updates erroneously made in [PR 3121](https://github.com/kubestellar/kubestellar/pull/3121) and rolled back in [PR 3163](https://github.com/kubestellar/kubestellar/pull/3163). Then delete this step from this file (`release.md`), because it will not need to be repeated in later releases.
+
+    - In `docs/content/direct/get-started.md` replace the two waits (on PCH and Job `its-with-clusteradm`) with the four waits (on PCH and Job `install-status-addon`, and PCH and Job `its-hub-init`).
+    - In `scripts/create-kubestellar-demo-env.sh` do the same replacement.
+    - In `test/e2e/common/setup-kubestellar.sh` replace the conditional double-or-quad wait with the unconditional quad wait.
+
 - Until we have our first stable release, edit the old docs README(`oldocs/README.md`, section "latest-stable-release") where it wishes it could cite a stable release but instead cites the latest release, to refer to the coming release.
 
 - Edit the release notes in `docs/content/direct/release-notes.md`.

--- a/docs/content/direct/release.md
+++ b/docs/content/direct/release.md
@@ -52,9 +52,9 @@ Making a new kubestellar release requires a contributor to do the following thin
 
 - Update the version in the core chart defaults, `core-chart/values.yaml`.
 
-- Update the version in `scripts/create-kubestellar-demo-env.sh`. Note: merging this change will cause the script to be broken until the release is made.
+- Update the version in `scripts/create-kubestellar-demo-env.sh`. **Note:** merging this change might cause the script to be broken until the release is made.
 
-- Finish the updates erroneously made in [PR 3121](https://github.com/kubestellar/kubestellar/pull/3121) and rolled back in [PR 3163](https://github.com/kubestellar/kubestellar/pull/3163). Then delete this step from this file (`release.md`), because it will not need to be repeated in later releases.
+- Finish the updates erroneously made in [PR 3121](https://github.com/kubestellar/kubestellar/pull/3121) and rolled back in [PR 3163](https://github.com/kubestellar/kubestellar/pull/3163). Then delete this step from this file (`release.md`), because it will not need to be repeated in later releases. **Note:** merging this change WILL cause `main` to be broken until the release is made.
 
     - In `docs/content/direct/get-started.md` replace the two waits (on PCH and Job `its-with-clusteradm`) with the four waits (on PCH and Job `install-status-addon`, and PCH and Job `its-hub-init`).
     - In `scripts/create-kubestellar-demo-env.sh` do the same replacement.


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Don't forget to first look for overlapping PRs. Remember, open source
is a collaborative rather than competitive activity.

If this PR includes changes to the source files for the website
(docs/content/** or a file included from there) then include a preview
of the modified website; see
docs/content/contribution-guidelines/operations/document-management.md.

Please put one of the following icons at the start of your PR title,
to indicate the type of your PR. You could use copy-and-paste from
here; alternatively, the indicated code is recognized by most browsers
as a way to input that icon.

✨ - code :sparkles:, type feature
🐛 - code :bug:, type bug fix
📖 - code :book:, type docs
📝 - code :memo:, type proposal
⚠️ - code :warning:, type breaking change
🌱 - code :seedling:, type other/misc
❓ - code :question:, type requires manual review/categorization

-->
## Summary
This PR documents the proper time to finish the work that was prematurely included in PR #3121 and temporarily undone in #3163 .

Preview at https://mikespreitzer.github.io/kcp-edge-mc/doc-next-release-change/direct/release/#making-a-new-kubestellar-release

## Related issue(s)

Fixes #
