### PR TITLE
🐛Add ArgoCD nginx sample app to hack/argo with required labels

### DIFF
--- a/docs/content/direct/core-chart-argocd.md
+++ b/docs/content/direct/core-chart-argocd.md
@@ -131,9 +131,9 @@ argocd:
   applications: # list of Argo CD applications to be create
   - name: scenario-6 # required, must be unique
     project: default # default: default
-    repoURL: https://github.com/pdettori/sample-apps.git
+    repoURL: https://github.com/kubestellar/kubestellar.git
     targetRevision: HEAD # default: HEAD
-    path: nginx
+    path: hack/argo/nginx
     destinationWDS: wds1
     destinationNamespace: nginx-sa # default: default
     syncPolicy: auto # default: manual
@@ -142,7 +142,7 @@ argocd:
 Alternatively, the same result can be achieved from Helm CLI by using the followig minimal argument (note that the default values are not explicitely set):
 
 ```shell
---set-json='argocd.applications=[ { "name": "scenario-6", "repoURL": "https://github.com/pdettori/sample-apps.git", "path": "nginx", "destinationWDS": "wds1", "destinationNamespace": "nginx-sa" } ]'
+--set-json='argocd.applications=[ { "name": "scenario-6", "repoURL": "https://github.com/kubestellar/kubestellar.git", "path": "hack/argo/nginx", "destinationWDS": "wds1", "destinationNamespace": "nginx-sa" } ]'
 ```
 
 ![alt text](images/argocd-application.png)

--- a/docs/content/direct/example-scenarios.md
+++ b/docs/content/direct/example-scenarios.md
@@ -535,7 +535,7 @@ kubectl config set-context --current --namespace=argocd
 Create a new application in ArgoCD:
 
 ```shell
-argocd app create nginx-sa --repo https://github.com/pdettori/sample-apps.git --path nginx --dest-server https://"${wds_cp}.${wds_cp}-system" --dest-namespace nginx-sa
+argocd app create nginx-sa --repo https://github.com/kubestellar/kubestellar.git --path hack/argo/nginx --dest-server https://"${wds_cp}.${wds_cp}-system" --dest-namespace nginx-sa
 ```
 
 Open browser to Argo UI:

--- a/hack/argo/nginx/deployment.yaml
+++ b/hack/argo/nginx/deployment.yaml
@@ -1,0 +1,23 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx-sa-deployment
+  namespace: nginx-sa
+  labels:
+    argocd.argoproj.io/instance: nginx-sa
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: nginx-sa
+  template:
+    metadata:
+      labels:
+        app: nginx-sa
+    spec:
+      serviceAccountName: nginx-sa
+      containers:
+      - name: nginx-sa
+        image: public.ecr.aws/nginx/nginx:latest
+        ports:
+        - containerPort: 80

--- a/hack/argo/nginx/namespace.yaml
+++ b/hack/argo/nginx/namespace.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: nginx-sa
+  labels:
+    argocd.argoproj.io/instance: nginx-sa

--- a/hack/argo/nginx/serviceaccount.yaml
+++ b/hack/argo/nginx/serviceaccount.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: nginx-sa
+  namespace: nginx-sa
+  labels:
+    argocd.argoproj.io/instance: nginx-sa

--- a/oldocs/examples.md
+++ b/oldocs/examples.md
@@ -625,7 +625,7 @@ kubectl config set-context --current --namespace=argocd
 Create a new application in ArgoCD:
 
 ```shell
-argocd app create nginx-sa --repo https://github.com/pdettori/sample-apps.git --path nginx --dest-server https://wds1.wds1-system --dest-namespace nginx-sa
+argocd app create nginx-sa --repo https://github.com/kubestellar/kubestellar.git --path hack/argo/nginx --dest-server https://wds1.wds1-system --dest-namespace nginx-sa
 ```
 
 Open browser to Argo UI:


### PR DESCRIPTION
## Summary
This PR addresses issue #3497 by bringing the ArgoCD nginx sample application into the repository.

## Changes
- Added nginx sample app to `hack/argo/nginx/` directory with namespace, serviceaccount, and deployment manifests
- Added the missing `argocd.argoproj.io/instance: nginx-sa` label to all resources (was missing in the original external repo)
- Updated all documentation references from `pdettori/sample-apps` to the new local `hack/argo/nginx` path

Fixes  #3497

Preview at : https://rishi-jat.github.io/kubestellar

