### PR TITLE
✨feat: add E2E compatibility tests for KubeFlex CLI versions (#3155)

### DIFF
--- a/.prow.yaml
+++ b/.prow.yaml
@@ -96,7 +96,7 @@ periodics:
       containers:
         - image: ghcr.io/kubestellar/infra/build:1.24.2-1
           command:
-            - ./hack/test-kflex-compatibility.sh
+            - hack/test-kflex-compatibility.sh
           workingDir: /home/prow/go/src/github.com/kubestellar/kubestellar
           resources:
             requests:

--- a/Makefile
+++ b/Makefile
@@ -167,7 +167,6 @@ fmt: ## Run go fmt against code.
 vet: ## Run go vet against code.
 	go vet ./...
 
-
 .PHONY: test
 test: manifests generate fmt vet ## Run tests.
 	go test ./api/... ./cmd/... ./pkg/... -coverprofile cover.out

--- a/hack/test-kflex-compatibility-unit.sh
+++ b/hack/test-kflex-compatibility-unit.sh
@@ -42,11 +42,7 @@ run_test() {
     local output
     
     # Capture both stdout and stderr, and the exit code
-    if output=$("$@" 2>&1); then
-        actual_exit_code=0
-    else
-        actual_exit_code=$?
-    fi
+    output=$("$@" 2>&1) || actual_exit_code=$?
     
     if [[ $actual_exit_code -eq $expected_exit_code ]]; then
         echo "  ✓ PASS"

--- a/hack/test-kflex-compatibility.sh
+++ b/hack/test-kflex-compatibility.sh
@@ -70,7 +70,7 @@ MIN_VERSION=$(echo "$MIN_VERSION_LINE" | grep -oE "v[0-9]+\.[0-9]+\.[0-9]+" | he
 version_le() {
     local v1_clean=${1#v}
     local v2_clean=${2#v}
-    [[ "$(printf '%s\n' "$v1_clean" "$v2_clean" | sort -V | head -n1)" == "$v1_clean" ]]
+    [[ "$v1_clean" < "$v2_clean" || "$v1_clean" == "$v2_clean" ]]
 }
 
 # Check prerequisites once before testing any versions
@@ -163,7 +163,7 @@ test_kflex_version() {
     local arch=$(uname -m)
     case $arch in
         x86_64) arch="amd64" ;;
-        aarch64|arm64) arch="arm64" ;;
+        aarch64) arch="arm64" ;;
     esac
     
     local download_url="https://github.com/kubestellar/kubeflex/releases/download/${version}/kubeflex_${version#v}_${os}_${arch}.tar.gz"


### PR DESCRIPTION
## Summary
This change adds automated testing to ensure compatibility between KubeStellar and different versions of the KubeFlex CLI, addressing the need for regular integration testing when new versions are released of either project.

Changes:
- Add hack/test-kflex-compatibility.sh: Main compatibility test script that downloads and tests KubeFlex CLI versions >= minimum requirement
- Add hack/test-kflex-compatibility-unit.sh: Unit test for script validation
- Add periodic Prow job for daily automated testing in CI
- Add Makefile target 'test-kflex-compatibility' for local testing
- Add documentation for KubeFlex compatibility testing

preview at https://rishi-jat.github.io/kubestellar

Fixes #3067