### PR TITLE
✨ feat: Implement declarative ArgoCD WDS registration via PostCreateHook

### DIFF
--- a/core-chart/templates/controlplanes/wds.yaml
+++ b/core-chart/templates/controlplanes/wds.yaml
@@ -16,6 +16,9 @@ spec:
       vars:
         WDSSecretName: admin-kubeconfig
         WDSSecretKey: kubeconfig-incluster
+    {{- if $.Values.argocd.install }}
+    - hookName: argocd-wds-registration
+    {{- end }}
   globalVars:
     ControlPlaneName: {{ .name }}
     ITSName: '{{ .ITSName }}'

--- a/core-chart/templates/postcreatehooks/argocd-wds-registration.yaml
+++ b/core-chart/templates/postcreatehooks/argocd-wds-registration.yaml
@@ -1,0 +1,71 @@
+{{- if and .Values.argocd.install .Values.InstallPCHs }}
+apiVersion: tenancy.kflex.kubestellar.org/v1alpha1
+kind: PostCreateHook
+metadata:
+  name: argocd-wds-registration
+  labels:
+    kflex.kubestellar.io/cptype: wds
+spec:
+  templates:
+  - apiVersion: batch/v1
+    kind: Job
+    metadata:
+      name: '{{"{{.HookName}}"}}'
+    spec:
+      template:
+        spec:
+          volumes:
+          - name: wds-kubeconfig-volume
+            secret:
+              secretName: '{{"{{.WDSSecretName}}"}}'
+          containers:
+          - name: create-argocd-secret
+            image: quay.io/kubestellar/kubectl:{{$.Values.KUBECTL_VERSION}}
+            command: ["/bin/bash", "-c"]
+            args:
+            - |
+              set -e
+              echo "Starting ArgoCD Registration for WDS: {{"{{.ControlPlaneName}}"}}"
+              KUBECONFIG_FILE=$(find /etc/kube/wds -type f -not -name '..*' | head -n 1)
+              if [ -z "$KUBECONFIG_FILE" ]; then
+                echo "Error: No kubeconfig file found in /etc/kube/wds"
+                exit 1
+              fi
+              SERVER=$(kubectl --kubeconfig "$KUBECONFIG_FILE" config view --minify -o jsonpath='{.clusters[0].cluster.server}')
+              CA_DATA=$(kubectl --kubeconfig "$KUBECONFIG_FILE" config view --minify -o jsonpath='{.clusters[0].cluster.certificate-authority-data}')
+              CERT_DATA=$(kubectl --kubeconfig "$KUBECONFIG_FILE" config view --minify -o jsonpath='{.users[0].user.client-certificate-data}')
+              KEY_DATA=$(kubectl --kubeconfig "$KUBECONFIG_FILE" config view --minify -o jsonpath='{.users[0].user.client-key-data}')
+              CP_UID=$(kubectl get controlplane {{"{{.ControlPlaneName}}"}} -o jsonpath='{.metadata.uid}')
+              echo "Found ControlPlane UID: $CP_UID. Linking Secret for garbage collection."
+              CONFIG_JSON="{\"tlsClientConfig\":{\"insecure\":false,\"caData\":\"$CA_DATA\",\"certData\":\"$CERT_DATA\",\"keyData\":\"$KEY_DATA\"}}"
+              echo "Creating ArgoCD Cluster Secret..."
+              cat <<INNEREOF | kubectl apply -f -
+              apiVersion: v1
+              kind: Secret
+              metadata:
+                name: {{"{{.ControlPlaneName}}"}}-cluster
+                namespace: argocd
+                labels:
+                  argocd.argoproj.io/secret-type: cluster
+                  kflex.kubestellar.io/cptype: wds
+                ownerReferences:
+                - apiVersion: tenancy.kflex.kubestellar.org/v1alpha1
+                  kind: ControlPlane
+                  name: {{"{{.ControlPlaneName}}"}}
+                  uid: $CP_UID
+                  controller: true
+                  blockOwnerDeletion: true
+              type: Opaque
+              stringData:
+                name: {{"{{.ControlPlaneName}}"}}
+                server: $SERVER
+                config: '$CONFIG_JSON'
+              INNEREOF
+              echo "Success! WDS registered with ArgoCD."
+            volumeMounts:
+            - name: wds-kubeconfig-volume
+              mountPath: /etc/kube/wds
+              readOnly: true
+          restartPolicy: Never
+      backoffLimit: 1
+{{- end }}

--- a/core-chart/values.yaml
+++ b/core-chart/values.yaml
@@ -129,3 +129,4 @@ WDSes: # all the CPs in this list will execute the transport-controller.yaml and
   #   type: host # optional type of control plane host or k8s (default to k8s, if not specified)
   #   APIGroups: "" # optional string holding a comma-separated list of APIGroups
   #   ITSName: its1 # optional name of the ITS control plane, this MUST be specified if more than one ITS exists at the moment the WDS PCH starts
+


### PR DESCRIPTION
Implements declarative ArgoCD cluster registration for WDS control planes using labeled Secrets. ✅ Status: Ready for Review

Related to #3066

What's Implemented
Added: core-chart/templates/postcreatehooks/argocd-wds-registration.yaml

Implements a PostCreateHook that triggers a Kubernetes Job upon WDS creation.

The Job securely extracts the WDS kubeconfig credentials (caData, certData, keyData, server) using kubectl and jsonpath.

Creates a generic Secret in the argocd namespace with the label argocd.argoproj.io/secret-type: cluster, allowing ArgoCD to automatically discover and manage the WDS.

Modified: core-chart/templates/controlplanes/wds.yaml

Added conditional logic to trigger the argocd-wds-registration hook only when argocd.install is set to true.

Updated to use the correct upstream variable WDSSecretKey.

Implementation Details
Kubeconfig Parsing: Replaced the initial TODOs with a bash-based solution using the standard quay.io/kubestellar/kubectl image.

Secret Management: The created Secret includes the correct cluster labels and OwnerReferences, ensuring it is garbage-collected if the WDS is deleted.

Testing Status
✅ Verified:

CI Checks passed (Run integration tests, Test end to end, pull-kubestellar-verify).

Verified clean git history (rebased on upstream/main with no bogus diffs).

Verified correct variable usage (WDSSecretKey) matches upstream changes.

Checklist
[x] Implementation matches the declarative Secret approach discussed in #3066.

[x] Code is synced with upstream/main.

[x] Formatting and line-endings verified.