### PR TITLE
🌱 Bump five actions to latest

### DIFF
--- a/.gha-reversemap.yml
+++ b/.gha-reversemap.yml
@@ -4,10 +4,10 @@ actions/checkout:
   tag: v5.0.0
   tag-url: https://github.com/actions/checkout/tree/v5.0.0
 actions/stale:
-  sha: 3a9db7e6a41a89f618792c92c0e97cc736e1b13f
-  sha-url: https://github.com/actions/stale/commit/3a9db7e6a41a89f618792c92c0e97cc736e1b13f
-  tag: v10.0.0
-  tag-url: https://github.com/actions/stale/tree/v10.0.0
+  sha: 5f858e3efba33a5ca4407a664cc011ad407f2008
+  sha-url: https://github.com/actions/stale/commit/5f858e3efba33a5ca4407a664cc011ad407f2008
+  tag: v10.1.0
+  tag-url: https://github.com/actions/stale/tree/v10.1.0
 actions/add-to-project:
   sha: 244f685bbc3b7adfa8466e08b698b5577571133e
   sha-url: https://github.com/actions/add-to-project/commit/244f685bbc3b7adfa8466e08b698b5577571133e
@@ -39,10 +39,10 @@ actions/setup-go:
   tag: v6.0.0
   tag-url: https://github.com/actions/setup-go/tree/v6.0.0
 anchore/sbom-action/download-syft:
-  sha: da167eac915b4e86f08b264dbdbc867b61be6f0c
-  sha-url: https://github.com/anchore/sbom-action/commit/da167eac915b4e86f08b264dbdbc867b61be6f0c
-  tag: v0.20.5
-  tag-url: https://github.com/anchore/sbom-action/tree/v0.20.5
+  sha: f8bdd1d8ac5e901a77a92f111440fdb1b593736b
+  sha-url: https://github.com/anchore/sbom-action/commit/f8bdd1d8ac5e901a77a92f111440fdb1b593736b
+  tag: v0.20.6
+  tag-url: https://github.com/anchore/sbom-action/tree/v0.20.6
 goreleaser/goreleaser-action:
   sha: e435ccd777264be153ace6237001ef4d979d3a7a
   sha-url: https://github.com/goreleaser/goreleaser-action/commit/e435ccd777264be153ace6237001ef4d979d3a7a
@@ -54,15 +54,15 @@ azure/setup-helm:
   tag: v4.3.1
   tag-url: https://github.com/azure/setup-helm/tree/v4.3.1
 docker/login-action:
-  sha: 184bdaa0721073962dff0199f1fb9940f07167d1
-  sha-url: https://github.com/docker/login-action/commit/184bdaa0721073962dff0199f1fb9940f07167d1
-  tag: v3.5.0
-  tag-url: https://github.com/docker/login-action/tree/v3.5.0
+  sha: 5e57cd118135c172c3672efd75eb46360885c0ef
+  sha-url: https://github.com/docker/login-action/commit/5e57cd118135c172c3672efd75eb46360885c0ef
+  tag: v3.6.0
+  tag-url: https://github.com/docker/login-action/tree/v3.6.0
 actions/first-interaction:
-  sha: 753c925c8d1ac6fede23781875376600628d9b5d
-  sha-url: https://github.com/actions/first-interaction/commit/753c925c8d1ac6fede23781875376600628d9b5d
-  tag: v3.0.0
-  tag-url: https://github.com/actions/first-interaction/tree/v3.0.0
+  sha: 1c4688942c71f71d4f5502a26ea67c331730fa4d
+  sha-url: https://github.com/actions/first-interaction/commit/1c4688942c71f71d4f5502a26ea67c331730fa4d
+  tag: v3.1.0
+  tag-url: https://github.com/actions/first-interaction/tree/v3.1.0
 azure/setup-kubectl:
   sha: 776406bce94f63e41d621b960d78ee25c8b76ede
   sha-url: https://github.com/azure/setup-kubectl/commit/776406bce94f63e41d621b960d78ee25c8b76ede
@@ -79,10 +79,10 @@ technote-space/assign-author:
   tag: v1.6.2
   tag-url: https://github.com/technote-space/assign-author/tree/v1.6.2
 rojopolis/spellcheck-github-actions:
