### PR TITLE
📖fixed the highlighting link error

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -80,7 +80,7 @@ Consistent with the CNCF Charter, any substantive changes to this Code of Conduc
 ## Acknowledgements
 
 This Code of Conduct is adapted from the Contributor Covenant
-(http://contributor-covenant.org), version 2.0 available at
-http://contributor-covenant.org/version/2/0/code_of_conduct/
+(<http://contributor-covenant.org>), version 2.0 available at
+<http://contributor-covenant.org/version/2/0/code_of_conduct/>
 
 <!--coc-end-->


### PR DESCRIPTION
<img width="645" height="129" alt="image" src="https://github.com/user-attachments/assets/397db3d2-bb52-499e-b16c-20fae2153999" />

Earlier, the link was not highlighted in the docs:
<img width="616" height="132" alt="image" src="https://github.com/user-attachments/assets/fba9cc2f-f7bb-4701-9928-6aadd8eb6847" />

Preview : https://antedotee.github.io/kubestellar/doc-link-highlighting-issue-fix/contribution-guidelines/contributing-inc/

Fixes #3344