### PR TITLE
🌱 feat(e2e): Dump Job YAML and Events in E2E workflow

### DIFF
--- a/.github/workflows/pr-test-e2e.yml
+++ b/.github/workflows/pr-test-e2e.yml
@@ -109,6 +109,14 @@ jobs:
         if: always()
         run: kubectl --context kind-kubeflex get deployments -A
 
+      - name: show Job objects and Events in hosting cluster
+        if: always()
+        run: |
+          echo "---Dumping Job YAML for diagnostics (kubestellar/kubestellar#3182)---"
+          kubectl --context kind-kubeflex get jobs -A -o yaml || echo "Failed to get jobs"
+          echo "---Dumping Job Events for diagnostics (kubestellar/kubestellar#3182)---"
+          kubectl --context kind-kubeflex get events -A --field-selector involvedObject.kind=Job || echo "Failed to get events"
+
       - name: show namespaces in its1
         if: always()
         run: kubectl --context its1 get namespaces
@@ -277,6 +285,14 @@ jobs:
       - name: show Deployment objects in hosting cluster
         if: always()
         run: kubectl --context kind-kubeflex get deployments -A
+
+      - name: show Job objects and Events in hosting cluster
+        if: always()
+        run: |
+          echo "---Dumping Job YAML for diagnostics (kubestellar/kubestellar#3182)---"
+          kubectl --context kind-kubeflex get jobs -A -o yaml || echo "Failed to get jobs"
+          echo "---Dumping Job Events for diagnostics (kubestellar/kubestellar#3182)---"
+          kubectl --context kind-kubeflex get events -A --field-selector involvedObject.kind=Job || echo "Failed to get events"
 
       - name: show namespaces in its1
         if: always()


### PR DESCRIPTION
This PR adds unconditional diagnostic output for Job objects and their related Events to the E2E test cleanup workflow, as requested in Epic #3151.

To ensure the diagnostic data is captured before the environment is destroyed, the commands have been added to the beginning of the test/e2e/common/cleanup.sh script.

This helps debug ITS initialization flakes by logging the final state of all Jobs, even if the test run succeeds. The commands are protected with || echo "..." to prevent the cleanup script from exiting if no jobs or events are found.

Fixes #3182