### PR TITLE
🐛refactor(install-status-addon): split CRD wait into separate initContainers

### DIFF
--- a/core-chart/templates/postcreatehooks/install-status-addon.yaml
+++ b/core-chart/templates/postcreatehooks/install-status-addon.yaml
@@ -35,35 +35,30 @@ spec:
               mountPath: "/etc/kube"
               readOnly: true
 
-          - name: wait-for-ocm-crds
+          - name: wait-for-placements-crd
             image: quay.io/kubestellar/kubectl:{{.Values.KUBECTL_VERSION}}
             command:
-              - sh
-              - -c
-              - |
-                echo "Waiting for OCM CRDs to be established..."
-                # Wait for essential OCM CRDs needed by the Status Add-on
-                # First check if clusteradm has created any OCM CRDs
-                echo "Checking if OCM CRDs exist..."
-                max_attempts=60
-                attempt=0
-                while [ $attempt -lt $max_attempts ]; do
-                  if kubectl get crd placements.cluster.open-cluster-management.io >/dev/null 2>&1; then
-                    echo "OCM CRDs found, waiting for them to be established..."
-                    kubectl wait --for=condition=Established crd/placements.cluster.open-cluster-management.io --timeout=300s
-                    kubectl wait --for=condition=Established crd/placementdecisions.cluster.open-cluster-management.io --timeout=300s
-                    echo "Required OCM CRDs are established"
-                    break
-                  else
-                    echo "OCM CRDs not found yet (attempt $((attempt+1))/$max_attempts), waiting..."
-                    sleep 10
-                    attempt=$((attempt+1))
-                  fi
-                done
-                if [ $attempt -eq $max_attempts ]; then
-                  echo "ERROR: OCM CRDs not found after $max_attempts attempts"
-                  exit 1
-                fi
+              - kubectl
+              - wait
+              - --for=condition=Established
+              - crd/placements.cluster.open-cluster-management.io
+              - --timeout=300s
+            env:
+            - name: KUBECONFIG
+              value: "{{"/etc/kube/{{.ITSkubeconfig}}"}}"
+            volumeMounts:
+            - name: kubeconfig
+              mountPath: "/etc/kube"
+              readOnly: true
+
+          - name: wait-for-placementdecisions-crd
+            image: quay.io/kubestellar/kubectl:{{.Values.KUBECTL_VERSION}}
+            command:
+              - kubectl
+              - wait
+              - --for=condition=Established
+              - crd/placementdecisions.cluster.open-cluster-management.io
+              - --timeout=300s
             env:
             - name: KUBECONFIG
               value: "{{"/etc/kube/{{.ITSkubeconfig}}"}}"

--- a/core-chart/templates/postcreatehooks/transport-controller.yaml
+++ b/core-chart/templates/postcreatehooks/transport-controller.yaml
@@ -59,8 +59,14 @@ spec:
         # get-kubeconfig.sh cp_name guess_its_name
 
         # input parameters
-        cp_name="${1%"-system"}" # cp name or cp namespace
+        cp_name="${1%-system}" # cp name or cp namespace
         guess_its_name="$2" # true: try guessing the name of the ITS CP
+
+        # Prefer explicit ITS_NAME if set
+        if [ -n "$ITS_NAME" ]; then
+          cp_name="$ITS_NAME"
+          guess_its_name="false"
+        fi
 
         # check if the CP name is valid or needs to be guessed
         while [ "$cp_name" == "" ] ; do
@@ -74,7 +80,7 @@ spec:
                 cp_name="${cps%% *}"
                 break;;
               (*)
-                >&2 echo "ERROR: found more than one Control Plane of type its!"
+                >&2 echo "ERROR: Multiple ITS control planes found, but none specified. Set ITSName Helm value or ITS_NAME env var to select one."
                 exit 1;;
             esac
           else
@@ -124,7 +130,10 @@ spec:
           - name: setup-its-kubeconfig
             image: quay.io/kubestellar/kubectl:{{.Values.KUBECTL_VERSION}}
             imagePullPolicy: IfNotPresent
-            command: [ "bin/sh", "-c", "sh /mnt/config/get-kubeconfig.sh '{{.ITSName}}' true | base64 -d > /mnt/shared/transport-kubeconfig" ]
+            env:
+            - name: ITS_NAME
+              value: "{{ .Values.ITSName }}"
+            command: [ "bin/sh", "-c", "sh /mnt/config/get-kubeconfig.sh '${ITS_NAME}' true | base64 -d > /mnt/shared/transport-kubeconfig" ]
             volumeMounts:
             - name: config-volume
               mountPath: /mnt/config

--- a/core-chart/values.yaml
+++ b/core-chart/values.yaml
@@ -3,6 +3,10 @@
 # Declare variables to be passed into your templates.
 
 
+# Name of the ITS control plane to use for transport-controller (optional)
+# If not set, auto-discovery will be used (legacy behavior)
+ITSName: ""
+
 # Container/chart image versions. These values are set during the chart release process,
 # please do not change them unless you know what you are doing.
 HELM_VERSION: "3.16.4"


### PR DESCRIPTION
## Summary
Refactors the status add-on PostCreateHook to use two sequential initContainers for waiting on OCM CRDs, replacing the previous bash-based loop. This simplifies the logic and improves maintainability by letting each kubectl wait run independently for CRD establishment.

Fixes #
