### PR TITLE
✨ Add utility for fetching the kubeconfig for a ControlPlane

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -24,6 +24,18 @@ builds:
   - arm64
   env:
   - CGO_ENABLED=0
+- id: "kflex-get-kubeconfig"
+  main: ./cmd/kflex-get-kubeconfig
+  binary: bin/kflex-get-kubeconfig
+  ldflags:
+  - "{{ .Env.LDFLAGS }}"
+  goos:
+  - linux
+  goarch:
+  - amd64
+  - arm64
+  env:
+  - CGO_ENABLED=0
 kos:           
   - id: kubestellar-controller-manager
     repository: ghcr.io/kubestellar/kubestellar/controller-manager
@@ -40,6 +52,18 @@ kos:
   - id: ocm-transport-controller
     repository: ghcr.io/kubestellar/kubestellar/ocm-transport-controller
     build: ocm-transport-controller
+    tags:
+    - '{{.Version}}'
+    bare: true
+    preserve_import_paths: false
+    ldflags:
+    - "{{ .Env.LDFLAGS }}"
+    platforms:
+    - linux/amd64
+    - linux/arm64
+  - id: kflex-get-kubeconfig
+    repository: ghcr.io/kubestellar/kubestellar/kflex-get-kubeconfig
+    build: kflex-get-kubeconfig
     tags:
     - '{{.Version}}'
     bare: true

--- a/cmd/kflex-get-kubeconfig/README.md
+++ b/cmd/kflex-get-kubeconfig/README.md
@@ -1,0 +1,63 @@
+# kflex-get-kubeconfig
+
+This is a simple utility for fetching a kubeconfig to use to access
+the apiservers of a KubeFlex `ControlPlane`.
+
+This utility is given either the name of the `ControlPlane` or a label
+selector (in the same format as given to `kubectl`) that is expected to
+match the labels of exactly 1 `ControlPlane`.
+
+This utility is told whether to extract the in-cluster or external
+kubeconfig.
+
+This utility is also given a file pathname where the fetched
+kubeconfig should be written. The special pathname `-` may be passed
+to indicate writing to stdout.
+
+Following is an example invocation.
+
+```shell
+kflex-get-kubeconfig --output-file taste \
+    --control-plane-label-selector kflex.kubestellar.io/cptype=its \
+    --in-cluster=false
+```
+
+## Command line flags
+
+### Specific to this utility
+
+```console
+      --control-plane-label-selector string   label selector that identifies exactly one ControlPlane
+      --control-plane-name string             name of ControlPlane to read; mutually exclusive with --control-plane-label-selector
+      --in-cluster                            whether to extract the kubeconfig for use in the kubeflex hosting cluster (default true)
+      --output-file string                    pathname of file where the kubeconfig will be written; '-' means stdout
+```
+
+### Kubernetes client
+
+```console
+      ---burst int                            Allowed burst in requests/sec for reading ControlPlane (default 10)
+      ---qps float                            Max average requests/sec for reading ControlPlane (default 5)
+      --cluster string                        The name of the kubeconfig cluster to use for reading ControlPlane
+      --context string                        The name of the kubeconfig context to use for reading ControlPlane
+      --kubeconfig string                     Path to the kubeconfig file to use for reading ControlPlane
+      --user string                           The name of the kubeconfig user to use for reading ControlPlane
+```
+
+### Go logging
+
+```console
+      --add_dir_header                        If true, adds the file directory to the header of the log messages
+      --alsologtostderr                       log to standard error as well as files (no effect when -logtostderr=true)
+      --log_backtrace_at traceLocation        when logging hits line file:N, emit a stack trace (default :0)
+      --log_dir string                        If non-empty, write log files in this directory (no effect when -logtostderr=true)
+      --log_file string                       If non-empty, use this log file (no effect when -logtostderr=true)
+      --log_file_max_size uint                Defines the maximum size a log file can grow to (no effect when -logtostderr=true). Unit is megabytes. If the value is 0, the maximum file size is unlimited. (default 1800)
+      --logtostderr                           log to standard error instead of files (default true)
+      --one_output                            If true, only write logs to their native severity level (vs also writing to each lower severity level; no effect when -logtostderr=true)
+      --skip_headers                          If true, avoid header prefixes in the log messages
+      --skip_log_headers                      If true, avoid headers when opening log files (no effect when -logtostderr=true)
+      --stderrthreshold severity              logs at or above this threshold go to stderr when writing to files and stderr (no effect when -logtostderr=true or -alsologtostderr=true) (default 2)
+  -v, --v Level                               number for the log level verbosity
+      --vmodule moduleSpec                    comma-separated list of pattern=N settings for file-filtered logging
+```

