### PR TITLE
🐛 Add golangci-lint configuration file

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,117 @@
+# golangci-lint configuration for KubeStellar
+# See: https://golangci-lint.run/usage/configuration/
+
+run:
+  timeout: 10m
+  tests: true
+  build-tags:
+    - e2e
+  skip-dirs:
+    - bin
+    - vendor
+    - third_party
+    - testdata
+    - examples
+  skip-files:
+    - ".*\\.pb\\.go$"
+    - ".*\\.generated\\.go$"
+    - "zz_generated.*\\.go$"
+
+output:
+  formats:
+    - format: colored-line-number
+  print-issued-lines: true
+  print-linter-name: true
+  sort-results: true
+
+linters:
+  disable-all: true
+  enable:
+    # Enabled linters from original config
+    - asciicheck      # checks for non-ASCII identifiers
+    - bidichk         # checks for dangerous unicode character sequences
+    - durationcheck   # checks for two durations multiplied together
+    - errname         # checks that sentinel errors are prefixed with Err
+    - errorlint       # finds code that will cause problems with error wrapping
+    - importas        # enforces consistent import aliases
+    - misspell        # finds commonly misspelled English words
+    - nilerr          # finds code that returns nil even though it checks that error is not nil
+    - nolintlint      # reports ill-formed or insufficient nolint directives
+    - unconvert       # removes unnecessary type conversions
+
+    # Additional recommended linters for Kubernetes projects
+    - gofmt           # checks whether code was gofmt-ed
+    - goimports       # checks import order and makes it consistent
+    - govet           # reports suspicious constructs
+    - ineffassign     # detects ineffectual assignments
+    - staticcheck     # is a go vet on steroids, applying static analysis
+    - unused          # checks for unused constants, variables, functions and types
+    - gosimple        # linter for Go source code that specializes in simplifying code
+    - typecheck       # parses and type-checks Go code
+    - revive          # fast, configurable, extensible, flexible, and beautiful linter for Go
+
+linters-settings:
+  misspell:
+    ignore-words:
+      - creater
+      - Creater
+
+  goimports:
+    local-prefixes: github.com/kubestellar/kubestellar
+
+  revive:
+    confidence: 0.8
+
+  govet:
+    enable-all: true
+    disable:
+      - shadow
+      - fieldalignment
+
+issues:
+  max-issues-per-linter: 0
+  max-same-issues: 0
+
+  # Exclude known issues and false positives
+  exclude-rules:
+    # Exclude some linters from running on tests files
+    - path: _test\.go
+      linters:
+        - errcheck
+        - gosec
+
+    # Exclude generated files
+    - path: zz_generated.*\.go
+      linters:
+        - goimports
+        - gofmt
+        - misspell
+
+    # Exclude third party and examples
+    - path: ^third_party/
+      linters:
+        - all
+
+    - path: ^examples/
+      linters:
+        - all
+
+    # Common false positives
+    - text: "should have( a package)? comment"
+      linters:
+        - revive
+
+    - text: "don't use an underscore in package name"
+      linters:
+        - revive
+
+  exclude-dirs:
+    - bin
+    - vendor
+    - third_party
+    - testdata
+    - examples
+    - builtin
+
+  # Show all issues from a linter
+  exclude-use-default: false

--- a/Makefile
+++ b/Makefile
@@ -62,7 +62,7 @@ else
 INSTALL_GOBIN=$(shell go env GOBIN)
 endif
 
-GOLANGCI_LINT_VER := v1.50.1
+GOLANGCI_LINT_VER := v1.62.2
 GOLANGCI_LINT_BIN := golangci-lint
 GOLANGCI_LINT := $(TOOLS_GOBIN_DIR)/$(GOLANGCI_LINT_BIN)-$(GOLANGCI_LINT_VER)
 
@@ -292,6 +292,7 @@ update-contextual-logging: $(LOGCHECK)
 
 .PHONY: lint
 lint: $(GOLANGCI_LINT) $(STATICCHECK) $(LOGCHECK)
+	$(GOLANGCI_LINT) run --config .golangci.yml ./...
 	./hack/verify-contextual-logging.sh
 
 VENVDIR=$(abspath docs/venv)


### PR DESCRIPTION
Adds `.golangci.yml` configuration file to ensure consistent linting behavior across contributors.

Changes
-Add `.golangci.yml` with comprehensive linting rules for Kubernetes projects
 Update Makefile to use golangci-lint v1.62.2 and reference config file explicitly
-GitHub Actions workflow update needed separately (`.github/workflows/golangci-lint.yml`)

The workflow file will need to be updated separately via the GitHub web UI or with proper auth scope to:
- Update golangci-lint version from v2.4.0 to v1.62.2
- Update config file reference from `.golangci.yaml` to `.golangci.yml`

 Testing
Verified that `make lint` runs successfully with the new configuration.

Fixes #3700