### PR TITLE
📖 Add Console section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,10 @@ In a single-cluster setup, developers typically access the cluster and deploy Ku
 
 KubeStellar simplifies this process by allowing developers to define a binding policy between clusters and Kubernetes objects. It then uses your regular single-cluster tooling to deploy and configure each cluster based on these binding policies, making multi-cluster operations as straightforward as managing a single cluster. This approach enhances productivity and efficiency, making KubeStellar a valuable tool in a multi-cluster Kubernetes environment.
 
+## Console
+
+Try the [KubeStellar Console](https://console.kubestellar.io) — an open-source web dashboard for managing multi-cluster Kubernetes deployments. Monitor clusters, deploy workloads, manage GPU resources, and troubleshoot with 400+ AI-powered missions. It starts in demo mode so you can explore immediately.
+
 ## Website
 
 For usage, architecture, and other documentation, see [the website](https://kubestellar.io).


### PR DESCRIPTION
## Summary
- Adds a **Console** section to the main README with a link to [console.kubestellar.io](https://console.kubestellar.io)
- The console is a key part of the KubeStellar ecosystem but was not discoverable from the main project README
- This backlink also helps SEO for the console site

## Changes
- `README.md`: Add Console section between the high-level description and Website section

## Test plan
- [ ] Verify README renders correctly on GitHub
- [ ] Verify link to console.kubestellar.io works