### PR TITLE
Add and fix Stale workflow for inactive issues

### DIFF
--- a/.gha-reversemap.yml
+++ b/.gha-reversemap.yml
@@ -83,3 +83,8 @@ actions/upload-artifact:
   sha-url: https://github.com/actions/upload-artifact/commit/ea165f8d65b6e75b540449e92b4886f43607fa02
   tag: v4
   tag-url: https://github.com/actions/upload-artifact/tree/v4
+actions/stale:
+  sha: 5bef64f19d7facfb25b37b414482c7164d639639
+  sha-url: https://github.com/actions/stale/commit/5bef64f19d7facfb25b37b414482c7164d639639
+  tag: v9.1.0
+  tag-url: https://github.com/actions/stale/tree/v9.1.0

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,45 @@
+name: Mark and close stale issues
+
+on:
+  schedule:
+    - cron: '0 0 * * *'
+  workflow_dispatch: {}
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+    steps:
+      - uses: actions/stale@5bef64f19d7facfb25b37b414482c7164d639639
+        with:
+          # Issues: mark after 60 days of inactivity, close after 14 more days
+          days-before-issue-stale: 60
+          days-before-issue-close: 14
+          stale-issue-label: lifecycle/stale
+          stale-pr-label: lifecycle/stale
+          stale-issue-message: >-
+            This issue has been automatically marked as stale because it has not had recent activity.
+            It will be closed in 14 days if no further activity occurs. If this is still relevant,
+            please add a comment to keep it open.
+          close-issue-message: >-
+            Closing this issue due to prolonged inactivity after being marked as stale. If this remains
+            an active concern, feel free to reopen or create a new issue with updated details.
+
+          # PRs: start conservatively by disabling stale for PRs
+          days-before-pr-stale: -1
+          days-before-pr-close: -1
+
+          # Exemptions and behavior
+          exempt-issue-labels: >-
+            security,bug,enhancement,good first issue,help wanted,do-not-stale,
+            priority/critical,priority/high,priority/medium,priority/low
+          exempt-pr-labels: >-
+            security,do-not-stale
+          exempt-all-assignees: true
+          exempt-all-milestones: true
+          remove-stale-when-updated: true
+          operations-per-run: 100
+          ascending: false
+


### PR DESCRIPTION
- Applies `lifecycle/stale` to inactive issues (not PRs by default), posts a friendly reminder, and closes after a grace period.
- Respects our exempt labels; activity removes the stale label.

Fixes #3221