### PR TITLE
✨ Speed up Helm chart deployment by removing unnecessary initContainer

### DIFF
--- a/core-chart/templates/postcreatehooks/install-status-addon.yaml
+++ b/core-chart/templates/postcreatehooks/install-status-addon.yaml
@@ -15,26 +15,6 @@ spec:
       template:
         spec:
           initContainers:
-          - name: wait-for-kubeconfig
-            image: busybox:latest
-            command:
-              - sh
-              - -c
-              - |
-                echo "Waiting for kubeconfig file '$KUBECONFIG' to exist and be non-empty..."
-                until [ -s "$KUBECONFIG" ]; do
-                  echo "Kubeconfig file not ready yet, waiting..."
-                  sleep 2
-                done
-                echo "Kubeconfig file is ready"
-            env:
-            - name: KUBECONFIG
-              value: "{{"/etc/kube/{{.ITSkubeconfig}}"}}"
-            volumeMounts:
-            - name: kubeconfig
-              mountPath: "/etc/kube"
-              readOnly: true
-
           - name: wait-for-placements-crd-created
             image: quay.io/kubestellar/kubectl:{{.Values.KUBECTL_VERSION}}
             command:


### PR DESCRIPTION
## Summary

Speed up Helm chart deployment by removing unnecessary initContainer and container image

KubeFlex controller manager already guarantees the existance of the CP secret and the validity of the kubeconfig file in the secret.

## Related issue(s)

Fixes #
