### PR TITLE
🐛 fix: update reversemap for anchore/sbom-action v0.21.1

### DIFF
--- a/.gha-reversemap.yml
+++ b/.gha-reversemap.yml
@@ -39,10 +39,10 @@ actions/setup-go:
   tag: v6.1.0
   tag-url: https://github.com/actions/setup-go/tree/v6.1.0
 anchore/sbom-action/download-syft:
-  sha: a930d0ac434e3182448fe678398ba5713717112a
-  sha-url: https://github.com/anchore/sbom-action/commit/a930d0ac434e3182448fe678398ba5713717112a
-  tag: v0.21.0
-  tag-url: https://github.com/anchore/sbom-action/tree/v0.21.0
+  sha: 0b82b0b1a22399a1c542d4d656f70cd903571b5c
+  sha-url: https://github.com/anchore/sbom-action/commit/0b82b0b1a22399a1c542d4d656f70cd903571b5c
+  tag: v0.21.1
+  tag-url: https://github.com/anchore/sbom-action/tree/v0.21.1
 goreleaser/goreleaser-action:
   sha: e435ccd777264be153ace6237001ef4d979d3a7a
   sha-url: https://github.com/goreleaser/goreleaser-action/commit/e435ccd777264be153ace6237001ef4d979d3a7a


### PR DESCRIPTION
## Summary
Update the reversemap entry for anchore/sbom-action/download-syft to match the SHA used in goreleaser.yml after PR #3597 bumped the action from v0.21.0 to v0.21.1.

## Changes
- Updated SHA from `a930d0ac434e3182448fe678398ba5713717112a` to `0b82b0b1a22399a1c542d4d656f70cd903571b5c`
- Updated tag from `v0.21.0` to `v0.21.1`

## Fixes
Fixes #3651

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)