### PR TITLE
📖 docs: Update .gitignore to block compiled binaries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,11 @@ core-chart/charts/
 # Python local stuff associated with KubeStellar performance tests
 /test/performance/common/.venv/
 /test/performance/common/__pycache__/
+
+# Compiled binaries and libraries
+*.exe
+*.dll
+*.so
+*.dylib
+*.jar
+*.class


### PR DESCRIPTION

This PR enhances the .gitignore to include patterns for compiled binaries and libraries (*.exe, *.dll, *.so, *.dylib, *.jar, *.class). These additions ensure no generated executable artifacts are committed,  addressing the OSPS-QA-05.01 requirement.

Related issue(s)
Fixes #3244 
Relates to #3236 