### PR TITLE
🌱 use stdlib slices.Equal and slices.Clone, remove dead code

### DIFF
--- a/pkg/abstract/slices.go
+++ b/pkg/abstract/slices.go
@@ -44,26 +44,6 @@ func NewSliceByFilter[Elt any](input []Elt, good func(Elt) bool) []Elt {
 	return newSlice
 }
 
-// SliceCopy copies a given slice into new storage
-func SliceCopy[Elt any](input []Elt) []Elt {
-	if input == nil {
-		return nil
-	}
-	return append(make([]Elt, 0, len(input)), input...)
-}
-
-func SliceEqual[Elt comparable](slice1, slice2 []Elt) bool {
-	if len(slice1) != len(slice2) {
-		return false
-	}
-	for idx, elt1 := range slice1 {
-		if elt1 != slice2[idx] {
-			return false
-		}
-	}
-	return true
-}
-
 func SliceMap[Domain, Range any](slice []Domain, fn func(Domain) Range) []Range {
 	if slice == nil {
 		return nil

--- a/pkg/binding/binding-controller.go
+++ b/pkg/binding/binding-controller.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"reflect"
+	"slices"
 	"time"
 
 	"github.com/go-logr/logr"
@@ -50,7 +51,6 @@ import (
 	"k8s.io/klog/v2"
 
 	"github.com/kubestellar/kubestellar/api/control/v1alpha1"
-	"github.com/kubestellar/kubestellar/pkg/abstract"
 	"github.com/kubestellar/kubestellar/pkg/crd"
 	ksclient "github.com/kubestellar/kubestellar/pkg/generated/clientset/versioned"
 	controlclient "github.com/kubestellar/kubestellar/pkg/generated/clientset/versioned/typed/control/v1alpha1"
@@ -623,7 +623,7 @@ func shouldQueueBindingOnUpdate(old, new *v1alpha1.Binding) bool {
 			return true
 		}
 	}
-	return !abstract.SliceEqual(old.Status.Errors, new.Status.Errors)
+	return !slices.Equal(old.Status.Errors, new.Status.Errors)
 }
 
 func shouldSkipUpdate(old, new interface{}) bool {

--- a/pkg/transport/generic/generic_transport_controller.go
+++ b/pkg/transport/generic/generic_transport_controller.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"go/token"
+	"slices"
 	"sync"
 	"time"
 
@@ -693,7 +694,7 @@ func (c *genericTransportController) updateWrappedObjectsAndFinalizer(ctx contex
 	if err != nil {
 		return fmt.Errorf("failed to build wrapped object(s) from Binding '%s' - %w", binding.GetName(), err)
 	}
-	if binding.Status.ObservedGeneration != binding.Generation || !abstract.SliceEqual(binding.Status.Errors, bindingErrors) {
+	if binding.Status.ObservedGeneration != binding.Generation || !slices.Equal(binding.Status.Errors, bindingErrors) {
 		bindingCopy := binding.DeepCopy()
 		bindingCopy.Status = v1alpha1.BindingStatus{
 			ObservedGeneration: binding.Generation,
@@ -849,7 +850,7 @@ func (c *genericTransportController) computeDestToCustomizedObjects(uncustomized
 			if customizeThisObject && destToCustomizedWrapees == nil {
 				destToCustomizedWrapees = map[v1alpha1.Destination][]WrapeeWithUID{}
 				for _, dest := range binding.Spec.Destinations {
-					destToCustomizedWrapees[dest] = abstract.SliceCopy(uncustomizedWrapees[:objIdx])
+					destToCustomizedWrapees[dest] = slices.Clone(uncustomizedWrapees[:objIdx])
 				}
 			}
 			if destToCustomizedWrapees != nil {

--- a/test/e2e/ginkgo/multiple_cluster_deployment_test.go
+++ b/test/e2e/ginkgo/multiple_cluster_deployment_test.go
@@ -21,6 +21,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"math"
+	"slices"
 	"strconv"
 	"time"
 
@@ -36,7 +37,6 @@ import (
 	ptr "k8s.io/utils/pointer"
 
 	ksapi "github.com/kubestellar/kubestellar/api/control/v1alpha1"
-	"github.com/kubestellar/kubestellar/pkg/abstract"
 	"github.com/kubestellar/kubestellar/test/util"
 )
 
@@ -734,7 +734,7 @@ var _ = ginkgo.Describe("end to end testing", func() {
 					return fmt.Errorf("expected combination for %q but got one for %q", fullStatusCollectorName, gotName)
 				}
 				expectedColumnNames := []string{"wecName", "status"}
-				if gotColumnNames := cs.Results[0].ColumnNames; !abstract.SliceEqual(expectedColumnNames, gotColumnNames) {
+				if gotColumnNames := cs.Results[0].ColumnNames; !slices.Equal(expectedColumnNames, gotColumnNames) {
 					return fmt.Errorf("expected ColumnNames %#v but got %#v", expectedColumnNames, gotColumnNames)
 				}
 				if n := len(cs.Results[0].Rows); n != 2 {
@@ -785,7 +785,7 @@ var _ = ginkgo.Describe("end to end testing", func() {
 					return fmt.Errorf("expected combination for %q but got one for %q", sumAvailableReplicasStatusCollectorName, gotName)
 				}
 				expectedColumnNames := []string{"sum"}
-				if gotColumnNames := cs.Results[0].ColumnNames; !abstract.SliceEqual(expectedColumnNames, gotColumnNames) {
+				if gotColumnNames := cs.Results[0].ColumnNames; !slices.Equal(expectedColumnNames, gotColumnNames) {
 					return fmt.Errorf("expected ColumnNames %#v but got %#v", expectedColumnNames, gotColumnNames)
 				}
 				if n := len(cs.Results[0].Rows); n != 1 {
@@ -826,7 +826,7 @@ var _ = ginkgo.Describe("end to end testing", func() {
 					return fmt.Errorf("expected combination for %q but got one for %q", listNginxWecsStatusCollectorName, gotName)
 				}
 				expectedColumnNames := []string{"wecName"}
-				if gotColumnNames := cs.Results[0].ColumnNames; !abstract.SliceEqual(expectedColumnNames, gotColumnNames) {
+				if gotColumnNames := cs.Results[0].ColumnNames; !slices.Equal(expectedColumnNames, gotColumnNames) {
 					return fmt.Errorf("expected ColumnNames %#v but got %#v", expectedColumnNames, gotColumnNames)
 				}
 				if n := len(cs.Results[0].Rows); n != 2 {
@@ -936,7 +936,7 @@ var _ = ginkgo.Describe("end to end testing", func() {
 					return fmt.Errorf("expected 1 NamedStatusCombination but got %d", n)
 				}
 				expectedColumnNames := []string{"count", "max", "min", "sum", "avg"}
-				if gotColumnNames := cs.Results[0].ColumnNames; !abstract.SliceEqual(expectedColumnNames, gotColumnNames) {
+				if gotColumnNames := cs.Results[0].ColumnNames; !slices.Equal(expectedColumnNames, gotColumnNames) {
 					return fmt.Errorf("expected columnNames %#v but got %#v", expectedColumnNames, gotColumnNames)
 				}
 				if n := len(cs.Results[0].Rows); n != 1 {


### PR DESCRIPTION
This PR removes dead code (`SliceHas`, `SliceFilter`) and replace `SliceEqual`/`SliceCopy`
with slices.Equal/slices.Clone from the Go standard library.(Also see commit description)

<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Don't forget to first look for overlapping PRs. Remember, open source
is a collaborative rather than competitive activity.

If this PR includes changes to the source files for the website
(docs/content/** or a file included from there) then include a preview
of the modified website; see
docs/content/contribution-guidelines/operations/document-management.md.

Please put one of the following icons at the start of your PR title,
to indicate the type of your PR. You could use copy-and-paste from
here; alternatively, the indicated code is recognized by most browsers
as a way to input that icon.

✨ - code :sparkles:, type feature
🐛 - code :bug:, type bug fix
📖 - code :book:, type docs
📝 - code :memo:, type proposal
⚠️ - code :warning:, type breaking change
🌱 - code :seedling:, type other/misc
❓ - code :question:, type requires manual review/categorization

-->
