### PR TITLE
✨:  add issue triage workflow and /triage-accepted command

### DIFF
--- a/.github/workflows/add-help-wanted.yml
+++ b/.github/workflows/add-help-wanted.yml
@@ -9,7 +9,12 @@ permissions:
 
 jobs:
   label-on-comment:
-    if: github.event.comment.body == '/help-wanted' || github.event.comment.body == '/good-first-issue' || github.event.comment.body == '/hacktober-fest'
+    if: |
+     github.event.comment.body == '/help-wanted' ||
+     github.event.comment.body == '/good-first-issue' ||
+     github.event.comment.body == '/hacktober-fest' ||
+     github.event.comment.body == '/triage-accepted'
+
     runs-on: ubuntu-latest
     steps:
       - name: Add label based on comment
@@ -20,7 +25,28 @@ jobs:
             const issue_number = context.payload.issue.number;
             const owner = context.repo.owner;
             const repo = context.repo.repo;
-
+            // Handle triage acceptance
+            if (comment === '/triage-accepted') {
+             // Remove need-triage if it exists
+             try {
+              await github.rest.issues.removeLabel({
+                owner,
+                repo,
+                issue_number,
+                name: 'need-triage',
+              });
+             } catch (_) {
+             // ignore if label does not exist
+            }
+             // Add triage-accepted
+              await github.rest.issues.addLabels({
+                owner,
+                repo,
+                issue_number,
+                labels: ['triage-accepted'],
+              });
+             return;
+            }
             let label = null;
             if (comment === '/help-wanted') {
               label = 'help wanted';

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,6 +34,20 @@ As a new contributor, we encourage you to start with issues labeled as **[good f
 
 We also have a subset of issues we've labeled **[help wanted!](https://github.com/kubestellar/kubestellar/labels/help%20wanted)**
 
+This repository uses labels to track the triage status of issues.
+
+#### Default State
+- All newly opened issues start with the `need-triage` label.
+- This indicates the issue has not yet been reviewed by maintainers.
+
+#### Accepting Triage
+- Once an issue has been reviewed and accepted
+- maintainer can comment:
+/triage-accepted
+- This will:
+- Remove the `need-triage` label
+- Add the `triage-accepted` label
+
 Your assistance in improving documentation is highly valued, regardless of your level of experience with the project.
 
 To claim an issue that you are interested in, assign it to yourself by leaving a comment "/assign". You may also remove yourself from an issue with "/unassign" in a comment.
@@ -49,6 +63,7 @@ KubeStellar uses Prow and GitHub bots to help manage issues and pull requests th
 - `/unassign` - Remove your assignment  
 - `/good-first-issue` - Add the "good first issue" label  
 - `/help-wanted` - Add the "help wanted" label  
+- `/triage-accepted` - Accept the issue as reviewed and accepted 
 
 **Pull Request Review Commands:**  
 - `/lgtm` - Indicate "looks good to me" (cannot be used on your own PR)  


### PR DESCRIPTION
### What this PR does
- Introduces a simple issue triage workflow using labels
- Adds a `/triage-accepted` slash command to mark issues as reviewed
- Automatically transitions issues from `need-triage` → `triage-accepted`
- Documents the triage process for contributors and maintainers

### Why this is needed
- Improves visibility into issue review status
- Reduces ambiguity for contributors
- Keeps issue management consistent and lightweight

### Testing
- Verified label changes using `/triage-accepted`
- Confirmed no effect for users without write access


Fixes 
#3601 
