### PR TITLE
🐛 fix(transport): clean up ctNameToSpec entries when no bindings remain for a GroupResource

### DIFF
--- a/pkg/transport/generic/custom_transform_collection.go
+++ b/pkg/transport/generic/custom_transform_collection.go
@@ -273,6 +273,9 @@ func (ctc *customTransformCollectionImpl) setBindingGroupResources(bindingName s
 			// When the set goes empty, time to delete this data
 			if grTransformData.bindingsThatCare.Len() == 0 {
 				delete(ctc.grToTransformData, groupResource)
+				for ctName := range grTransformData.ctNames {
+					delete(ctc.ctNameToSpec, ctName)
+				}
 			}
 		}
 	}


### PR DESCRIPTION
## Summary

In `setBindingGroupResources`, when a GroupResource is removed from a Binding's dependency set and no other Binding references it anymore, the `grToTransformData` entry was correctly deleted, but the corresponding `ctNameToSpec` entries for that GroupResource's CustomTransform names were left behind, causing unbounded memory growth over time as CustomTransforms cycle through GroupResources.

This fix mirrors the cleanup already done in `invalidateCacheEntryLocked`, which correctly deletes `ctNameToSpec` entries alongside the `grToTransformData` entry when a GroupResource is invalidated.

**Change:** In the `grTransformData.bindingsThatCare.Len() == 0` block inside `setBindingGroupResources`, added cleanup of `ctNameToSpec` entries for the removed GroupResource's associated CustomTransform names.

## Related issue(s)
Fixes #