### PR TITLE
🌱 Bump sbom-action, checkout, setup-go

### DIFF
--- a/.gha-reversemap.yml
+++ b/.gha-reversemap.yml
@@ -1,8 +1,8 @@
 actions/checkout:
-  sha: 08c6903cd8c0fde910a37f88322edcfb5dd907a8
-  sha-url: https://github.com/actions/checkout/commit/08c6903cd8c0fde910a37f88322edcfb5dd907a8
-  tag: v5.0.0
-  tag-url: https://github.com/actions/checkout/tree/v5.0.0
+  sha: 1af3b93b6815bc44a9784bd300feb67ff0d1eeb3
+  sha-url: https://github.com/actions/checkout/commit/1af3b93b6815bc44a9784bd300feb67ff0d1eeb3
+  tag: v6.0.0
+  tag-url: https://github.com/actions/checkout/tree/v6.0.0
 actions/stale:
   sha: 5f858e3efba33a5ca4407a664cc011ad407f2008
   sha-url: https://github.com/actions/stale/commit/5f858e3efba33a5ca4407a664cc011ad407f2008
@@ -34,15 +34,15 @@ actions/setup-python:
   tag: v6.0.0
   tag-url: https://github.com/actions/setup-python/tree/v6.0.0
 actions/setup-go:
-  sha: 44694675825211faa026b3c33043df3e48a5fa00
-  sha-url: https://github.com/actions/setup-go/commit/44694675825211faa026b3c33043df3e48a5fa00
-  tag: v6.0.0
-  tag-url: https://github.com/actions/setup-go/tree/v6.0.0
+  sha: 4dc6199c7b1a012772edbd06daecab0f50c9053c
+  sha-url: https://github.com/actions/setup-go/commit/4dc6199c7b1a012772edbd06daecab0f50c9053c
+  tag: v6.1.0
+  tag-url: https://github.com/actions/setup-go/tree/v6.1.0
 anchore/sbom-action/download-syft:
-  sha: 8e94d75ddd33f69f691467e42275782e4bfefe84
-  sha-url: https://github.com/anchore/sbom-action/commit/8e94d75ddd33f69f691467e42275782e4bfefe84
-  tag: v0.20.9
-  tag-url: https://github.com/anchore/sbom-action/tree/v0.20.9
+  sha: fbfd9c6c189226748411491745178e0c2017392d
+  sha-url: https://github.com/anchore/sbom-action/commit/fbfd9c6c189226748411491745178e0c2017392d
+  tag: v0.20.10
+  tag-url: https://github.com/anchore/sbom-action/tree/v0.20.10
 goreleaser/goreleaser-action:
   sha: e435ccd777264be153ace6237001ef4d979d3a7a
   sha-url: https://github.com/goreleaser/goreleaser-action/commit/e435ccd777264be153ace6237001ef4d979d3a7a

--- a/.github/workflows/add-to-project.yml
+++ b/.github/workflows/add-to-project.yml
@@ -21,7 +21,7 @@ jobs:
         id: date
         run: echo "date=$(date +'%Y-%m-%d')" >> $GITHUB_OUTPUT
 
-      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
+      - uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3
         with:
           token: ${{ secrets.GH_ALL_PROJECT_TOKEN }}
           persist-credentials: "false"

--- a/.github/workflows/check-docs-pr-preview.yml
+++ b/.github/workflows/check-docs-pr-preview.yml
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
+        uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3
       - name: Check for Preview Link in PR Description (bash)
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/create-our-meeting-bi-weekly.yml
+++ b/.github/workflows/create-our-meeting-bi-weekly.yml
@@ -28,7 +28,7 @@ jobs:
           fi
 
       # This is the resolved checkout step
-      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
+      - uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3
         with:
           token: ${{ secrets.GH_ALL_PROJECT_TOKEN }}
           persist-credentials: "false"

--- a/.github/workflows/docs-gen-and-push.yml
+++ b/.github/workflows/docs-gen-and-push.yml
@@ -44,7 +44,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
+      - uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3
         with:
           token: ${{ github.repository_owner == 'kubestellar' && secrets.GH_ALL_PROJECT_TOKEN || github.token }}
           persist-credentials: "true"

--- a/.github/workflows/elapsed-time-collector.yml
+++ b/.github/workflows/elapsed-time-collector.yml
@@ -47,7 +47,7 @@ jobs:
       - run: echo "${{ github.event_name }}"
 
       - name: echo fetching push or pull_request branch
-        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
+        uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3
         with:
           token: ${{ secrets.GH_ALL_PROJECT_TOKEN }}
           persist-credentials: "false"
@@ -56,7 +56,7 @@ jobs:
       #     if: github.event_name == 'push' || github.event_name == 'pull_request'
 
       #   - name: echo fetching workflow_dispatch branch
-      #     uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
+      #     uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3
       #     with:
       #         ref: ${GITHUB_REF##*/}
       #     if: github.event_name == 'workflow_dispatch'
@@ -70,7 +70,7 @@ jobs:
           echo "$EOF" >> "$GITHUB_ENV"
         id: run_make
 
-      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
+      - uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3
         with:
           token: ${{ secrets.GH_ALL_PROJECT_TOKEN }}
           persist-credentials: "false"

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -22,11 +22,11 @@ jobs:
     timeout-minutes: 10
 
     steps:
-      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
+      - uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00
+      - uses: actions/setup-go@4dc6199c7b1a012772edbd06daecab0f50c9053c
         with:
           go-version-file: go.mod
           cache: true

