### PR TITLE
🐛 Delete CustomTransform object before each ginkgo node

### DIFF
--- a/test/util/util.go
+++ b/test/util/util.go
@@ -575,6 +575,9 @@ func CleanupWDS(ctx context.Context, wds *kubernetes.Clientset, ksWds *ksClient.
 	DeleteAll[*ksapi.BindingPolicyList](ctx, ksWds.ControlV1alpha1().BindingPolicies(), func(objList *ksapi.BindingPolicyList) []string {
 		return objectsToNames((*ksapi.BindingPolicy).GetName, objList.Items)
 	})
+	DeleteAll[*ksapi.CustomTransformList](ctx, ksWds.ControlV1alpha1().CustomTransforms(), func(objList *ksapi.CustomTransformList) []string {
+		return objectsToNames((*ksapi.CustomTransform).GetName, objList.Items)
+	})
 	DeleteAll[*ksapi.StatusCollectorList](ctx, ksWds.ControlV1alpha1().StatusCollectors(), func(objList *ksapi.StatusCollectorList) []string {
 		return objectsToNames((*ksapi.StatusCollector).GetName, objList.Items)
 	})


### PR DESCRIPTION
## Summary
In the ginkgo node `propagates deployment to the WECs while applying CustomTransform`,  a CustomTransform object `test` is created.
https://github.com/kubestellar/kubestellar/blob/12332e4fb269263cdaecfca19e7aa6689a924d02/test/e2e/ginkgo/multiple_cluster_deployment_test.go#L70

If we use the `-skip-setup` flag to rerun this ginkgo node, then the existing object fails the creation.

To fix this, we should delete the CustomTransform object before each node, similar to what we did to objects of kinds BindingPolicy, StatusCollector, etc., in `CleanupWDS`.
