### PR TITLE
📖 docs: add CVE documentation process for releases

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -180,7 +180,30 @@ _Congratulations! Your pull request has been successfully merged!_ 👏
 
 If you have any questions about contributing, don't hesitate to reach out to us on the KubeStellar-dev [Slack channel](https://cloud-native.slack.com/archives/C097094RZ3M/).
 
+## Release Security Checklist
 
+Before creating a release, maintainers must:
+
+1. **Check for vulnerabilities:**
+   ```bash
+   # Install govulncheck if not present
+   go install golang.org/x/vuln/cmd/govulncheck@latest
+   
+   # Run vulnerability check
+   govulncheck ./...
+   ```
+
+2. **Review security alerts:**
+   - Check [Dependabot alerts](https://github.com/kubestellar/kubestellar/security/dependabot)
+   - Check [Security advisories](https://github.com/kubestellar/kubestellar/security/advisories)
+
+3. **Update release notes:**
+   - In `docs/content/direct/release-notes.md`, add a "Security Fixes" section
+   - If CVEs were fixed: List them with CVE-ID and description
+   - If no CVEs: Add "**No CVEs were addressed in this release.**"
+
+4. **Include in GitHub release:**
+   - Copy the security section to the GitHub release notes
 
 ## Testing Locally
 

--- a/docs/content/direct/release-notes.md
+++ b/docs/content/direct/release-notes.md
@@ -1,8 +1,22 @@
 # Release notes
 
+---
+
+**Security Note:** KubeStellar has not had any CVEs assigned to its codebase. All releases are monitored for dependency vulnerabilities via Dependabot. For security reporting, see [SECURITY.md](https://github.com/kubestellar/kubestellar/blob/main/SECURITY.md).
+
+---
+
 The following sections list the known issues for each release. The issue list is not differential (i.e., compared to previous releases) but a full list representing the overall state of the specific release. 
 
 ## 0.29.0
+
+### Security Fixes
+
+**No CVEs were addressed in this release.**
+
+KubeStellar actively monitors for vulnerabilities using Dependabot and GitHub Security Advisories.
+
+---
 
 This release makes some backward-incompatible changes, as follows.
 
@@ -19,6 +33,12 @@ This release makes some backward-incompatible changes, as follows.
 * If (a) the workload object count or volume vs the configured limits on content of a `ManifestWork` causes multiple `ManifestWork` to be created for one `Binding` (`BindingPolicy`) AND (b) the limit on number of workload objects in one `ManifestWork` is greater then 1, then there may be transients where workload objects are deleted and re-created in a WEC --- which, in addition to possibly being troubling on its own, will certainly thwart the "create-only" functionality. The default limit on the number of workload objects in one `ManifestWork` is 1, so this issue will only arise when you use a non-default value. In this case you will avoid this issue if you set that limit to be at least the highest number of workload objects that will appear in a `Binding` (do check your `Binding` objects, lest you be surprised) AND your workload is not so large that multiple `ManifestWork` are created due to the limit on their size.
 
 ## 0.28.0
+
+### Security Fixes
+
+**No CVEs were addressed in this release.**
+
+---
 
 Helm chart, the name of the subobject for ArgoCD has changed from
 `argo-cd` to `argocd`.


### PR DESCRIPTION
### Summary

Implements CVE documentation process to meet OpenSSF Best Practices requirements. Adds "Security Fixes" sections to recent release notes (v0.29.0, v0.28.0) confirming no CVEs exist in KubeStellar codebase. Documents 4-step pre-release security checklist in CONTRIBUTING.md including govulncheck, Dependabot alerts review, and release notes update procedures.

### Related issue(s)
Fixes #3253