### PR TITLE
🐛 Log CEL evaluation errors during CombinedStatus Resolution

### DIFF
--- a/pkg/status/combinedstatus-resolution.go
+++ b/pkg/status/combinedstatus-resolution.go
@@ -19,6 +19,7 @@ package status
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"math"
 	"reflect"
@@ -386,7 +387,7 @@ func (c *combinedStatusResolution) evaluateWorkStatus(ctx context.Context, celEv
 		if wsData != nil && len(wsData.evalErrors) > 0 {
 			for _, errIC := range wsData.evalErrors {
 				logger.Error(
-					fmt.Errorf("%s", errIC.Error),
+					errors.New(errIC.Error),
 					"Error evaluating workstatus",
 					"bindingName", bindingName,
 					"workloadObjectID", workloadObjectID,


### PR DESCRIPTION

## Summary
This PR adds logging for CEL evaluation errors that occur while evaluating workstatus data during CombinedStatus resolution. Previously, these errors were stored internally but were not visible, which made debugging difficult. The change improves observability without changing existing behavior or APIs.

## Related issue(s)

Fixes #3694 
