### PR TITLE
🐛fix: prevent snapshot crash when open-cluster-management namespace is missing

### DIFF
--- a/scripts/kubestellar-snapshot.sh
+++ b/scripts/kubestellar-snapshot.sh
@@ -464,7 +464,7 @@ for i in "${!cps[@]}" ; do # for all control planes in context ${context}
             ocm_version=""
             # Fix for Issue #2724: Check if namespace exists to prevent crash
             if KUBECONFIG=${cp_kubeconfig[cp_n]} kubectl get ns open-cluster-management > /dev/null 2>&1; then
-                ocm_version=$(KUBECONFIG=${cp_kubeconfig[cp_n]} kubectl get deploy -n open-cluster-management cluster-manager -o jsonpath={.spec.template.spec.containers[0].image} 2>/dev/null | cut -d: -f2 || true)
+               ocm_version=$(KUBECONFIG=${cp_kubeconfig[cp_n]} kubectl get deploy -n open-cluster-management cluster-manager -o jsonpath={.spec.template.spec.containers[0].image} | cut -d: -f2 || true)
             fi
 
             if [ -n "$ocm_version" ]; then


### PR DESCRIPTION
### Description
This PR fixes a bug where `scripts/kubestellar-snapshot.sh` would crash if the `open-cluster-management` namespace was not present.

The script runs with `set -e`, so the previous command (`kubectl get deploy -n open-cluster-management ...`) caused an immediate exit when it returned a non-zero status code on clusters without OCM.

### Changes
- Added a conditional check (`kubectl get ns open-cluster-management`) before attempting to query resources inside that namespace.
- If the namespace is missing, the script now safely reports "Open-cluster-manager: not found" and continues execution.

### Related Issue
Fixes #2724