### PR TITLE
🐛 fix: correct wrong map lookups in workstatus change detection

### DIFF
--- a/pkg/status/combinedstatus-resolution.go
+++ b/pkg/status/combinedstatus-resolution.go
@@ -545,7 +545,7 @@ func evaluateWorkStatusAgainstStatusCollectorWriteLocked(celEvaluator *celEvalua
 			eval = celtypes.DefaultTypeAdapter.NativeToValue(err.Error())
 		}
 
-		prevVal, exists := wsData.selectEval[groupByNamedExp.Name]
+		prevVal, exists := wsData.groupByEval[groupByNamedExp.Name]
 		if eval != nil {
 			updated = updated || !exists || eval.Equal(prevVal).Value() != true
 		} else {
@@ -575,7 +575,7 @@ func evaluateWorkStatusAgainstStatusCollectorWriteLocked(celEvaluator *celEvalua
 			})
 		}
 
-		prevVal, exists := wsData.selectEval[combinedFieldNamedAgg.Name]
+		prevVal, exists := wsData.combinedFieldsEval[combinedFieldNamedAgg.Name]
 		if eval != nil {
 			updated = updated || !exists || eval.Equal(prevVal).Value() != true
 		} else {


### PR DESCRIPTION
When checking if `groupBy` or `combinedFields` values changed, the code was looking up previous values from the wrong map (`selectEval`). This meant changes could go unnoticed and `CombinedStatus` would not update.

Fixed by reading from `groupByEval` in the `groupBy` loop and from `combinedFieldsEval` in the `combinedFields` loop.

<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Don't forget to first look for overlapping PRs. Remember, open source
is a collaborative rather than competitive activity.

If this PR includes changes to the source files for the website
(docs/content/** or a file included from there) then include a preview
of the modified website; see
docs/content/contribution-guidelines/operations/document-management.md.

Please put one of the following icons at the start of your PR title,
to indicate the type of your PR. You could use copy-and-paste from
here; alternatively, the indicated code is recognized by most browsers
as a way to input that icon.

✨ - code :sparkles:, type feature
🐛 - code :bug:, type bug fix
📖 - code :book:, type docs
📝 - code :memo:, type proposal
⚠️ - code :warning:, type breaking change
🌱 - code :seedling:, type other/misc
❓ - code :question:, type requires manual review/categorization

-->
