### PR TITLE
✨feat: add E2E compatibility tests for KubeFlex versions (#3067)

### DIFF
--- a/.github/workflows/kflex-compatibility.yml
+++ b/.github/workflows/kflex-compatibility.yml
@@ -1,0 +1,100 @@
+name: KubeFlex CLI Compatibility Matrix
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+  release:
+    types: [published]
+
+jobs:
+  build-matrix:
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Extract min kflex CLI version
+        id: minver
+        run: |
+          MIN_VERSION=$(python3 scripts/extract_min_kflex_version.py)
+          echo "min_kflex_version=$MIN_VERSION" >> $GITHUB_OUTPUT
+
+      - name: Fetch all kflex CLI releases >= min version
+        id: set-matrix
+        run: |
+          MIN_VERSION=${{ steps.minver.outputs.min_kflex_version }}
+          # Get all release tags (vX.Y.Z)
+          VERSIONS=$(curl -s https://api.github.com/repos/kubestellar/kubeflex/releases | jq -r '.[].tag_name' | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | sort -V)
+          # Filter for >= min version
+          MATRIX_LIST=[]
+          for V in $VERSIONS; do
+            # Strip leading 'v' and compare
+            VNUM=${V#v}
+            # Compare using sort -V
+            if [ "$(printf "%s\n%s" "$MIN_VERSION" "$VNUM" | sort -V | head -1)" = "$MIN_VERSION" ]; then
+              MATRIX_LIST+="\"$V\","  # Append
+            fi
+          done
+          # Remove trailing comma and wrap in brackets
+          MATRIX_LIST="[${MATRIX_LIST%,}]"
+          echo "matrix=$MATRIX_LIST" >> $GITHUB_OUTPUT
+
+  test-compatibility:
+    needs: build-matrix
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        kflex_version: ${{fromJson(needs.build-matrix.outputs.matrix)}}
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+
+      - name: Download kflex CLI ${{ matrix.kflex_version }}
+        run: |
+          curl -LO https://github.com/kubestellar/kubeflex/releases/download/${{ matrix.kflex_version }}/kflex-linux-amd64
+          chmod +x kflex-linux-amd64
+          sudo mv kflex-linux-amd64 /usr/local/bin/kflex
+
+      - name: Install Kind and Helm
+        run: |
+          curl -Lo ./kind https://kind.sigs.k8s.io/dl/v0.20.0/kind-linux-amd64
+          chmod +x ./kind
+          sudo mv ./kind /usr/local/bin/kind
+          curl https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | bash
+
+      - name: Create Kind cluster
+        run: |
+          kind create cluster --name kflex-compatibility --wait 120s
+
+      - name: Install KubeStellar core chart
+        run: |
+          helm repo add kubestellar https://kubestellar.github.io/helm-charts
+          helm repo update
+          helm install ks-core kubestellar/ks-core --namespace kubestellar --create-namespace
+
+      - name: Wait for KubeStellar core pods to be ready
+        run: |
+          kubectl wait --namespace kubestellar --for=condition=Ready pods --all --timeout=180s
+
+      - name: Run kflex CLI commands for compatibility test
+        run: |
+          set -e
+          # Example kflex commands that KubeStellar depends on
+          kflex get kubeconfigs
+          kflex list clusters
+          kflex version
+
+      - name: Cleanup Kind cluster
+        if: always()
+        run: |
+          kind delete cluster --name kflex-compatibility

--- a/scripts/extract_min_kflex_version.py
+++ b/scripts/extract_min_kflex_version.py
@@ -1,0 +1,19 @@
+import re
+import sys
+
+# Usage: python extract_min_kflex_version.py [path_to_check_pre_req.sh]
+if len(sys.argv) > 1:
+    path = sys.argv[1]
+else:
+    path = 'scripts/check_pre_req.sh'
+
+with open(path) as f:
+    content = f.read()
+
+# Look for the is_installed_kflex() function and extract the min version
+match = re.search(r"is_installed_kflex\(\) \{.*?['\"]Kubeflex version: v([0-9.]+)['\"]", content, re.DOTALL)
+if match:
+    print(match.group(1))
+else:
+    print("ERROR: Could not find min kflex CLI version in {}".format(path), file=sys.stderr)
+    sys.exit(1)


### PR DESCRIPTION
## Summary
Added automated end-to-end tests to check compatibility between KubeFlex and KubeStellar whenever either is updated. The tests run across all supported kflex CLI versions using a Kind cluster and verify that key CLI commands work correctly with the installed KubeStellar core chart. Also improved the version extraction script to reliably detect the minimum required kflex CLI version.

Fixes #3067
