### PR TITLE
🌱 Simplify wait-for-placements-crd-created init container

### DIFF
--- a/core-chart/templates/postcreatehooks/install-status-addon.yaml
+++ b/core-chart/templates/postcreatehooks/install-status-addon.yaml
@@ -38,13 +38,14 @@ spec:
           - name: wait-for-placements-crd-created
             image: quay.io/kubestellar/kubectl:{{.Values.KUBECTL_VERSION}}
             command:
-              - sh
-              - -c
-              - |
-                until kubectl get crd placements.cluster.open-cluster-management.io >/dev/null 2>&1; do sleep 2; done
+              - kubectl
+              - wait
+              - --for=create
+              - crd/placements.cluster.open-cluster-management.io
+              - --timeout=300s
             env:
             - name: KUBECONFIG
-              value: "{{"/etc/kube/{{.ITSkubeconfig}}"}}"
+              value: '{{"/etc/kube/{{.ITSkubeconfig}}"}}'
             volumeMounts:
             - name: kubeconfig
               mountPath: "/etc/kube"


### PR DESCRIPTION
## Summary

Simplify `wait-for-placements-crd-created` init container to remove bash dependency

## Related issue(s)

Fixes #
