### PR TITLE
Fix typo in font name in `mkdocs.yml`

### DIFF
--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -124,7 +124,7 @@ nav:
 
 theme:
   font:
-    text: 'SapceMono'
+    text: 'SpaceMono'
     code: 'Roboto Mono'
   name: material
 


### PR DESCRIPTION
**Description:**
This PR fixes a typo in the `mkdocs.yml` configuration file where the font name was incorrectly written as `SapceMono`. The correct font name is `SpaceMono`.

**Changes Made:**

* Updated `mkdocs.yml` to use `spacemono` instead of `sapcemono`.

**Impact:**

* Ensures that the documentation renders with the correct font.
