### PR TITLE
🐛 Fix flaky k3d test by improving transport controller initialization

### DIFF
--- a/core-chart/templates/postcreatehooks/transport-controller.yaml
+++ b/core-chart/templates/postcreatehooks/transport-controller.yaml
@@ -54,12 +54,26 @@ spec:
               - '{{"{{.ITSName}}"}}'
               - --output-file
               - /etc/kube/its/kubeconfig
+            resources:
+              requests:
+                memory: "64Mi"
+                cpu: "100m"
+              limits:
+                memory: "256Mi"
+                cpu: "500m"
             volumeMounts:
             - name: its-kubeconfig-volume
               mountPath: /etc/kube/its
           containers:
           - name: transport-controller
             image: ghcr.io/kubestellar/kubestellar/ocm-transport-controller:{{.Values.TRANSPORT_VERSION | default .Values.KUBESTELLAR_VERSION}}
+            resources:
+              requests:
+                memory: "128Mi"
+                cpu: "100m"
+              limits:
+                memory: "512Mi"
+                cpu: "1000m"
             args:
             - --metrics-bind-address={{.Values.transport_controller.metrics_bind_addr}}
             - --pprof-bind-address={{.Values.transport_controller.pprof_bind_addr}}

--- a/scripts/create-kubestellar-demo-env.sh
+++ b/scripts/create-kubestellar-demo-env.sh
@@ -254,13 +254,31 @@ kubectl --context its1 label managedcluster cluster1 location-group=edge name=cl
 kubectl --context its1 label managedcluster cluster2 location-group=edge name=cluster2
 
 echo
-echo Waiting for transport controller to create namespace customization-properties
+echo "Waiting for transport controller pod to be ready..."
+kubectl --context $k8s_platform-kubeflex wait -n wds1-system pod \
+    -l name=transport-controller \
+    --for=condition=Ready \
+    --timeout=300s || {
+    echo "Transport controller pod failed to become ready. Current status:" >&2
+    kubectl --context $k8s_platform-kubeflex get pod -n wds1-system -l name=transport-controller -o wide >&2
+    kubectl --context $k8s_platform-kubeflex logs -n wds1-system -l name=transport-controller --all-containers --tail=50 >&2
+    exit 1
+}
+echo -e "\033[33m✔\033[0m Transport controller pod is ready"
+
+echo
+echo "Waiting for transport controller to create namespace customization-properties"
 # We allow versions of kubectl that do not support `kubectl wait --for=create`
 wait_counter=0
-while ! (kubectl --context its1 get ns customization-properties) ; do
-    if (($wait_counter > 20)); then
-        echo "Namespace customization-properties failed to appear!" >&2
+while ! (kubectl --context its1 get ns customization-properties 2>/dev/null) ; do
+    if (($wait_counter > 30)); then
+        echo "Namespace customization-properties failed to appear after 5 minutes!" >&2
+        echo "Transport controller logs:" >&2
+        kubectl --context $k8s_platform-kubeflex logs -n wds1-system -l name=transport-controller --tail=100 >&2
         exit 1
+    fi
+    if (($wait_counter % 6 == 0)) && (($wait_counter > 0)); then
+        echo "  Still waiting for customization-properties namespace (${wait_counter}0s elapsed)..."
     fi
     ((wait_counter += 1))
     sleep 10


### PR DESCRIPTION
## Summary
Fixes intermittent failures in the "Test demo env creation script on k3d" test where:
- Transport controller pod gets stuck in `PodInitializing` state
- `customization-properties` namespace times out after ~200 seconds

## Root Cause
The k3d test is flakier than kind due to:
1. Single server node with potential resource constraints
2. No resource limits on transport controller, making it vulnerable to memory pressure
3. Race condition: checking for namespace before pod is ready
4. Timeout too short for k3d's slower initialization

## Changes
- **Add resource requests/limits** to transport controller init container and main container
  - Init container: 64Mi/256Mi memory, 100m/500m CPU
  - Main container: 128Mi/512Mi memory, 100m/1000m CPU
- **Wait for pod Ready** before checking for `customization-properties` namespace
- **Increase timeout** from 200s to 300s (20 → 30 iterations)
- **Add progress logging** every 60s during wait
- **Improve error diagnostics** by dumping transport controller logs on failure

## Files Modified
- `core-chart/templates/postcreatehooks/transport-controller.yaml` - resource constraints
- `scripts/create-kubestellar-demo-env.sh` - improved wait logic

## Test Plan
- [ ] Verify k3d test passes consistently (run multiple times)
- [ ] Verify kind test still passes
- [ ] Check transport controller has resource limits after deployment

---
🤖 Generated with [Claude Code](https://claude.ai/code)
