### PR TITLE
🌱 Use slices.Sort([]string) instead of sort.Sort(a sort.StringSlice)

### DIFF
--- a/pkg/status/combinedstatus-resolution.go
+++ b/pkg/status/combinedstatus-resolution.go
@@ -22,7 +22,7 @@ import (
 	"fmt"
 	"math"
 	"reflect"
-	"sort"
+	"slices"
 	"strconv"
 	"strings"
 	"sync"
@@ -1186,7 +1186,7 @@ func numericEqual(a, b interface{}) bool {
 }
 
 func sortedStringSlice(s []string) []string {
-	sort.Sort(sort.StringSlice(s))
+	slices.Sort(s)
 	return s
 }
 


### PR DESCRIPTION
## Summary
Use slices.Sort for []string instead of sort.StringSlice.

## Related issue(s)

Fixes #3672
