### PR TITLE
🐛 Fix transport controller panic: hash of unhashable type []interface {}

### DIFF
--- a/pkg/transport/generic/custom_transform_collection.go
+++ b/pkg/transport/generic/custom_transform_collection.go
@@ -213,7 +213,7 @@ func (ctc *customTransformCollectionImpl) invalidateCacheEntryLocked(ctx context
 		if bindingName == triggerBindingName {
 			continue
 		}
-		logger.V(5).Info("Enqueuing reference to Binding because "+reason, append(extraLogArgs, "bindingName", bindingName, "customTransformName", ctName, "oldGroupResource", oldGroupResource))
+		logger.V(5).Info("Enqueuing reference to Binding because "+reason, append(extraLogArgs, "bindingName", bindingName, "customTransformName", ctName, "oldGroupResource", oldGroupResource)...)
 		ctc.enqueue(bindingName)
 	}
 	for ctName := range oldGRTransformData.ctNames {


### PR DESCRIPTION
## Summary

Fixes a panic in the transport controller caused by a missing `...` spread operator when passing variadic arguments to `klog`'s structured logger.


## Testing

- This panic was reproduced during E2E testing in #3707
- Steps to reproduce:
  1. Create a `Binding` that propagates workloads to WECs
  2. Wait for ManifestWorks to be created in the ITS
  3. Create a `CustomTransform` targeting the same `GroupResource`
  4. Without this fix → transport controller panics
  5. With this fix → controller continues running normally

## Related

- Exposed by: #3707
- Related issue: #3662
- this PR fixes only the panic..
- fixes : #3719

/cc @MikeSpreitzer