### PR TITLE
🌱 Bump actions stale, setup-python, setup-go, github-script

### DIFF
--- a/.gha-reversemap.yml
+++ b/.gha-reversemap.yml
@@ -4,10 +4,10 @@ actions/checkout:
   tag: v5.0.0
   tag-url: https://github.com/actions/checkout/tree/v5.0.0
 actions/stale:
-  sha: 5bef64f19d7facfb25b37b414482c7164d639639
-  sha-url: https://github.com/actions/stale/commit/5bef64f19d7facfb25b37b414482c7164d639639
-  tag: v9.1.0
-  tag-url: https://github.com/actions/stale/tree/v9.1.0
+  sha: 3a9db7e6a41a89f618792c92c0e97cc736e1b13f
+  sha-url: https://github.com/actions/stale/commit/3a9db7e6a41a89f618792c92c0e97cc736e1b13f
+  tag: v10.0.0
+  tag-url: https://github.com/actions/stale/tree/v10.0.0
 actions/add-to-project:
   sha: 244f685bbc3b7adfa8466e08b698b5577571133e
   sha-url: https://github.com/actions/add-to-project/commit/244f685bbc3b7adfa8466e08b698b5577571133e
@@ -29,15 +29,15 @@ JasonEtco/create-an-issue:
   tag: v2
   tag-url: https://github.com/JasonEtco/create-an-issue/tree/v2
 actions/setup-python:
-  sha: a26af69be951a213d495a4c3e4e4022e16d87065
-  sha-url: https://github.com/actions/setup-python/commit/a26af69be951a213d495a4c3e4e4022e16d87065
-  tag: v5
-  tag-url: https://github.com/actions/setup-python/tree/v5
+  sha: e797f83bcb11b83ae66e0230d6156d7c80228e7c
+  sha-url: https://github.com/actions/setup-python/commit/e797f83bcb11b83ae66e0230d6156d7c80228e7c
+  tag: v6.0.0
+  tag-url: https://github.com/actions/setup-python/tree/v6.0.0
 actions/setup-go:
-  sha: d35c59abb061a4a6fb18e82ac0862c26744d6ab5
-  sha-url: https://github.com/actions/setup-go/commit/d35c59abb061a4a6fb18e82ac0862c26744d6ab5
-  tag: v5
-  tag-url: https://github.com/actions/setup-go/tree/v5
+  sha: 44694675825211faa026b3c33043df3e48a5fa00
+  sha-url: https://github.com/actions/setup-go/commit/44694675825211faa026b3c33043df3e48a5fa00
+  tag: v6.0.0
+  tag-url: https://github.com/actions/setup-go/tree/v6.0.0
 anchore/sbom-action/download-syft:
   sha: da167eac915b4e86f08b264dbdbc867b61be6f0c
   sha-url: https://github.com/anchore/sbom-action/commit/da167eac915b4e86f08b264dbdbc867b61be6f0c
@@ -89,7 +89,7 @@ actions/upload-artifact:
   tag: v4
   tag-url: https://github.com/actions/upload-artifact/tree/v4
 actions/github-script:
-  sha: 60a0d83039c74a4aee543508d2ffcb1c3799cdea
-  sha-url: https://github.com/actions/github-script/commit/60a0d83039c74a4aee543508d2ffcb1c3799cdea
-  tag: v7.0.1
-  tag-url: https://github.com/actions/github-script/tree/v7.0.1
+  sha: ed597411d8f924073f98dfc5c65a23a2325f34cd
+  sha-url: https://github.com/actions/github-script/commit/ed597411d8f924073f98dfc5c65a23a2325f34cd
+  tag: v8
+  tag-url: https://github.com/actions/github-script/tree/v8

--- a/.github/workflows/add-help-wanted.yml
+++ b/.github/workflows/add-help-wanted.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Add label based on comment
-        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd
         with:
           script: |
             const comment = context.payload.comment.body.trim().toLowerCase();

--- a/.github/workflows/docs-gen-and-push.yml
+++ b/.github/workflows/docs-gen-and-push.yml
@@ -51,7 +51,7 @@ jobs:
 
       - run: git fetch origin gh-pages
 
-      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
+      - uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c
         with:
           python-version: "3.10"
           cache: "pip"

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -26,7 +26,7 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5
+      - uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00
         with:
           go-version-file: go.mod
           cache: true

--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -25,7 +25,7 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5
+      - uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00
         with:
           go-version: 1.24
 

--- a/.github/workflows/ocp-self-runner.yml
+++ b/.github/workflows/ocp-self-runner.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
 
-      - uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5
+      - uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00
         with:
           go-version: 1.24
           cache: true
@@ -67,7 +67,7 @@ jobs:
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
 
-      - uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5
+      - uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00
         with:
           go-version: 1.24
           cache: true

--- a/.github/workflows/pr-test-e2e.yml
+++ b/.github/workflows/pr-test-e2e.yml
@@ -52,7 +52,7 @@ jobs:
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
 
-      - uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5
+      - uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00
         with:
           go-version: 1.24
           cache: true
@@ -183,7 +183,7 @@ jobs:
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
 
-      - uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5
+      - uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00
         with:
           go-version: 1.24
           cache: true

--- a/.github/workflows/pr-test-integration.yml
+++ b/.github/workflows/pr-test-integration.yml
@@ -37,7 +37,7 @@ jobs:
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
 
-      - uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5
+      - uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00
         with:
           go-version: 1.24
           cache: true

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -11,7 +11,7 @@ jobs:
     permissions:
       issues: write
     steps:
-      - uses: actions/stale@5bef64f19d7facfb25b37b414482c7164d639639
+      - uses: actions/stale@3a9db7e6a41a89f618792c92c0e97cc736e1b13f
         with:
           # Issues: mark after 90 days of inactivity, close after 90 more days
           days-before-issue-stale: 90

--- a/.github/workflows/test-latest-release.yml
+++ b/.github/workflows/test-latest-release.yml
@@ -21,7 +21,7 @@ jobs:
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
 
-      - uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5
+      - uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00
         with:
           go-version: 1.24
           cache: true
@@ -96,7 +96,7 @@ jobs:
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
 
-      - uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5
+      - uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00
         with:
           go-version: 1.24
           cache: true


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Don't forget to first look for overlapping PRs. Remember, open source
is a collaborative rather than competitive activity.

If this PR includes changes to the source files for the website
(docs/content/** or a file included from there) then include a preview
of the modified website; see
docs/content/contribution-guidelines/operations/document-management.md.

Please put one of the following icons at the start of your PR title,
to indicate the type of your PR. You could use copy-and-paste from
here; alternatively, the indicated code is recognized by most browsers
as a way to input that icon.

✨ - code :sparkles:, type feature
🐛 - code :bug:, type bug fix
📖 - code :book:, type docs
📝 - code :memo:, type proposal
⚠️ - code :warning:, type breaking change
🌱 - code :seedling:, type other/misc
❓ - code :question:, type requires manual review/categorization

-->
## Summary
This PR bumps some GitHub Actions dependencies.

- actions/stale fro 9.1.0 to 10.0.0
- actions/setup-python from 5.6.0 to 6.0.0
- actions/setup-go from 5.5.0 to 6.0.0
- actions/github-script from 7.0.1 to 8(.0.0)

This is the principled version of #3292, #3293, #3294, and #3295 .

## Related issue(s)

Fixes #
