### PR TITLE
🐛fix(binding): use OR semantics in SelectorsMatchLabels for clusterSelectors

### DIFF
--- a/pkg/util/labels.go
+++ b/pkg/util/labels.go
@@ -63,16 +63,14 @@ func SplitLabelKeyAndValue(keyvalue string) (Label, error) {
 }
 
 func SelectorsMatchLabels(selectors []metav1.LabelSelector, labelsSet labels.Set) (bool, error) {
-	matches := true
 	for _, selectorApi := range selectors {
 		selector, err := metav1.LabelSelectorAsSelector(&selectorApi)
 		if err != nil {
 			return false, err
 		}
-		if !selector.Matches(labelsSet) {
-			matches = false
-			break
+		if selector.Matches(labelsSet) {
+			return true, nil
 		}
 	}
-	return matches, nil
+	return false, nil
 }


### PR DESCRIPTION
## Description

I realized `SelectorsMatchLabels` is using AND logic, which contradicts our API spec requiring OR semantics for cluster selectors. Since this function gates `BindingPolicy` re-evaluation, it's causing silent placement drift. If a cluster only matches one of multiple selectors, the logic returns false and the controller skips reconciliation. The workload effectively gets stuck without any error logs.

## Fix

I updated the logic to return true on the first match. This aligns the change-detection path with the actual placement logic used in `FindClustersBySelectors`.

```go
func SelectorsMatchLabels(selectors []metav1.LabelSelector, labelsSet labels.Set) (bool, error) {
    for _, sApi := range selectors {
        s, err := metav1.LabelSelectorAsSelector(&sApi)
        if err != nil { return false, err }
        if s.Matches(labelsSet) { return true, nil }
    }
    return false, nil
}
```
