### PR TITLE
Remove unused DeprecatedAddToFlags function

### DIFF
--- a/options/process-options.go
+++ b/options/process-options.go
@@ -32,8 +32,3 @@ func (po *ProcessOptions) AddToFlags(flags *pflag.FlagSet) {
 	flags.StringVar(&po.HealthProbeBindAddr, "health-probe-bind-address", po.HealthProbeBindAddr, "the [host]:port from which to serve /healthz,/readyz (empty string to not serve)")
 }
 
-func (po *ProcessOptions) DeprecatedAddToFlags(flags *pflag.FlagSet) {
-	flags.StringVar(&po.MetricsBindAddr, "metrics-bind-addr", po.MetricsBindAddr, "the [host]:port from which to serve /metrics")
-	flags.StringVar(&po.PProfBindAddr, "pprof-bind-addr", po.PProfBindAddr, "the [host]:port from which to serve /debug/pprof")
-	flags.StringVar(&po.HealthProbeBindAddr, "health-bind-addr", po.HealthProbeBindAddr, "the [host]:port from which to serve /healthz,/readyz (empty string to not serve)")
-}


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Don't forget to first look for overlapping PRs. Remember, open source
is a collaborative rather than competitive activity.

If this PR includes changes to the source files for the website
(docs/content/** or a file included from there) then include a preview
of the modified website; see
docs/content/contribution-guidelines/operations/document-management.md.

Please put one of the following icons at the start of your PR title,
to indicate the type of your PR. You could use copy-and-paste from
here; alternatively, the indicated code is recognized by most browsers
as a way to input that icon.

✨ - code :sparkles:, type feature
🐛 - code :bug:, type bug fix
📖 - code :book:, type docs
📝 - code :memo:, type proposal
⚠️ - code :warning:, type breaking change
🌱 - code :seedling:, type other/misc
❓ - code :question:, type requires manual review/categorization

-->
## Summary

This function in options/process-options.go is no longer used and was marked for deletion in issue #3298.
