### PR TITLE
🐛fix: update .gitignore to resolve LFX Insight OSPS-QA-05.01

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,10 @@ core-chart/charts/
 *.dylib
 *.jar
 *.class
+# Additional binary artifacts (Fix for LFX OSPS-QA-05.01)
+*.test
+*.out
+*.o
+*.a
+*.pyc
+__pycache__/


### PR DESCRIPTION
Fixes #3308

**Summary**
This PR updates `.gitignore` to explicitly exclude common generated artifacts (Go test binaries, Python cache) that were triggering the LFX Insights "OSPS-QA-05.01" compliance failure.

**Changes**
* Added `*.test`, `*.out`, `*.o`, `*.a` (common build/test artifacts).
* Added `*.pyc` and `__pycache__/` (Python artifacts).

**Context**
This builds upon the work in PR #3251, adding the specific patterns that were previously overlooked.