### PR TITLE
🌱 feat(e2e): Lengthen ITS setup timeouts 

### DIFF
--- a/test/e2e/common/setup-kubestellar.sh
+++ b/test/e2e/common/setup-kubestellar.sh
@@ -127,14 +127,14 @@ else
 popd
 
 : Waiting for OCM hub to be ready...
-kubectl wait controlplane.tenancy.kflex.kubestellar.org/its1 --for 'jsonpath={.status.postCreateHooks.its-hub-init}=true' --timeout 400s
-kubectl wait -n its1-system job.batch/its-hub-init --for condition=Complete --timeout 400s
-kubectl wait controlplane.tenancy.kflex.kubestellar.org/its1 --for 'jsonpath={.status.postCreateHooks.install-status-addon}=true' --timeout 400s
-kubectl wait -n its1-system job.batch/install-status-addon --for condition=Complete --timeout 400s
+kubectl wait controlplane.tenancy.kflex.kubestellar.org/its1 --for 'jsonpath={.status.postCreateHooks.its-hub-init}=true' --timeout 800s
+kubectl wait -n its1-system job.batch/its-hub-init --for condition=Complete --timeout 800s
+kubectl wait controlplane.tenancy.kflex.kubestellar.org/its1 --for 'jsonpath={.status.postCreateHooks.install-status-addon}=true' --timeout 800s
+kubectl wait -n its1-system job.batch/install-status-addon --for condition=Complete --timeout 800s
 
-kubectl wait -n its1-system job.batch/update-cluster-info --for condition=Complete --timeout 200s
+kubectl wait -n its1-system job.batch/update-cluster-info --for condition=Complete --timeout 400s
 
-kubectl --context "$HOSTING_CONTEXT" -n wds1-system wait --for=condition=Ready pod -l name=transport-controller --timeout 400s
+kubectl --context "$HOSTING_CONTEXT" -n wds1-system wait --for=condition=Ready pod -l name=transport-controller --timeout 800s
 
 echo "transport controller is running."
 

--- a/test/e2e/common/setup-shell.sh
+++ b/test/e2e/common/setup-shell.sh
@@ -25,7 +25,7 @@ function wait-for-cmd() (
     cmd="$@"
     wait_counter=0
     while ! (eval "$cmd") ; do
-        if (($wait_counter > 36)); then
+        if (($wait_counter > 72)); then
             echo "Failed to ${cmd}."
             exit 1
         fi


### PR DESCRIPTION
This PR addresses flakiness in the E2E tests by generously increasing the timeouts for the ITS setup, as requested in Epic #3151.

This includes:
* Doubling the specific `kubectl wait` timeouts in `test/e2e/common/setup-kubestellar.sh`.
* Doubling the default timeout in the `wait-for-cmd` helper function in `test/e2e/common/setup-shell.sh` from ~3 minutes to ~6 minutes.

Fixes #3185
