### PR TITLE
✨ Automated docs preview for PRs

### DIFF
--- a/.github/workflows/docs-pr-preview.yml
+++ b/.github/workflows/docs-pr-preview.yml
@@ -1,0 +1,49 @@
+name: Docs PR Preview
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize, closed]
+    paths:
+      - 'docs/**'      # Adjust if your docs are elsewhere
+      
+
+permissions:
+  contents: write        # To push preview branches to gh-pages
+  pull-requests: write   # To comment on the PR automatically
+
+jobs:
+  build-and-deploy-preview:
+    runs-on: ubuntu-latest
+
+    steps:
+      # Step 1: Check out the PR code
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      # Step 2: Setup Python (matches your docs environment)
+      - name: Setup Python 3.x
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+
+      # Step 3: Install dependencies inside virtual environment
+      - name: Install dependencies
+        run: |
+          python -m venv venv
+          source venv/bin/activate
+          pip install -r docs/requirements.txt
+
+      # Step 4: Build documentation site
+      - name: Build documentation
+        run: |
+          source venv/bin/activate
+          mkdocs build --site-dir build/
+
+      # Step 5: Deploy preview to gh-pages branch under pr-preview path
+      - name: Deploy preview
+        uses: rossjrw/pr-preview-action@v1
+        with:
+          source-dir: ./build/
+          preview-branch: gh-pages
+          umbrella-dir: pr-preview
+          action: auto

--- a/.github/workflows/docs-pr-preview.yml
+++ b/.github/workflows/docs-pr-preview.yml
@@ -4,11 +4,11 @@ on:
   pull_request:
     types: [opened, reopened, synchronize, closed]
     paths:
-      - 'docs/**'      # Adjust if your docs are elsewhere
+      - 'docs/**'      
       
 
 permissions:
-  contents: write        # To push preview branches to gh-pages
+  contents: write       
   pull-requests: write   # To comment on the PR automatically
 
 jobs:
@@ -16,30 +16,30 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      # Step 1: Check out the PR code
+      #  Check out the PR code
       - name: Checkout code
         uses: actions/checkout@v4
 
-      # Step 2: Setup Python (matches your docs environment)
+      # Setup Python (matches your docs environment)
       - name: Setup Python 3.x
         uses: actions/setup-python@v4
         with:
           python-version: '3.x'
 
-      # Step 3: Install dependencies inside virtual environment
+      # Install dependencies inside virtual environment
       - name: Install dependencies
         run: |
           python -m venv venv
           source venv/bin/activate
           pip install -r docs/requirements.txt
 
-      # Step 4: Build documentation site
+      #  Build documentation site
       - name: Build documentation
         run: |
           source venv/bin/activate
           mkdocs build --site-dir build/
 
-      # Step 5: Deploy preview to gh-pages branch under pr-preview path
+      # Deploy preview to gh-pages branch under pr-preview path
       - name: Deploy preview
         uses: rossjrw/pr-preview-action@v1
         with:


### PR DESCRIPTION
✨ - code ✨, type feature

Summary
This PR introduces a fully automated workflow for documentation website previews on Pull Requests.
With this feature, contributors who open PRs to modify documentation (in docs/content/**) receive an automatic preview URL posted as a comment on the PR, streamlining review and feedback. This eliminates the manual steps previously required for generating docs previews.

Related Issue(s)
Fixes https://github.com/kubestellar/kubestellar/issues/3189

Details
Adds .github/workflows/docs-pr-preview.yml which builds docs and publishes a live preview link for every relevant PR.

Conforms to the [Contribution Guidelines](https://www.perplexity.ai/search/docs/content/contribution-guidelines/operations/document-management.md) regarding website/documentation PRs.

No need to manually fork gh-pages or generate preview links; this is now automatic.