--- a/cmd/kflex-get-kubeconfig/main.go
+++ b/cmd/kflex-get-kubeconfig/main.go
@@ -1,0 +1,171 @@
+/*
+Copyright 2023 The KubeStellar Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+// Import all Kubernetes client auth plugins (e.g. Azure, GCP, OIDC, etc.)
+// to ensure that exec-entrypoint and run can make use of them.
+
+import (
+	"context"
+	"flag"
+	"os"
+	"time"
+
+	"github.com/spf13/pflag"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/wait"
+	dynclient "k8s.io/client-go/dynamic"
+	"k8s.io/client-go/kubernetes"
+	_ "k8s.io/client-go/plugin/pkg/client/auth"
+	"k8s.io/klog/v2"
+
+	kfapi "github.com/kubestellar/kubeflex/api/v1alpha1"
+
+	clientopts "github.com/kubestellar/kubestellar/options"
+)
+
+func main() {
+	clientOptions := clientopts.NewClientOptions[*pflag.FlagSet]("", "reading ControlPlane")
+	var cpName, cpLabelSelectorStr string
+	var outputFilePath string
+	inCluster := true
+	clientOptions.AddFlagsSansName(pflag.CommandLine)
+	pflag.StringVar(&cpName, "control-plane-name", cpName, "name of ControlPlane to read; mutually exclusive with --control-plane-label-selector")
+	pflag.StringVar(&cpLabelSelectorStr, "control-plane-label-selector", cpLabelSelectorStr, "label selector that identifies exactly one ControlPlane")
+	pflag.StringVar(&outputFilePath, "output-file", outputFilePath, "pathname of file where the kubeconfig will be written; '-' means stdout")
+	pflag.BoolVar(&inCluster, "in-cluster", inCluster, "whether to extract the kubeconfig for use in the kubeflex hosting cluster")
+	klog.InitFlags(nil)
+	pflag.CommandLine.AddGoFlagSet(flag.CommandLine)
+	pflag.Parse()
+	ctx := context.Background()
+	logger := klog.FromContext(ctx)
+	ctx = klog.NewContext(ctx, logger)
+	setupLog := logger.WithName("setup")
+
+	pflag.VisitAll(func(flg *pflag.Flag) {
+		setupLog.V(1).Info("Command line flag", "name", flg.Name, "value", flg.Value)
+	})
+
+	if cpName == "" && cpLabelSelectorStr == "" {
+		logger.Error(nil, "You must provide either a non-empty --control-plane-name OR a non-empty --control-plane-label-selector")
+		os.Exit(1)
+	}
+	if cpName != "" && cpLabelSelectorStr != "" {
+		logger.Error(nil, "You may not provide both a non-empty --control-plane-name AND a non-empty --control-plane-label-selector")
+		os.Exit(1)
+	}
+	if outputFilePath == "" {
+		logger.Error(nil, "The output file pathname may not be empty")
+		os.Exit(1)
+	}
+
+	restConfig, err := clientOptions.ToRESTConfig()
+	if err != nil {
+		logger.Error(err, "failed to determine REST client config")
+		os.Exit(10)
+	}
+
+	kubeClient := kubernetes.NewForConfigOrDie(restConfig)
+	coreClient := kubeClient.CoreV1()
+
+	dynClient := dynclient.NewForConfigOrDie(restConfig)
+	controlplanes := kfapi.GroupVersion.WithResource("controlplanes")
+	cpClient := dynClient.Resource(controlplanes)
+
+	var kubeconfigContent []byte
+	backoff := wait.Backoff{
+		Duration: time.Second * 5,
+		Factor:   1.414,
+		Jitter:   0.25,
+		Steps:    24 * 60 * 3,
+		Cap:      time.Second * 20,
+	}
+	err = wait.ExponentialBackoffWithContext(ctx, backoff, func(ctx context.Context) (done bool, err error) {
+		var cpU *unstructured.Unstructured
+		if cpName != "" {
+			cpU, err = cpClient.Get(ctx, cpName, metav1.GetOptions{})
+			if err != nil {
+				logger.Info("Failed to fetch ControlPlane", "name", cpName, "err", err)
+				return false, nil
+			}
+		} else {
+			cpsU, err := cpClient.List(ctx, metav1.ListOptions{LabelSelector: cpLabelSelectorStr})
+			if err != nil {
+				logger.Info("Failed to fetch ControlPlanes by label selector", "name", cpLabelSelectorStr, "err", err)
+				return false, nil
+			}
+			if numGot := len(cpsU.Items); numGot != 1 {
+				logger.Info("Did not get exactly 1 ControlPlane", "numGot", numGot)
+				return false, nil
+			}
+			cpU = &cpsU.Items[0]
+		}
+		var cp kfapi.ControlPlane
+		err = runtime.DefaultUnstructuredConverter.FromUnstructuredWithValidation(cpU.UnstructuredContent(), &cp, true)
+		if err != nil {
+			logger.Info("Failed to unmarshal", "err", err)
+			return false, nil
+		}
+		if !kfapi.HasConditionAvailable(cp.Status.Conditions) {
+			logger.Info("The ControlPlane is not ready")
+			return false, nil
+		}
+		secretsClient := coreClient.Secrets(cp.Status.SecretRef.Namespace)
+		secret, err := secretsClient.Get(ctx, cp.Status.SecretRef.Name, metav1.GetOptions{})
+		if err != nil {
+			logger.Info("Failed to read Secret", "namespace", cp.Status.SecretRef.Namespace, "name", cp.Status.SecretRef.Name, "err", err)
+			return false, nil
+		}
+		key := cp.Status.SecretRef.Key
+		if inCluster {
+			key = cp.Status.SecretRef.InClusterKey
+		}
+		kubeconfigContent = secret.Data[key]
+		if len(kubeconfigContent) == 0 {
+			logger.Info("Secret lacks kubeconfig", "namespace", cp.Status.SecretRef.Namespace, "name", cp.Status.SecretRef.Name, "key", key)
+			return false, nil
+		}
+		return true, nil
+	})
+	if err != nil {
+		logger.Error(err, "Timed out waiting for ready ControlPlane")
+		os.Exit(86)
+	}
+	out := os.Stdout
+	if outputFilePath != "-" {
+		out, err = os.Create(outputFilePath)
+		if err != nil {
+			logger.Error(err, "Failed to open file for writing", "path", outputFilePath)
+			os.Exit(99)
+		}
+	}
+	_, err = out.Write(kubeconfigContent)
+	if err != nil {
+		logger.Error(err, "Failed to write into the file")
+		os.Exit(100)
+	}
+	if outputFilePath != "-" {
+		err = out.Close()
+		if err != nil {
+			logger.Error(err, "Failed to close the file")
+			os.Exit(101)
+		}
+	}
+}

--- a/options/client-options.go
+++ b/options/client-options.go
@@ -65,6 +65,11 @@ func (opts *ClientLimits) AddFlags(flags *pflag.FlagSet) {
 	flags.IntVar(&opts.Burst, opts.name+"-burst", opts.Burst, "Allowed burst in requests/sec for "+opts.description)
 }
 
+func (opts *ClientLimits) AddFlagsSansName(flags *pflag.FlagSet) {
+	flags.Float64Var(&opts.QPS, "qps", opts.QPS, "Max average requests/sec for "+opts.description)
+	flags.IntVar(&opts.Burst, "burst", opts.Burst, "Allowed burst in requests/sec for "+opts.description)
+}
+
 func (opts *ClientOptions) AddFlags(flags *pflag.FlagSet) {
 	opts.ClientLimits.AddFlags(flags)
 	flags.StringVar(&opts.loadingRules.ExplicitPath, opts.name+"-kubeconfig", opts.loadingRules.ExplicitPath, "Path to the kubeconfig file to use for "+opts.description)
@@ -72,6 +77,14 @@ func (opts *ClientOptions) AddFlags(flags *pflag.FlagSet) {
 	flags.StringVar(&opts.overrides.Context.AuthInfo, opts.name+"-user", opts.overrides.Context.AuthInfo, "The name of the kubeconfig user to use for "+opts.description)
 	flags.StringVar(&opts.overrides.Context.Cluster, opts.name+"-cluster", opts.overrides.Context.Cluster, "The name of the kubeconfig cluster to use for "+opts.description)
 
+}
+
+func (opts *ClientOptions) AddFlagsSansName(flags *pflag.FlagSet) {
+	opts.ClientLimits.AddFlags(flags)
+	flags.StringVar(&opts.loadingRules.ExplicitPath, "kubeconfig", opts.loadingRules.ExplicitPath, "Path to the kubeconfig file to use for "+opts.description)
+	flags.StringVar(&opts.overrides.CurrentContext, "context", opts.overrides.CurrentContext, "The name of the kubeconfig context to use for "+opts.description)
+	flags.StringVar(&opts.overrides.Context.AuthInfo, "user", opts.overrides.Context.AuthInfo, "The name of the kubeconfig user to use for "+opts.description)
+	flags.StringVar(&opts.overrides.Context.Cluster, "cluster", opts.overrides.Context.Cluster, "The name of the kubeconfig cluster to use for "+opts.description)
 }
 
 func (opts *ClientOptions) ToRESTConfig() (*rest.Config, error) {


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Don't forget to first look for overlapping PRs. Remember, open source
is a collaborative rather than competitive activity.

If this PR includes changes to the source files for the website
(docs/content/** or a file included from there) then include a preview
of the modified website; see
docs/content/contribution-guidelines/operations/document-management.md.

Please put one of the following icons at the start of your PR title,
to indicate the type of your PR. You could use copy-and-paste from
here; alternatively, the indicated code is recognized by most browsers
as a way to input that icon.

✨ - code :sparkles:, type feature
🐛 - code :bug:, type bug fix
📖 - code :book:, type docs
📝 - code :memo:, type proposal
⚠️ - code :warning:, type breaking change
🌱 - code :seedling:, type other/misc
❓ - code :question:, type requires manual review/categorization

-->
## Summary
This PR adds a simple utility for fetching the kubeconfig for a KubeFlex ControlPlane, including waiting for the ControlPlane to exist and be ready.

## Related issue(s)

Fixes #
