### PR TITLE
🐛 Track CustomTransform state on wrapped objects

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,24 @@
+# Contributor Agent Notes
+
+Use this file as a quick orientation layer. The project rules remain in `CONTRIBUTING.md`; when there is a conflict, follow `CONTRIBUTING.md`.
+
+## Contribution Flow
+
+- Work from a topic branch, not `main`.
+- Prefer small, issue-linked patches. Check for existing open PRs before starting an issue.
+- Claim an issue with `/assign` when you begin active work, and ask for clarification on the issue if the expected behavior or scope is unclear.
+- Sign off commits with `git commit -s` to satisfy the DCO requirement.
+- Keep public comments direct and specific: state what was tested, what remains uncertain, or what input is needed.
+
+## Local Validation
+
+- Run focused Go tests for touched packages first, for example `go test ./pkg/transport/...`.
+- Use `git diff --check` before committing.
+- For docs changes, verify the source file is in the active docs tree before editing; `docs/CLAUDE.md` notes current console-doc locations.
+
+## Transport Controller Notes
+
+- Generic transport code lives in `pkg/transport/generic/`.
+- CustomTransform cache and invalidation logic lives in `pkg/transport/generic/custom_transform_collection.go`.
+- Wrapped object propagation decisions are in `pkg/transport/generic/generic_transport_controller.go`.
+- When changing propagation skip/update logic, add focused unit coverage in `pkg/transport/generic/generic_transport_controller_test.go`.

--- a/pkg/transport/generic/custom_transform_collection.go
+++ b/pkg/transport/generic/custom_transform_collection.go
@@ -18,7 +18,10 @@ package transport
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/json"
 	"fmt"
+	"sort"
 	"sync"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -46,7 +49,8 @@ type customTransformCollection interface {
 }
 
 type customTransformChanges struct {
-	removes []jsonpath.Query // immutable
+	removes     []jsonpath.Query // immutable
+	stateDigest string
 }
 
 // customTransformCollectionImpl implements customTransformCollection
@@ -132,6 +136,7 @@ func (ctc *customTransformCollectionImpl) getCustomTransformChanges(ctx context.
 		bindingsThatCare: sets.New(bindingName),
 		ctNames:          abstract.SliceMapToK8sSet(cts, (*v1alpha1.CustomTransform).GetName),
 	}
+	grTransformData.changes.stateDigest = customTransformStateDigest(cts)
 	var commonWarnings []string // warnings common to all the ct
 	if len(cts) > 1 {
 		commonWarnings = []string{fmt.Sprintf("multiple CustomTransform objects specify the same GroupResource; their names are %v", grTransformData.ctNames)}
@@ -144,6 +149,28 @@ func (ctc *customTransformCollectionImpl) getCustomTransformChanges(ctx context.
 	}
 	ctc.grToTransformData[groupResource] = grTransformData
 	return grTransformData.changes
+}
+
+func customTransformStateDigest(cts []*v1alpha1.CustomTransform) string {
+	if len(cts) == 0 {
+		return ""
+	}
+	type customTransformState struct {
+		Name string                       `json:"name"`
+		Spec v1alpha1.CustomTransformSpec `json:"spec"`
+	}
+	states := make([]customTransformState, len(cts))
+	for idx, ct := range cts {
+		states[idx] = customTransformState{Name: ct.Name, Spec: ct.Spec}
+	}
+	sort.Slice(states, func(i, j int) bool { return states[i].Name < states[j].Name })
+	payload, err := json.Marshal(states)
+	if err != nil {
+		// The payload is a local struct of JSON-safe Kubernetes API fields.
+		panic(err)
+	}
+	sum := sha256.Sum256(payload)
+	return fmt.Sprintf("sha256:%x", sum[:])
 }
 
 // digestCustomTransformLocked digests one CustomTransform.

