### PR TITLE
✨ Update self-references for release 0.30.0-rc.1

### DIFF
--- a/.github/workflows/test-demo-env-creation-script.yml
+++ b/.github/workflows/test-demo-env-creation-script.yml
@@ -42,11 +42,11 @@ jobs:
 
       - name: Install dependencies
         run: |
-          bash <(curl -sSL https://raw.githubusercontent.com/open-cluster-management-io/clusteradm/refs/tags/v0.10.1/install.sh) 0.10.1
-          wget -nv https://github.com/kubestellar/kubeflex/releases/download/v0.9.1/kubeflex_0.9.1_linux_amd64.tar.gz
-          tar -xvf kubeflex_0.9.1_linux_amd64.tar.gz bin/kflex
+          bash <(curl -sSL https://raw.githubusercontent.com/open-cluster-management-io/clusteradm/refs/tags/v1.0.0/install.sh) 1.0.0
+          wget -nv https://github.com/kubestellar/kubeflex/releases/download/v0.9.3/kubeflex_0.9.3_linux_amd64.tar.gz
+          tar -xvf kubeflex_0.9.3_linux_amd64.tar.gz bin/kflex
           mv bin/kflex /usr/local/bin
-          rm -fr bin kubeflex_0.9.1_linux_amd64.tar.gz
+          rm -fr bin kubeflex_0.9.3_linux_amd64.tar.gz
 
       - name: Run test
         run: test/e2e/ci/test-demo-env.sh kind
@@ -172,11 +172,11 @@ jobs:
 
       - name: Install dependencies
         run: |
-          bash <(curl -sSL https://raw.githubusercontent.com/open-cluster-management-io/clusteradm/refs/tags/v0.10.1/install.sh) 0.10.1
-          wget -nv https://github.com/kubestellar/kubeflex/releases/download/v0.9.1/kubeflex_0.9.1_linux_amd64.tar.gz
-          tar -xvf kubeflex_0.9.1_linux_amd64.tar.gz bin/kflex
+          bash <(curl -sSL https://raw.githubusercontent.com/open-cluster-management-io/clusteradm/refs/tags/v1.0.0/install.sh) 1.0.0
+          wget -nv https://github.com/kubestellar/kubeflex/releases/download/v0.9.3/kubeflex_0.9.3_linux_amd64.tar.gz
+          tar -xvf kubeflex_0.9.3_linux_amd64.tar.gz bin/kflex
           mv bin/kflex /usr/local/bin
-          rm -fr bin kubeflex_0.9.1_linux_amd64.tar.gz
+          rm -fr bin kubeflex_0.9.3_linux_amd64.tar.gz
           bash <(curl -sSL https://raw.githubusercontent.com/k3d-io/k3d/main/install.sh)
 
       - name: Run test

--- a/.github/workflows/test-latest-release.yml
+++ b/.github/workflows/test-latest-release.yml
@@ -34,11 +34,11 @@ jobs:
 
       - name: Install dependencies
         run: |
-          bash <(curl -L https://raw.githubusercontent.com/open-cluster-management-io/clusteradm/refs/tags/v0.10.1/install.sh) 0.10.1
-          wget https://github.com/kubestellar/kubeflex/releases/download/v0.9.1/kubeflex_0.9.1_linux_amd64.tar.gz
-          tar -xvf kubeflex_0.9.1_linux_amd64.tar.gz bin/kflex
+          bash <(curl -L https://raw.githubusercontent.com/open-cluster-management-io/clusteradm/refs/tags/v1.0.0/install.sh) 1.0.0
+          wget https://github.com/kubestellar/kubeflex/releases/download/v0.9.3/kubeflex_0.9.3_linux_amd64.tar.gz
+          tar -xvf kubeflex_0.9.3_linux_amd64.tar.gz bin/kflex
           mv bin/kflex /usr/local/bin
-          rm -fr bin kubeflex_0.9.1_linux_amd64.tar.gz
+          rm -fr bin kubeflex_0.9.3_linux_amd64.tar.gz
           go install github.com/onsi/ginkgo/v2/ginkgo
 
       - name: Run test
@@ -109,11 +109,11 @@ jobs:
 
       - name: Install dependencies
         run: |
-          bash <(curl -L https://raw.githubusercontent.com/open-cluster-management-io/clusteradm/refs/tags/v0.10.1/install.sh) 0.10.1
-          wget https://github.com/kubestellar/kubeflex/releases/download/v0.9.1/kubeflex_0.9.1_linux_amd64.tar.gz
-          tar -xvf kubeflex_0.9.1_linux_amd64.tar.gz bin/kflex
+          bash <(curl -L https://raw.githubusercontent.com/open-cluster-management-io/clusteradm/refs/tags/v1.0.0/install.sh) 1.0.0
+          wget https://github.com/kubestellar/kubeflex/releases/download/v0.9.3/kubeflex_0.9.3_linux_amd64.tar.gz
+          tar -xvf kubeflex_0.9.3_linux_amd64.tar.gz bin/kflex
           mv bin/kflex /usr/local/bin
-          rm -fr bin kubeflex_0.9.1_linux_amd64.tar.gz
+          rm -fr bin kubeflex_0.9.3_linux_amd64.tar.gz
 
       - name: Run test
         run: |

--- a/config/default/manager_auth_proxy_patch.yaml
+++ b/config/default/manager_auth_proxy_patch.yaml
@@ -30,7 +30,7 @@ spec:
           capabilities:
             drop:
               - "ALL"
-        image: quay.io/brancz/kube-rbac-proxy:v0.17.1
+        image: quay.io/brancz/kube-rbac-proxy:v0.20.2
         args:
         - "--secure-listen-address=0.0.0.0:8443"
         - "--upstream=http://127.0.0.1:8080/"

--- a/core-chart/templates/postcreatehooks/kubestellar-controller.yaml
+++ b/core-chart/templates/postcreatehooks/kubestellar-controller.yaml
@@ -157,7 +157,7 @@ spec:
                 - --upstream=http://127.0.0.1:8080/
                 - --logtostderr=true
                 - --v=0
-              image: quay.io/brancz/kube-rbac-proxy:v0.19.1
+              image: quay.io/brancz/kube-rbac-proxy:v0.20.2
               name: kube-rbac-proxy
               ports:
                 - containerPort: 8443

--- a/core-chart/values.yaml
+++ b/core-chart/values.yaml
@@ -6,7 +6,7 @@
 # please do not change them unless you know what you are doing.
 HELM_VERSION: "3.16.4"
 KUBECTL_VERSION: "1.32.13"
-KUBESTELLAR_VERSION: "0.29.0"
+KUBESTELLAR_VERSION: "0.30.0-rc.1"
 # TRANSPORT_VERSION: e.g., "0.24.0"; defaults to KUBESTELLAR_VERSION value, if not defined
 # KFLEX_GET_KUBECONFIG: e.g., "0.24.0"; defaults to KUBESTELLAR_VERSION value, if not defined
 CLUSTERADM_VERSION: "1.0.0"

--- a/scripts/check_pre_req.sh
+++ b/scripts/check_pre_req.sh
@@ -17,7 +17,7 @@
 # NOTE WELL: Two copies of this file exist, one in kubestellar/hack/
 # and one in kubestellar/scripts/ . Keep them both up-to-date.
 BASE_URL="https://docs.kubestellar.io"
-VERSION="release-0.29.0"
+VERSION="release-0.30.0-rc.1"
 INSTALLATION_ERROR_URL="${BASE_URL}/${VERSION}/direct/installation-errors#pod-errors-due-to-too-many-open-files"
 
 set -e # exit on error
@@ -232,7 +232,7 @@ is_installed_ocm() {
         'clusteradm' \
         'clusteradm version 2> /dev/null | grep ^client' \
         "clusteradm version 2> /dev/null | grep ^client | awk '"'{ print $3 }'"'" \
-        'bash <(curl -L https://raw.githubusercontent.com/open-cluster-management-io/clusteradm/main/install.sh) 1.0.0' \
+        'bash <(curl -L https://raw.githubusercontent.com/open-cluster-management-io/clusteradm/refs/tags/v1.0.0/install.sh) 1.0.0' \
         "" \
         :v1.0 \
         :v1.1

--- a/scripts/create-kubestellar-demo-env.sh
+++ b/scripts/create-kubestellar-demo-env.sh
@@ -68,7 +68,7 @@ if ! dunsel=$(docker ps 2>&1); then
 fi
 echo "Container runtime is running."
 
-kubestellar_version=0.29.0
+kubestellar_version=0.30.0-rc.1
 echo -e "KubeStellar Version: ${kubestellar_version}"
 
 echo -e "Checking that pre-req softwares are installed..."

--- a/test/performance/long-running-tests/README.md
+++ b/test/performance/long-running-tests/README.md
@@ -5,7 +5,7 @@ To generate the sample workload for KubeStellar performance experiments for long
 1. Clone the following clusterloader2 repo. It's the tool used to deploy the benchmark workload in a KubeStellar environment:
 
    ```bash 
-   git clone -b release-1.31 https://github.com/kubernetes/perf-tests.git
+   git clone -b release-1.32 https://github.com/kubernetes/perf-tests.git
    ```
 
 2. Configure clusterloader2 to generate KS performance workloads:

--- a/test/performance/short-running-tests/README.md
+++ b/test/performance/short-running-tests/README.md
@@ -7,7 +7,7 @@ To generate the sample workload for KubeStellar performance experiments for shor
 1. Clone the following clusterloader2 repo: 
 
    ```bash
-   git clone -b release-1.31 https://github.com/kubernetes/perf-tests.git
+   git clone -b release-1.32 https://github.com/kubernetes/perf-tests.git
    ```
 
 2. Configure clusterloader2 to generate KS performance workloads:

--- a/test/scale-infra/deploy_ks_core.yaml
+++ b/test/scale-infra/deploy_ks_core.yaml
@@ -35,12 +35,12 @@
              sudo chmod a+x /usr/local/bin/yq
 
     - name: install OCM CLI
-      shell: curl -L https://raw.githubusercontent.com/open-cluster-management-io/clusteradm/main/install.sh | bash
+      shell: curl -L https://raw.githubusercontent.com/open-cluster-management-io/clusteradm/refs/tags/v1.0.0/install.sh | bash -s 1.0.0
         
     - name: install the KubeFlex CLI
       shell: |
              sudo su <<EOF
-             bash <(curl -s https://raw.githubusercontent.com/kubestellar/kubeflex/main/scripts/install-kubeflex.sh) --ensure-folder /usr/local/bin --strip-bin --version v0.8.8
+             bash <(curl -s https://raw.githubusercontent.com/kubestellar/kubeflex/refs/tags/v0.9.3/scripts/install-kubeflex.sh) --ensure-folder /usr/local/bin --strip-bin --version v0.9.3
              EOF
 
     - name: install Helm

--- a/test/scale-infra/deploy_ks_wec.yaml
+++ b/test/scale-infra/deploy_ks_wec.yaml
@@ -41,7 +41,7 @@
              sudo mv ./kind /usr/local/bin/kind
 
     - name: install OCM CLI
-      shell: curl -L https://raw.githubusercontent.com/open-cluster-management-io/clusteradm/main/install.sh | bash
+      shell: curl -L https://raw.githubusercontent.com/open-cluster-management-io/clusteradm/refs/tags/v1.0.0/install.sh | bash -s 1.0.0
 
     - name: install kubectl
       shell: |


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Don't forget to first look for overlapping PRs. Remember, open source
is a collaborative rather than competitive activity.

If this PR includes changes to the source files for the website
(docs/content/** or a file included from there) then include a preview
of the modified website; see
docs/content/contribution-guidelines/operations/document-management.md.

Please put one of the following icons at the start of your PR title,
to indicate the type of your PR. You could use copy-and-paste from
here; alternatively, the indicated code is recognized by most browsers
as a way to input that icon.

✨ - code :sparkles:, type feature
🐛 - code :bug:, type bug fix
📖 - code :book:, type docs
📝 - code :memo:, type proposal
⚠️ - code :warning:, type breaking change
🌱 - code :seedling:, type other/misc
❓ - code :question:, type requires manual review/categorization

-->
## Summary
This PR updates the self-references, in preparation for ks/ks release 0.30.0-rc.1. This will be the first that depends on Kubernetes release 1.32, and so has an unusually large collection of changes (due to moves to higher releases of intermediate dependencies to make a coordinated move from kube 1.30 to 1.32).

This PR also fixes some cases of using an install script from the `main` branch of a dependency.

**NOTE**: The CI tests of `scripts/create-kubestellar-demo-env.sh` are expected to fail, as noted in https://main--kubestellar-docs.netlify.app/docs/contributing/release-process#making-a-new-kubestellar-release .

## Related issue(s)

