### PR TITLE
📖 Add MacOS user note for Docker memory allocation

### DIFF
--- a/docs/content/direct/get-started.md
+++ b/docs/content/direct/get-started.md
@@ -14,6 +14,10 @@ The two ways to create this simple configuration are as follows.
 
 For some users on WSL, use of the setup procedure on this page and/or the demo environment creation script may require running as the user `root` in Linux. There is a [known issue about this](knownissue-helm-ghcr.md).
 
+### Note for MacOS users
+Running multiple `kind` clusters on macOS may require increasing Docker Desktop’s memory allocation  
+(4–6 GB recommended). Users with 8 GB RAM should avoid running more than 2–3 clusters concurrently or prefer `k3d` for lower overhead.
+
 ### Important: Shell Variables for Example Scenarios
 
 After completing the setup, you will need to define several shell variables to run the example scenarios. The meanings of these variables are defined [at the start of the example scenarios document](example-scenarios.md#assumptions-and-variables). What is shown later in this document are the specific values that are correct for the setup procedure described in this guide.


### PR DESCRIPTION
## Added note for MacOS users regarding Docker memory allocation when running multiple kind clusters.

<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Don't forget to first look for overlapping PRs. Remember, open source
is a collaborative rather than competitive activity.

If this PR includes changes to the source files for the website
(docs/content/** or a file included from there) then include a preview
of the modified website; see
docs/content/contribution-guidelines/operations/document-management.md.

Please put one of the following icons at the start of your PR title,
to indicate the type of your PR. You could use copy-and-paste from
here; alternatively, the indicated code is recognized by most browsers
as a way to input that icon.

✨ - code :sparkles:, type feature
🐛 - code :bug:, type bug fix
📖 - code :book:, type docs
📝 - code :memo:, type proposal
⚠️ - code :warning:, type breaking change
🌱 - code :seedling:, type other/misc
❓ - code :question:, type requires manual review/categorization

-->
## Summary
This PR improves the self-service onboarding experience of the “Getting Started with KubeStellar” documentation.

Changes included:
- Added MacOS specific note on Docker memory requirements 
- Minor grammar and clarity improvements

Preview : 
<img width="1047" height="245" alt="Screenshot 2025-12-02 at 12 48 53 PM" src="https://github.com/user-attachments/assets/d8d864d2-64cb-4372-9d8f-e898e364f6f0" />

These changes support the LFX 26 Documentation & Self-Service Enablement objectives of enabling new users to complete an end-to-end deployment smoothly.

Happy to iterate based on feedback!

## Related issue : #3521 
