### PR TITLE
🐛cleanup: remove unused kubestellar-config ConfigMap from postcreatehooks

### DIFF
--- a/core-chart/templates/postcreatehooks/kubestellar-controller.yaml
+++ b/core-chart/templates/postcreatehooks/kubestellar-controller.yaml
@@ -112,11 +112,6 @@ spec:
         name: default
         namespace: '{{"{{.Namespace}}"}}'
   - apiVersion: v1
-    data: {}
-    kind: ConfigMap
-    metadata:
-      name: kubestellar-config
-  - apiVersion: v1
     kind: Service
     metadata:
       labels:


### PR DESCRIPTION
Removed the unused kubestellar-config ConfigMap from the postcreatehooks template to simplify the Helm chart and remove unnecessary resources.

fixes #3456
