### PR TITLE
✨Upgrade Argo CD dependency to 9.1.0 in core-chart

### DIFF
--- a/core-chart/Chart.yaml
+++ b/core-chart/Chart.yaml
@@ -33,7 +33,7 @@ dependencies:
   repository: oci://ghcr.io/kubestellar/kubeflex/chart
   condition: kubeflex-operator.install
 - name: argo-cd
-  version: 8.3.5
+  version: 9.1.0
   repository: oci://ghcr.io/argoproj/argo-helm
   condition: argocd.install
   alias: argocd


### PR DESCRIPTION
## Summary
Updated Argo CD dependency in core-chart/Chart.yaml from 8.6.0 to 9.1.0 and updated Helm dependencies. 
Tested chart deployment on Kind cluster using sample ITS/WDS apps. Verified Argo CD installs and apps sync correctly.

Fixes #3462

