### PR TITLE
✨ Improve resource handling in kubectl-rbac-flatten

### DIFF
--- a/cmd/kubectl-rbac-flatten/README.md
+++ b/cmd/kubectl-rbac-flatten/README.md
@@ -9,6 +9,67 @@ The kubectl-rbac-flatten command takes all the standard arguments for
 a Kubernetes command-line tool, and so can be used as a [kubectl
 plugin](https://kubernetes.io/docs/tasks/extend-kubectl/kubectl-plugins/).
 
+## Data Model
+
+The semantics of the collection of RBAC objects in a cluster is a
+collection of _privilege grants_, each of which has the following
+attributes.  Here we expand the semantics of the RBAC objects to
+atomic tuples; that is, each one identifies just one subject, verb,
+object, role-ism, and binding --- with the exception of wildcards.
+
+- **Subject**: who the privilege is granted to. A user (ordinary or
+  ServiceAccount) or group. Kubernetes authentication of a request
+  identifies the user and the set of groups that the user belongs
+  to. This set always includes either `system:authenticated` or
+  `system:unauthenticated`.
+
+- **Verb**: the action being allowed. When the _object_ is a
+  _resource_, the verb is one of: `create`, `update`, `patch`,
+  `delete`, `deletecollection`, `get`, `list`, `watch`.  When the
+  object is not a resource, the verb is one of: `get`, `put`,
+  `delete`, `post`.  The wildcard `*` grants usage of all verbs.
+
+- **Object**: the thing that the subject is allowed to invoke the verb on.
+  There are two cases here: API object, and "non-resource" URL path.
+
+    A non-resource URL path is just the path part of a URL; the schema
+    and authority of the authorized URL are implicitly those of the
+    apiserver.
+
+    An API object is identified by a "resource", "object name"
+    (misnamed "ResourceName" in the RBAC API), and possibly
+    "namespace".  A resource exists within an _api group_. A resource
+    is identified by a string of the form
+    `<base>.<apigroup>/<subresource>`, where `<base>` is the lowercase
+    plural way of identifying a kind of object. The `.<apigroup>` is
+    empty for the core API group.  The `/<subresource>` is optional.
+    Example resources: `nodes`, `jobs.batch`,
+    `clusterroles.rbac.authorization.k8s.io`,
+    `certificatesigningrequests/approval.certificates.k8s.io`. The
+    wildcard `*` can stand for all resources, for all namespaces, and
+    for all object names.
+
+    Each resource has a _scope_, which is either "cluster" or
+    "namespace".
+
+    Only a ClusterRoleBinding grants access to a
+    cluster-scoped resource. Nothing stops a RoleBinding from
+    referring to a ClusterRole that refers to cluster-scoped
+    resources, but that RoleBinding grants no actual privileges
+    regarding those resources.
+
+- **Role-ism**: the Role or ClusterRole object that defines the verb
+  and object.
+
+- **Binding**: the RoleBinding or ClusterRoleBinding object that
+  associates the role-ism with the subject.
+
+## Query semantics
+
+This command can be directed to filter the reported grants to include
+only those that involve a given set of subjects, set of verbs, and/or
+set of objects.
+
 ## Usage
 
 No filesystem I/O is done except that involved in reading the
@@ -19,23 +80,16 @@ client command line flags (e.g., `--kubeconfig`, `--context`) plus the
 additional ones listed below.
 
 ```
-      --api-groups strings               comma-separated list of API groups to include; '*' means all (default [*])
   -o, --output-format string             output format, either json or table (default "table")
-      --resources strings                comma-separated list of resources to include; '*' means all (default [*])
+      --resources strings                comma-separated list of resources to include; resource syntax is plural.group/subresource; .group and /subresource are omitted when appropriate; '*' means all resources (default [*])
+      --show-role                        include role in listing for resource grans (default true)
 ```
 
-The syntax shown for the default value of `--api-groups` and
-`--resources` is wrong. The correct syntax is a comma-separated
-collection of strings. For example, `--api-groups
-networking.k8s.io,certificates.k8s.io`.
-
-When filtering on API group or "resource", an RBAC rule that matches
-"*" is included in the result.
 
 ## Output
 
-Errors are logged to stderr, and as much processing as possible is
-done.
+Warnings about ineffective RBAC are logged to stderr, and as much
+processing as possible is done.
 
 There are two possible output formats, chosen by a command line flag.
 
@@ -49,10 +103,18 @@ describing their source. The precise data type is as follows, where
 
 ```go
 type Tuple struct {
-	Binding  NamespacedName
-	RoleName string
-	Subject  rbac.Subject
-	Rule     rbac.PolicyRule
+	Binding       NamespacedName
+	RoleInCluster bool
+	RoleName      string
+	Subject       rbac.Subject
+	Rule          PolicyRule
+}
+
+type PolicyRule struct {
+	Verbs            []string
+	Resources        []string
+	ObjectNames      []string
+	NonResourcePaths []string
 }
 ```
 
@@ -65,9 +127,9 @@ Following is an example of JSON output.
 
 ```json
 [
-{"Binding":{"Namespace":"","Name":"cluster-admin"},"RoleName":"cluster-admin","Subject":{"kind":"Group","apiGroup":"rbac.authorization.k8s.io","name":"system:masters"},"Rule":{"verbs":["*"],"apiGroups":["*"],"resources":["*"]}}
+{"Binding":{"Namespace":"","Name":"cluster-admin"},"RoleInCluster":true,"RoleName":"cluster-admin","Subject":{"kind":"Group","apiGroup":"rbac.authorization.k8s.io","name":"system:masters"},"Rule":{"Verbs":["*"],"Resources":null,"ObjectNames":null,"NonResourcePaths":["*"]}}
 ,
-{"Binding":{"Namespace":"","Name":"cluster-admin"},"RoleName":"cluster-admin","Subject":{"kind":"Group","apiGroup":"rbac.authorization.k8s.io","name":"system:masters"},"Rule":{"verbs":["*"],"nonResourceURLs":["*"]}}
+{"Binding":{"Namespace":"","Name":"dpctlr-node-viewer"},"RoleInCluster":true,"RoleName":"node-viewer","Subject":{"kind":"ServiceAccount","name":"dual-pods-controller","namespace":"default"},"Rule":{"Verbs":["get","list","watch"],"Resources":["nodes"],"ObjectNames":null,"NonResourcePaths":null}}
 ,
 ...
 ]
@@ -86,18 +148,18 @@ group is output as an empty string (thus between two TABs).
 
 The resource-based table omits the column for the role, for brevity.
 
-Following are excerpts from example tabular output.
+Following are excerpts from example tabular output, with `--show-role=false`.
 
 ```
-BINDING                                                         SUBJECT                                                        VERB               APIGROUP                        RESOURCE                                    OBJNAME
-/cluster-admin                                                  G:system:masters                                               *                  *                               *                                           *
-/ingress-nginx                                                  SA:ingress-nginx/ingress-nginx                                 list                                               configmaps                                  *
-/ingress-nginx                                                  SA:ingress-nginx/ingress-nginx                                 list                                               endpoints                                   *
+BINDING                                                          SUBJECT                                                        VERB               RESOURCE                                                          OBJNAME
+/cluster-admin                                                   G:system:masters                                               *                  apiservices.apiregistration.k8s.io                                *
+/cluster-admin                                                   G:system:masters                                               *                  apiservices/status.apiregistration.k8s.io                         *
 ...
 
-BINDING                                       ROLE                                      SUBJECT                                          VERB   NRURL
-/cluster-admin                                cluster-admin                             G:system:masters                                 *      *
-/kubeadm:cluster-admins                       cluster-admin                             G:kubeadm:cluster-admins                         *      *
+BINDING                                    ROLE                                      SUBJECT                    VERB   PATH
+/cluster-admin                             cluster-admin                             G:system:masters           *      *
+/kubeadm:cluster-admins                    cluster-admin                             G:kubeadm:cluster-admins   *      *
+/system:discovery                          system:discovery                          G:system:authenticated     get    /api
 ...
 ```
 
@@ -107,7 +169,6 @@ The columns are as follows.
 - **ROLE:** The name of the `ClusterRole` or `Role` object referenced by the BINDING.
 - **SUBJECT:** A slightly compacted representation of the `rbac.Subject`.
 - **VERB**
-- **APIGROUP:** As usual in Kubernetes, the empty string represents the "core" API group. This column is omitted if filtering on API group and exactly one API group is allowed.
-- **RESOURCE:** Identifies a collection of objects, similarly to a "kind". This column is omitted if filtering on "resource" and exactly one is allowed.
+- **RESOURCE:** Including API group and subresource. Omitted if exactly 1 resource is being queried for.
 - **OBJNAME:** Name of an individual object. `*` matches all names.
 - **NRURL:** A URL path usable in Non-Resource URLs; `*` matches all paths.


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Don't forget to first look for overlapping PRs. Remember, open source
is a collaborative rather than competitive activity.

If this PR includes changes to the source files for the website
(docs/content/** or a file included from there) then include a preview
of the modified website; see
docs/content/contribution-guidelines/operations/document-management.md.

Please put one of the following icons at the start of your PR title,
to indicate the type of your PR. You could use copy-and-paste from
here; alternatively, the indicated code is recognized by most browsers
as a way to input that icon.

✨ - code :sparkles:, type feature
🐛 - code :bug:, type bug fix
📖 - code :book:, type docs
📝 - code :memo:, type proposal
⚠️ - code :warning:, type breaking change
🌱 - code :seedling:, type other/misc
❓ - code :question:, type requires manual review/categorization

-->
## Summary
This PR improves the handling of "resources" in `kubectl-rbac-flatten`.

- Fold API group and resource together.

- Resolve rules against actual list of resources.

- Reject RoleBindings of cluster-scoped resources (because they don't work).

## Related issue(s)

Fixes #
