### PR TITLE
🐛 Remove outdated debug job step

### DIFF
--- a/.github/workflows/test-demo-env-creation-script.yml
+++ b/.github/workflows/test-demo-env-creation-script.yml
@@ -236,10 +236,6 @@ jobs:
         if: always()
         run: kubectl --context k3d-kubeflex -n wds1-system logs $(kubectl --context k3d-kubeflex -n wds1-system get pods -l name=transport-controller -o jsonpath='{.items[0].metadata.name}')
 
-      - name: show ConfigMap transport-controller-config
-        if: always()
-        run: kubectl --context k3d-kubeflex get cm -n wds1-system transport-controller-config -o yaml
-
       - name: show bindingpolicies
         if: always()
         run: kubectl --context wds1 get bindingpolicies.control.kubestellar.io -o yaml


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Don't forget to first look for overlapping PRs. Remember, open source
is a collaborative rather than competitive activity.

If this PR includes changes to the source files for the website
(docs/content/** or a file included from there) then include a preview
of the modified website; see
docs/content/contribution-guidelines/operations/document-management.md.

Please put one of the following icons at the start of your PR title,
to indicate the type of your PR. You could use copy-and-paste from
here; alternatively, the indicated code is recognized by most browsers
as a way to input that icon.

✨ - code :sparkles:, type feature
🐛 - code :bug:, type bug fix
📖 - code :book:, type docs
📝 - code :memo:, type proposal
⚠️ - code :warning:, type breaking change
🌱 - code :seedling:, type other/misc
❓ - code :question:, type requires manual review/categorization

-->
## Summary
Removed the job step that displays transport-controller-config, because it no longer is part of the design. This ConfigMap was removed in PR #3442 .

## Related issue(s)

Fixes #3777
