### PR TITLE
🐛fix(ci): sanitize and validate testFlags input for OSPS-BR-01.01 compliance

### DIFF
--- a/.github/workflows/pr-test-e2e.yml
+++ b/.github/workflows/pr-test-e2e.yml
@@ -72,24 +72,15 @@ jobs:
           rm -fr bin kubeflex_0.9.0_linux_amd64.tar.gz
           go install github.com/onsi/ginkgo/v2/ginkgo
 
-      - name: Validate and sanitize test flags
-        id: validate_flags
+      - name: Run test
+        env:
+          TEST_FLAGS: ${{ github.event.inputs.testFlags }}
         run: |
-          # Validate testFlags input
-          TEST_FLAGS="${{ github.event.inputs.testFlags }}"
-          
-          # Only allow specific safe values
-          if [[ "$TEST_FLAGS" == "" || "$TEST_FLAGS" == "--released" ]]; then
-            echo "SANITIZED_TEST_FLAGS=$TEST_FLAGS" >> $GITHUB_OUTPUT
-          else
+          # Validate testFlags input - only allow safe values
+          if [[ "$TEST_FLAGS" != "" && "$TEST_FLAGS" != "--released" ]]; then
             echo "Error: Invalid testFlags value. Only empty string or '--released' are allowed."
             exit 1
           fi
-
-      - name: Run test
-        env:
-          TEST_FLAGS: ${{ steps.validate_flags.outputs.SANITIZED_TEST_FLAGS }}
-        run: |
           cd test/e2e/ginkgo
           KFLEX_DISABLE_CHATTY=true ginkgo -vv --trace --no-color --fail-fast $TEST_FLAGS -- -kubestellar-setup-flags="--kubestellar-controller-manager-verbosity 5 --transport-controller-verbosity 5"
 
@@ -216,24 +207,15 @@ jobs:
           mv bin/kflex /usr/local/bin
           rm -fr bin kubeflex_0.9.0_linux_amd64.tar.gz
 
-      - name: Validate and sanitize test flags
-        id: validate_flags_2
+      - name: Run test
+        env:
+          TEST_FLAGS: ${{ github.event.inputs.testFlags }}
         run: |
-          # Validate testFlags input
-          TEST_FLAGS="${{ github.event.inputs.testFlags }}"
-          
-          # Only allow specific safe values
-          if [[ "$TEST_FLAGS" == "" || "$TEST_FLAGS" == "--released" ]]; then
-            echo "SANITIZED_TEST_FLAGS=$TEST_FLAGS" >> $GITHUB_OUTPUT
-          else
+          # Validate testFlags input - only allow safe values
+          if [[ "$TEST_FLAGS" != "" && "$TEST_FLAGS" != "--released" ]]; then
             echo "Error: Invalid testFlags value. Only empty string or '--released' are allowed."
             exit 1
           fi
-
-      - name: Run test
-        env:
-          TEST_FLAGS: ${{ steps.validate_flags_2.outputs.SANITIZED_TEST_FLAGS }}
-        run: |
           cd test/e2e/
           KFLEX_DISABLE_CHATTY=true ./run-test.sh $TEST_FLAGS
 


### PR DESCRIPTION
## Summary
- Added validation and sanitization steps for the testFlags input in the pr-test-e2e GitHub Actions workflow.
- Only allows "" (empty) or "--released" as valid testFlags values.
- The workflow now fails early if an invalid value is provided, preventing unsafe input from reaching shell commands.
- This fully addresses OSPS-BR-01.01 by ensuring all CI/CD input parameters are validated and sanitized before use.

Fixes #3245
