### PR TITLE
🐛 Fix GitHub Actions docs URL to point to new docs site

### DIFF
--- a/hack/gha-reversemap.sh
+++ b/hack/gha-reversemap.sh
@@ -250,7 +250,7 @@ run_verify_mapusage() {
         done
     done
     if [ "$failed" == true ]; then
-        _exit_with_error $ERR_VERIFY_FAIL "Action reference problems found; see https://docs.kubestellar.io/unreleased-development/contribution-guidelines/contributing-inc/#github-action-reference-discipline"
+        _exit_with_error $ERR_VERIFY_FAIL "Action reference problems found; see https://kubestellar.io/docs/contributing/ci-cd/github-actions"
     fi
 }
 


### PR DESCRIPTION
## Summary
Update the error message URL in `hack/gha-reversemap.sh` to point to the new kubestellar.io/docs site where the GitHub Actions reference discipline documentation has been added.

The documentation was added in kubestellar/docs#640.

## Related issue(s)
Fixes #3637

Supersedes #3638 (which was a workaround pointing to the old mkdocs site)

## Test plan
- [ ] Verify the new URL https://kubestellar.io/docs/contributing/ci-cd/github-actions works once kubestellar/docs#640 is merged

---
Generated with [Claude Code](https://claude.com/claude-code)