### PR TITLE
📖 Fix typos in code comments

### DIFF
--- a/pkg/ctrlutil/kubeconfig.go
+++ b/pkg/ctrlutil/kubeconfig.go
@@ -92,7 +92,7 @@ func getRestConfig(logger logr.Logger, cpName, labelValue string) (*rest.Config,
 			targetCP = &list.Items[0]
 			return true, nil
 		}
-		// TODO - we do not allow this case for a WDS as there is a 1:1 relashionship controller:cp for WDS.
+		// TODO - we do not allow this case for a WDS as there is a 1:1 relationship controller:cp for WDS.
 		// Need to revisit for ITS where we can have multiple shards.
 		// Assume we are not waiting for control planes to go away.
 		return true, fmt.Errorf(ErrMultipleControlPlanes, labelValue)

--- a/pkg/status/combinedstatus-resolution.go
+++ b/pkg/status/combinedstatus-resolution.go
@@ -795,7 +795,7 @@ func handleAggregationReadLocked(scName string, scData *statusCollectorData) *v1
 	// 1. groupBy Evaluation Value -> unique ID
 	// 2. N-values tuple -> []*workStatusData
 	// 		Where the N-values tuple is the string concatenation of the assigned numbers
-	// 		seperated by commas, ordered by the groupBy expressions in scData.GroupBy slice.
+	// 		separated by commas, ordered by the groupBy expressions in scData.GroupBy slice.
 	generator := 0
 	ValueToNumber := map[any]int{}
 	idToAggregationGroup := map[string]*aggregationGroup{}


### PR DESCRIPTION
📖 docs: fix typos in code comments

## Summary
Fixed minor typos in code comments to improve code readability:
- Corrected "seperated" → "separated" in `pkg/status/combinedstatus-resolution.go`
- Corrected "relashionship" → "relationship" in `pkg/ctrlutil/kubeconfig.go`

## Related issue(s)
N/A (Minor documentation improvements)