### PR TITLE
🐛 kos.repository is deprecated from goreleaser v2.5

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -37,8 +37,9 @@ builds:
   env:
   - CGO_ENABLED=0
 kos:           
-  - id: kubestellar-controller-manager
-    repository: ghcr.io/kubestellar/kubestellar/controller-manager
+  - id: controller-manager
+    repositories: 
+      - ghcr.io/kubestellar/kubestellar/controller-manager
     build: controller-manager
     tags:
     - '{{.Version}}'
@@ -50,7 +51,8 @@ kos:
     - linux/amd64
     - linux/arm64
   - id: ocm-transport-controller
-    repository: ghcr.io/kubestellar/kubestellar/ocm-transport-controller
+    repositories: 
+      - ghcr.io/kubestellar/kubestellar/ocm-transport-controller
     build: ocm-transport-controller
     tags:
     - '{{.Version}}'
@@ -62,7 +64,8 @@ kos:
     - linux/amd64
     - linux/arm64
   - id: kflex-get-kubeconfig
-    repository: ghcr.io/kubestellar/kubestellar/kflex-get-kubeconfig
+    repositories: 
+      -ghcr.io/kubestellar/kubestellar/kflex-get-kubeconfig
     build: kflex-get-kubeconfig
     tags:
     - '{{.Version}}'

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -65,7 +65,7 @@ kos:
     - linux/arm64
   - id: kflex-get-kubeconfig
     repositories: 
-      -ghcr.io/kubestellar/kubestellar/kflex-get-kubeconfig
+      - ghcr.io/kubestellar/kubestellar/kflex-get-kubeconfig
     build: kflex-get-kubeconfig
     tags:
     - '{{.Version}}'

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -37,7 +37,7 @@ builds:
   env:
   - CGO_ENABLED=0
 kos:           
-  - id: controller-manager
+  - id: kubestellar-controller-manager
     repositories: 
       - ghcr.io/kubestellar/kubestellar/controller-manager
     build: controller-manager


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Don't forget to first look for overlapping PRs. Remember, open source
is a collaborative rather than competitive activity.

If this PR includes changes to the source files for the website
(docs/content/** or a file included from there) then include a preview
of the modified website; see
docs/content/contribution-guidelines/operations/document-management.md.

Please put one of the following icons at the start of your PR title,
to indicate the type of your PR. You could use copy-and-paste from
here; alternatively, the indicated code is recognized by most browsers
as a way to input that icon.

✨ - code :sparkles:, type feature
🐛 - code :bug:, type bug fix
📖 - code :book:, type docs
📝 - code :memo:, type proposal
⚠️ - code :warning:, type breaking change
🌱 - code :seedling:, type other/misc
❓ - code :question:, type requires manual review/categorization

-->
## Summary
As per https://github.com/kubestellar/kubestellar/issues/3776, it was reported that goreleaser throws a deprecation warnning 
`• DEPRECATED: kos.repository should not be used anymore, check https://goreleaser.com/deprecations#kosrepository for more info`

According to https://goreleaser.com/resources/deprecations/#kosrepository , kos.repository has been deprecated in favour of kos.repositories starting from version 2.5. As I see, the repository is currently using v2.14.3 and hence the warning. 

## Related issue(s)
https://github.com/kubestellar/kubestellar/issues/3776

Fixes #
