### PR TITLE
test: add unit tests for pkg/binding and pkg/status helpers

### DIFF
--- a/pkg/binding/bindingpolicy_helpers_test.go
+++ b/pkg/binding/bindingpolicy_helpers_test.go
@@ -1,0 +1,567 @@
+/*
+Copyright 2025 The KubeStellar Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package binding
+
+import (
+	"fmt"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/klog/v2"
+
+	"github.com/kubestellar/kubestellar/api/control/v1alpha1"
+	"github.com/kubestellar/kubestellar/pkg/util"
+)
+
+func TestLabelsMatchAny(t *testing.T) {
+	logger := klog.Background()
+
+	cases := []struct {
+		name      string
+		labelSet  map[string]string
+		selectors []metav1.LabelSelector
+		want      bool
+	}{
+		{
+			name:      "empty selectors returns false",
+			labelSet:  map[string]string{"app": "nginx"},
+			selectors: nil,
+			want:      false,
+		},
+		{
+			name:     "single matchLabels selector matches",
+			labelSet: map[string]string{"app": "nginx", "env": "prod"},
+			selectors: []metav1.LabelSelector{
+				{MatchLabels: map[string]string{"app": "nginx"}},
+			},
+			want: true,
+		},
+		{
+			name:     "matchLabels mismatch returns false",
+			labelSet: map[string]string{"app": "nginx"},
+			selectors: []metav1.LabelSelector{
+				{MatchLabels: map[string]string{"app": "postgres"}},
+			},
+			want: false,
+		},
+		{
+			name:     "first selector fails but second matches (OR semantics)",
+			labelSet: map[string]string{"app": "nginx"},
+			selectors: []metav1.LabelSelector{
+				{MatchLabels: map[string]string{"app": "postgres"}},
+				{MatchLabels: map[string]string{"app": "nginx"}},
+			},
+			want: true,
+		},
+		{
+			name:     "empty matchLabels selector matches everything",
+			labelSet: map[string]string{"app": "nginx"},
+			selectors: []metav1.LabelSelector{
+				{},
+			},
+			want: true,
+		},
+		{
+			name:     "matchExpressions In operator matches",
+			labelSet: map[string]string{"env": "staging"},
+			selectors: []metav1.LabelSelector{
+				{
+					MatchExpressions: []metav1.LabelSelectorRequirement{
+						{Key: "env", Operator: metav1.LabelSelectorOpIn, Values: []string{"staging", "prod"}},
+					},
+				},
+			},
+			want: true,
+		},
+		{
+			name:     "matchExpressions NotIn rejects matching value",
+			labelSet: map[string]string{"env": "staging"},
+			selectors: []metav1.LabelSelector{
+				{
+					MatchExpressions: []metav1.LabelSelectorRequirement{
+						{Key: "env", Operator: metav1.LabelSelectorOpNotIn, Values: []string{"staging"}},
+					},
+				},
+			},
+			want: false,
+		},
+		{
+			name:     "nil label set does not match non-empty requirement",
+			labelSet: nil,
+			selectors: []metav1.LabelSelector{
+				{MatchLabels: map[string]string{"app": "nginx"}},
+			},
+			want: false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := labelsMatchAny(logger, tc.labelSet, tc.selectors)
+			if got != tc.want {
+				t.Errorf("labelsMatchAny() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestALabelSelectorIsEmpty(t *testing.T) {
+	cases := []struct {
+		name      string
+		selectors []metav1.LabelSelector
+		want      bool
+	}{
+		{
+			name:      "no selectors",
+			selectors: nil,
+			want:      false,
+		},
+		{
+			name: "one non-empty matchLabels",
+			selectors: []metav1.LabelSelector{
+				{MatchLabels: map[string]string{"k": "v"}},
+			},
+			want: false,
+		},
+		{
+			name: "one empty selector",
+			selectors: []metav1.LabelSelector{
+				{},
+			},
+			want: true,
+		},
+		{
+			name: "first non-empty then empty — empty wins",
+			selectors: []metav1.LabelSelector{
+				{MatchLabels: map[string]string{"k": "v"}},
+				{},
+			},
+			want: true,
+		},
+		{
+			name: "both non-empty",
+			selectors: []metav1.LabelSelector{
+				{MatchLabels: map[string]string{"a": "1"}},
+				{MatchLabels: map[string]string{"b": "2"}},
+			},
+			want: false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := ALabelSelectorIsEmpty(tc.selectors...)
+			if got != tc.want {
+				t.Errorf("ALabelSelectorIsEmpty() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestDestinationsMatch(t *testing.T) {
+	cases := []struct {
+		name          string
+		resolvedDests sets.Set[string]
+		bindingDests  []v1alpha1.Destination
+		want          bool
+	}{
+		{
+			name:          "both empty",
+			resolvedDests: sets.New[string](),
+			bindingDests:  nil,
+			want:          true,
+		},
+		{
+			name:          "length mismatch",
+			resolvedDests: sets.New("cluster1", "cluster2"),
+			bindingDests:  []v1alpha1.Destination{{ClusterId: "cluster1"}},
+			want:          false,
+		},
+		{
+			name:          "same elements",
+			resolvedDests: sets.New("cluster1", "cluster2"),
+			bindingDests: []v1alpha1.Destination{
+				{ClusterId: "cluster1"},
+				{ClusterId: "cluster2"},
+			},
+			want: true,
+		},
+		{
+			name:          "same length but different elements",
+			resolvedDests: sets.New("cluster1", "cluster3"),
+			bindingDests: []v1alpha1.Destination{
+				{ClusterId: "cluster1"},
+				{ClusterId: "cluster2"},
+			},
+			want: false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := destinationsMatch(tc.resolvedDests, tc.bindingDests)
+			if got != tc.want {
+				t.Errorf("destinationsMatch() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestDestinationsStringSetToSortedDestinations(t *testing.T) {
+	cases := []struct {
+		name  string
+		input sets.Set[string]
+	}{
+		{name: "nil set", input: nil},
+		{name: "empty set", input: sets.New[string]()},
+		{name: "single element", input: sets.New("cluster1")},
+		{name: "multiple elements sorted lexicographically", input: sets.New("zz", "aa", "mm")},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := destinationsStringSetToSortedDestinations(tc.input)
+
+			if len(got) != tc.input.Len() {
+				t.Fatalf("expected %d destinations, got %d", tc.input.Len(), len(got))
+			}
+
+			gotSet := sets.New[string]()
+			for _, d := range got {
+				gotSet.Insert(d.ClusterId)
+			}
+			if !gotSet.Equal(tc.input) {
+				t.Errorf("element mismatch: got %v, want %v", gotSet, tc.input)
+			}
+
+			for i := 1; i < len(got); i++ {
+				if got[i-1].ClusterId > got[i].ClusterId {
+					t.Errorf("not sorted: %q > %q at indices %d,%d",
+						got[i-1].ClusterId, got[i].ClusterId, i-1, i)
+				}
+			}
+		})
+	}
+}
+
+func TestSortBindingWorkloadObjects(t *testing.T) {
+	t.Run("cluster-scope sorted by GVR then name", func(t *testing.T) {
+		input := v1alpha1.DownsyncObjectClauses{
+			ClusterScope: []v1alpha1.ClusterScopeDownsyncClause{
+				{ClusterScopeDownsyncObject: v1alpha1.ClusterScopeDownsyncObject{
+					GroupVersionResource: metav1.GroupVersionResource{Group: "apps", Version: "v1", Resource: "deployments"},
+					Name:                 "zzz",
+				}},
+				{ClusterScopeDownsyncObject: v1alpha1.ClusterScopeDownsyncObject{
+					GroupVersionResource: metav1.GroupVersionResource{Group: "apps", Version: "v1", Resource: "deployments"},
+					Name:                 "aaa",
+				}},
+			},
+		}
+		sortBindingWorkloadObjects(&input)
+		if input.ClusterScope[0].Name != "aaa" || input.ClusterScope[1].Name != "zzz" {
+			t.Errorf("expected [aaa, zzz], got [%s, %s]",
+				input.ClusterScope[0].Name, input.ClusterScope[1].Name)
+		}
+	})
+
+	t.Run("namespace-scope sorted by namespace", func(t *testing.T) {
+		input := v1alpha1.DownsyncObjectClauses{
+			NamespaceScope: []v1alpha1.NamespaceScopeDownsyncClause{
+				{NamespaceScopeDownsyncObject: v1alpha1.NamespaceScopeDownsyncObject{
+					GroupVersionResource: metav1.GroupVersionResource{Group: "", Version: "v1", Resource: "pods"},
+					Namespace:            "z-ns", Name: "pod1",
+				}},
+				{NamespaceScopeDownsyncObject: v1alpha1.NamespaceScopeDownsyncObject{
+					GroupVersionResource: metav1.GroupVersionResource{Group: "", Version: "v1", Resource: "pods"},
+					Namespace:            "a-ns", Name: "pod1",
+				}},
+			},
+		}
+		sortBindingWorkloadObjects(&input)
+		if input.NamespaceScope[0].Namespace != "a-ns" || input.NamespaceScope[1].Namespace != "z-ns" {
+			t.Errorf("expected [a-ns, z-ns], got [%s, %s]",
+				input.NamespaceScope[0].Namespace, input.NamespaceScope[1].Namespace)
+		}
+	})
+
+	t.Run("already sorted is stable", func(t *testing.T) {
+		input := v1alpha1.DownsyncObjectClauses{
+			ClusterScope: []v1alpha1.ClusterScopeDownsyncClause{
+				{ClusterScopeDownsyncObject: v1alpha1.ClusterScopeDownsyncObject{
+					GroupVersionResource: metav1.GroupVersionResource{Group: "apps", Version: "v1", Resource: "deployments"},
+					Name:                 "aaa",
+				}},
+				{ClusterScopeDownsyncObject: v1alpha1.ClusterScopeDownsyncObject{
+					GroupVersionResource: metav1.GroupVersionResource{Group: "apps", Version: "v1", Resource: "deployments"},
+					Name:                 "zzz",
+				}},
+			},
+		}
+		sortBindingWorkloadObjects(&input)
+		if input.ClusterScope[0].Name != "aaa" || input.ClusterScope[1].Name != "zzz" {
+			t.Errorf("expected [aaa, zzz], got [%s, %s]",
+				input.ClusterScope[0].Name, input.ClusterScope[1].Name)
+		}
+	})
+}
+
+func TestDownsyncModulationEqual(t *testing.T) {
+	cases := []struct {
+		name  string
+		left  DownsyncModulation
+		right DownsyncModulation
+		want  bool
+	}{
+		{
+			name:  "identical zero values",
+			left:  DownsyncModulation{StatusCollectors: sets.New[string]()},
+			right: DownsyncModulation{StatusCollectors: sets.New[string]()},
+			want:  true,
+		},
+		{
+			name:  "same status collectors",
+			left:  DownsyncModulation{StatusCollectors: sets.New("sc1", "sc2")},
+			right: DownsyncModulation{StatusCollectors: sets.New("sc1", "sc2")},
+			want:  true,
+		},
+		{
+			name:  "different status collectors",
+			left:  DownsyncModulation{StatusCollectors: sets.New("sc1", "sc2")},
+			right: DownsyncModulation{StatusCollectors: sets.New("sc1")},
+			want:  false,
+		},
+		{
+			name:  "createOnly differs",
+			left:  DownsyncModulation{CreateOnly: true, StatusCollectors: sets.New[string]()},
+			right: DownsyncModulation{CreateOnly: false, StatusCollectors: sets.New[string]()},
+			want:  false,
+		},
+		{
+			name:  "wantSingleton differs",
+			left:  DownsyncModulation{WantSingletonReportedState: true, StatusCollectors: sets.New[string]()},
+			right: DownsyncModulation{WantSingletonReportedState: false, StatusCollectors: sets.New[string]()},
+			want:  false,
+		},
+		{
+			name:  "wantMultiWEC differs",
+			left:  DownsyncModulation{WantMultiWECReportedState: true, StatusCollectors: sets.New[string]()},
+			right: DownsyncModulation{WantMultiWECReportedState: false, StatusCollectors: sets.New[string]()},
+			want:  false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := tc.left.Equal(tc.right); got != tc.want {
+				t.Errorf("Equal() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestDownsyncModulationAddExternal(t *testing.T) {
+	t.Run("ORs boolean flags and unions StatusCollectors", func(t *testing.T) {
+		dm := ZeroDownsyncModulation()
+		dm.AddExternal(v1alpha1.DownsyncModulation{
+			CreateOnly:                 true,
+			StatusCollectors:           []string{"sc1", "sc2"},
+			WantSingletonReportedState: true,
+		})
+
+		if !dm.CreateOnly {
+			t.Error("expected CreateOnly = true")
+		}
+		if !dm.WantSingletonReportedState {
+			t.Error("expected WantSingletonReportedState = true")
+		}
+		if !dm.StatusCollectors.HasAll("sc1", "sc2") {
+			t.Errorf("expected sc1, sc2 in StatusCollectors, got %v", dm.StatusCollectors)
+		}
+	})
+
+	t.Run("accumulates across multiple calls", func(t *testing.T) {
+		dm := ZeroDownsyncModulation()
+		dm.AddExternal(v1alpha1.DownsyncModulation{StatusCollectors: []string{"sc1"}})
+		dm.AddExternal(v1alpha1.DownsyncModulation{StatusCollectors: []string{"sc2"}})
+		dm.AddExternal(v1alpha1.DownsyncModulation{WantMultiWECReportedState: true})
+
+		if !dm.StatusCollectors.HasAll("sc1", "sc2") {
+			t.Errorf("expected sc1, sc2, got %v", dm.StatusCollectors)
+		}
+		if !dm.WantMultiWECReportedState {
+			t.Error("expected WantMultiWECReportedState = true")
+		}
+	})
+}
+
+func TestDownsyncModulationRoundTrip(t *testing.T) {
+	orig := v1alpha1.DownsyncModulation{
+		CreateOnly:                 true,
+		StatusCollectors:           []string{"sc-a", "sc-b"},
+		WantSingletonReportedState: true,
+		WantMultiWECReportedState:  false,
+	}
+	internal := DownsyncModulationFromExternal(orig)
+	rt := internal.ToExternal()
+
+	if rt.CreateOnly != orig.CreateOnly {
+		t.Errorf("CreateOnly: got %v, want %v", rt.CreateOnly, orig.CreateOnly)
+	}
+	if rt.WantSingletonReportedState != orig.WantSingletonReportedState {
+		t.Errorf("WantSingletonReportedState: got %v, want %v", rt.WantSingletonReportedState, orig.WantSingletonReportedState)
+	}
+	if rt.WantMultiWECReportedState != orig.WantMultiWECReportedState {
+		t.Errorf("WantMultiWECReportedState: got %v, want %v", rt.WantMultiWECReportedState, orig.WantMultiWECReportedState)
+	}
+	if got, want := sets.New(rt.StatusCollectors...), sets.New(orig.StatusCollectors...); !got.Equal(want) {
+		t.Errorf("StatusCollectors: got %v, want %v", got, want)
+	}
+}
+
+func TestErrorIsBindingPolicyResolutionNotFound(t *testing.T) {
+	cases := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{
+			name: "has the expected prefix",
+			err:  fmt.Errorf("%s - bindingpolicy-key: my-policy", bindingPolicyResolutionNotFoundErrorPrefix),
+			want: true,
+		},
+		{
+			name: "unrelated error",
+			err:  fmt.Errorf("some other error"),
+			want: false,
+		},
+		{
+			name: "partial prefix text does not match",
+			err:  fmt.Errorf("bindingpolicy resolution"),
+			want: false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := errorIsBindingPolicyResolutionNotFound(tc.err)
+			if got != tc.want {
+				t.Errorf("errorIsBindingPolicyResolutionNotFound() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestBindingPolicyResolverLifecycle(t *testing.T) {
+	resolver := NewBindingPolicyResolver()
+	policy := &v1alpha1.BindingPolicy{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-policy", UID: "uid-123"},
+	}
+
+	if resolver.ResolutionExists(policy.Name) {
+		t.Fatal("resolution should not exist before NoteBindingPolicy")
+	}
+
+	resolver.NoteBindingPolicy(policy)
+	if !resolver.ResolutionExists(policy.Name) {
+		t.Fatal("resolution should exist after NoteBindingPolicy")
+	}
+
+	resolver.NoteBindingPolicy(policy)
+	if !resolver.ResolutionExists(policy.Name) {
+		t.Fatal("resolution should still exist after second NoteBindingPolicy")
+	}
+
+	dests := sets.New("cluster1", "cluster2")
+	if err := resolver.SetDestinations(policy.Name, dests); err != nil {
+		t.Fatalf("SetDestinations: %v", err)
+	}
+
+	spec := resolver.GenerateBinding(policy.Name)
+	if spec == nil {
+		t.Fatal("GenerateBinding returned nil")
+	}
+	gotDests := sets.New[string]()
+	for _, d := range spec.Destinations {
+		gotDests.Insert(d.ClusterId)
+	}
+	if !gotDests.Equal(dests) {
+		t.Errorf("destinations: got %v, want %v", gotDests, dests)
+	}
+
+	resolver.DeleteResolution(policy.Name)
+	if resolver.ResolutionExists(policy.Name) {
+		t.Fatal("resolution should be gone after DeleteResolution")
+	}
+	if resolver.GenerateBinding(policy.Name) != nil {
+		t.Error("GenerateBinding should return nil after DeleteResolution")
+	}
+}
+
+func TestBindingPolicyResolverSetDestinationsOnMissingKey(t *testing.T) {
+	resolver := NewBindingPolicyResolver()
+	err := resolver.SetDestinations("nonexistent", sets.New("c1"))
+	if err == nil {
+		t.Fatal("expected error for missing resolution, got nil")
+	}
+	if !errorIsBindingPolicyResolutionNotFound(err) {
+		t.Errorf("expected resolution-not-found error, got: %v", err)
+	}
+}
+
+func TestBindingPolicyResolverEnsureAndRemoveObject(t *testing.T) {
+	resolver := NewBindingPolicyResolver()
+	policy := &v1alpha1.BindingPolicy{
+		ObjectMeta: metav1.ObjectMeta{Name: "pol", UID: "uid-pol"},
+	}
+	resolver.NoteBindingPolicy(policy)
+
+	objID := makeObjID("default", "nginx")
+	mod := ZeroDownsyncModulation()
+
+	changed, err := resolver.EnsureObjectData(policy.Name, objID, "uid-obj", "rv1", mod)
+	if err != nil {
+		t.Fatalf("EnsureObjectData: %v", err)
+	}
+	if !changed {
+		t.Error("expected resolution to be changed on first EnsureObjectData")
+	}
+
+	changed, err = resolver.EnsureObjectData(policy.Name, objID, "uid-obj", "rv1", mod)
+	if err != nil {
+		t.Fatalf("EnsureObjectData (no-op): %v", err)
+	}
+	if changed {
+		t.Error("expected no change on identical EnsureObjectData")
+	}
+
+	if removed := resolver.RemoveObjectIdentifier(policy.Name, objID); !removed {
+		t.Error("expected RemoveObjectIdentifier to report a change")
+	}
+	if removed := resolver.RemoveObjectIdentifier(policy.Name, objID); removed {
+		t.Error("expected RemoveObjectIdentifier to report no change when object is absent")
+	}
+}
+
+func makeObjID(ns, name string) util.ObjectIdentifier {
+	return util.ObjectIdentifier{
+		Resource:   "pods",
+		ObjectName: cache.ObjectName{Namespace: ns, Name: name},
+	}
+}

--- a/pkg/status/aggregation/aggregation_test.go
+++ b/pkg/status/aggregation/aggregation_test.go
@@ -1,0 +1,323 @@
+/*
+Copyright 2025 The KubeStellar Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package aggregation
+
+import (
+	"testing"
+)
+
+func TestGetMin(t *testing.T) {
+	cases := []struct {
+		name     string
+		statuses []map[string]interface{}
+		field    string
+		want     int64
+	}{
+		{
+			name:     "empty statuses returns 0",
+			statuses: nil,
+			field:    "replicas",
+			want:     0,
+		},
+		{
+			name:     "field absent in all statuses returns 0",
+			statuses: []map[string]interface{}{{"other": int64(5)}},
+			field:    "replicas",
+			want:     0,
+		},
+		{
+			name:     "single value",
+			statuses: []map[string]interface{}{{"replicas": int64(3)}},
+			field:    "replicas",
+			want:     3,
+		},
+		{
+			name: "picks minimum",
+			statuses: []map[string]interface{}{
+				{"replicas": int64(5)},
+				{"replicas": int64(2)},
+				{"replicas": int64(8)},
+			},
+			field: "replicas",
+			want:  2,
+		},
+		{
+			name: "ignores entries where field has wrong type",
+			statuses: []map[string]interface{}{
+				{"replicas": "not-an-int"},
+				{"replicas": int64(4)},
+			},
+			field: "replicas",
+			want:  4,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := GetMin(tc.statuses, tc.field)
+			if got != tc.want {
+				t.Errorf("GetMin() = %d, want %d", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestGetMax(t *testing.T) {
+	cases := []struct {
+		name     string
+		statuses []map[string]interface{}
+		field    string
+		want     int64
+	}{
+		{
+			name:     "empty statuses returns 0",
+			statuses: nil,
+			field:    "unavailableReplicas",
+			want:     0,
+		},
+		{
+			name:     "field absent returns 0",
+			statuses: []map[string]interface{}{{"other": int64(1)}},
+			field:    "unavailableReplicas",
+			want:     0,
+		},
+		{
+			name: "picks maximum",
+			statuses: []map[string]interface{}{
+				{"unavailableReplicas": int64(1)},
+				{"unavailableReplicas": int64(5)},
+				{"unavailableReplicas": int64(3)},
+			},
+			field: "unavailableReplicas",
+			want:  5,
+		},
+		{
+			name: "ignores entries where field has wrong type",
+			statuses: []map[string]interface{}{
+				{"unavailableReplicas": "bad"},
+				{"unavailableReplicas": int64(7)},
+			},
+			field: "unavailableReplicas",
+			want:  7,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := GetMax(tc.statuses, tc.field)
+			if got != tc.want {
+				t.Errorf("GetMax() = %d, want %d", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestAggregateDeploymentStatus(t *testing.T) {
+	t.Run("aggregates numeric fields correctly", func(t *testing.T) {
+		statuses := []map[string]any{
+			{
+				"replicas":            int64(5),
+				"availableReplicas":   int64(4),
+				"readyReplicas":       int64(3),
+				"updatedReplicas":     int64(5),
+				"unavailableReplicas": int64(1),
+				"observedGeneration":  int64(2),
+			},
+			{
+				"replicas":            int64(3),
+				"availableReplicas":   int64(2),
+				"readyReplicas":       int64(2),
+				"updatedReplicas":     int64(3),
+				"unavailableReplicas": int64(3),
+				"observedGeneration":  int64(1),
+			},
+		}
+		got, err := AggregateDeploymentStatus(statuses)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		assertInt64Field(t, got, "replicas", 3)
+		assertInt64Field(t, got, "availableReplicas", 2)
+		assertInt64Field(t, got, "readyReplicas", 2)
+		assertInt64Field(t, got, "updatedReplicas", 3)
+		assertInt64Field(t, got, "unavailableReplicas", 3)
+		assertInt64Field(t, got, "observedGeneration", 1)
+	})
+
+	t.Run("returns ProgressDeadlineExceeded condition when present", func(t *testing.T) {
+		deadlineCondition := map[string]any{
+			"type":   "Progressing",
+			"reason": "ProgressDeadlineExceeded",
+			"status": "False",
+		}
+		statuses := []map[string]any{
+			{"conditions": []any{deadlineCondition}},
+			{"conditions": []any{map[string]any{"type": "Available", "status": "True"}}},
+		}
+		got, err := AggregateDeploymentStatus(statuses)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		conditions, ok := got["conditions"].([]any)
+		if !ok {
+			t.Fatal("conditions field missing or wrong type")
+		}
+		if len(conditions) != 1 {
+			t.Fatalf("expected 1 condition, got %d", len(conditions))
+		}
+		cond, ok := conditions[0].(map[string]any)
+		if !ok {
+			t.Fatal("condition is not a map")
+		}
+		if cond["reason"] != "ProgressDeadlineExceeded" {
+			t.Errorf("expected ProgressDeadlineExceeded, got %v", cond["reason"])
+		}
+	})
+
+	t.Run("returns empty conditions when no ProgressDeadlineExceeded", func(t *testing.T) {
+		statuses := []map[string]any{
+			{"conditions": []any{map[string]any{"type": "Available", "status": "True"}}},
+		}
+		got, err := AggregateDeploymentStatus(statuses)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		conditions, ok := got["conditions"].([]any)
+		if !ok {
+			t.Fatal("conditions missing")
+		}
+		if len(conditions) != 0 {
+			t.Errorf("expected empty conditions, got %d", len(conditions))
+		}
+	})
+}
+
+func TestAggregateDaemonSetStatus(t *testing.T) {
+	statuses := []map[string]any{
+		{
+			"currentNumberScheduled": int64(10),
+			"numberMisscheduled":     int64(2),
+			"desiredNumberScheduled": int64(10),
+			"numberReady":            int64(8),
+			"observedGeneration":     int64(3),
+			"updatedNumberScheduled": int64(10),
+			"numberAvailable":        int64(8),
+		},
+		{
+			"currentNumberScheduled": int64(5),
+			"numberMisscheduled":     int64(5),
+			"desiredNumberScheduled": int64(5),
+			"numberReady":            int64(3),
+			"observedGeneration":     int64(2),
+			"updatedNumberScheduled": int64(4),
+			"numberAvailable":        int64(3),
+		},
+	}
+	got, err := AggregateDaemonSetStatus(statuses)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	assertInt64Field(t, got, "currentNumberScheduled", 5)
+	assertInt64Field(t, got, "numberMisscheduled", 5)
+	assertInt64Field(t, got, "desiredNumberScheduled", 5)
+	assertInt64Field(t, got, "numberReady", 3)
+	assertInt64Field(t, got, "observedGeneration", 2)
+	assertInt64Field(t, got, "updatedNumberScheduled", 4)
+	assertInt64Field(t, got, "numberAvailable", 3)
+}
+
+func TestAggregateReplicaSetStatus(t *testing.T) {
+	t.Run("aggregates numeric fields", func(t *testing.T) {
+		statuses := []map[string]any{
+			{
+				"replicas":             int64(6),
+				"fullyLabeledReplicas": int64(6),
+				"readyReplicas":        int64(5),
+				"availableReplicas":    int64(5),
+				"observedGeneration":   int64(4),
+			},
+			{
+				"replicas":             int64(4),
+				"fullyLabeledReplicas": int64(3),
+				"readyReplicas":        int64(2),
+				"availableReplicas":    int64(2),
+				"observedGeneration":   int64(3),
+			},
+		}
+		got, err := AggregateReplicaSetStatus(statuses)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		assertInt64Field(t, got, "replicas", 4)
+		assertInt64Field(t, got, "fullyLabeledReplicas", 3)
+		assertInt64Field(t, got, "readyReplicas", 2)
+		assertInt64Field(t, got, "availableReplicas", 2)
+		assertInt64Field(t, got, "observedGeneration", 3)
+	})
+
+	t.Run("surfaces ReplicaFailure condition", func(t *testing.T) {
+		failureCondition := map[string]any{
+			"type":   "ReplicaFailure",
+			"status": "True",
+			"reason": "FailedCreate",
+		}
+		statuses := []map[string]any{
+			{"conditions": []any{failureCondition}},
+			{"conditions": []any{map[string]any{"type": "Available", "status": "True"}}},
+		}
+		got, err := AggregateReplicaSetStatus(statuses)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		conditions, ok := got["conditions"].([]any)
+		if !ok || len(conditions) != 1 {
+			t.Fatalf("expected 1 condition, got %v", got["conditions"])
+		}
+		cond := conditions[0].(map[string]any)
+		if cond["type"] != "ReplicaFailure" {
+			t.Errorf("expected ReplicaFailure, got %v", cond["type"])
+		}
+	})
+
+	t.Run("empty conditions when no ReplicaFailure", func(t *testing.T) {
+		statuses := []map[string]any{
+			{"conditions": []any{map[string]any{"type": "Available", "status": "True"}}},
+		}
+		got, _ := AggregateReplicaSetStatus(statuses)
+		conditions := got["conditions"].([]any)
+		if len(conditions) != 0 {
+			t.Errorf("expected 0 conditions, got %d", len(conditions))
+		}
+	})
+}
+
+func assertInt64Field(t *testing.T, m map[string]any, field string, want int64) {
+	t.Helper()
+	v, ok := m[field]
+	if !ok {
+		t.Errorf("field %q missing from result", field)
+		return
+	}
+	got, ok := v.(int64)
+	if !ok {
+		t.Errorf("field %q: expected int64, got %T", field, v)
+		return
+	}
+	if got != want {
+		t.Errorf("field %q: got %d, want %d", field, got, want)
+	}
+}

--- a/pkg/status/workstatus_helpers_test.go
+++ b/pkg/status/workstatus_helpers_test.go
@@ -1,0 +1,133 @@
+/*
+Copyright 2025 The KubeStellar Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package status
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestGetObjectStatusLastUpdateTime(t *testing.T) {
+	makeRaw := func(fields map[string]interface{}) *metav1.FieldsV1 {
+		raw, err := json.Marshal(fields)
+		if err != nil {
+			t.Fatalf("json.Marshal: %v", err)
+		}
+		return &metav1.FieldsV1{Raw: raw}
+	}
+
+	now := metav1.NewTime(time.Date(2025, 1, 15, 12, 0, 0, 0, time.UTC))
+	earlier := metav1.NewTime(time.Date(2025, 1, 10, 8, 0, 0, 0, time.UTC))
+
+	cases := []struct {
+		name          string
+		managedFields []metav1.ManagedFieldsEntry
+		wantZero      bool
+		wantTime      *metav1.Time
+	}{
+		{
+			name:          "no managed fields returns zero time",
+			managedFields: nil,
+			wantZero:      true,
+		},
+		{
+			name: "entry without f:status key is ignored",
+			managedFields: []metav1.ManagedFieldsEntry{
+				{
+					FieldsType: "FieldsV1",
+					FieldsV1:   makeRaw(map[string]interface{}{"f:metadata": map[string]interface{}{}}),
+					Time:       &now,
+				},
+			},
+			wantZero: true,
+		},
+		{
+			name: "entry with f:status key is picked up",
+			managedFields: []metav1.ManagedFieldsEntry{
+				{
+					FieldsType: "FieldsV1",
+					FieldsV1:   makeRaw(map[string]interface{}{"f:status": map[string]interface{}{}}),
+					Time:       &now,
+				},
+			},
+			wantZero: false,
+			wantTime: &now,
+		},
+		{
+			name: "latest time among multiple status entries wins",
+			managedFields: []metav1.ManagedFieldsEntry{
+				{
+					FieldsType: "FieldsV1",
+					FieldsV1:   makeRaw(map[string]interface{}{"f:status": map[string]interface{}{}}),
+					Time:       &earlier,
+				},
+				{
+					FieldsType: "FieldsV1",
+					FieldsV1:   makeRaw(map[string]interface{}{"f:status": map[string]interface{}{}}),
+					Time:       &now,
+				},
+			},
+			wantZero: false,
+			wantTime: &now,
+		},
+		{
+			name: "nil FieldsV1 entry is skipped",
+			managedFields: []metav1.ManagedFieldsEntry{
+				{
+					FieldsType: "FieldsV1",
+					FieldsV1:   nil,
+					Time:       &now,
+				},
+			},
+			wantZero: true,
+		},
+		{
+			name: "non-FieldsV1 type is skipped",
+			managedFields: []metav1.ManagedFieldsEntry{
+				{
+					FieldsType: "FieldsV2",
+					FieldsV1:   makeRaw(map[string]interface{}{"f:status": map[string]interface{}{}}),
+					Time:       &now,
+				},
+			},
+			wantZero: true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			obj := &metav1.ObjectMeta{ManagedFields: tc.managedFields}
+			got := getObjectStatusLastUpdateTime(obj)
+
+			if tc.wantZero {
+				if got != nil && !got.IsZero() {
+					t.Errorf("expected zero time, got %v", got)
+				}
+				return
+			}
+			if got == nil {
+				t.Fatal("expected non-nil time, got nil")
+			}
+			if !got.Equal(tc.wantTime) {
+				t.Errorf("got %v, want %v", got, tc.wantTime)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Closes #3727

Added unit tests for deterministic helper logic in `pkg/binding` and `pkg/status` that had no direct coverage. No cluster or controller-runtime needed to run them.

**What's tested:**
- `pkg/binding` — `labelsMatchAny`, `ALabelSelectorIsEmpty`, `destinationsMatch`, `sortBindingWorkloadObjects`, `DownsyncModulation` helpers, `BindingPolicyResolver` lifecycle
- `pkg/status/aggregation` — `GetMin`, `GetMax`, `AggregateDeploymentStatus`, `AggregateDaemonSetStatus`, `AggregateReplicaSetStatus`
- `pkg/status` — `getObjectStatusLastUpdateTime`

**Testing:**
```bash
go test ./pkg/binding/... ./pkg/status/aggregation/... ./pkg/status/... -count=1
