### PR TITLE
🐛 Fix broken link redirects for deleted knownissue file

### DIFF
--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -242,11 +242,10 @@ plugins:
       module_name: 'main'
   # Configure multiple language support
 
-  # - redirects:
-  #       redirect_maps:
-  #           'docs': 'docs/Coding%20Milestones/PoC2023q1/outline/'
-  #           'old/file.md': 'new/file.md'
-  #           'some_file.md': 'http://external.url.com/foobar'
+  - redirects:
+      redirect_maps:
+          'direct/get-started/knownissue-wsl-ghcr-helm.md': 'direct/knownissue-helm-ghcr.md'
+          'direct/knownissue-wsl-ghcr-helm.md': 'direct/knownissue-helm-ghcr.md' 
 
 markdown_extensions:
   - markdown_captions

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -21,3 +21,4 @@ Pygments>=2.16,<3.0
 
 # Include Markdown Plugin
 mkdocs-include-markdown-plugin>=7.1.2,<8.0
+mkdocs-redirects>=1.2.0,<2.0


### PR DESCRIPTION
Fixes #3217

### Problem
The broken links crawler reports 404 errors for `knownissue-wsl-ghcr-helm.md`, which was deleted in commit 7154722a and merged into `knownissue-helm-ghcr.md`. The old URL is still discovered through site navigation, causing CI failures.

### Solution
Enable the `mkdocs-redirects` plugin and configure redirects from old URLs to the new location:
- `direct/get-started/knownissue-wsl-ghcr-helm.md` → `direct/knownissue-helm-ghcr.md`
- `direct/knownissue-wsl-ghcr-helm.md` → `direct/knownissue-helm-ghcr.md`

### Changes
- Added `mkdocs-redirects>=1.2.0,<2.0` to `docs/requirements.txt`
- Enabled redirects plugin in `docs/mkdocs.yml` with proper mappings

### Testing
- Built docs successfully with `mkdocs build`  
- Verified redirect configuration syntax  
- Confirmed no source files reference the old filename  

### Type of Change
- [x] Bug fix (CI broken links check)
- [x] Documentation infrastructure update