### PR TITLE
🐛Fix #3192: Allow explicit ITSName selection to avoid transport-controller ambiguity

### DIFF
--- a/core-chart/templates/postcreatehooks/transport-controller.yaml
+++ b/core-chart/templates/postcreatehooks/transport-controller.yaml
@@ -59,8 +59,14 @@ spec:
         # get-kubeconfig.sh cp_name guess_its_name
 
         # input parameters
-        cp_name="${1%"-system"}" # cp name or cp namespace
+        cp_name="${1%-system}" # cp name or cp namespace
         guess_its_name="$2" # true: try guessing the name of the ITS CP
+
+        # Prefer explicit ITS_NAME if set
+        if [ -n "$ITS_NAME" ]; then
+          cp_name="$ITS_NAME"
+          guess_its_name="false"
+        fi
 
         # check if the CP name is valid or needs to be guessed
         while [ "$cp_name" == "" ] ; do
@@ -74,7 +80,7 @@ spec:
                 cp_name="${cps%% *}"
                 break;;
               (*)
-                >&2 echo "ERROR: found more than one Control Plane of type its!"
+                >&2 echo "ERROR: Multiple ITS control planes found, but none specified. Set ITSName Helm value or ITS_NAME env var to select one."
                 exit 1;;
             esac
           else
@@ -124,7 +130,10 @@ spec:
           - name: setup-its-kubeconfig
             image: quay.io/kubestellar/kubectl:{{.Values.KUBECTL_VERSION}}
             imagePullPolicy: IfNotPresent
-            command: [ "bin/sh", "-c", "sh /mnt/config/get-kubeconfig.sh '{{.ITSName}}' true | base64 -d > /mnt/shared/transport-kubeconfig" ]
+            env:
+            - name: ITS_NAME
+              value: "{{ .Values.ITSName }}"
+            command: [ "bin/sh", "-c", "sh /mnt/config/get-kubeconfig.sh '${ITS_NAME}' true | base64 -d > /mnt/shared/transport-kubeconfig" ]
             volumeMounts:
             - name: config-volume
               mountPath: /mnt/config

--- a/core-chart/values.yaml
+++ b/core-chart/values.yaml
@@ -3,6 +3,10 @@
 # Declare variables to be passed into your templates.
 
 
+# Name of the ITS control plane to use for transport-controller (optional)
+# If not set, auto-discovery will be used (legacy behavior)
+ITSName: ""
+
 # Container/chart image versions. These values are set during the chart release process,
 # please do not change them unless you know what you are doing.
 HELM_VERSION: "3.16.4"


### PR DESCRIPTION
## Summary
Adds support for explicit ITS control plane selection via the new ITSName Helm value.
Prevents transport-controller crash/ambiguity when multiple ITS control planes exist.
If ITSName is not set and multiple ITS are present, a clear error message is shown.

## Local Testing:
Verified with multiple ITS/WDS pairs deployed in parallel.
Both transport-controllers start and operate correctly with no ambiguity.

Fixes #3192
