### PR TITLE
🐛 Switch URLs in error message about missing preview

### DIFF
--- a/.github/workflows/check-docs-pr-preview.yml
+++ b/.github/workflows/check-docs-pr-preview.yml
@@ -46,8 +46,8 @@ jobs:
           if ! PREVIEW_LINE=$(echo "$BODY" | grep -iE '^\s*Preview.*https?://') ; then
             echo "${RED}[ERROR] Docs PR: No preview link found. Please include a line starting with 'Preview' and a valid GitHub Pages URL for your changes.${NC}"
             echo "👉 For instructions on how to create a preview, see:"
-            echo "   https://docs.kubestellar.io/unreleased-development/contribution-guidelines/operations/document-management/#rendering-and-previewing-modifications-to-the-website"
-            echo "   The easier choice is https://docs.kubestellar.io/unreleased-development/contribution-guidelines/operations/document-management/#serving-up-documents-globally-from-a-fork-of-the-repository-via-github"
+            echo "   https://github.com/kubestellar/kubestellar/blob/main/docs/content/contribution-guidelines/operations/document-management.md#rendering-and-previewing-modifications-to-the-website"
+            echo "   The easier choice is https://github.com/kubestellar/kubestellar/blob/main/docs/content/contribution-guidelines/operations/document-management.md#automatically-render-the-website"
             echo "   That requires just two things: prepare the gh-pages branch in your fork, and naming your PR's branch doc-<something>"
             echo
             exit 1


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Don't forget to first look for overlapping PRs. Remember, open source
is a collaborative rather than competitive activity.

If this PR includes changes to the source files for the website
(docs/content/** or a file included from there) then include a preview
of the modified website; see
docs/content/contribution-guidelines/operations/document-management.md.

Please put one of the following icons at the start of your PR title,
to indicate the type of your PR. You could use copy-and-paste from
here; alternatively, the indicated code is recognized by most browsers
as a way to input that icon.

✨ - code :sparkles:, type feature
🐛 - code :bug:, type bug fix
📖 - code :book:, type docs
📝 - code :memo:, type proposal
⚠️ - code :warning:, type breaking change
🌱 - code :seedling:, type other/misc
❓ - code :question:, type requires manual review/categorization

-->
## Summary
Switched to view the instructions directly on GitHub, due to current website chaos. Prior to this change, the error message cited URLs that are now incorrect (404).

## Related issue(s)

Fixes #
