### PR TITLE
📖 Fix KubeFlex logo path in documentation

### DIFF
--- a/docs/to-be-deleted/content/direct/kubeflex-intro.md
+++ b/docs/to-be-deleted/content/direct/kubeflex-intro.md
@@ -1,4 +1,4 @@
-# <img alt="Logo" width="90px" src="../images/kubeflex-logo.png" style="vertical-align: middle;" /> KubeFlex
+# <img alt="Logo" width="90px" src="images/kubeflex-logo.png" style="vertical-align: middle;" /> KubeFlex
 
 One of the technologies underlying KubeStellar is KubeFlex, a kubernetes-based platform designed to:
 


### PR DESCRIPTION
## Fix KubeFlex Logo Missing on Documentation Page

### Issue
Closes #3560

The KubeFlex logo was not displaying on the KubeFlex introduction documentation page.

### Root Cause
The image source path in `kubeflex-intro.md` was using an incorrect relative path (`../images/kubeflex-logo.png`) that pointed to a non-existent location in the docs directory structure.

### Solution
Updated the image source path from `../images/kubeflex-logo.png` to the correct relative path `images/kubeflex-logo.png`, which properly references the images directory at the correct location.

### Changes
- Updated image path reference in `kubeflex-intro.md` to point to the correct location of the KubeFlex logo

### Testing
The logo should now display correctly on the KubeFlex introduction page at https://kubestellar.io/docs/ui-tools/kubeflex-intro/

### Related
- Issue #3560: KubeFlex logo missing from documentation