--- a/pkg/transport/generic/generic_transport_controller.go
+++ b/pkg/transport/generic/generic_transport_controller.go
@@ -18,9 +18,11 @@ package transport
 
 import (
 	"context"
+	"crypto/sha256"
 	"fmt"
 	"go/token"
 	"slices"
+	"strings"
 	"sync"
 	"time"
 
@@ -70,6 +72,7 @@ const (
 	originOwnerReferenceLabel       = "transport.kubestellar.io/originOwnerReferenceBindingKey"
 	originWdsLabel                  = "transport.kubestellar.io/originWdsName"
 	originOwnerGenerationAnnotation = "transport.kubestellar.io/originOwnerReferenceBindingGeneration"
+	customTransformStateAnnotation  = "transport.kubestellar.io/applied-custom-transform-state"
 
 	customTransformDomainIndexName = "custom-transform-domain"
 )
@@ -738,9 +741,12 @@ func (c *genericTransportController) getWrapeesFromWDS(ctx context.Context, bind
 		gr := metav1.GroupResource{Group: gvr.Group, Resource: gvr.Resource}
 		groupResources.Insert(gr)
 		kindToResource[object.GroupVersionKind().GroupKind()] = gvr.Resource
+		transformedObject, customTransformState := transformObject(ctx, c.customTransformCollection, gr, object, binding.Name)
 		wrapees = append(wrapees, WrapeeWithUID{
-			transport.NewWrapee(TransformObject(ctx, c.customTransformCollection, gr, object, binding.Name), createOnly),
-			string(object.GetUID())})
+			Wrapee:               transport.NewWrapee(transformedObject, createOnly),
+			UID:                  string(object.GetUID()),
+			CustomTransformState: customTransformState,
+		})
 	}
 	// add cluster-scoped objects to the 'objectsToPropagate' slice
 	for _, clause := range binding.Spec.Workload.ClusterScope {
@@ -855,7 +861,11 @@ func (c *genericTransportController) computeDestToCustomizedObjects(uncustomized
 			}
 			if destToCustomizedWrapees != nil {
 				customizedObjectsSoFar := destToCustomizedWrapees[dest]
-				customizedObjectsSoFar = append(customizedObjectsSoFar, WrapeeWithUID{transport.NewWrapee(objC, wrapee.CreateOnly), wrapee.UID})
+				customizedObjectsSoFar = append(customizedObjectsSoFar, WrapeeWithUID{
+					Wrapee:               transport.NewWrapee(objC, wrapee.CreateOnly),
+					UID:                  wrapee.UID,
+					CustomTransformState: wrapee.CustomTransformState,
+				})
 				destToCustomizedWrapees[dest] = customizedObjectsSoFar
 			}
 		}
