### PR TITLE
✨ Upgrade ArgoCD core-chart dependency to v8.3.5

### DIFF
--- a/core-chart/Chart.yaml
+++ b/core-chart/Chart.yaml
@@ -33,7 +33,7 @@ dependencies:
   repository: oci://ghcr.io/kubestellar/kubeflex/chart
   condition: kubeflex-operator.install
 - name: argo-cd
-  version: 7.8.5
+  version: 8.3.5
   repository: oci://ghcr.io/argoproj/argo-helm
   condition: argocd.install
   alias: argocd


### PR DESCRIPTION
## Summary

Upgrade ArgoCD Helm chart in the KubeStellar Helm core-chart to v8.3.5

## Related issue(s)

Fixes #3311
