### PR TITLE
fearure: add star history on the Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,21 @@ There are several ways to communicate with us:
 <br>
 <br>
 
+<div>
+<h2><font size="6"><img src="https://raw.githubusercontent.com/Tarikul-Islam-Anik/Animated-Fluent-Emojis/master/Emojis/Travel%20and%20places/Star.png" alt="Star" width="40" height="40" /> Star History </font></h2>
+</div>
+<br>
+
+<a href="https://www.star-history.com/#kubestellar/kubestellar&type=date&legend=top-left">
+ <picture>
+   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=kubestellar/kubestellar&type=date&legend=top-left&theme=dark" />
+   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=kubestellar/kubestellar&type=date&legend=top-left" />
+   <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=kubestellar/kubestellar&type=date&legend=top-left" width="100%" />
+ </picture>
+</a>
+<br>
+<br>
+
 [![CLOMonitor report summary](https://clomonitor.io/api/projects/cncf/kubestellar/report-summary?theme=light)](https://clomonitor.io/projects/cncf/kubestellar)
 <br>
 <br>

--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -1,0 +1,6 @@
+{
+  "name": "docs",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {}
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,6 @@
+{
+  "name": "kubestellar",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {}
+}


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Don't forget to first look for overlapping PRs. Remember, open source
is a collaborative rather than competitive activity.

If this PR includes changes to the source files for the website
(docs/content/** or a file included from there) then include a preview
of the modified website; see
docs/content/contribution-guidelines/operations/document-management.md.

Please put one of the following icons at the start of your PR title,
to indicate the type of your PR. You could use copy-and-paste from
here; alternatively, the indicated code is recognized by most browsers
as a way to input that icon.

✨ - code :sparkles:, type feature
🐛 - code :bug:, type bug fix
📖 - code :book:, type docs
📝 - code :memo:, type proposal
⚠️ - code :warning:, type breaking change
🌱 - code :seedling:, type other/misc
❓ - code :question:, type requires manual review/categorization

-->
## Summary
Added a Star History section to the 
README.md
 to showcase the project's GitHub star growth over time. The section:

- Uses the same HTML heading style (with animated emoji) as the existing Contributors section for visual consistency
Includes a <picture> element with dark/light theme support, so the chart adapts to the viewer's GitHub color scheme preference
- Links to the interactive [star-history.com](https://www.star-history.com/#kubestellar/kubestellar&type=date&legend=top-left) page for the KubeStellar repo
- Is placed between the Contributors and CLOMonitor sections
<img width="871" height="737" alt="image" src="https://github.com/user-attachments/assets/f97fd96a-0f1c-4b71-8a77-62ba39f1de8e" />


Fixes:  #3582
