### PR TITLE
🌱 Add docs release automation trigger

### DIFF
--- a/.github/workflows/docs-release.yml
+++ b/.github/workflows/docs-release.yml
@@ -1,0 +1,20 @@
+name: Trigger Docs Update
+
+on:
+  release:
+    types: [published]
+
+# No GITHUB_TOKEN permissions needed - uses WORKFLOW_SYNC_TOKEN secret
+permissions: {}
+
+jobs:
+  trigger-docs:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger docs repo
+        env:
+          GH_TOKEN: ${{ secrets.WORKFLOW_SYNC_TOKEN }}
+        run: |
+          gh api repos/kubestellar/docs/dispatches \
+            -f event_type=create-version-branch \
+            -f client_payload="{\"project\":\"kubestellar\",\"version\":\"${{ github.event.release.tag_name }}\",\"source_repo\":\"${{ github.repository }}\",\"source_branch\":\"${{ github.event.release.target_commitish }}\"}"


### PR DESCRIPTION
## Summary

Add workflow to automatically trigger docs updates when releases are published.

When a release is published, this workflow triggers the docs repo's `create-version-branch` workflow to:
1. Create a version branch with the release docs
2. Update `versions.ts` to include the new version
3. Create a PR to merge the version update

## Related

- kubestellar/docs PR #694 - Added the receiver workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)