### PR TITLE
📖  Remove stop applying PCHes too early from roadmap

### DIFF
--- a/docs/content/direct/roadmap.md
+++ b/docs/content/direct/roadmap.md
@@ -6,7 +6,6 @@ This document defines the KubeStellar feature roadmap. This document is a work-i
 - Address security vulnerabilities that can be addressed while sticking to Kubernetes 1.30.
     - E.g., see the full security report [about the core Helm chart at ArtifactHUB](https://artifacthub.io/packages/helm/kubestellar/core-chart).
 - Address failings in the [OpenSSF Best Practices scorecared](https://www.bestpractices.dev/en/projects/8266).
-- Make KubeFlex [stop applying PCHes too early](https://github.com/kubestellar/kubeflex/issues/490).
 - Make a KubeFlex release.
 - Update KubeStellar to use that KubeFlex release.
 - Upgrade to Kubernetes 1.31 .


### PR DESCRIPTION
## Summary
This PR removes stop applying PCHes too early point from roadmap as it is closed.

## Related issue(s)
Preview at : https://gaurab-khanal.github.io/kubestellar

Fixes #3362 
