### PR TITLE
🌱  Bump docker/login-action, set actions/github-script

### DIFF
--- a/.gha-reversemap.yml
+++ b/.gha-reversemap.yml
@@ -49,10 +49,10 @@ azure/setup-helm:
   tag: v4.3.0
   tag-url: https://github.com/azure/setup-helm/tree/v4.3.0
 docker/login-action:
-  sha: 74a5d142397b4f367a81961eba4e8cd7edddf772
-  sha-url: https://github.com/docker/login-action/commit/74a5d142397b4f367a81961eba4e8cd7edddf772
-  tag: v3
-  tag-url: https://github.com/docker/login-action/tree/v3
+  sha: 184bdaa0721073962dff0199f1fb9940f07167d1
+  sha-url: https://github.com/docker/login-action/commit/184bdaa0721073962dff0199f1fb9940f07167d1
+  tag: v3.5.0
+  tag-url: https://github.com/docker/login-action/tree/v3.5.0
 actions/first-interaction:
   sha: 2d4393e6bc0e2efb2e48fba7e06819c3bf61ffc9
   sha-url: https://github.com/actions/first-interaction/commit/2d4393e6bc0e2efb2e48fba7e06819c3bf61ffc9
@@ -83,3 +83,8 @@ actions/upload-artifact:
   sha-url: https://github.com/actions/upload-artifact/commit/ea165f8d65b6e75b540449e92b4886f43607fa02
   tag: v4
   tag-url: https://github.com/actions/upload-artifact/tree/v4
+actions/github-script:
+  sha: 60a0d83039c74a4aee543508d2ffcb1c3799cdea
+  sha-url: https://github.com/actions/github-script/commit/60a0d83039c74a4aee543508d2ffcb1c3799cdea
+  tag: v7.0.1
+  tag-url: https://github.com/actions/github-script/tree/v7.0.1

--- a/.github/workflows/add-help-wanted.yml
+++ b/.github/workflows/add-help-wanted.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Add label based on comment
-        uses: actions/github-script@v7
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea
         with:
           script: |
             const comment = context.payload.comment.body.trim().toLowerCase();

--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -55,7 +55,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Login to registry
-        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772
+        uses: docker/login-action@184bdaa0721073962dff0199f1fb9940f07167d1
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Don't forget to first look for overlapping PRs. Remember, open source
is a collaborative rather than competitive activity.

If this PR includes changes to the source files for the website
(docs/content/** or a file included from there) then include a preview
of the modified website; see
docs/content/contribution-guidelines/operations/document-management.md.

Please put one of the following icons at the start of your PR title,
to indicate the type of your PR. You could use copy-and-paste from
here; alternatively, the indicated code is recognized by most browsers
as a way to input that icon.

✨ - code :sparkles:, type feature
🐛 - code :bug:, type bug fix
📖 - code :book:, type docs
📝 - code :memo:, type proposal
⚠️ - code :warning:, type breaking change
🌱 - code :seedling:, type other/misc
❓ - code :question:, type requires manual review/categorization

-->
## Summary
This PR bumps the version of GitHub Action docker/login-action to 3.5.0 . This is what we need instead of #3179 .

This PR also brings the usage of actions/github-script into conformance with https://docs.kubestellar.io/unreleased-development/contribution-guidelines/contributing-inc/#github-action-reference-discipline .

## Related issue(s)

Fixes #
