### PR TITLE
🌱 Add Copilot DCO override workflow

### DIFF
--- a/.github/workflows/copilot-dco.yml
+++ b/.github/workflows/copilot-dco.yml
@@ -1,0 +1,9 @@
+name: Copilot DCO
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+jobs:
+  copilot-dco:
+    uses: kubestellar/infra/.github/workflows/reusable-copilot-dco.yml@main


### PR DESCRIPTION
## Summary
- Adds workflow that calls reusable workflow from kubestellar/infra
- Automatically sets DCO status to success for Copilot PRs
- Removes dco-signoff: no label and adds dco-signoff: yes

Fixes #3683

🤖 Generated with [Claude Code](https://claude.com/claude-code)