### PR TITLE
🌱  binding: replace custom `SliceContains` with `slices.Contains` from stdlib

### DIFF
--- a/pkg/binding/bindingpolicy.go
+++ b/pkg/binding/bindingpolicy.go
@@ -272,12 +272,3 @@ func ALabelSelectorIsEmpty(selectors ...metav1.LabelSelector) bool {
 	}
 	return false
 }
-
-func SliceContains[Elt comparable](slice []Elt, seek Elt) bool {
-	for _, elt := range slice {
-		if elt == seek {
-			return true
-		}
-	}
-	return false
-}

--- a/pkg/binding/selectors.go
+++ b/pkg/binding/selectors.go
@@ -19,6 +19,7 @@ package binding
 import (
 	"context"
 	"fmt"
+	"slices"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -149,16 +150,16 @@ func (c *Controller) testObject(ctx context.Context, bindingName string, objIden
 		if test.APIGroup != nil && (*test.APIGroup) != objIdentifier.GVK.Group {
 			continue
 		}
-		if len(test.Resources) > 0 && !(SliceContains(test.Resources, "*") ||
-			SliceContains(test.Resources, objIdentifier.Resource)) {
+		if len(test.Resources) > 0 && !(slices.Contains(test.Resources, "*") ||
+			slices.Contains(test.Resources, objIdentifier.Resource)) {
 			continue
 		}
-		if len(test.Namespaces) > 0 && !(SliceContains(test.Namespaces, "*") ||
-			SliceContains(test.Namespaces, objIdentifier.ObjectName.Namespace)) {
+		if len(test.Namespaces) > 0 && !(slices.Contains(test.Namespaces, "*") ||
+			slices.Contains(test.Namespaces, objIdentifier.ObjectName.Namespace)) {
 			continue
 		}
-		if len(test.ObjectNames) > 0 && !(SliceContains(test.ObjectNames, "*") ||
-			SliceContains(test.ObjectNames, objIdentifier.ObjectName.Name)) {
+		if len(test.ObjectNames) > 0 && !(slices.Contains(test.ObjectNames, "*") ||
+			slices.Contains(test.ObjectNames, objIdentifier.ObjectName.Name)) {
 			continue
 		}
 		if len(test.ObjectSelectors) > 0 && !labelsMatchAny(c.logger, objLabels, test.ObjectSelectors) {

--- a/test/integration/controller-manager/matching_test.go
+++ b/test/integration/controller-manager/matching_test.go
@@ -23,6 +23,7 @@ import (
 	"math/rand"
 	"net/http"
 	"os"
+	"slices"
 	"strconv"
 	"sync"
 	"sync/atomic"
@@ -464,13 +465,13 @@ func (mor mrObjRsc) MatchesAny(t *testing.T, tests []ksapi.DownsyncPolicyClause)
 		if test.APIGroup != nil && gvk.Group != *test.APIGroup {
 			continue
 		}
-		if len(test.Resources) > 0 && !(binding.SliceContains(test.Resources, mor.Resource) || binding.SliceContains(test.Resources, "*")) {
+		if len(test.Resources) > 0 && !(slices.Contains(test.Resources, mor.Resource) || slices.Contains(test.Resources, "*")) {
 			continue
 		}
-		if len(test.Namespaces) > 0 && !(binding.SliceContains(test.Namespaces, mor.MRObject.GetNamespace()) || binding.SliceContains(test.Namespaces, "*")) {
+		if len(test.Namespaces) > 0 && !(slices.Contains(test.Namespaces, mor.MRObject.GetNamespace()) || slices.Contains(test.Namespaces, "*")) {
 			continue
 		}
-		if len(test.ObjectNames) > 0 && !(binding.SliceContains(test.ObjectNames, mor.MRObject.GetName()) || binding.SliceContains(test.ObjectNames, "*")) {
+		if len(test.ObjectNames) > 0 && !(slices.Contains(test.ObjectNames, mor.MRObject.GetName()) || slices.Contains(test.ObjectNames, "*")) {
 			continue
 		}
 		if len(test.NamespaceSelectors) > 0 && !(mor.Namespace == nil && binding.ALabelSelectorIsEmpty(test.NamespaceSelectors...) ||


### PR DESCRIPTION
The binding pkg had a hand-rolled generic function `SliceContains` that does exactly what` slices.Contains` from the Go standard library does. Since the project already uses Go 1.24, we can just use the stdlib version instead.

This removes the custom function and updates all call sites in pkg/binding/selectors.go and the matching integration test to use slices.Contains directly.

<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Don't forget to first look for overlapping PRs. Remember, open source
is a collaborative rather than competitive activity.

If this PR includes changes to the source files for the website
(docs/content/** or a file included from there) then include a preview
of the modified website; see
docs/content/contribution-guidelines/operations/document-management.md.

Please put one of the following icons at the start of your PR title,
to indicate the type of your PR. You could use copy-and-paste from
here; alternatively, the indicated code is recognized by most browsers
as a way to input that icon.

✨ - code :sparkles:, type feature
🐛 - code :bug:, type bug fix
📖 - code :book:, type docs
📝 - code :memo:, type proposal
⚠️ - code :warning:, type breaking change
🌱 - code :seedling:, type other/misc
❓ - code :question:, type requires manual review/categorization



