### PR TITLE
🐛Fix: sanitize CI/CD inputs and update workflows; include CoC reference

### DIFF
--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -1,0 +1,47 @@
+name: Link checks
+
+on:
+  pull_request:
+    branches: [ main ]
+  push:
+    branches: [ main ]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  scheme-enforce:
+    name: Enforce HTTPS scheme (no http except localhost)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Fail on non-localhost http links
+        shell: bash
+        run: |
+          set -euo pipefail
+          echo "Scanning for non-localhost http:// links in Markdown files"
+          MATCHES="$(grep -RInE 'http://' --include='*.md' --include='*.MD' --include='*.markdown' . | grep -vE 'http://(localhost|127\.0\.0\.1)(:[0-9]+)?(/|$)')"
+          if [ -n "${MATCHES}" ]; then
+            echo "Found non-localhost http links:"
+            echo "${MATCHES}"
+            echo
+            echo "Please replace http:// with https:// where appropriate, or justify with localhost/127.0.0.1."
+            exit 1
+          fi
+          echo "No non-localhost http links found."
+
+  lychee:
+    name: Link validity (lychee)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run lychee
+        uses: lycheeverse/lychee-action@v2
+        with:
+          args: >-
+            --no-progress
+            --config .lychee.toml
+            .
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ocp-self-runner.yml
+++ b/.github/workflows/ocp-self-runner.yml
@@ -105,3 +105,5 @@ jobs:
           export PATH=~/oc:$PATH
           export KFLEX_DISABLE_CHATTY=true
           bash <(curl -s https://raw.githubusercontent.com/kubestellar/kubestellar/release-$KUBESTELLAR_VERSION/test/e2e/multi-cluster-deployment/run-test.sh) --env ocp --released
+        env:
+          TEST_FLAGS: ""

--- a/.github/workflows/pr-test-e2e.yml
+++ b/.github/workflows/pr-test-e2e.yml
@@ -52,6 +52,12 @@ jobs:
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
 
+      - name: Validate inputs
+        run: |
+          bash scripts/validate-inputs.sh
+        env:
+          TEST_FLAGS: ${{ github.event.inputs.testFlags || '' }}
+
       - uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5
         with:
           go-version: 1.24
@@ -74,7 +80,7 @@ jobs:
 
       - name: Run test
         env:
-          TEST_FLAGS: ${{ github.event.inputs.testFlags }}
+          TEST_FLAGS: ${{ github.event.inputs.testFlags || '' }}
         run: |
           cd test/e2e/ginkgo
           KFLEX_DISABLE_CHATTY=true ginkgo -vv --trace --no-color --fail-fast $TEST_FLAGS -- -kubestellar-setup-flags="--kubestellar-controller-manager-verbosity 5 --transport-controller-verbosity 5"
@@ -183,6 +189,12 @@ jobs:
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
 
+      - name: Validate inputs
+        run: |
+          bash scripts/validate-inputs.sh
+        env:
+          TEST_FLAGS: ${{ github.event.inputs.testFlags || '' }}
+
       - uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5
         with:
           go-version: 1.24
@@ -204,7 +216,7 @@ jobs:
 
       - name: Run test
         env:
-          TEST_FLAGS: ${{ github.event.inputs.testFlags }}
+          TEST_FLAGS: ${{ github.event.inputs.testFlags || '' }}
         run: |
           cd test/e2e/
           KFLEX_DISABLE_CHATTY=true ./run-test.sh $TEST_FLAGS

--- a/.lychee.toml
+++ b/.lychee.toml
@@ -1,0 +1,6 @@
+# lychee configuration for KubeStellar
+# Exclude localhost HTTP links from validation (dev-only)
+exclude = [
+  "^http://localhost(:[0-9]+)?(/|$)",
+  "^http://127\\.0\\.0\\.1(:[0-9]+)?(/|$)"
+]

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -80,7 +80,7 @@ Consistent with the CNCF Charter, any substantive changes to this Code of Conduc
 ## Acknowledgements
 
 This Code of Conduct is adapted from the Contributor Covenant
-(http://contributor-covenant.org), version 2.0 available at
-http://contributor-covenant.org/version/2/0/code_of_conduct/
+(https://contributor-covenant.org), version 2.0 available at
+https://contributor-covenant.org/version/2/0/code_of_conduct/
 
 <!--coc-end-->

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Have a look at what we are working on next, see our [Roadmap](docs/content/direc
 
 There are several ways to communicate with us:
 
-Instantly get access to our documents and meeting invites at http://kubestellar.io/joinus
+Instantly get access to our documents and meeting invites at https://kubestellar.io/joinus
 
 - The [`#kubestellar-dev` channel](https://cloud-native.slack.com/archives/C097094RZ3M) in the [CNCF Slack workspace](https://communityinviter.com/apps/cloud-native/cncf)
 - Our mailing lists:

--- a/dispatch-bad.json
+++ b/dispatch-bad.json
@@ -1,0 +1,4 @@
+{
+  "ref": "refs/heads/main",
+  "inputs": { "testFlags": "--bad" }
+}

--- a/dispatch-ok.json
+++ b/dispatch-ok.json
@@ -1,0 +1,4 @@
+{
+  "ref": "refs/heads/main",
+  "inputs": { "testFlags": "--released" }
+}

--- a/pr.json
+++ b/pr.json
@@ -1,0 +1,1 @@
+{ "pull_request": { "number": 1 } }

--- a/scripts/validate-inputs.sh
+++ b/scripts/validate-inputs.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Reusable CI input validator for GitHub Actions
+# Fails fast on unexpected or unsafe input values.
+
+die() { echo "Input validation error: $*" >&2; exit 2; }
+
+# Validate that inputs contain no control characters
+check_no_ctrl() {
+  local name="$1" val
+  val="${!name-}"
+  if printf '%s' "$val" | LC_ALL=C grep -q '[[:cntrl:]]'; then
+    die "$name contains control characters"
+  fi
+}
+
+# --- Known inputs ---
+# TEST_FLAGS: allowed values are empty or "--released"
+check_test_flags() {
+  local val="${TEST_FLAGS-}"
+  case "$val" in
+    ""|"--released") ;;
+    *) die "TEST_FLAGS must be one of: '' or '--released' (got: '$val')" ;;
+  esac
+}
+
+# Run checks
+check_no_ctrl TEST_FLAGS
+check_test_flags
+
+echo "Inputs validated successfully."


### PR DESCRIPTION
## Summary
This pull request addresses the OSPS-BR-01.01 compliance issue by implementing strict input validation for CI/CD workflows. Key changes include:

-Input Validation: Added scripts/validate-inputs.sh to strictly validate TEST_FLAGS.

-Workflows: Updated .github/workflows/pr-test-e2e.yml and .github/workflows/ocp-self-runner.yml for early validation and safe defaults.

-HTTPS & Link Check: Updated links in README.md, docs/content/readme.md, and CODE_OF_CONDUCT.md to HTTPS, and added a link-check workflow.

Fixes #3245 
