### PR TITLE
fix: resolve CI failures in scorecard and image-scanning workflows

### DIFF
--- a/.gha-reversemap.yml
+++ b/.gha-reversemap.yml
@@ -98,3 +98,18 @@ actions/github-script:
   sha-url: https://github.com/actions/github-script/commit/ed597411d8f924073f98dfc5c65a23a2325f34cd
   tag: v8
   tag-url: https://github.com/actions/github-script/tree/v8
+ossf/scorecard-action:
+  sha: 4eaacf0543bb3f2c246792bd56e8cdeffafb205a
+  sha-url: https://github.com/ossf/scorecard-action/commit/4eaacf0543bb3f2c246792bd56e8cdeffafb205a
+  tag: v2.4.3
+  tag-url: https://github.com/ossf/scorecard-action/tree/v2.4.3
+aquasecurity/trivy-action:
+  sha: b6643a29fecd7f34b3597bc6acb0a98b03d33ff8
+  sha-url: https://github.com/aquasecurity/trivy-action/commit/b6643a29fecd7f34b3597bc6acb0a98b03d33ff8
+  tag: 0.33.1
+  tag-url: https://github.com/aquasecurity/trivy-action/tree/0.33.1
+github/codeql-action/upload-sarif:
+  sha: 45c373516f557556c15d420e3f5e0aa3d64366bc
+  sha-url: https://github.com/github/codeql-action/commit/45c373516f557556c15d420e3f5e0aa3d64366bc
+  tag: v3.31.9
+  tag-url: https://github.com/github/codeql-action/tree/v3.31.9

--- a/.github/workflows/image-scanning.yml
+++ b/.github/workflows/image-scanning.yml
@@ -7,7 +7,8 @@ on:
     branches:
       - main
     paths:
-      - 'Dockerfile*'
+      - '*.Dockerfile'
+      - 'core.Dockerfile'
       - 'go.mod'
       - 'go.sum'
       - '.github/workflows/image-scanning.yml'
@@ -15,7 +16,8 @@ on:
     branches:
       - main
     paths:
-      - 'Dockerfile*'
+      - '*.Dockerfile'
+      - 'core.Dockerfile'
       - 'go.mod'
       - 'go.sum'
   schedule:
@@ -37,14 +39,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
 
       - name: Build image
         run: |
-          docker build -t local/image:${{ github.sha }} .
+          docker build -f core.Dockerfile -t local/image:${{ github.sha }} .
 
       - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@0.28.0
+        uses: aquasecurity/trivy-action@b6643a29fecd7f34b3597bc6acb0a98b03d33ff8 # 0.33.1
         with:
           image-ref: 'local/image:${{ github.sha }}'
           format: 'sarif'
@@ -53,7 +55,7 @@ jobs:
           ignore-unfixed: true
 
       - name: Upload Trivy scan results
-        uses: github/codeql-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarif@45c373516f557556c15d420e3f5e0aa3d64366bc # v3.31.9
         if: always()
         with:
           sarif_file: 'trivy-results.sarif'

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -13,38 +13,42 @@ on:
   # Allow manual trigger
   workflow_dispatch:
 
-# Required permissions for scorecard
-permissions:
-  security-events: write  # Upload SARIF results
-  id-token: write         # For badge generation
-  contents: read
-  actions: read
+# Minimal default permissions - job-level permissions are set below
+permissions: read-all
 
 jobs:
   analysis:
     name: Scorecard analysis
     runs-on: ubuntu-latest
+    permissions:
+      # Needed for Code Scanning upload
+      security-events: write
+      # Needed for GitHub OIDC token if publish_results is true
+      id-token: write
+      # Required for repo access
+      contents: read
+      actions: read
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
         with:
           persist-credentials: false
 
       - name: Run analysis
-        uses: ossf/scorecard-action@v2.4.0
+        uses: ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a # v2.4.3
         with:
           results_file: results.sarif
           results_format: sarif
           publish_results: true
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         with:
           name: SARIF file
           path: results.sarif
           retention-days: 5
 
       - name: Upload to code-scanning
-        uses: github/codeql-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarif@45c373516f557556c15d420e3f5e0aa3d64366bc # v3.31.9
         with:
           sarif_file: results.sarif


### PR DESCRIPTION
## Summary
- Add ossf/scorecard-action, aquasecurity/trivy-action, and github/codeql-action/upload-sarif to .gha-reversemap.yml with proper commit hashes
- Fix scorecard.yml: use job-level permissions instead of workflow-level to satisfy OSSF scorecard webapp restrictions
- Fix image-scanning.yml: use core.Dockerfile instead of missing root Dockerfile, update path triggers
- Update all action references to use commit hashes per KubeStellar contribution guidelines

## Details
Fixes CI failures introduced by #3605:

1. **Verify Action Hashes** - New workflows used version tags instead of commit hashes
2. **OpenSSF Scorecard** - Workflow had global write permissions which OSSF webapp rejects
3. **Container Image Scanning** - Tried to build from non-existent root Dockerfile

## Test plan
- [ ] Verify Action Hashes workflow passes
- [ ] Verify OpenSSF Scorecard workflow passes
- [ ] Verify Container Image Scanning workflow passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)