--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -21,11 +21,11 @@ jobs:
       packages: write
     steps:
       - name: Checkout
-        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
+        uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00
+      - uses: actions/setup-go@4dc6199c7b1a012772edbd06daecab0f50c9053c
         with:
           go-version: 1.24
 
@@ -36,7 +36,7 @@ jobs:
         run: echo LDFLAGS="$(make ldflags)" >> $GITHUB_ENV
 
       - name: Install syft binary executable
-        uses: anchore/sbom-action/download-syft@8e94d75ddd33f69f691467e42275782e4bfefe84
+        uses: anchore/sbom-action/download-syft@fbfd9c6c189226748411491745178e0c2017392d
 
       - name: Run GoReleaser on tag
         uses: goreleaser/goreleaser-action@e435ccd777264be153ace6237001ef4d979d3a7a

--- a/.github/workflows/ocp-self-runner.yml
+++ b/.github/workflows/ocp-self-runner.yml
@@ -13,9 +13,9 @@ jobs:
     name: ginkgo tests
     runs-on: self-hosted
     steps:
-      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
+      - uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3
 
-      - uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00
+      - uses: actions/setup-go@4dc6199c7b1a012772edbd06daecab0f50c9053c
         with:
           go-version: 1.24
           cache: true
@@ -65,9 +65,9 @@ jobs:
     name: bash script tests
     runs-on: self-hosted
     steps:
-      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
+      - uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3
 
-      - uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00
+      - uses: actions/setup-go@4dc6199c7b1a012772edbd06daecab0f50c9053c
         with:
           go-version: 1.24
           cache: true

--- a/.github/workflows/pr-test-e2e.yml
+++ b/.github/workflows/pr-test-e2e.yml
@@ -50,9 +50,9 @@ jobs:
     name: Tests in ginkgo
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
+      - uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3
 
-      - uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00
+      - uses: actions/setup-go@4dc6199c7b1a012772edbd06daecab0f50c9053c
         with:
           go-version: 1.24
           cache: true
@@ -228,9 +228,9 @@ jobs:
     name: Test in bash
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
+      - uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3
 
-      - uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00
+      - uses: actions/setup-go@4dc6199c7b1a012772edbd06daecab0f50c9053c
         with:
           go-version: 1.24
           cache: true

--- a/.github/workflows/pr-test-integration.yml
+++ b/.github/workflows/pr-test-integration.yml
@@ -35,9 +35,9 @@ jobs:
     name: Test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
+      - uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3
 
-      - uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00
+      - uses: actions/setup-go@4dc6199c7b1a012772edbd06daecab0f50c9053c
         with:
           go-version: 1.24
           cache: true

--- a/.github/workflows/pr-verify-title.yaml
+++ b/.github/workflows/pr-verify-title.yaml
@@ -13,7 +13,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
+        uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3
 
       - name: Validate PR Title Format
         env:

--- a/.github/workflows/spellcheck_action.yml
+++ b/.github/workflows/spellcheck_action.yml
@@ -33,7 +33,7 @@ jobs:
     name: Spellcheck
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
+      - uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3
 
       - uses: rojopolis/spellcheck-github-actions@6f2326b663e2dbab920da0fc4144b9f3202434ba
         name: Spellcheck

--- a/.github/workflows/test-latest-release.yml
+++ b/.github/workflows/test-latest-release.yml
@@ -19,9 +19,9 @@ jobs:
     name: Tests in ginkgo
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
+      - uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3
 
-      - uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00
+      - uses: actions/setup-go@4dc6199c7b1a012772edbd06daecab0f50c9053c
         with:
           go-version: 1.24
           cache: true
@@ -94,9 +94,9 @@ jobs:
     name: Test in bash
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
+      - uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3
 
-      - uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00
+      - uses: actions/setup-go@4dc6199c7b1a012772edbd06daecab0f50c9053c
         with:
           go-version: 1.24
           cache: true

--- a/.github/workflows/verify-action-hashes.yaml
+++ b/.github/workflows/verify-action-hashes.yaml
@@ -26,7 +26,7 @@ jobs:
     name: Verify
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
+      - uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3
 
       - name: Run test
         run: |


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Don't forget to first look for overlapping PRs. Remember, open source
is a collaborative rather than competitive activity.

If this PR includes changes to the source files for the website
(docs/content/** or a file included from there) then include a preview
of the modified website; see
docs/content/contribution-guidelines/operations/document-management.md.

Please put one of the following icons at the start of your PR title,
to indicate the type of your PR. You could use copy-and-paste from
here; alternatively, the indicated code is recognized by most browsers
as a way to input that icon.

✨ - code :sparkles:, type feature
🐛 - code :bug:, type bug fix
📖 - code :book:, type docs
📝 - code :memo:, type proposal
⚠️ - code :warning:, type breaking change
🌱 - code :seedling:, type other/misc
❓ - code :question:, type requires manual review/categorization

-->
## Summary
This PR bumps three GitHub Actions used in workflows.
- Bump actions/checkout from 5.0.0 to 6.0.0
- Bump actions/setup-go from 6.0.0 to 6.1.0
- https://github.com/kubestellar/kubestellar/pull/3499

For each, I:
- checked release notes for incompatible changes, found no such remarks;
- checked github.com/advistories, found no new problems;
- did a web search for the action, found no new problems in the first few pages of results.

This is the principled version of #3499, #3510, and #3511 .

## Related issue(s)

Fixes #
