### PR TITLE
📖 Add community meeting agenda section to home page

### DIFF
--- a/docs/content/icons/calendar.svg
+++ b/docs/content/icons/calendar.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="#000000" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="4" width="18" height="18" rx="2" ry="2"></rect><line x1="16" y1="2" x2="16" y2="6"></line><line x1="8" y1="2" x2="8" y2="6"></line><line x1="3" y1="10" x2="21" y2="10"></line></svg>

--- a/docs/overrides/home.html
+++ b/docs/overrides/home.html
@@ -522,6 +522,26 @@
       </a>
     </div>
   </section>
+
+  <!-- COMMUNITY MEETING AGENDA -->
+  <section class="section-card">
+    <div style="width:100%; display:flex; flex-direction:column; align-items:center; gap:1rem;">
+      <h2 class="section-title" style="text-align:center; margin-bottom:0.5rem;">
+        Join Our Community Meetings
+      </h2>
+      <p class="section-text" style="text-align:center; max-width:800px;">
+        Connect with the KubeStellar community in our regular meetings. Share your use cases, 
+        discuss development, get support, and collaborate with other users and contributors.
+      </p>
+      <a href="https://kubestellar.io/agenda"
+         class="github-button"
+         style="display:inline-flex; align-items:center; background:#3B82F6; color:#fff; padding:0.75rem 1.5rem; border-radius:4px; text-decoration:none; gap:8px; font-size:1rem; margin-top:0.5rem;"
+         target="_blank">
+        <img src="{{ base_url }}/icons/calendar.svg" alt="Calendar" style="filter: brightness(0) invert(1); width:20px; height:auto;">
+        View Meeting Schedule
+      </a>
+    </div>
+  </section>
 </div>
 <!-- =========================
      FOOTER


### PR DESCRIPTION
### Summary
Added a new "Community Meeting Agenda" section to the home page that includes:
- A dedicated section with calendar icon for easy visual identification
- Direct link to the KubeStellar community meeting agenda
- Invitation text encouraging users to join meetings, share use cases, and collaborate
- "View Meeting Schedule" button with calendar icon for improved user experience

This enhancement makes it easier for community members to discover and participate in regular KubeStellar meetings.

### Related issue(s)
Fixes #3596

after fix:
<img width="1744" height="961" alt="Screenshot 2026-01-10 031908" src="https://github.com/user-attachments/assets/008e5fcb-3c0f-4947-aafa-049694180e0e" />
