### PR TITLE
🐛fix: add doc link to preview check failure message

### DIFF
--- a/.github/workflows/check-docs-pr-preview.yml
+++ b/.github/workflows/check-docs-pr-preview.yml
@@ -45,6 +45,8 @@ jobs:
 
           if ! PREVIEW_LINE=$(echo "$BODY" | grep -iE '^\s*Preview.*https?://') ; then
             echo "${RED}[ERROR] Docs PR: No preview link found. Please include a line starting with 'Preview' and a valid GitHub Pages URL for your changes.${NC}"
+            echo "👉 For instructions on how to create a preview, see:"
+            echo "   https://docs.kubestellar.io/unreleased-development/contribution-guidelines/operations/document-management/#rendering-and-previewing-modifications-to-the-website"
             echo
             exit 1
           else


### PR DESCRIPTION
## Summary
add documentation link to preview check failure message
 
 Fixes #3186