### PR TITLE
🐛 Fix docs-release workflow JSON payload

### DIFF
--- a/.github/workflows/docs-release.yml
+++ b/.github/workflows/docs-release.yml
@@ -31,6 +31,14 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.WORKFLOW_SYNC_TOKEN }}
         run: |
-          gh api repos/kubestellar/docs/dispatches \
-            -f event_type=create-version-branch \
-            -f client_payload="{\"project\":\"kubestellar\",\"version\":\"${{ steps.version.outputs.tag }}\",\"source_repo\":\"${{ github.repository }}\",\"source_branch\":\"${{ steps.version.outputs.branch }}\"}"
+          cat <<EOF | gh api repos/kubestellar/docs/dispatches --input -
+          {
+            "event_type": "create-version-branch",
+            "client_payload": {
+              "project": "kubestellar",
+              "version": "${{ steps.version.outputs.tag }}",
+              "source_repo": "${{ github.repository }}",
+              "source_branch": "${{ steps.version.outputs.branch }}"
+            }
+          }
+          EOF


### PR DESCRIPTION
## Summary
Fix the docs-release workflow to properly pass JSON payload to gh api.

The `-f client_payload="{...}"` syntax was passing the payload as a string instead of a JSON object, causing HTTP 422 errors:
```
For 'properties/client_payload', "{...}" is not an object.
```

## Changes
- Use heredoc with `--input -` to pass proper JSON body

## Testing
Verified fix works in kubectl-claude v0.4.3 release automation.

🤖 Generated with Claude Code