### PR TITLE
🌱 Improved error handling in hack/gha-reversemap.sh

### DIFF
--- a/docs/content/contribution-guidelines/contributing-inc.md
+++ b/docs/content/contribution-guidelines/contributing-inc.md
@@ -144,6 +144,36 @@ script](https://github.com/kubestellar/kubestellar/blob/main/hack/gha-reversemap
 for updating and checking this stuff. There is a workflow that checks
 that every workflow follows the discipline here.
 
+The following abbreviated typescript shows an example of using that
+script to bump the GitHub Action `actions/checkout` in the reversemap
+file to the Action's latest version and then applying that file to all
+the workflows --- thus bumping that Action in all the workflows while
+maintaining discipline.
+
+```console
+$ hack/gha-reversemap.sh update-action-version actions/checkout
+2025-08-22T02:13:38-04:00;INFO;running update-action-version on actions/checkout
+2025-08-22T02:13:38-04:00;INFO;updating dependency 'actions/checkout' tag to latest version available inside reverse map '.gha-reversemap.yml'
+
+$ hack/gha-reversemap.sh apply-reversemap      
+2025-08-22T02:13:50-04:00;INFO;running apply-reversemap on ./.github/workflows/*.y*ml
+2025-08-22T02:13:50-04:00;INFO;applying '.gha-reversemap.yml' commit sha to be used in './.github/workflows/add-help-wanted.yml' ...
+2025-08-22T02:13:50-04:00;INFO;found 'actions/github-script' in reversemap with sha=60a0d83039c74a4aee543508d2ffcb1c3799cdea
+2025-08-22T02:13:50-04:00;INFO;applying '.gha-reversemap.yml' commit sha to be used in './.github/workflows/add-to-project.yml' ...
+2025-08-22T02:13:50-04:00;INFO;found 'actions/checkout' in reversemap with sha=08c6903cd8c0fde910a37f88322edcfb5dd907a8
+...
+```
+
+The `update-action-version` and `update-reversemap` operations in that
+script make calls on the GitHub API --- which are [rate
+limited](https://docs.github.com/en/rest/using-the-rest-api/rate-limits-for-the-rest-api). Unauthenticated
+calls have a relatively low rate limit. Modest usage of this script is
+unlikely to hit this rate limit. If you run into the rate limit when
+not using authentication then you can add authentication by setting
+the environment variable `GITHUB_TOKEN` to a GitHub Personal Access
+Token. All "classic" tokens suffice. For "fine-grained" tokens, the
+only privilege needed is Read access to `metadata`.
+
 #### Review and Approval Process
 
 Reviewers will review your PR within a business day. A PR requires both an `/lgtm` and then an `/approve` in order to get merged. These are commands to Prow, each appearing alone on a line in a comment of the PR. You may `/approve` your own PR but you may not `/lgtm` it. Once both forms of assent have been given and the other gating checks have passed, the PR will go into the Prow merge queue and eventually be merged. Once that happens, you will be notified:

--- a/hack/gha-reversemap.sh
+++ b/hack/gha-reversemap.sh
@@ -29,14 +29,23 @@ YQ_MIN_VERSION="yq (https://github.com/mikefarah/yq/) version v4.45"
 GIT_COMMITSHA_LENGTH=40
 TMP_OUTPUT="/tmp/$(date -u -Iseconds | cut -d '+' -f1).json"
 
+ERR_LIMITED=47
 ERR_YQ_DOWNLOAD_FAILED=50
 ERR_YQ_NOT_INSTALLED=60
 ERR_GITHUB_TOKEN_INVALID=70
+ERR_FETCH_TAG_FAIL=74
+ERR_FETCH_BRANCH_FAIL=76
 ERR_NO_SHA=79
 ERR_ARCH_UNSUPPORTED=80
+ERR_NO_ACTION=84
 ERR_NO_LATEST=86
 ERR_NO_TAG=87
 ERR_VERIFY_FAIL=90
+
+if [[ -n "$GITHUB_TOKEN" ]]
+then github_auth=("-H" "Authorization: Bearer $GITHUB_TOKEN")
+else github_auth=()
+fi
 
 help() {
     cat <<EOF
@@ -95,9 +104,16 @@ _check_yq_version() {
     fi
 }
 
-# Check github token
+# Check github token.
+# This function is not needed because commonly the user will not
+# run into the GitHub rate limit, not even without a GITHUB_TOKEN,
+# and an understandable error message is given if and when the limit
+# is hit.
+# We temporarily make this function a no-op, while gaining confidence
+# in the improved error messaging.
+# Eventually we will delete this function and the calls on it.
 _check_github_token(){
-    if [[ -z $GITHUB_TOKEN ]]; then
+    if [[ -z $GITHUB_TOKEN ]] && false; then
         _exit_with_error $ERR_GITHUB_TOKEN_INVALID "environment variable GITHUB_TOKEN is not set."
     fi
 }
@@ -109,13 +125,20 @@ _fetch_sha_from_upstream_ref() {
     action_ref_safe=$(echo "$action_ref" | cut -d '/' -f 1,2)
     API_GITHUB_BRANCH="https://api.github.com/repos/${action_ref_safe}/git/refs/heads/${tag_or_branch}"
     API_GITHUB_TAG="https://api.github.com/repos/${action_ref_safe}/git/refs/tags/${tag_or_branch}"
-    HTTP_STATUS=$(curl -o "$TMP_OUTPUT" -s -w "%{http_code}" -H "Authorization: Bearer $GITHUB_TOKEN" "$API_GITHUB_TAG")
+    HTTP_STATUS=$(curl -o "$TMP_OUTPUT" -s -w "%{http_code}" "${github_auth[@]}" "$API_GITHUB_TAG")
     if [[ $HTTP_STATUS -ge 200 && $HTTP_STATUS -lt 300 ]]; then
         commit_sha=$(jq -r '.object.sha' $TMP_OUTPUT)
         # _loginfo "tag api $commit_sha"
+    elif [[ "$HTTP_STATUS" =~ 403|429 ]]; then
+        _exit_with_error $ERR_LIMITED "GitHub rejected 'GET $API_GITHUB_TAG' with status $HTTP_STATUS, probably due to rate limiting. See https://docs.github.com/en/rest/using-the-rest-api/rate-limits-for-the-rest-api and information about 'GitHub Action reference discipline' on the [KubeStellar website](https://kubestellar.io/), then invoke this script with the environment variable GITHUB_TOKEN set to any valid token"
+    elif [[ "$HTTP_STATUS" != 404 ]]; then
+        _exit_with_error $ERR_FETCH_TAG_FAIL "GitHub rejected 'GET $API_GITHUB_TAG' with status $HTTP_STATUS"
+    elif { HTTP_STATUS=$(curl -o "$TMP_OUTPUT" -s -w "%{http_code}" "${github_auth[@]}" "$API_GITHUB_BRANCH"); } && [[ $HTTP_STATUS -ge 200 && $HTTP_STATUS -lt 300 ]]; then
+        commit_sha=$(jq -r '.object.sha' $TMP_OUTPUT)
+    elif [[ "$HTTP_STATUS" =~ 403|429 ]]; then
+        _exit_with_error $ERR_LIMITED "GitHub rejected 'GET $API_GITHUB_BRANCH' with status $HTTP_STATUS, probably due to rate limiting. See https://docs.github.com/en/rest/using-the-rest-api/rate-limits-for-the-rest-api and information about 'GitHub Action reference discipline' on the [KubeStellar website](https://kubestellar.io/), then invoke this script with the environment variable GITHUB_TOKEN set to any valid token"
     else
-        commit_sha=$(curl -s -H "Authorization: Bearer $GITHUB_TOKEN" "$API_GITHUB_BRANCH" | jq -r '.object.sha')
-        # _loginfo "branch api $commit_sha"
+        _exit_with_error $ERR_FETCH_BRANCH_FAIL "GitHub rejected 'GET $API_GITHUB_BRANCH' with status $HTTP_STATUS"
     fi
     _return "$commit_sha"
 }
@@ -154,7 +177,16 @@ _fetch_latest_tag() {
     action_ref=$1
     action_ref_safe=$(echo "$action_ref" | cut -d '/' -f 1,2)
     API_GITHUB_LATEST_RELEASE=https://api.github.com/repos/${action_ref_safe}/releases/latest
-    latest_json=$(curl -s -H "Authorization: Bearer $GITHUB_TOKEN" "$API_GITHUB_LATEST_RELEASE")
+    HTTP_STATUS=$(curl -o "$TMP_OUTPUT" -s -w "%{http_code}" "${github_auth[@]}" "$API_GITHUB_LATEST_RELEASE")
+    if [[ $HTTP_STATUS -ge 200 && $HTTP_STATUS -lt 300 ]]; then
+        latest_json=$(cat "$TMP_OUTPUT")
+    elif [[ "$HTTP_STATUS" =~ 403|429 ]]; then
+        _exit_with_error $ERR_LIMITED "GitHub rejected 'GET $API_GITHUB_LATEST_RELEASE' with status $HTTP_STATUS, probably due to rate limiting. See https://docs.github.com/en/rest/using-the-rest-api/rate-limits-for-the-rest-api and information about 'GitHub Action reference discipline' on the [KubeStellar website](https://kubestellar.io/), then invoke this script with the environment variable GITHUB_TOKEN set to any valid token"
+    elif [[ "$HTTP_STATUS" == 404 ]]; then
+        _exit_with_error $ERR_NO_ACTION "There is no action named '$action_ref'"
+    else
+        _exit_with_error $ERR_NO_LATEST "GitHub rejected 'GET $API_GITHUB_LATEST_RELEASE' with status $HTTP_STATUS"
+    fi
     if [ -z "$latest_json" ]; then
         _exit_with_error $ERR_NO_LATEST "GitHub returned empty response to query for latest"
     fi
@@ -307,7 +339,7 @@ run_cli() {
         exit 1
         ;;
     esac
-
+    rm -rf "$TMP_OUTPUT"
 }
 
 # Execute the main program

--- a/hack/gha-reversemap.sh
+++ b/hack/gha-reversemap.sh
@@ -174,9 +174,9 @@ _fetch_latest_tag() {
     action_ref_safe=$(echo "$action_ref" | cut -d '/' -f 1,2)
     API_GITHUB_LATEST_RELEASE=https://api.github.com/repos/${action_ref_safe}/releases/latest
     HTTP_STATUS=$(curl -o "$TMP_OUTPUT" -s -w "%{http_code}" "${github_auth[@]}" "$API_GITHUB_LATEST_RELEASE")
-    if [[ $HTTP_STATUS -ge 200 && $HTTP_STATUS -lt 300 ]]; then
+    if [[ "$HTTP_STATUS" -ge 200 && "$HTTP_STATUS" -lt 300 ]]; then
         latest_json=$(cat "$TMP_OUTPUT")
-    elif [[ "$HTTP_STATUS" =~ 403|429 ]]; then
+    elif [[ "$HTTP_STATUS" == 403 || "$HTTP_STATUS" == 429 ]]; then
         _exit_with_error $ERR_LIMITED "GitHub rejected 'GET $API_GITHUB_LATEST_RELEASE' with status $HTTP_STATUS, probably due to rate limiting. See https://docs.github.com/en/rest/using-the-rest-api/rate-limits-for-the-rest-api and information about 'GitHub Action reference discipline' on the relevant version of the [KubeStellar website](https://kubestellar.io/), then invoke this script with the environment variable GITHUB_TOKEN set to any valid token"
     elif [[ "$HTTP_STATUS" == 404 ]]; then
         _exit_with_error $ERR_NO_ACTION "There is no action named '$action_ref'"


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Don't forget to first look for overlapping PRs. Remember, open source
is a collaborative rather than competitive activity.

If this PR includes changes to the source files for the website
(docs/content/** or a file included from there) then include a preview
of the modified website; see
docs/content/contribution-guidelines/operations/document-management.md.

Please put one of the following icons at the start of your PR title,
to indicate the type of your PR. You could use copy-and-paste from
here; alternatively, the indicated code is recognized by most browsers
as a way to input that icon.

✨ - code :sparkles:, type feature
🐛 - code :bug:, type bug fix
📖 - code :book:, type docs
📝 - code :memo:, type proposal
⚠️ - code :warning:, type breaking change
🌱 - code :seedling:, type other/misc
❓ - code :question:, type requires manual review/categorization

-->
## Summary
This PR improves the error handling in `hack/gha-reversemap.sh` so that it prints an understandable and actionable error message in all cases where the GitHub API rate limit is hit.

This PR also removes the insistence that the envar GITHUB_TOKEN is set, because it that setting is rarely needed and there is now a serviceable error message when the problem occurs.

This PR also improves the website documentation of that script a little.

Preview at https://mikespreitzer.github.io/kcp-edge-mc/doc-actions/contribution-guidelines/contributing-inc/#github-action-reference-discipline

## Related issue(s)

Fixes #
