### PR TITLE
🌱  Remove unecessary configmaps role

### DIFF
--- a/core-chart/templates/postcreatehooks/kubestellar-controller.yaml
+++ b/core-chart/templates/postcreatehooks/kubestellar-controller.yaml
@@ -12,9 +12,6 @@ spec:
     metadata:
       name: kubestellar-leader-election-role
     rules:
-      - apiGroups: [""]
-        resources: ["configmaps"]
-        verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
       - apiGroups: ["coordination.k8s.io"]
         resources: ["leases"]
         verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Don't forget to first look for overlapping PRs. Remember, open source
is a collaborative rather than competitive activity.

If this PR includes changes to the source files for the website
(docs/content/** or a file included from there) then include a preview
of the modified website; see
docs/content/contribution-guidelines/operations/document-management.md.

Please put one of the following icons at the start of your PR title,
to indicate the type of your PR. You could use copy-and-paste from
here; alternatively, the indicated code is recognized by most browsers
as a way to input that icon.

✨ - code :sparkles:, type feature
🐛 - code :bug:, type bug fix
📖 - code :book:, type docs
📝 - code :memo:, type proposal
⚠️ - code :warning:, type breaking change
🌱 - code :seedling:, type other/misc
❓ - code :question:, type requires manual review/categorization

-->
## Summary
This PR removes ConfigMaps role in **kubestellar-leader-election-role** from [kubestellar-controller.yaml](https://github.com/kubestellar/kubestellar/blob/b0714e16ba6a2271e80a96847cad0d7f0d34fc39/core-chart/templates/postcreatehooks/kubestellar-controller.yaml#L15) as current version of **controller-runtime** doesn't require it.

## Related issue(s)

Fixes #3466
