### PR TITLE
🐛 Fix stuck lifecycle/stale label caused by assignee exemption

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -17,6 +17,7 @@ jobs:
           days-before-issue-stale: 90
           days-before-issue-close: 90
           stale-issue-label: lifecycle/stale
+          remove-stale-when-updated: true
           stale-pr-label: lifecycle/stale
           stale-issue-message: >-
             This issue has been automatically marked as stale because it has not had recent activity.
@@ -36,4 +37,3 @@ jobs:
             lifecycle/frozen
           exempt-pr-labels: >-
             security,lifecycle/frozen
-          exempt-all-assignees: true


### PR DESCRIPTION
Fixes an issue where the `lifecycle/stale` label could become permanently
stuck on issues, even after a human comment was added.
This restores the behavior promised by the stale bot message:
> “If this is still relevant, please add a comment to keep it open.”
The stale workflow used `exempt-all-assignees: true`.
In `actions/stale`, this exemption prevents **all** stale processing on
assigned issues — including **removing** the stale label when an issue
is updated or commented on. 
fixes #3587 