### PR TITLE
chore: add OpenSSF Scorecard and Trivy image scanning workflows

### DIFF
--- a/.github/workflows/image-scanning.yml
+++ b/.github/workflows/image-scanning.yml
@@ -1,0 +1,59 @@
+# Container Image Vulnerability Scanning with Trivy
+# Scans container images for known vulnerabilities
+name: Container Image Scanning
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'Dockerfile*'
+      - 'go.mod'
+      - 'go.sum'
+      - '.github/workflows/image-scanning.yml'
+  pull_request:
+    branches:
+      - main
+    paths:
+      - 'Dockerfile*'
+      - 'go.mod'
+      - 'go.sum'
+  schedule:
+    # Weekly scan
+    - cron: '0 8 * * 0'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  security-events: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
+jobs:
+  build-and-scan:
+    name: Build and scan image
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Build image
+        run: |
+          docker build -t local/image:${{ github.sha }} .
+
+      - name: Run Trivy vulnerability scanner
+        uses: aquasecurity/trivy-action@0.28.0
+        with:
+          image-ref: 'local/image:${{ github.sha }}'
+          format: 'sarif'
+          output: 'trivy-results.sarif'
+          severity: 'CRITICAL,HIGH'
+          ignore-unfixed: true
+
+      - name: Upload Trivy scan results
+        uses: github/codeql-action/upload-sarif@v3
+        if: always()
+        with:
+          sarif_file: 'trivy-results.sarif'

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,0 +1,50 @@
+# OpenSSF Scorecard - Security scoring and visibility
+# Based on https://github.com/ossf/scorecard-action
+name: OpenSSF Scorecard
+
+on:
+  # Run on changes to main branch
+  push:
+    branches:
+      - main
+  # Weekly scan
+  schedule:
+    - cron: '0 6 * * 0'
+  # Allow manual trigger
+  workflow_dispatch:
+
+# Required permissions for scorecard
+permissions:
+  security-events: write  # Upload SARIF results
+  id-token: write         # For badge generation
+  contents: read
+  actions: read
+
+jobs:
+  analysis:
+    name: Scorecard analysis
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Run analysis
+        uses: ossf/scorecard-action@v2.4.0
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          publish_results: true
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: SARIF file
+          path: results.sarif
+          retention-days: 5
+
+      - name: Upload to code-scanning
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: results.sarif


### PR DESCRIPTION
## Summary
- Add OpenSSF Scorecard workflow for security scoring and visibility
- Add Trivy container image scanning for CVE detection
- Both workflows integrate with GitHub Security tab via SARIF

## Details
These workflows are based on best practices from argoproj/argo-cd and karmada-io/karmada:

1. **OpenSSF Scorecard** - Provides security scoring to track security posture over time. Runs weekly and on pushes to main.

2. **Trivy Image Scanning** - Scans container images for known CVEs. Reports CRITICAL and HIGH vulnerabilities to the Security tab.

## Test plan
- [ ] Verify scorecard workflow runs successfully
- [ ] Verify image scanning workflow runs on Dockerfile changes
- [ ] Verify results appear in Security tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)