### PR TITLE
📖 Fix: Add Meeting Agenda link to Community menu for better visibility

### DIFF
--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -104,9 +104,9 @@ nav:
       - Sign-off and Signing Contributions: direct/pr-signoff.md
   - Community:
     - Get Involved: Community/_index.md
+    - Meeting Agenda: https://kubestellar.io/agenda
     - Contact Us:
         - Mailing List: https://kubestellar.io/join_us
-        - Community Meeting Agenda (join mailing list first): https://kubestellar.io/agenda
         - Slack: https://kubestellar.io/slack
         - Medium Blog: https://kubestellar.io/blog
         - YouTube Channel: https://kubestellar.io/tv


### PR DESCRIPTION
## Summary
This PR addresses the issue of the Community meeting agenda link being difficult to discover on the kubestellar.io website. The link to https://kubestellar.io/agenda existed but was buried deep within the navigation menu under "Contact Us", making it effectively a "secret URL" that users needed to know about.

### Website Preview:
The Meeting Agenda link now appears prominently in the Community dropdown menu, making it easily discoverable for users wanting to participate in community meetings.
https://aresphoenix345.github.io/kubestellar/


## Related issue(s)
Fixes #3596

