### PR TITLE
🌱 Update actions/setup-go to v6.2.0 in reversemap

### DIFF
--- a/.gha-reversemap.yml
+++ b/.gha-reversemap.yml
@@ -34,10 +34,10 @@ actions/setup-python:
   tag: v6.1.0
   tag-url: https://github.com/actions/setup-python/tree/v6.1.0
 actions/setup-go:
-  sha: 4dc6199c7b1a012772edbd06daecab0f50c9053c
-  sha-url: https://github.com/actions/setup-go/commit/4dc6199c7b1a012772edbd06daecab0f50c9053c
-  tag: v6.1.0
-  tag-url: https://github.com/actions/setup-go/tree/v6.1.0
+  sha: 7a3fe6cf4cb3a834922a1244abfce67bcef6a0c5
+  sha-url: https://github.com/actions/setup-go/commit/7a3fe6cf4cb3a834922a1244abfce67bcef6a0c5
+  tag: v6.2.0
+  tag-url: https://github.com/actions/setup-go/tree/v6.2.0
 anchore/sbom-action/download-syft:
   sha: 0b82b0b1a22399a1c542d4d656f70cd903571b5c
   sha-url: https://github.com/anchore/sbom-action/commit/0b82b0b1a22399a1c542d4d656f70cd903571b5c


### PR DESCRIPTION
## Summary

Update the approved hash for `actions/setup-go` from v6.1.0 to v6.2.0 in the GitHub Actions reversemap to unblock PR #3654.

## Changes

| Action | Old Version | New Version |
|--------|-------------|-------------|
| actions/setup-go | v6.1.0 (`4dc6199c...`) | v6.2.0 (`7a3fe6cf...`) |

## Related

- Unblocks: #3654 (dependabot bump for actions/setup-go)
- Fixes verify failures in workflows using setup-go

## Test Plan

- [ ] CI passes on this PR
- [ ] After merge, #3654 verify check should pass

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>