### PR TITLE
🐛 Fix font name typo in mkdocs.yml

### DIFF
--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -126,7 +126,7 @@ nav:
 
 theme:
   font:
-    text: 'SapceMono'
+    text: 'Space Mono'
     code: 'Roboto Mono'
   name: material
   icon:


### PR DESCRIPTION
Fixes #3355

## Description
This PR corrects the font name typo in `docs/mkdocs.yml` from `SapceMono` to `Space Mono`, ensuring proper Google Fonts rendering.

## Changes Made
- Updated `docs/mkdocs.yml`: `text: 'SapceMono'` → `text: 'Space Mono'`

## Testing
- ✅ Built documentation locally with `mkdocs build` - no errors
- ✅ Verified font loads correctly in browser DevTools
- ✅ Confirmed "Space Mono" is properly applied to text elements

## Preview


You can verify the font change by inspecting any text element on the documentation site and checking the computed `font-family` property.
 https://aresphoenix345.github.io/kubestellar/
 
Before
<img width="1354" height="641" alt="Screenshot 2026-01-08 235852" src="https://github.com/user-attachments/assets/924a0301-a9ef-46c8-a2ca-6a78d626a199" />


After
<img width="1546" height="626" alt="Screenshot 2026-01-08 235637" src="https://github.com/user-attachments/assets/b59a984b-d402-46d8-bfd7-0ec98e636b36" />



## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Documentation update