-  sha: 35a02bae020e6999c5c37fabaf447f2eb8822ca7
-  sha-url: https://github.com/rojopolis/spellcheck-github-actions/commit/35a02bae020e6999c5c37fabaf447f2eb8822ca7
-  tag: 0.51.0
-  tag-url: https://github.com/rojopolis/spellcheck-github-actions/tree/0.51.0
+  sha: 739a1e3ceb79a98a5d4a9bf76f351137f9d78892
+  sha-url: https://github.com/rojopolis/spellcheck-github-actions/commit/739a1e3ceb79a98a5d4a9bf76f351137f9d78892
+  tag: 0.52.0
+  tag-url: https://github.com/rojopolis/spellcheck-github-actions/tree/0.52.0
 actions/upload-artifact:
   sha: ea165f8d65b6e75b540449e92b4886f43607fa02
   sha-url: https://github.com/actions/upload-artifact/commit/ea165f8d65b6e75b540449e92b4886f43607fa02

--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -36,7 +36,7 @@ jobs:
         run: echo LDFLAGS="$(make ldflags)" >> $GITHUB_ENV
 
       - name: Install syft binary executable
-        uses: anchore/sbom-action/download-syft@da167eac915b4e86f08b264dbdbc867b61be6f0c
+        uses: anchore/sbom-action/download-syft@f8bdd1d8ac5e901a77a92f111440fdb1b593736b
 
       - name: Run GoReleaser on tag
         uses: goreleaser/goreleaser-action@e435ccd777264be153ace6237001ef4d979d3a7a
@@ -55,7 +55,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Login to registry
-        uses: docker/login-action@184bdaa0721073962dff0199f1fb9940f07167d1
+        uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}

--- a/.github/workflows/greetings.yml
+++ b/.github/workflows/greetings.yml
@@ -18,7 +18,7 @@ jobs:
       issues: write
       pull-requests: write
     steps:
-      - uses: actions/first-interaction@753c925c8d1ac6fede23781875376600628d9b5d
+      - uses: actions/first-interaction@1c4688942c71f71d4f5502a26ea67c331730fa4d
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           issue-message: "Thank you for contributing your first Issue to KubeStellar. We are delighted to have you in our Universe!"

--- a/.github/workflows/spellcheck_action.yml
+++ b/.github/workflows/spellcheck_action.yml
@@ -35,7 +35,7 @@ jobs:
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
 
-      - uses: rojopolis/spellcheck-github-actions@35a02bae020e6999c5c37fabaf447f2eb8822ca7
+      - uses: rojopolis/spellcheck-github-actions@739a1e3ceb79a98a5d4a9bf76f351137f9d78892
         name: Spellcheck
         with:
           config_path: .github/spellcheck/.spellcheck.yml

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -11,7 +11,7 @@ jobs:
     permissions:
       issues: write
     steps:
-      - uses: actions/stale@3a9db7e6a41a89f618792c92c0e97cc736e1b13f
+      - uses: actions/stale@5f858e3efba33a5ca4407a664cc011ad407f2008
         with:
           # Issues: mark after 90 days of inactivity, close after 90 more days
           days-before-issue-stale: 90


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Don't forget to first look for overlapping PRs. Remember, open source
is a collaborative rather than competitive activity.

If this PR includes changes to the source files for the website
(docs/content/** or a file included from there) then include a preview
of the modified website; see
docs/content/contribution-guidelines/operations/document-management.md.

Please put one of the following icons at the start of your PR title,
to indicate the type of your PR. You could use copy-and-paste from
here; alternatively, the indicated code is recognized by most browsers
as a way to input that icon.

✨ - code :sparkles:, type feature
🐛 - code :bug:, type bug fix
📖 - code :book:, type docs
📝 - code :memo:, type proposal
⚠️ - code :warning:, type breaking change
🌱 - code :seedling:, type other/misc
❓ - code :question:, type requires manual review/categorization

-->
## Summary

This PR bumps five GitHub Actions dependencies properly.

- Bump rojopolis/spellcheck-github-actions from 0.51.0 to 0.52.0
- Bump anchore/sbom-action from 0.20.5 to 0.20.6
- Bump docker/login-action from 3.5.0 to 3.6.0
- Bump actions/first-interaction from 3.0.0 to 3.1.0
- Bump actions/stale from 10.0.0 to 10.1.0

Yes, I looked for vulnerabilities, did not find any.

## Related issue(s)

Fixes #
