### PR TITLE
📖 docs: add Release Notes section to documentation site home page

### DIFF
--- a/docs/content/readme.md
+++ b/docs/content/readme.md
@@ -70,6 +70,11 @@ Instantly get access to our documents and meeting invites [http://kubestellar.io
 - Follow us on:
    - LinkedIn - [#kubestellar](https://www.linkedin.com/feed/hashtag/?keywords=kubestellar)
    - Medium - [kubestellar.medium.com](https://medium.com/@kubestellar/list/predefined:e785a0675051:READING_LIST)
+## Release Notes
+
+For detailed, summaries of each release—including new features, bug fixes, and breaking changes—please visit our release notes page:
+
+https://docs.kubestellar.io/unreleased-development/direct/release-notes/   
    
    
 ## ❤️ Contributors


### PR DESCRIPTION
This PR adds a new Release Notes section to the main page of the documentation  linking to the full release notes page. This improves discoverability of release summaries directly from the documentation homepage.
part of  #3223  

preview : https://shivansh-source.github.io/kubestellar/document_release