### PR TITLE
🌱 Restrict workflow token permissions

### DIFF
--- a/.github/workflows/ai-fix.yml
+++ b/.github/workflows/ai-fix.yml
@@ -13,12 +13,14 @@ on:
     types: [opened]
 
 permissions:
-  contents: write
-  issues: write
-  pull-requests: write
+  contents: read
 
 jobs:
   ai-fix:
+    permissions:
+      contents: write
+      issues: write
+      pull-requests: write
     uses: kubestellar/infra/.github/workflows/reusable-ai-fix.yml@main
     with:
       issue_number: ${{ github.event.inputs.issue_number || '' }}

--- a/.github/workflows/check-docs-pr-preview.yml
+++ b/.github/workflows/check-docs-pr-preview.yml
@@ -19,6 +19,10 @@ on:
       - 'GOVERNANCE.md'
       - 'ONBOARDING.md'
 
+permissions:
+  contents: read
+  pull-requests: read
+
 jobs:
   check-preview-link:
     if: false

--- a/.github/workflows/copilot-automation.yml
+++ b/.github/workflows/copilot-automation.yml
@@ -11,10 +11,7 @@ on:
     types: [opened, synchronize, ready_for_review]
 
 permissions:
-  contents: write
-  pull-requests: write
-  issues: write
-  statuses: write
+  contents: read
 
 concurrency:
   group: copilot-automation-${{ github.event.pull_request.number || github.event.inputs.pr_number || github.sha }}
@@ -22,6 +19,11 @@ concurrency:
 
 jobs:
   copilot-automation:
+    permissions:
+      contents: read
+      pull-requests: read
+      issues: write
+      statuses: write
     uses: kubestellar/infra/.github/workflows/reusable-copilot-automation.yml@main
     with:
       pr_number: ${{ github.event.inputs.pr_number || '' }}

--- a/.github/workflows/copilot-dco.yml
+++ b/.github/workflows/copilot-dco.yml
@@ -6,10 +6,12 @@ on:
 
 permissions:
   contents: read
-  issues: write
-  pull-requests: read
-  statuses: write
 
 jobs:
   copilot-dco:
+    permissions:
+      contents: read
+      issues: write
+      pull-requests: read
+      statuses: write
     uses: kubestellar/infra/.github/workflows/reusable-copilot-dco.yml@main

--- a/.github/workflows/copilot-dco.yml
+++ b/.github/workflows/copilot-dco.yml
@@ -4,6 +4,12 @@ on:
   pull_request:
     types: [opened, synchronize, reopened]
 
+permissions:
+  contents: read
+  issues: write
+  pull-requests: read
+  statuses: write
+
 jobs:
   copilot-dco:
     uses: kubestellar/infra/.github/workflows/reusable-copilot-dco.yml@main

--- a/.github/workflows/image-scanning.yml
+++ b/.github/workflows/image-scanning.yml
@@ -20,7 +20,6 @@ on:
 
 permissions:
   contents: read
-  security-events: write
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -28,6 +27,9 @@ concurrency:
 
 jobs:
   scan:
+    permissions:
+      contents: read
+      security-events: write
     uses: kubestellar/infra/.github/workflows/reusable-image-scanning.yml@main
     secrets: inherit
     with:

--- a/.github/workflows/pr-verifier.yml
+++ b/.github/workflows/pr-verifier.yml
@@ -5,10 +5,13 @@ on:
     types: [opened, edited, synchronize, reopened]
 
 permissions:
-  checks: write
-  pull-requests: read
+  contents: read
 
 jobs:
   verify:
+    permissions:
+      checks: write
+      pull-requests: read
+      packages: read
     uses: kubestellar/infra/.github/workflows/reusable-pr-verifier.yml@main
     secrets: inherit

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -8,12 +8,13 @@ on:
   workflow_dispatch:
 
 permissions:
-  security-events: write
   contents: read
-  actions: read
-  id-token: write
 
 jobs:
   analysis:
+    permissions:
+      security-events: write
+      contents: read
+      actions: read
     uses: kubestellar/infra/.github/workflows/reusable-scorecard.yml@main
     secrets: inherit


### PR DESCRIPTION
## Summary

- Add explicit least-privilege `GITHUB_TOKEN` permissions to the docs preview workflow.
- Move remaining required write scopes in reusable-workflow callers from workflow-wide permissions to job-scoped permissions.
- Reduce unused write scopes where the called workflow only reads PR or repository metadata, including removing the unused Scorecard `id-token: write` caller permission.
- Leave action references unchanged.

Part of #2626. Also improves the CLOMonitor token-permissions signal tracked by #2595.

## Validation

- `git show --check --oneline --decorate HEAD`
- `git diff --check HEAD~1..HEAD`
- `hack/gha-reversemap.sh verify-mapusage`
- `yq e '.' .github/workflows/ai-fix.yml .github/workflows/copilot-automation.yml .github/workflows/copilot-dco.yml .github/workflows/image-scanning.yml .github/workflows/pr-verifier.yml .github/workflows/scorecard.yml >/dev/null`
- `go run github.com/ossf/scorecard/v5@latest --checks=Token-Permissions --local=. --show-details` reports `10 / 10` for Token-Permissions