### PR TITLE
📖 Add vulnerability report response SLA and monitoring

### DIFF
--- a/.gha-reversemap.yml
+++ b/.gha-reversemap.yml
@@ -94,7 +94,7 @@ actions/upload-artifact:
   tag: v6.0.0
   tag-url: https://github.com/actions/upload-artifact/tree/v6.0.0
 actions/github-script:
-  sha: 60a0d83039c74a4aee543508d2ffcb1c3799cdea
-  sha-url: https://github.com/actions/github-script/commit/60a0d83039c74a4aee543508d2ffcb1c3799cdea
-  tag: v7.0.1
-  tag-url: https://github.com/actions/github-script/tree/v7.0.1
+  sha: ed597411d8f924073f98dfc5c65a23a2325f34cd
+  sha-url: https://github.com/actions/github-script/commit/ed597411d8f924073f98dfc5c65a23a2325f34cd
+  tag: v8
+  tag-url: https://github.com/actions/github-script/tree/v8

--- a/.github/workflows/vulnerability-triage-reminder.yml
+++ b/.github/workflows/vulnerability-triage-reminder.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check for untriaged vulnerability reports
-        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea  # v7.0.1
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd  # v8
         with:
           script: |
             const fourteenDaysAgo = new Date(Date.now() - 14 * 24 * 60 * 60 * 1000);


### PR DESCRIPTION
Closes #3257

This PR updates KubeStellar's security vulnerability response policy to meet OpenSSF Best Practices requirements for the [vulnerability_report_response] criterion.

### Changes

#### 1. Updated SECURITY.md : 
14-day response SLA for vulnerability reports, 3-day acknowledgment target, N/A justification for periods without reports, maintainer monitoring process documented

#### 2. Added Automation: Created \`.github/workflows/vulnerability-triage-reminder.yml\`
Daily checks at 9 AM UTC, flags untriaged reports >14 days old, auto-alerts maintainers on SLA risk, manual trigger support, uses actions/github-script@v8

### Testing

- [x] YAML syntax validated
- [x] GitHub Action hash verified (v8, matches repo standard)
- [x] SECURITY.md links verified
- [x] Workflow logic tested and validated
- [x] All pre-commit checks passed
- [x] No trailing whitespace
- [x] DCO sign-off included

#### For OpenSSF Badge Updated SECURITY.md.