### PR TITLE
🐛 bug: golangci-lint workflow: remove deprecated --fast flag

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -35,17 +35,17 @@ jobs:
         run: |
           curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v2.4.0
 
-      - name: Run golangci-lint (Fast Mode)
+      - name: Run golangci-lint
         run: |
-          golangci-lint run --timeout=8m --issues-exit-code=0 --config=.golangci.yaml --fast --max-issues-per-linter=50 --max-same-issues=10
+          golangci-lint run --timeout=8m --issues-exit-code=0 --config=.golangci.yaml --max-issues-per-linter=50 --max-same-issues=10
 
       - name: Add Lint Summary
         if: always()
         run: |
           echo "### Static Analysis (Resource-Efficient Mode)" >> $GITHUB_STEP_SUMMARY
-          echo "- **Schedule**: Weekly runs (Mondays 2 AM UTC) + main branch pushes" >> $GITHUB_STEP_SUMMARY
+          echo "- **Schedule**: Weekly runs (Mondays 2 AM UTC) + manual dispatch only" >> $GITHUB_STEP_SUMMARY
           echo "- **Timeout**: Strict 10-minute limit" >> $GITHUB_STEP_SUMMARY
-          echo "- **Mode**: Fast lint with concurrency controls" >> $GITHUB_STEP_SUMMARY
+          echo "- **Mode**: Standard lint with concurrency controls" >> $GITHUB_STEP_SUMMARY
           echo "- **Purpose**: OpenSSF badge compliance visibility" >> $GITHUB_STEP_SUMMARY
           echo "- **Config**: .golangci.yaml" >> $GITHUB_STEP_SUMMARY
-          echo "- **Resource Impact**: 99% reduction vs per-PR runs" >> $GITHUB_STEP_SUMMARY
+          echo "- **Resource Impact**: Minimal overhead - weekly scheduled runs only" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Don't forget to first look for overlapping PRs. Remember, open source
is a collaborative rather than competitive activity.

If this PR includes changes to the source files for the website
(docs/content/** or a file included from there) then include a preview
of the modified website; see
docs/content/contribution-guidelines/operations/document-management.md.

Please put one of the following icons at the start of your PR title,
to indicate the type of your PR. You could use copy-and-paste from
here; alternatively, the indicated code is recognized by most browsers
as a way to input that icon.

✨ - code :sparkles:, type feature
🐛 - code :bug:, type bug fix
📖 - code :book:, type docs
📝 - code :memo:, type proposal
⚠️ - code :warning:, type breaking change
🌱 - code :seedling:, type other/misc
❓ - code :question:, type requires manual review/categorization

-->

## Root Cause
The `--fast` flag was deprecated and removed in golangci-lint v2.4.0, but the workflow was still using it.

## Summary of solution
- Removed the deprecated `--fast` flag from golangci-lint command
-  Updated workflow step name from "Run golangci-lint (Fast Mode)" to "Run golangci-lint" 
- Fixed workflow summary to accurately reflect actual triggers (weekly + manual dispatch only)
- Fixed resource impact description 

## Testing
-  Tested locally - golangci-lint runs without errors
-  Tested on fork's GitHub Actions - workflow passes successfully
-   Verified YAML syntax and workflow structure


Fixes #3264