@@ -874,7 +884,7 @@ func (c *genericTransportController) computeDestToCustomizedObjects(uncustomized
 
 // wrapBatch invokes the transport's WrapObjects.
 // uidToPropagate is the UID (in the WDS) of one of the objects in batchToPropagate.
-func (c *genericTransportController) wrapBatch(batchToPropagate []transport.Wrapee, uidToPropagate string, kindToResource func(schema.GroupKind) (string, bool), binding *v1alpha1.Binding, numShard int) (*unstructured.Unstructured, error) {
+func (c *genericTransportController) wrapBatch(batchToPropagate []transport.Wrapee, customTransformStates []string, uidToPropagate string, kindToResource func(schema.GroupKind) (string, bool), binding *v1alpha1.Binding, numShard int) (*unstructured.Unstructured, error) {
 	wrapped := c.transport.WrapObjects(batchToPropagate, abstract.DropOK11(kindToResource))
 	wrappedObject, err := convertObjectToUnstructured(wrapped)
 	if err != nil {
@@ -895,13 +905,32 @@ func (c *genericTransportController) wrapBatch(batchToPropagate []transport.Wrap
 	setLabel(wrappedObject, originOwnerReferenceLabel, binding.GetName())
 	setLabel(wrappedObject, originWdsLabel, c.wdsName)
 	setAnnotation(wrappedObject, originOwnerGenerationAnnotation, binding.GetGeneration())
+	if customTransformState := combinedCustomTransformState(customTransformStates); customTransformState != "" {
+		setAnnotation(wrappedObject, customTransformStateAnnotation, customTransformState)
+	}
 	return wrappedObject, err
+}
+
+func combinedCustomTransformState(states []string) string {
+	needsAnnotation := false
+	for _, state := range states {
+		if state != "" {
+			needsAnnotation = true
+			break
+		}
+	}
+	if !needsAnnotation {
+		return ""
+	}
+	sum := sha256.Sum256([]byte(strings.Join(states, "\x00")))
+	return fmt.Sprintf("sha256:%x", sum[:])
 }
 
 type WrapeeWithUID struct {
 	transport.Wrapee
 	// UID of the object in the WDS
-	UID string
+	UID                  string
+	CustomTransformState string
 }
 
 // transportTask is one wrapped object and a gloss of its contents
@@ -913,6 +942,7 @@ type transportTask struct {
 func (c *genericTransportController) wrap(wrapeesToPropagate []WrapeeWithUID, kindToResource func(schema.GroupKind) (string, bool), binding *v1alpha1.Binding) ([]transportTask, error) {
 	var transportTasks []transportTask
 	var batchToPropagate []transport.Wrapee = nil
+	var customTransformStates []string
 	var uidToPropagate string
 	gloss := transport.Gloss{}
 	maxSize := c.MaxSizeWrapped
@@ -930,25 +960,27 @@ func (c *genericTransportController) wrap(wrapeesToPropagate []WrapeeWithUID, ki
 			return nil, fmt.Errorf("failed to wrap object that is larger than max size")
 		}
 		if (objSize+batchSize >= maxSize) || (batchCount+1 > maxCount) {
-			wrappedObject, err := c.wrapBatch(batchToPropagate, uidToPropagate, kindToResource, binding, numShard)
+			wrappedObject, err := c.wrapBatch(batchToPropagate, customTransformStates, uidToPropagate, kindToResource, binding, numShard)
 			if err != nil {
 				return nil, err
 			}
 			numShard += 1
 			transportTasks = append(transportTasks, transportTask{wrappedObject, gloss})
 			batchToPropagate = nil
+			customTransformStates = nil
 			gloss = transport.Gloss{}
 			batchSize = 0
 			batchCount = 0
 		}
 		batchToPropagate = append(batchToPropagate, wrapee.Wrapee)
+		customTransformStates = append(customTransformStates, wrapee.CustomTransformState)
 		uidToPropagate = wrapee.UID
 		gloss.Insert(wrapee.GetID())
 		batchSize += objSize
 		batchCount += 1
 	}
 	if batchToPropagate != nil {
-		wrappedObject, err := c.wrapBatch(batchToPropagate, uidToPropagate, kindToResource, binding, numShard)
+		wrappedObject, err := c.wrapBatch(batchToPropagate, customTransformStates, uidToPropagate, kindToResource, binding, numShard)
 		if err != nil {
 			return nil, err
 		}
@@ -1087,16 +1119,20 @@ func (c *genericTransportController) propagateWrappedObjectToClusters(ctx contex
 				}
 				desiredGeneration := task.ObjU.GetAnnotations()[originOwnerGenerationAnnotation]
 				actualGeneration := currentWrappedObject.GetAnnotations()[originOwnerGenerationAnnotation]
+				desiredCustomTransformState := task.ObjU.GetAnnotations()[customTransformStateAnnotation]
+				actualCustomTransformState := currentWrappedObject.GetAnnotations()[customTransformStateAnnotation]
 				// This test covers workload object ResourceVersion and the create-only bit.
-				// This test is also an imperfect test for consistency in customization.
-				// It does not take into account the effects of absence of, or changes in, CustomTransform objects.
+				// This test also covers customization and CustomTransform consistency.
 				generationMatch := actualGeneration == desiredGeneration
+				customTransformStateMatch := actualCustomTransformState == desiredCustomTransformState
 				glossEqual := abstract.PrimitiveMapEqual(task.Gloss, gloss)
-				if generationMatch && glossEqual {
+				if generationMatch && customTransformStateMatch && glossEqual {
 					logger.V(5).Info("No need to change wrapped object", "id", wrappedID)
 					continue
 				}
-				if glossEqual {
+				if !customTransformStateMatch {
+					logger.V(5).Info("Need to change wrapped object because of CustomTransform state mismatch", "id", wrappedID, "desiredCustomTransformState", desiredCustomTransformState, "actualCustomTransformState", actualCustomTransformState)
+				} else if glossEqual {
 					logger.V(5).Info("Need to change wrapped object because of Binding generation mismatch", "id", wrappedID, "desiredGeneration", desiredGeneration, "actualGeneration", actualGeneration)
 				} else {
 					logger.V(5).Info("Need to change wrapped object because of (at least) gloss mismatch", "id", wrappedID, "desiredGeneration", desiredGeneration, "actualGeneration", actualGeneration, "desiredGloss", util.K8sSet4Log(task.Gloss), "actualGloss", util.K8sSet4Log(gloss))
@@ -1278,6 +1314,11 @@ func setLabel(object metav1.Object, key string, value any) {
 // 2. Removal that is specific to a Kind of object and fixed in KubeStellar code;
 // 3. Removal that is specific to a Kind of object and configured by API object(s).
 func TransformObject(ctx context.Context, ctc customTransformCollection, groupResource metav1.GroupResource, object *unstructured.Unstructured, bindingName string) *unstructured.Unstructured {
+	objectCopy, _ := transformObject(ctx, ctc, groupResource, object, bindingName)
+	return objectCopy
+}
+
+func transformObject(ctx context.Context, ctc customTransformCollection, groupResource metav1.GroupResource, object *unstructured.Unstructured, bindingName string) (*unstructured.Unstructured, string) {
 	objectCopy := object.DeepCopy() // don't modify object directly. create a copy before zeroing fields
 	objectCopy.SetManagedFields(nil)
 	objectCopy.SetFinalizers(nil)
@@ -1309,7 +1350,7 @@ func TransformObject(ctx context.Context, ctc customTransformCollection, groupRe
 		}
 		objectCopy.SetUnstructuredContent(objectData)
 	}
-	return objectCopy
+	return objectCopy, customChanges.stateDigest
 }
 
 func customTransformToDomain(obj any) ([]string, error) {

--- a/pkg/transport/generic/generic_transport_controller_test.go
+++ b/pkg/transport/generic/generic_transport_controller_test.go
@@ -333,6 +333,141 @@ func (tt *testTransport) UnwrapObjects(wrapped runtime.Object, kindToResource fu
 	return transport.Gloss{}, nil
 }
 
+type staticTransport struct {
+	gloss transport.Gloss
+}
+
+func (st staticTransport) WrapObjects([]transport.Wrapee, func(k8sschema.GroupKind) string) runtime.Object {
+	return &workapi.ManifestWork{
+		TypeMeta: typeMeta("ManifestWork", workapi.GroupVersion),
+	}
+}
+
+func (st staticTransport) UnwrapObjects(runtime.Object, func(k8sschema.GroupKind) (string, bool)) (transport.Gloss, error) {
+	return st.gloss, nil
+}
+
+func newWrappedManifestWork(t *testing.T, namespace, name string, annotations map[string]string) *unstructured.Unstructured {
+	t.Helper()
+	wrapped := &workapi.ManifestWork{
+		TypeMeta: typeMeta("ManifestWork", workapi.GroupVersion),
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace:   namespace,
+			Name:        name,
+			Annotations: annotations,
+		},
+	}
+	obj, err := runtime.DefaultUnstructuredConverter.ToUnstructured(wrapped)
+	if err != nil {
+		t.Fatalf("Failed to convert ManifestWork to unstructured: %v", err)
+	}
+	return &unstructured.Unstructured{Object: obj}
+}
+
+func TestWrapBatchAnnotatesCustomTransformState(t *testing.T) {
+	ctlr := &genericTransportController{
+		transport: staticTransport{},
+		wdsName:   "test-wds",
+	}
+	wrapee := &unstructured.Unstructured{}
+	wrapee.SetAPIVersion("v1")
+	wrapee.SetKind("ConfigMap")
+	wrapee.SetName("sample")
+
+	wrapped, err := ctlr.wrapBatch([]transport.Wrapee{transport.NewWrapee(wrapee, false)},
+		[]string{"sha256:custom-transform"}, "sample-uid",
+		func(k8sschema.GroupKind) (string, bool) { return "", false },
+		&ksapi.Binding{
+			ObjectMeta: metav1.ObjectMeta{Name: "binding", UID: "binding-uid", Generation: 1},
+		}, 0)
+	if err != nil {
+		t.Fatalf("wrapBatch returned an error: %v", err)
+	}
+	if got := wrapped.GetAnnotations()[customTransformStateAnnotation]; got == "" {
+		t.Fatalf("Expected %s annotation to be set", customTransformStateAnnotation)
+	}
+}
+
+func TestCustomTransformStateDigestIsStable(t *testing.T) {
+	first := &ksapi.CustomTransform{
+		ObjectMeta: metav1.ObjectMeta{Name: "first"},
+		Spec: ksapi.CustomTransformSpec{
+			APIGroup: "apps",
+			Resource: "deployments",
+			Remove:   []string{"$.status"},
+		},
+	}
+	second := &ksapi.CustomTransform{
+		ObjectMeta: metav1.ObjectMeta{Name: "second"},
+		Spec: ksapi.CustomTransformSpec{
+			APIGroup: "",
+			Resource: "configmaps",
+			Remove:   []string{"$.metadata.annotations"},
+		},
+	}
+	digest := customTransformStateDigest([]*ksapi.CustomTransform{first, second})
+	if digest == "" {
+		t.Fatal("Expected non-empty digest")
+	}
+	if reordered := customTransformStateDigest([]*ksapi.CustomTransform{second, first}); reordered != digest {
+		t.Fatalf("Expected digest to be stable across informer order, got %q and %q", digest, reordered)
+	}
+	modified := second.DeepCopy()
+	modified.Spec.Remove = append(modified.Spec.Remove, "$.metadata.labels")
+	if changed := customTransformStateDigest([]*ksapi.CustomTransform{first, modified}); changed == digest {
+		t.Fatal("Expected digest to change when a CustomTransform spec changes")
+	}
+}
+
+func TestPropagateWrappedObjectUpdatesCustomTransformStateMismatch(t *testing.T) {
+	logger, ctx := ktesting.NewTestContext(t)
+	scheme := runtime.NewScheme()
+	if err := workapi.AddToScheme(scheme); err != nil {
+		t.Fatalf("Failed to add work API to scheme: %v", err)
+	}
+	wrapperGVR := workapi.GroupVersion.WithResource("manifestworks")
+	current := newWrappedManifestWork(t, "cluster-a", "wrapped", map[string]string{
+		originOwnerGenerationAnnotation: "7",
+		customTransformStateAnnotation:  "sha256:old",
+	})
+	desired := newWrappedManifestWork(t, "cluster-a", "wrapped", map[string]string{
+		originOwnerGenerationAnnotation: "7",
+		customTransformStateAnnotation:  "sha256:new",
+	})
+	itsDynamicClient := dynamicfake.NewSimpleDynamicClient(scheme, current.DeepCopy())
+	ctlr := &genericTransportController{
+		logger:           logger,
+		transport:        staticTransport{gloss: transport.Gloss{}},
+		transportClient:  itsDynamicClient,
+		wrappedObjectGVR: wrapperGVR,
+	}
+	currentWrappedObjectList := &unstructured.UnstructuredList{
+		Items: []unstructured.Unstructured{*current.DeepCopy()},
+	}
+	dest := ksapi.Destination{ClusterId: "cluster-a"}
+
+	err := ctlr.propagateWrappedObjectToClusters(ctx,
+		func(candidate ksapi.Destination) ([]transportTask, bool) {
+			if candidate != dest {
+				return nil, false
+			}
+			return []transportTask{{ObjU: desired, Gloss: transport.Gloss{}}}, true
+		},
+		func(k8sschema.GroupKind) (string, bool) { return "", false },
+		currentWrappedObjectList,
+		[]ksapi.Destination{dest})
+	if err != nil {
+		t.Fatalf("propagateWrappedObjectToClusters returned an error: %v", err)
+	}
+	got, err := itsDynamicClient.Resource(wrapperGVR).Namespace(dest.ClusterId).Get(ctx, "wrapped", metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("Failed to get updated wrapped object: %v", err)
+	}
+	if gotState := got.GetAnnotations()[customTransformStateAnnotation]; gotState != "sha256:new" {
+		t.Fatalf("Expected CustomTransform state to be updated, got %q", gotState)
+	}
+}
+
 func TestGenericController(t *testing.T) {
 	rg := rand.New(rand.NewSource(42))
 	rg.Uint64()


### PR DESCRIPTION
## Summary

- Track relevant CustomTransform state on wrapped ManifestWorks so changed transforms trigger updates even when Binding generation and propagated object gloss are unchanged
- Add focused generic transport tests for CustomTransform state changes and skip behavior
- Add contributor agent notes for future issue work in this checkout

Fixes #3723

## Validation

- go test ./pkg/transport/...
- git diff --check main...HEAD
- git show --check --oneline --decorate HEAD