### PR TITLE
✨ Add .gitattributes to normalize line endings and ignore generated files in diffs

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,4 @@
+* text=auto eol=lf
 # Ignore generated code in diffs.
-**/zz_generated.*.go linguist-generated=true
-/pkg/client/** linguist-generated=true
+**/zz_generated.*.go linguist-generated=true -diff
+/pkg/client/** linguist-generated=true -diff

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,4 +1,4 @@
-* text=auto eol=lf
+text=auto 
 # Ignore generated code in diffs.
 **/zz_generated.*.go linguist-generated=true -diff
 /pkg/client/** linguist-generated=true -diff

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,4 +1,4 @@
 text=auto 
 # Ignore generated code in diffs.
 **/zz_generated.*.go linguist-generated=true -diff
-/pkg/client/** linguist-generated=true -diff
+/pkg/generated/** linguist-generated=true -diff


### PR DESCRIPTION
This pull request adds a .gitattributes file to the repository to:

Enforce consistent LF line endings across all platforms by setting * text=auto eol=lf.

Mark generated files (e.g., zz_generated.*.go and files inside /pkg/client/) with linguist-generated=true and -diff to minimize diff noise both locally and in GitHub pull requests. 

fixes #3211 