### PR TITLE
📘 docs: add MkDocs config and internal blog support

### DIFF
--- a/docs/blog/index.md
+++ b/docs/blog/index.md
@@ -1,0 +1,15 @@
+# KubeStellar Blog
+
+This section hosts official KubeStellar blog posts.
+
+## Why internal blogs?
+Earlier, KubeStellar blog posts were published on external platforms such as Medium.
+To improve long-term ownership, accessibility, and discoverability, blog content is
+being moved into the official KubeStellar documentation site.
+
+## Migration plan
+- New blog posts will be added here.
+- Existing Medium posts will be gradually migrated.
+- External links will remain available during the transition.
+
+Stay tuned for upcoming posts 🚀

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,10 @@
+site_name: KubeStellar
+docs_dir: docs
+
+theme:
+  name: material
+
+nav:
+  - Home: index.md
+  - Blog: blog/index.md
+


### PR DESCRIPTION
## Summary
This PR adds initial support for hosting KubeStellar blogs internally using MkDocs.

## What changed
- Added mkdocs.yml configuration for documentation site
- Added an internal blog entry point at docs/blog/index.md
- Prepared structure to move blogs away from external platforms like Medium

## Why this change
Currently, blog posts are hosted externally. This improves:
- Content ownership
- Discoverability
- Long-term maintainability of documentation

## Related issue
Fixes #3378