### PR TITLE
fix broken link for roadmap.md in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ We ❤️ our contributors! If you're interested in helping us out, please head 
 This community has a [Code of Conduct](./CODE_OF_CONDUCT.md). Please make sure to follow it.
 
 ## Our Roadmap
-Have a look at what we are working on next, see our [Roadmap](docs/content/direct/roadmap.md) 
+Have a look at what we are working on next, see our [Roadmap](https://github.com/kubestellar/kubestellar/blob/main/docs/to-be-deleted/content/direct/roadmap.md) 
 
 ## Getting in touch
 

--- a/README.md
+++ b/README.md
@@ -59,8 +59,7 @@ We ❤️ our contributors! If you're interested in helping us out, please head 
 This community has a [Code of Conduct](./CODE_OF_CONDUCT.md). Please make sure to follow it.
 
 ## Our Roadmap
-Have a look at what we are working on next, see our [Roadmap](https://github.com/kubestellar/kubestellar/blob/main/docs/to-be-deleted/content/direct/roadmap.md) 
-
+Have a look at what we are working on next, see our [Roadmap](https://github.com/kubestellar/docs/blob/main/docs/content/kubestellar/roadmap.md)
 ## Getting in touch
 
 There are several ways to communicate with us:


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Don't forget to first look for overlapping PRs. Remember, open source
is a collaborative rather than competitive activity.

If this PR includes changes to the source files for the website
(docs/content/** or a file included from there) then include a preview
of the modified website; see
docs/content/contribution-guidelines/operations/document-management.md.

Please put one of the following icons at the start of your PR title,
to indicate the type of your PR. You could use copy-and-paste from
here; alternatively, the indicated code is recognized by most browsers
as a way to input that icon.

✨ - code :sparkles:, type feature
🐛 - code :bug:, type bug fix
📖 - code :book:, type docs
📝 - code :memo:, type proposal
⚠️ - code :warning:, type breaking change
🌱 - code :seedling:, type other/misc
❓ - code :question:, type requires manual review/categorization

-->
## Summary

The link to roadmap.md in the README was broken. Fixed it to point to the correct path.

## Related issue(s)

Fixes #
