### PR TITLE
📖 Relocating The Inline Comments From Script Inside Getting Started Document

### DIFF
--- a/docs/content/direct/get-started.md
+++ b/docs/content/direct/get-started.md
@@ -123,18 +123,22 @@ helm upgrade --install ks-core oci://ghcr.io/kubestellar/kubestellar/core-chart 
     --version "$kubestellar_version" \
     --set-json ITSes='[{"name":"its1"}]' \
     --set-json WDSes='[{"name":"wds1"},{"name":"wds2","type":"host"}]' \
-    --set verbosity.default=5  # so we can debug your problem reports
+    --set verbosity.default=5
 ```
+The `verbosity.default=5` flag enables more detailed logs for easier debugging.
 
 That command will print some notes about how to get kubeconfig "contexts" named "its1", "wds1", and "wds2" defined. Do that, because those contexts are used in the steps that follow.
 
 ```shell
-kubectl config use-context kind-kubeflex # this is here only to remind you, it will already be the current context if you are following this recipe exactly
-kflex ctx --set-current-for-hosting # make sure the KubeFlex CLI's hidden state is right for what the Helm chart just did
+kubectl config use-context kind-kubeflex 
+kflex ctx --set-current-for-hosting 
 kflex ctx --overwrite-existing-context wds1
 kflex ctx --overwrite-existing-context wds2
 kflex ctx --overwrite-existing-context its1
 ```
+
+The first command, `kubectl config use-context kind-kubeflex`, is only to remind you, it will already be the current context if you are following this recipe exactly.
+The second command, `kflex ctx --set-current-for-hosting`, is for making sure the KubeFlex CLI's hidden state is right for what the Helm chart just did.
 
 #### Wait for ITS to be fully initialized
 


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Don't forget to first look for overlapping PRs. Remember, open source
is a collaborative rather than competitive activity.

If this PR includes changes to the source files for the website
(docs/content/** or a file included from there) then include a preview
of the modified website; see
docs/content/contribution-guidelines/operations/document-management.md.

Please put one of the following icons at the start of your PR title,
to indicate the type of your PR. You could use copy-and-paste from
here; alternatively, the indicated code is recognized by most browsers
as a way to input that icon.

✨ - code :sparkles:, type feature
🐛 - code :bug:, type bug fix
📖 - code :book:, type docs
📝 - code :memo:, type proposal
⚠️ - code :warning:, type breaking change
🌱 - code :seedling:, type other/misc
❓ - code :question:, type requires manual review/categorization

-->
## Summary

In this PR, I removed the inline comments from the script commands under the _Use Core Helm chart to initialize KubeFlex and create ITS and WDS_ section, and relocated them to the lines outside the script.
This change helps the users to easily copy, paste, and run the script without modifying it manually.

## Related issue(s)

Fixes #3417

## Screenshot

<img width="1217" height="894" alt="Screenshot 2025-10-14 at 19 13 28" src="https://github.com/user-attachments/assets/d8cae235-3a0f-4e07-95f4-613a2d4dd66b" />

<img width="1217" height="894" alt="Screenshot 2025-10-14 at 19 13 00" src="https://github.com/user-attachments/assets/bbedf767-6f69-42a7-a1eb-9a4b4abe95f7" />