### PR TITLE
✨Cleanup install-status-addon PCH

### DIFF
--- a/core-chart/templates/postcreatehooks/install-status-addon.yaml
+++ b/core-chart/templates/postcreatehooks/install-status-addon.yaml
@@ -10,7 +10,7 @@ spec:
   - apiVersion: batch/v1
     kind: Job
     metadata:
-      name: "{{"{{.HookName}}"}}"
+      name: '{{"{{.HookName}}"}}'
     spec:
       template:
         spec:
@@ -30,27 +30,23 @@ spec:
             - name: kubeconfig
               mountPath: "/etc/kube"
               readOnly: true
-
           - name: wait-for-placements-crd
             image: quay.io/kubestellar/kubectl:{{.Values.KUBECTL_VERSION}}
-            command:
-              - kubectl
+            args:
               - wait
               - --for=condition=Established
               - crd/placements.cluster.open-cluster-management.io
               - --timeout=300s
             env:
             - name: KUBECONFIG
-              value: "{{"/etc/kube/{{.ITSkubeconfig}}"}}"
+              value: '{{"/etc/kube/{{.ITSkubeconfig}}"}}'
             volumeMounts:
             - name: kubeconfig
               mountPath: "/etc/kube"
               readOnly: true
-
           - name: wait-for-managedclustersetbindings-crd-created
             image: quay.io/kubestellar/kubectl:{{.Values.KUBECTL_VERSION}}
-            command:
-              - kubectl
+            args:
               - wait
               - --for=create
               - crd/managedclustersetbindings.cluster.open-cluster-management.io
@@ -62,18 +58,16 @@ spec:
             - name: kubeconfig
               mountPath: "/etc/kube"
               readOnly: true
-
           - name: wait-for-managedclustersetbindings-crd
             image: quay.io/kubestellar/kubectl:{{.Values.KUBECTL_VERSION}}
-            command:
-              - kubectl
+            args:
               - wait
               - --for=condition=Established
               - crd/managedclustersetbindings.cluster.open-cluster-management.io
               - --timeout=300s
             env:
             - name: KUBECONFIG
-              value: "{{"/etc/kube/{{.ITSkubeconfig}}"}}"
+              value: '{{"/etc/kube/{{.ITSkubeconfig}}"}}'
             volumeMounts:
             - name: kubeconfig
               mountPath: "/etc/kube"
@@ -119,7 +113,7 @@ spec:
             - name: HELM_CACHE_HOME
               value: "/tmp"
             - name: KUBECONFIG
-              value: "{{"/etc/kube/{{.ITSkubeconfig}}"}}"
+              value: '{{"/etc/kube/{{.ITSkubeconfig}}"}}'
             volumeMounts:
             - name: kubeconfig
               mountPath: "/etc/kube"
@@ -127,7 +121,7 @@ spec:
           volumes:
           - name: kubeconfig
             secret:
-              secretName: "{{"{{.ITSSecretName}}"}}"
+              secretName: '{{"{{.ITSSecretName}}"}}'
           restartPolicy: Never
       backoffLimit: 1
 {{- end }}


### PR DESCRIPTION
## Summary

Cleanup `install-status-addon` PCH:
- switch from `command:` to `args:`
- remove spaces
- replace `"{{"` and `"}}"` with `'{{"` and `"}}'` to reduce misinterpretation and code syntax highlight

## Related issue(s)

Fixes #
