### PR TITLE
📖 Clarify ControlPlane id args to kflex-get-kubeconfig

### DIFF
--- a/cmd/kflex-get-kubeconfig/README.md
+++ b/cmd/kflex-get-kubeconfig/README.md
@@ -3,9 +3,10 @@
 This is a simple utility for fetching a kubeconfig to use to access
 the apiservers of a KubeFlex `ControlPlane`.
 
-This utility is given either the name of the `ControlPlane` or a label
-selector (in the same format as given to `kubectl`) that is expected to
-match the labels of exactly 1 `ControlPlane`.
+This utility is given either (1) a non-empty string that is the name
+of the `ControlPlane` or (2) a non-empty label selector (in the same
+format as given to `kubectl`) that is expected to match the labels of
+exactly 1 `ControlPlane`.
 
 This utility is told whether to extract the in-cluster or external
 kubeconfig.
@@ -27,8 +28,8 @@ kflex-get-kubeconfig --output-file taste \
 ### Specific to this utility
 
 ```console
-      --control-plane-label-selector string   label selector that identifies exactly one ControlPlane
-      --control-plane-name string             name of ControlPlane to read; mutually exclusive with --control-plane-label-selector
+      --control-plane-label-selector string   label selector that identifies exactly one ControlPlane, or empty string (meaning to pick by name); default is empty string
+      --control-plane-name string             name of ControlPlane to read, or empty string (meaning to pick by label selector); default is empty string
       --in-cluster                            whether to extract the kubeconfig for use in the kubeflex hosting cluster (default true)
       --output-file string                    pathname of file where the kubeconfig will be written; '-' means stdout
 ```

--- a/cmd/kflex-get-kubeconfig/main.go
+++ b/cmd/kflex-get-kubeconfig/main.go
@@ -47,8 +47,8 @@ func main() {
 	var outputFilePath string
 	inCluster := true
 	clientOptions.AddFlagsSansName(pflag.CommandLine)
-	pflag.StringVar(&cpName, "control-plane-name", cpName, "name of ControlPlane to read; mutually exclusive with --control-plane-label-selector")
-	pflag.StringVar(&cpLabelSelectorStr, "control-plane-label-selector", cpLabelSelectorStr, "label selector that identifies exactly one ControlPlane")
+	pflag.StringVar(&cpName, "control-plane-name", cpName, "name of ControlPlane to read, or empty string (meaning to pick by label selector); default is empty string")
+	pflag.StringVar(&cpLabelSelectorStr, "control-plane-label-selector", cpLabelSelectorStr, "label selector that identifies exactly one ControlPlane, or empty string (meaning to pick by name); default is empty string")
 	pflag.StringVar(&outputFilePath, "output-file", outputFilePath, "pathname of file where the kubeconfig will be written; '-' means stdout")
 	pflag.BoolVar(&inCluster, "in-cluster", inCluster, "whether to extract the kubeconfig for use in the kubeflex hosting cluster")
 	klog.InitFlags(nil)


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Don't forget to first look for overlapping PRs. Remember, open source
is a collaborative rather than competitive activity.

If this PR includes changes to the source files for the website
(docs/content/** or a file included from there) then include a preview
of the modified website; see
docs/content/contribution-guidelines/operations/document-management.md.

Please put one of the following icons at the start of your PR title,
to indicate the type of your PR. You could use copy-and-paste from
here; alternatively, the indicated code is recognized by most browsers
as a way to input that icon.

✨ - code :sparkles:, type feature
🐛 - code :bug:, type bug fix
📖 - code :book:, type docs
📝 - code :memo:, type proposal
⚠️ - code :warning:, type breaking change
🌱 - code :seedling:, type other/misc
❓ - code :question:, type requires manual review/categorization

-->
## Summary
This PR clarifies the descriptions of the arguments to `kflex-get-kubeconfig` that identify which ControlPlane to read.

## Related issue(s)

Fixes #
