### PR TITLE
📖 docs: Add implementation note for condition aggregation

### DIFF
--- a/docs/content/direct/multi-wec-aggregated-status.md
+++ b/docs/content/direct/multi-wec-aggregated-status.md
@@ -100,6 +100,8 @@ These rules avoid making assumptions about workload semantics while still provid
 
 Conditions use uniform rules across all workload kinds.
 
+> **Implementation Note:** For Kubernetes resource kinds that are specially handled by KubeStellar and have built-in health checks in Argo CD (such as Deployment, StatefulSet, ReplicaSet, and DaemonSet), only condition types necessary for Argo CD's health evaluation are aggregated. This ensures compatibility with Argo CD's health assessment logic.
+
 ### Truth Value
 
 | WEC condition values | Aggregated value |


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Don't forget to first look for overlapping PRs. Remember, open source
is a collaborative rather than competitive activity.

If this PR includes changes to the source files for the website
(docs/content/** or a file included from there) then include a preview
of the modified website; see
docs/content/contribution-guidelines/operations/document-management.md.

Please put one of the following icons at the start of your PR title,
to indicate the type of your PR. You could use copy-and-paste from
here; alternatively, the indicated code is recognized by most browsers
as a way to input that icon.

✨ - code :sparkles:, type feature
🐛 - code :bug:, type bug fix
📖 - code :book:, type docs
📝 - code :memo:, type proposal
⚠️ - code :warning:, type breaking change
🌱 - code :seedling:, type other/misc
❓ - code :question:, type requires manual review/categorization

-->
## Summary

Adds a clarifying note in the Condition Aggregation section explaining that for workload kinds with Argo CD built-in health checks (Deployment, StatefulSet, ReplicaSet, DaemonSet), only condition types necessary for Argo CD health evaluation are aggregated.

This makes the selective aggregation approach explicit in the documentation.

## Related issue(s)

Fixes #3535
