### PR TITLE
📖 Self-reference updates in prep for 0.29.0-rc.1

### DIFF
--- a/core-chart/values.yaml
+++ b/core-chart/values.yaml
@@ -6,7 +6,7 @@
 # please do not change them unless you know what you are doing.
 HELM_VERSION: "3.16.4"
 KUBECTL_VERSION: "1.30.14"
-KUBESTELLAR_VERSION: "0.29.0-alpha.1"
+KUBESTELLAR_VERSION: "0.29.0-rc.1"
 # TRANSPORT_VERSION: e.g., "0.24.0"; defaults to KUBESTELLAR_VERSION value, if not defined
 CLUSTERADM_VERSION: "0.10.1"
 OCM_STATUS_ADDON_VERSION: "0.2.0-rc16"

--- a/docs/content/direct/release-notes.md
+++ b/docs/content/direct/release-notes.md
@@ -9,6 +9,15 @@ This release makes some backward-incompatible changes, as follows.
 - Changes to the names of the PostCreateHooks and their Jobs that are using in a KubeFlex `ControlPlane` for an ITS. This changes what a careful user (and the KubeStellar scripts) wait on after instantiating KubeStellar's core Helm chart.
 - Not actually shipped through KubeStellar, but the latest KubeFlex CLI makes a backward-incompatible change in the extensions that it puts in the user's kubeconfig file.
 
+### Remaining limitations in 0.29.0
+
+* Although the create-only feature can be used with Job objects to avoid trouble with `.spec.selector`, requesting singleton reported state return will still lead to a controller fight over `.status.replicas` while the Job is in progress.
+* Removing of WorkStatus objects (in the transport namespace) is not supported and may not result in recreation of that object
+* Objects on two different WDSes shouldn't have the exact same identifier (same group, version, kind, name and namespace). Such a conflict is currently not identified.
+* Creation, deletion, and modification of `CustomTransform` objects does not cause corresponding updates to the workload objects in the WECs; the current state of the `CustomTransform` objects is simply read at any moment when the objects in the WECs are being updated for other reasons.
+* It is not known what actually happens when two different `Binding` objects list the same workload object and either or both say "create only".
+* If (a) the workload object count or volume vs the configured limits on content of a `ManifestWork` causes multiple `ManifestWork` to be created for one `Binding` (`BindingPolicy`) AND (b) the limit on number of workload objects in one `ManifestWork` is greater then 1, then there may be transients where workload objects are deleted and re-created in a WEC --- which, in addition to possibly being troubling on its own, will certainly thwart the "create-only" functionality. The default limit on the number of workload objects in one `ManifestWork` is 1, so this issue will only arise when you use a non-default value. In this case you will avoid this issue if you set that limit to be at least the highest number of workload objects that will appear in a `Binding` (do check your `Binding` objects, lest you be surprised) AND your workload is not so large that multiple `ManifestWork` are created due to the limit on their size.
+
 ## 0.28.0
 
 Helm chart, the name of the subobject for ArgoCD has changed from

--- a/docs/content/direct/release.md
+++ b/docs/content/direct/release.md
@@ -52,7 +52,7 @@ Making a new kubestellar release requires a contributor to do the following thin
 
 - Update the version in the core chart defaults, `core-chart/values.yaml`.
 
-- Update the version in `scripts/create-kubestellar-demo-env.sh`. **Note:** merging this change might cause the script to be broken until the release is made.
+- Update the version in `scripts/create-kubestellar-demo-env.sh`. **Note:** merging this change will cause the script to be broken until the release is made.
 
 - Until we have our first stable release, edit the old docs README(`oldocs/README.md`, section "latest-stable-release") where it wishes it could cite a stable release but instead cites the latest release, to refer to the coming release.
 

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -15,7 +15,7 @@ edit_uri: edit/main/docs/content
 ks_branch: 'main'
 ks_tag: 'latest'
 ks_latest_regular_release: '0.28.0'
-ks_latest_release: '0.29.0-alpha.1'
+ks_latest_release: '0.29.0-rc.1'
 
 ks_kind_port_num: '1119'
 

--- a/scripts/check_pre_req.sh
+++ b/scripts/check_pre_req.sh
@@ -17,7 +17,7 @@
 # NOTE WELL: Two copies of this file exist, one in kubestellar/hack/
 # and one in kubestellar/scripts/ . Keep them both up-to-date.
 BASE_URL="https://docs.kubestellar.io"
-VERSION="release-0.29.0-alpha.1"
+VERSION="release-0.29.0-rc.1"
 INSTALLATION_ERROR_URL="${BASE_URL}/${VERSION}/direct/installation-errors#pod-errors-due-to-too-many-open-files"
 
 set -e # exit on error

--- a/scripts/create-kubestellar-demo-env.sh
+++ b/scripts/create-kubestellar-demo-env.sh
@@ -68,7 +68,7 @@ if ! dunsel=$(docker ps 2>&1); then
 fi
 echo "Container runtime is running."
 
-kubestellar_version=0.29.0-alpha.1
+kubestellar_version=0.29.0-rc.1
 echo -e "KubeStellar Version: ${kubestellar_version}"
 
 echo -e "Checking that pre-req softwares are installed..."


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Don't forget to first look for overlapping PRs. Remember, open source
is a collaborative rather than competitive activity.

If this PR includes changes to the source files for the website
(docs/content/** or a file included from there) then include a preview
of the modified website; see
docs/content/contribution-guidelines/operations/document-management.md.

Please put one of the following icons at the start of your PR title,
to indicate the type of your PR. You could use copy-and-paste from
here; alternatively, the indicated code is recognized by most browsers
as a way to input that icon.

✨ - code :sparkles:, type feature
🐛 - code :bug:, type bug fix
📖 - code :book:, type docs
📝 - code :memo:, type proposal
⚠️ - code :warning:, type breaking change
🌱 - code :seedling:, type other/misc
❓ - code :question:, type requires manual review/categorization

-->
## Summary
This PR updates the self-references in preparation for test release 0.29.0-rc.1.

Also a fix to docs/content/direct/release.md: Updating the version in `scripts/create-kubestellar-demo-env.sh` will certainly break the script until the release is made.

Preview at https://mikespreitzer.github.io/kcp-edge-mc/doc-prep4-0290rc1/readme/

## Related issue(s)

Fixes #
