### PR TITLE
📖  Expand a11y section in docs style guide

### DIFF
--- a/docs/content/contribution-guidelines/operations/docs-styleguide.md
+++ b/docs/content/contribution-guidelines/operations/docs-styleguide.md
@@ -15,7 +15,7 @@ As a starting point, here are some very basic items to consider when working on 
 
 - [Use clear and concise prose](#use-clear-and-concise-prose)
 - [Avoid use of emojis (especially in headings)](#avoid-use-of-emojis-in-prose)
-- [Think Accessibility](#compose-and-format-for-accessibility)
+- [Compose and format for Accessibility](#compose-and-format-for-accessibility)
 - [Use care if using generative AI](#use-care-if-using-generative-ai) for writing assistance. Review text carefully to make sure it is both coherent and accurate.
 - [Always check spelling and grammar](#always-do-a-spelling-and-grammar-check) before committing docs changes
 
@@ -38,11 +38,11 @@ Writing for accessibility means ensuring that screen readers can easily read you
 
 Accessibility is a part of any good web project, and docs are no different. As a bare minimum, we require that all our images and diagrams always have an appropriate 'alt-text' to support visually impared users and screenreaders. In Markdown, you can add alt-text using the following syntax:
 
-```{.bash}
+```{bash}
 ![An image of KubeStellar Contributors](images/contributors.png)
 ```
 
-In this example, the text inside the square brackets ([An image of KubeStellar Contributors]) serves as the alt-text, and it should clearly describe the content or purpose of the image.
+In this example, the text inside the square brackets [An image of KubeStellar Contributors] serves as the alt-text, and it should clearly describe the content or purpose of the image.
 
 For a more detailed guidance on writing alt-texts, we recommend checking out [WebAIM Guide to Alternative Texts.](https://webaim.org/techniques/alttext/)
 
@@ -56,9 +56,12 @@ If you want to deepen your understanding of accessibility, we recommend checking
 - [Web Content Accessibility Guidelines (WCAG)](https://www.w3.org/WAI/standards-guidelines/wcag/)
 - [Google's Style Guide for Writing Inclusive Documentation](https://developers.google.com/style/inclusive-documentation)
 
+>**Note:** KubeStellar docs are authored primarily in **Markdown**. The examples in this guide therefore use Markdown syntax (for example, `![Alt text](path/to/image.png)`).
+>While some resources above reference **HTML**, they remain useful for understanding core accessibility principles (like alt text and headings) and for cases where we embed raw HTML in Markdown. If you’re new to Markdown, start with Markdown-focused references first.
+
 ### Use Care If Using Generative AI
 
-The use of generative AI for writing assistance is becoming more common. Any text created via generative AI tools should be **carefully** reviewed to make sure it is both coherent and accurate. Among the items to check for (this is just a start): 
+The use of generative AI for writing assistance is becoming more common. Any text created via generative AI tools should be **carefully** reviewed to make sure it is both coherent and accurate. Among the items to check for (this is just a start):
 
 - Ensure the generated text is not outright plagiarism, as some LLMs have been trained on copyrighted works.
 - The generated text should contain no derivative works (as understood in copyright law) of other copyrighted material.

--- a/docs/content/contribution-guidelines/operations/docs-styleguide.md
+++ b/docs/content/contribution-guidelines/operations/docs-styleguide.md
@@ -15,7 +15,7 @@ As a starting point, here are some very basic items to consider when working on 
 
 - [Use clear and concise prose](#use-clear-and-concise-prose)
 - [Avoid use of emojis (especially in headings)](#avoid-use-of-emojis-in-prose)
-- [Thinking about Accessibility](#think-accessibility)
+- [Think Accessibility](#compose-and-format-for-accessibility)
 - [Use care if using generative AI](#use-care-if-using-generative-ai) for writing assistance. Review text carefully to make sure it is both coherent and accurate.
 - [Always check spelling and grammar](#always-do-a-spelling-and-grammar-check) before committing docs changes
 
@@ -32,20 +32,29 @@ Much of KubeStellar's existing documentation -- especially introductory and over
 The **Design Guide** will include guidance on use and placement of iconography in KubeStellar docs and UIs.
 In textual documentation, however, emojis may interfere with rendering and navigation of the website documentation, _especially_ if they are used in headings or titles. They also may make the documentation inaccessible to visitors who must use screen reader technology.
 
-### Think Accessibility
+### Compose and Format for Accessibility
 
 Writing for accessibility means ensuring that screen readers can easily read your text, your content is easy to navigate, visually clear and logically structured. This includes the appropriate usage of Heading tags, styling your text consistently and using a 'gender-neutral' language where applicable.
 
-Accessibility is a part of any good web project, and docs are no different.
-As a bare minimum, we require that all our images and diagrams always have an appropriate 'alt-text' attribute to support visually impared users and screenreaders. We also recommend keeping the [W3C Guidelines for Accessibility](https://www.w3.org/TR/WCAG21/) in mind when writing/illustrating KubeStellar documentation.
+Accessibility is a part of any good web project, and docs are no different. As a bare minimum, we require that all our images and diagrams always have an appropriate 'alt-text' to support visually impared users and screenreaders. In Markdown, you can add alt-text using the following syntax:
+
+```{.bash}
+![An image of KubeStellar Contributors](images/contributors.png)
+```
+
+In this example, the text inside the square brackets ([An image of KubeStellar Contributors]) serves as the alt-text, and it should clearly describe the content or purpose of the image.
+
+For a more detailed guidance on writing alt-texts, we recommend checking out [WebAIM Guide to Alternative Texts.](https://webaim.org/techniques/alttext/)
+
+We also recommend keeping the [W3C Guidelines for Accessibility](https://www.w3.org/TR/WCAG21/) in mind when writing/illustrating KubeStellar documentation.
 
 That said, accessibility is an ever-evolving area in technical content. As an open-source contributor, familiarizing yourself with accessibility standards will help you make more thoughtful and inclusive descisions, whether in documentation, or other areas of your work.
 
 If you want to deepen your understanding of accessibility, we recommend checking out the following resources:
 
+- [Gruntwork Markdown Style Guide](https://docs.gruntwork.io/guides/style/markdown-style-guide/)
 - [Web Content Accessibility Guidelines (WCAG)](https://www.w3.org/WAI/standards-guidelines/wcag/)
 - [Google's Style Guide for Writing Inclusive Documentation](https://developers.google.com/style/inclusive-documentation)
-- [Introduction to Web Accessibility Course by W3C and EdX (free)](https://www.edx.org/learn/web-accessibility/the-world-wide-web-consortium-w3c-introduction-to-web-accessibility)
 
 ### Use Care If Using Generative AI
 

--- a/docs/content/contribution-guidelines/operations/docs-styleguide.md
+++ b/docs/content/contribution-guidelines/operations/docs-styleguide.md
@@ -38,7 +38,7 @@ Writing for accessibility means ensuring that screen readers can easily read you
 
 Accessibility is a part of any good web project, and docs are no different. As a bare minimum, we require that all our images and diagrams always have an appropriate 'alt-text' to support visually impared users and screenreaders. In Markdown, you can add alt-text using the following syntax:
 
-```{bash}
+```markdown
 ![An image of KubeStellar Contributors](images/contributors.png)
 ```
 

--- a/docs/content/contribution-guidelines/operations/docs-styleguide.md
+++ b/docs/content/contribution-guidelines/operations/docs-styleguide.md
@@ -13,11 +13,11 @@ This **Style Guide** is intended to complement the Design Guide to govern the _p
 
 As a starting point, here are some very basic items to consider when working on documentation for KubeStellar and its components:
 
--  [Use clear and concise prose](#use-clear-and-concise-prose)
--  [Avoid use of emojis (especially in headings)](#avoid-use-of-emojis-in-prose)
--  [Always include alt-text for images](#always-include-alt-text-for-images)
--  [Use care if using generative AI](#use-care-if-using-generative-ai) for writing assistance. Review text carefully to make sure it is both coherent and accurate.
--  [Always check spelling and grammar](#always-do-a-spelling-and-grammar-check) before committing docs changes
+- [Use clear and concise prose](#use-clear-and-concise-prose)
+- [Avoid use of emojis (especially in headings)](#avoid-use-of-emojis-in-prose)
+- [Thinking about Accessibility](#think-accessibility)
+- [Use care if using generative AI](#use-care-if-using-generative-ai) for writing assistance. Review text carefully to make sure it is both coherent and accurate.
+- [Always check spelling and grammar](#always-do-a-spelling-and-grammar-check) before committing docs changes
 
 ### Use Clear and Concise Prose
 
@@ -32,9 +32,20 @@ Much of KubeStellar's existing documentation -- especially introductory and over
 The **Design Guide** will include guidance on use and placement of iconography in KubeStellar docs and UIs.
 In textual documentation, however, emojis may interfere with rendering and navigation of the website documentation, _especially_ if they are used in headings or titles. They also may make the documentation inaccessible to visitors who must use screen reader technology.
 
-### Always include alt-text for images
+### Think Accessibility
 
-This is a basic requirement for accessibility. Images and diagrams should always have an appropriate alt-text attribute. In general, keep the [W3C Guidelines for Accessibility](https://www.w3.org/TR/WCAG21/) in mind when writing/illustrating KubeStellar documentation 
+Writing for accessibility means ensuring that screen readers can easily read your text, your content is easy to navigate, visually clear and logically structured. This includes the appropriate usage of Heading tags, styling your text consistently and using a 'gender-neutral' language where applicable.
+
+Accessibility is a part of any good web project, and docs are no different.
+As a bare minimum, we require that all our images and diagrams always have an appropriate 'alt-text' attribute to support visually impared users and screenreaders. We also recommend keeping the [W3C Guidelines for Accessibility](https://www.w3.org/TR/WCAG21/) in mind when writing/illustrating KubeStellar documentation.
+
+That said, accessibility is an ever-evolving area in technical content. As an open-source contributor, familiarizing yourself with accessibility standards will help you make more thoughtful and inclusive descisions, whether in documentation, or other areas of your work.
+
+If you want to deepen your understanding of accessibility, we recommend checking out the following resources:
+
+- [Web Content Accessibility Guidelines (WCAG)](https://www.w3.org/WAI/standards-guidelines/wcag/)
+- [Google's Style Guide for Writing Inclusive Documentation](https://developers.google.com/style/inclusive-documentation)
+- [Introduction to Web Accessibility Course by W3C and EdX (free)](https://www.edx.org/learn/web-accessibility/the-world-wide-web-consortium-w3c-introduction-to-web-accessibility)
 
 ### Use Care If Using Generative AI
 


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Don't forget to first look for overlapping PRs. Remember, open source
is a collaborative rather than competitive activity.

If this PR includes changes to the source files for the website
(docs/content/** or a file included from there) then include a preview
of the modified website; see
docs/content/contribution-guidelines/operations/document-management.md.

Please put one of the following icons at the start of your PR title,
to indicate the type of your PR. You could use copy-and-paste from
here; alternatively, the indicated code is recognized by most browsers
as a way to input that icon.

✨ - code :sparkles:, type feature
🐛 - code :bug:, type bug fix
📖 - code :book:, type docs
📝 - code :memo:, type proposal
⚠️ - code :warning:, type breaking change
🌱 - code :seedling:, type other/misc
❓ - code :question:, type requires manual review/categorization

-->
## Summary

Preview: https://eeshaansa.github.io/kubestellar-core/doc-a11y/contribution-guidelines/operations/docs-styleguide/

This PR addresses the addition of a new “Accessibility Guidelines” section to the existing KubeStellar Documentation Style Guide.

Replacement for #3178 . Same commit; name branch to support docs workflow
## Related issue(s)
#3130 


Fixes #3160 
