### PR TITLE
🌱 Refactor `ValidateNumDeploymentReplicas` in ginkgo e2e test

### DIFF
--- a/test/e2e/ginkgo/multiple_cluster_deployment_test.go
+++ b/test/e2e/ginkgo/multiple_cluster_deployment_test.go
@@ -84,15 +84,15 @@ var _ = ginkgo.Describe("end to end testing", func() {
 				ctx, "nginx", types.MergePatchType, patch, metav1.PatchOptions{})
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
-			util.ValidateNumDeploymentReplicas(ctx, wec1, ns, 2)
-			util.ValidateNumDeploymentReplicas(ctx, wec2, ns, 2)
+			util.ValidateDeploymentReplicas(ctx, wec1, ns, "nginx", 2)
+			util.ValidateDeploymentReplicas(ctx, wec2, ns, "nginx", 2)
 		})
 
 		ginkgo.It("supports create-only mode", func(ctx context.Context) {
 			ginkgo.By("deleting old BindingPolicy and expecting Deployment deletions")
 			util.DeleteBindingPolicy(ctx, ksWds, "nginx")
-			util.ValidateNumDeploymentReplicas(ctx, wec1, ns, 0)
-			util.ValidateNumDeploymentReplicas(ctx, wec2, ns, 0)
+			util.ValidateDeploymentDeletion(ctx, wec1, ns, "nginx")
+			util.ValidateDeploymentDeletion(ctx, wec2, ns, "nginx")
 
 			ginkgo.By("creating new BindingPolicy and expecting corresponding Binding")
 			util.CreateBindingPolicy(ctx, ksWds, "nginx",
@@ -119,8 +119,8 @@ var _ = ginkgo.Describe("end to end testing", func() {
 					len(binding.Spec.Workload.NamespaceScope) == 1 &&
 					binding.Spec.Workload.NamespaceScope[0].CreateOnly
 			})
-			util.ValidateNumDeploymentReplicas(ctx, wec1, ns, 1)
-			util.ValidateNumDeploymentReplicas(ctx, wec2, ns, 1)
+			util.ValidateDeploymentReplicas(ctx, wec1, ns, "nginx", 1)
+			util.ValidateDeploymentReplicas(ctx, wec2, ns, "nginx", 1)
 			dep1 := util.GetDeployment(ctx, wec1, ns, "nginx")
 			dep2 := util.GetDeployment(ctx, wec2, ns, "nginx")
 

--- a/test/util/util.go
+++ b/test/util/util.go
@@ -529,18 +529,29 @@ func GetDeployment(ctx context.Context, wec *kubernetes.Clientset, ns, name stri
 	return ans
 }
 
-func ValidateNumDeploymentReplicas(ctx context.Context, wec *kubernetes.Clientset, ns string, numReplicas int) {
+func ValidateDeploymentDeletion(ctx context.Context, wec *kubernetes.Clientset, ns, name string) {
 	ginkgo.GinkgoHelper()
-	gomega.Eventually(func() int {
-		deployments, err := wec.AppsV1().Deployments(ns).List(ctx, metav1.ListOptions{})
-		gomega.Expect(err).NotTo(gomega.HaveOccurred())
-		if len(deployments.Items) != 1 {
-			return 0
+	gomega.Eventually(func() error {
+		_, err := wec.AppsV1().Deployments(ns).Get(ctx, name, metav1.GetOptions{})
+		if k8serrors.IsNotFound(err) {
+			return nil
 		}
-		d := deployments.Items[0]
-		print()
-		return int(*d.Spec.Replicas)
-	}, timeout).Should(gomega.Equal(numReplicas))
+		return fmt.Errorf("Deployment %q in namespace %q still exists, or some error other than NotFound occurred", name, ns)
+	}, timeout).Should(gomega.Succeed())
+}
+
+func ValidateDeploymentReplicas(ctx context.Context, wec *kubernetes.Clientset, ns, name string, numReplicas int) {
+	ginkgo.GinkgoHelper()
+	gomega.Eventually(func() error {
+		d, err := wec.AppsV1().Deployments(ns).Get(ctx, name, metav1.GetOptions{})
+		if err != nil {
+			return fmt.Errorf("Failed to get Deployment %q in namespace %q: %w", name, ns, err)
+		}
+		if int(*d.Spec.Replicas) != numReplicas {
+			return fmt.Errorf("Deployment %q in namespace %q has %d replicas, expected %d", name, ns, *d.Spec.Replicas, numReplicas)
+		}
+		return nil
+	}, timeout).Should(gomega.Succeed())
 }
 
 func DeleteWECDeployments(ctx context.Context, wec *kubernetes.Clientset, ns string) {


### PR DESCRIPTION
## Summary
Looks like the function body of `ValidateNumDeploymentReplicas` is not doing what the function name suggests, thus somehow not easy to follow.

It confusingly said "if there is not exactly one Deployment, then assert the replica of the concerned Deployment to be zero".

This PR tries to make this cleaner.
