### PR TITLE
🐛 Add safeguard for kubeflex-system ns creation

### DIFF
--- a/core-chart/templates/kubeflex/namespaces.yaml
+++ b/core-chart/templates/kubeflex/namespaces.yaml
@@ -1,4 +1,4 @@
-{{- if index .Values "kubeflex-operator" "install" }}
+{{- if and (index .Values "kubeflex-operator" "install") (not (lookup "v1" "Namespace" "" "kubeflex-system")) }}
 apiVersion: v1
 kind: Namespace
 metadata:


### PR DESCRIPTION
## Summary

Update KubeStellar core-chart to check for the existence of `kubeflex-system` namespace before it tries to create it when installing KubeFlex.

## Related issue(s)

Fixes #3314
