### PR TITLE
🐛Rename ITSkubeconfig to ITSSecretKey in CP YAML and ITS PCHs

### DIFF
--- a/core-chart/templates/controlplanes/its.yaml
+++ b/core-chart/templates/controlplanes/its.yaml
@@ -15,7 +15,7 @@ spec:
     - hookName: install-status-addon
   globalVars:
     ITSSecretName: {{ or (eq $cp.type "host") (eq $cp.type "external") | ternary "admin-kubeconfig" "vc-vcluster" }}
-    ITSkubeconfig: {{ or (eq $cp.type "host") (eq $cp.type "external") | ternary "kubeconfig-incluster" "config-incluster" }}
+    ITSSecretKey: {{ or (eq $cp.type "host") (eq $cp.type "external") | ternary "kubeconfig-incluster" "config-incluster" }}
   {{- if eq $cp.type "external" }}
   bootstrapSecretRef:
     name: {{ ($cp.bootstrapSecret).name | default (printf "%s-bootstrap" $cp.name) }}

--- a/core-chart/templates/postcreatehooks/install-status-addon.yaml
+++ b/core-chart/templates/postcreatehooks/install-status-addon.yaml
@@ -25,7 +25,7 @@ spec:
               - --timeout=300s
             env:
             - name: KUBECONFIG
-              value: '{{"/etc/kube/{{.ITSkubeconfig}}"}}'
+              value: '{{"/etc/kube/{{.ITSSecretKey}}"}}'
             volumeMounts:
             - name: kubeconfig
               mountPath: "/etc/kube"
@@ -39,7 +39,7 @@ spec:
               - --timeout=300s
             env:
             - name: KUBECONFIG
-              value: '{{"/etc/kube/{{.ITSkubeconfig}}"}}'
+              value: '{{"/etc/kube/{{.ITSSecretKey}}"}}'
             volumeMounts:
             - name: kubeconfig
               mountPath: "/etc/kube"
@@ -53,7 +53,7 @@ spec:
               - --timeout=300s
             env:
             - name: KUBECONFIG
-              value: '{{"/etc/kube/{{.ITSkubeconfig}}"}}'
+              value: '{{"/etc/kube/{{.ITSSecretKey}}"}}'
             volumeMounts:
             - name: kubeconfig
               mountPath: "/etc/kube"
@@ -67,7 +67,7 @@ spec:
               - --timeout=300s
             env:
             - name: KUBECONFIG
-              value: '{{"/etc/kube/{{.ITSkubeconfig}}"}}'
+              value: '{{"/etc/kube/{{.ITSSecretKey}}"}}'
             volumeMounts:
             - name: kubeconfig
               mountPath: "/etc/kube"
@@ -113,7 +113,7 @@ spec:
             - name: HELM_CACHE_HOME
               value: "/tmp"
             - name: KUBECONFIG
-              value: '{{"/etc/kube/{{.ITSkubeconfig}}"}}'
+              value: '{{"/etc/kube/{{.ITSSecretKey}}"}}'
             volumeMounts:
             - name: kubeconfig
               mountPath: "/etc/kube"

--- a/core-chart/templates/postcreatehooks/its-hub-init.yaml
+++ b/core-chart/templates/postcreatehooks/its-hub-init.yaml
@@ -24,7 +24,7 @@ spec:
             - --timeout=300
             env:
             - name: KUBECONFIG
-              value: '{{"/etc/kube/{{.ITSkubeconfig}}"}}'
+              value: '{{"/etc/kube/{{.ITSSecretKey}}"}}'
             volumeMounts:
             - name: kubeconfig
               mountPath: "/etc/kube"


### PR DESCRIPTION
## Summary 
Renamed ITSkubeconfig to ITSSecretKey in the ITS CP YAML and the two ITS PCH templates (install-status-addon.yaml and its-hub-init.yaml) to align with WDS changes and ensure proper secret references.

fixes #3460
