### PR TITLE
🌱 util: add missing test cases for `IsAPIGroupAllowed`

### DIFF
--- a/pkg/util/resources_test.go
+++ b/pkg/util/resources_test.go
@@ -81,6 +81,18 @@ func TestIsAPIGroupAllowed(t *testing.T) {
 			allowedAPIGroups: nil,
 			expected:         true,
 		},
+		{
+			name:             "api group is not in allowed set",
+			resourceGroup:    "batch",
+			allowedAPIGroups: sets.New("apps", "networking.k8s.io", "policy"),
+			expected:         false,
+		},
+		{
+			name:             "api group is allowed by empty set (no restrictions)",
+			resourceGroup:    "apps",
+			allowedAPIGroups: sets.New[string](),
+			expected:         true,
+		},
 	}
 
 	// Iterate over the test cases and run the function with the input


### PR DESCRIPTION
The existing tests only covered positive cases where a group is allowed. This adds two more cases to cover the full behavior:

- a group that is not in the allowed set (should return false)
- an empty set, which means no restrictions (should return true, same as nil)

These new cases make it easier to understand the function's semantics and catch regressions if someone changes the len==0 check.

<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Don't forget to first look for overlapping PRs. Remember, open source
is a collaborative rather than competitive activity.

If this PR includes changes to the source files for the website
(docs/content/** or a file included from there) then include a preview
of the modified website; see
docs/content/contribution-guidelines/operations/document-management.md.

Please put one of the following icons at the start of your PR title,
to indicate the type of your PR. You could use copy-and-paste from
here; alternatively, the indicated code is recognized by most browsers
as a way to input that icon.

✨ - code :sparkles:, type feature
🐛 - code :bug:, type bug fix
📖 - code :book:, type docs
📝 - code :memo:, type proposal
⚠️ - code :warning:, type breaking change
🌱 - code :seedling:, type other/misc
❓ - code :question:, type requires manual review/categorization

-->
