### PR TITLE
📖 Fix reference to github icon

### DIFF
--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -129,7 +129,7 @@ theme:
     code: 'Roboto Mono'
   name: material
   icon:
-    repo: github.svg
+    repo: github
 
   language: en
   # Common files such as images, stylesheets, theme overrides


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Don't forget to first look for overlapping PRs. Remember, open source
is a collaborative rather than competitive activity.

If this PR includes changes to the source files for the website
(docs/content/** or a file included from there) then include a preview
of the modified website; see
docs/content/contribution-guidelines/operations/document-management.md.

Please put one of the following icons at the start of your PR title,
to indicate the type of your PR. You could use copy-and-paste from
here; alternatively, the indicated code is recognized by most browsers
as a way to input that icon.

✨ - code :sparkles:, type feature
🐛 - code :bug:, type bug fix
📖 - code :book:, type docs
📝 - code :memo:, type proposal
⚠️ - code :warning:, type breaking change
🌱 - code :seedling:, type other/misc
❓ - code :question:, type requires manual review/categorization

-->
## Summary
This PR fixes the reference from `docs/mkdocs.yml` to the GitHub icon. Apparently there is an implicit addition of `.svg` to the end of the filename.

Preview at https://mikespreitzer.github.io/kcp-edge-mc/doc-fix-github-icon-fix/readme/

Make it wide enough that the GitHub reference appears in the upper right hand corner, zoom in, and you will see the following.

<img width="786" height="163" alt="image" src="https://github.com/user-attachments/assets/35b7eaa8-b4b7-4b61-99da-2f247502ec5f" />


## Related issue(s)

Fixes #3507 
