### PR TITLE
🐛Fix #3722: modernize create-kubestellar-demo-env.sh and resolve circular dependencies

### DIFF
--- a/.github/workflows/test-demo-env-creation-script.yml
+++ b/.github/workflows/test-demo-env-creation-script.yml
@@ -9,6 +9,7 @@ on:
     paths:
       - ".github/workflows/test-demo-env-creation-script.yml"
       - "scripts/create-kubestellar-demo-env.sh"
+      - "scripts/create-demo-env-from-given-release.sh"
       - "test/e2e/ci/test-demo-env.sh"
       - "test/e2e/common/setup-shell.sh"
       - "test/e2e/bash/use-kubestellar.sh"
@@ -16,6 +17,7 @@ on:
     paths:
       - ".github/workflows/test-demo-env-creation-script.yml"
       - "scripts/create-kubestellar-demo-env.sh"
+      - "scripts/create-demo-env-from-given-release.sh"
       - "test/e2e/ci/test-demo-env.sh"
       - "test/e2e/common/setup-shell.sh"
       - "test/e2e/bash/use-kubestellar.sh"

--- a/docs/to-be-deleted/content/direct/get-started.md
+++ b/docs/to-be-deleted/content/direct/get-started.md
@@ -46,13 +46,13 @@ The script can install KubeStellar's demonstration environment on top of kind or
 For use with kind
 
 ```shell
-bash <(curl -s https://raw.githubusercontent.com/kubestellar/kubestellar/refs/tags/v{{ config.ks_latest_release }}/scripts/create-demo-env-from-given-release.sh) --version {{ config.ks_latest_release }} --platform kind
+bash <(curl -s https://raw.githubusercontent.com/kubestellar/kubestellar/refs/tags/v{{ config.ks_latest_release }}/scripts/create-kubestellar-demo-env.sh) --platform kind
 ```
 
 For use with k3d
 
 ```shell
-bash <(curl -s https://raw.githubusercontent.com/kubestellar/kubestellar/refs/tags/v{{ config.ks_latest_release }}/scripts/create-demo-env-from-given-release.sh) --version {{ config.ks_latest_release }} --platform k3d
+bash <(curl -s https://raw.githubusercontent.com/kubestellar/kubestellar/refs/tags/v{{ config.ks_latest_release }}/scripts/create-kubestellar-demo-env.sh) --platform k3d
 ```
 
 If successful, the script will output the variable definitions that you would use when proceeding to the example scenarios. After successfully running the script, proceed to the [Exercise KubeStellar](#exercise-kubestellar) section below.

--- a/docs/to-be-deleted/content/direct/get-started.md
+++ b/docs/to-be-deleted/content/direct/get-started.md
@@ -46,13 +46,13 @@ The script can install KubeStellar's demonstration environment on top of kind or
 For use with kind
 
 ```shell
-bash <(curl -s https://raw.githubusercontent.com/kubestellar/kubestellar/refs/tags/v{{ config.ks_latest_release }}/scripts/create-kubestellar-demo-env.sh) --platform kind
+bash <(curl -s https://raw.githubusercontent.com/kubestellar/kubestellar/refs/tags/v{{ config.ks_latest_release }}/scripts/create-demo-env-from-given-release.sh) --version {{ config.ks_latest_release }} --platform kind
 ```
 
 For use with k3d
 
 ```shell
-bash <(curl -s https://raw.githubusercontent.com/kubestellar/kubestellar/refs/tags/v{{ config.ks_latest_release }}/scripts/create-kubestellar-demo-env.sh) --platform k3d
+bash <(curl -s https://raw.githubusercontent.com/kubestellar/kubestellar/refs/tags/v{{ config.ks_latest_release }}/scripts/create-demo-env-from-given-release.sh) --version {{ config.ks_latest_release }} --platform k3d
 ```
 
 If successful, the script will output the variable definitions that you would use when proceeding to the example scenarios. After successfully running the script, proceed to the [Exercise KubeStellar](#exercise-kubestellar) section below.

--- a/docs/to-be-deleted/content/direct/release.md
+++ b/docs/to-be-deleted/content/direct/release.md
@@ -52,7 +52,7 @@ Making a new kubestellar release requires a contributor to do the following thin
 
 - Update the version in the core chart defaults, `core-chart/values.yaml`.
 
-- Update the version in `scripts/create-kubestellar-demo-env.sh`. **Note:** merging this change will cause the script to be broken until the release is made.
+- Update the version in `scripts/create-kubestellar-demo-env.sh`. **Note:** merging this change will cause the script to be broken until the release is made. Note that the new script `scripts/create-demo-env-from-given-release.sh` has no default version and does not need version updates during a release.
 
 - Until we have our first stable release, edit the old docs README(`oldocs/README.md`, section "latest-stable-release") where it wishes it could cite a stable release but instead cites the latest release, to refer to the coming release.
 

--- a/scripts/check_pre_req.sh
+++ b/scripts/check_pre_req.sh
@@ -158,6 +158,24 @@ is_installed_jq() {
         'jq-1.5'
 }
 
+is_installed_lsof() {
+    is_installed 'lsof' \
+        'lsof' \
+        'lsof -v 2>/dev/null | head -1' \
+        'lsof -v 2>/dev/null | head -1' \
+        'sudo apt-get install lsof or brew install lsof' \
+        ''
+}
+
+is_installed_timeout() {
+    is_installed 'timeout' \
+        'timeout' \
+        'timeout --version 2>/dev/null | head -1' \
+        'timeout --version 2>/dev/null | head -1' \
+        'sudo apt-get install coreutils or brew install coreutils' \
+        ''
+}
+
 is_installed_kcp() {
     is_installed 'kcp' \
         'kcp' \
@@ -245,7 +263,7 @@ is_installed_yq() {
 
 
 # Global constants
-PROGRAMS="@(argo|brew|docker|go|helm|jq|kflex|kind|ko|kubectl|make|ocm|yq|k3d|ginkgo)"
+PROGRAMS="@(argo|brew|docker|go|helm|jq|kflex|kind|ko|kubectl|lsof|make|ocm|timeout|yq|k3d|ginkgo)"
 
 # Global parameters
 assert="false"  # true => exit on missing program

--- a/scripts/create-demo-env-from-given-release.sh
+++ b/scripts/create-demo-env-from-given-release.sh
@@ -16,31 +16,55 @@
 set -e
 
 # Script info
-SCRIPT_NAME="create-kubestellar-demo-env.sh"
-
-echo "WARNING: ${SCRIPT_NAME} is deprecated and will be removed in a future release." >&2
-echo "Please use create-demo-env-from-given-release.sh instead, which requires explicitly specifying the KubeStellar version via the --version option." >&2
+SCRIPT_NAME="create-demo-env-from-given-release.sh"
 
 # Default Kubernetes platform parameter
 k8s_platform="kind"
+kubestellar_version=""
 
 # Parse command-line arguments
 while [[ "$#" -gt 0 ]]; do
     case $1 in
-        --platform) k8s_platform="$2"; shift ;;
-        -X) set -x ;;
+        --platform)
+            if [[ -z "$2" ]]; then
+                echo "Error: --platform requires an argument." >&2
+                exit 1
+            fi
+            k8s_platform="$2"
+            shift
+            ;;
+        -v|--version)
+            if [[ -z "$2" ]]; then
+                echo "Error: --version requires an argument." >&2
+                exit 1
+            fi
+            kubestellar_version="$2"
+            shift
+            ;;
+        -X)
+            set -x
+            ;;
         -h|--help)
-            echo "Usage: ${SCRIPT_NAME} [--platform <kind|k3d>] [-X] [-h|--help]" >&2
+            echo "Usage: ${SCRIPT_NAME} --version <version> [--platform <kind|k3d>] [-X] [-h|--help]" >&2
             exit 0
             ;;
         *)
             echo "Unknown parameter passed: $1" >&2
-            echo "Usage: ${SCRIPT_NAME} [--platform <kind|k3d>] [-X] [-h|--help]" >&2
+            echo "Usage: ${SCRIPT_NAME} --version <version> [--platform <kind|k3d>] [-X] [-h|--help]" >&2
             exit 1
             ;;
     esac
     shift
 done
+
+if [[ -z "$kubestellar_version" ]]; then
+    echo "Error: --version <version> is required." >&2
+    echo "Usage: ${SCRIPT_NAME} --version <version> [--platform <kind|k3d>] [-X] [-h|--help]" >&2
+    exit 1
+fi
+
+kubestellar_version="${kubestellar_version#v}"
+kubestellar_ref="v${kubestellar_version}"
 
 if [[ "$k8s_platform" != "kind" && "$k8s_platform" != "k3d" ]]; then
     echo "Invalid platform specified: $k8s_platform"
@@ -49,6 +73,23 @@ if [[ "$k8s_platform" != "kind" && "$k8s_platform" != "k3d" ]]; then
 fi
 
 echo "Selected Kubernetes platform: $k8s_platform"
+echo "KubeStellar Version: ${kubestellar_version}"
+echo "KubeStellar Git ref for helper scripts: ${kubestellar_ref}"
+
+SRC_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd || echo ".")"
+
+run_helper_script() {
+    local script_name="$1"
+    shift
+
+    if [ -f "${SRC_DIR}/${script_name}" ]; then
+        echo "Using local ${script_name}"
+        bash "${SRC_DIR}/${script_name}" "$@"
+    else
+        echo "Fetching ${script_name} from GitHub (ref: ${kubestellar_ref})..."
+        curl -s "https://raw.githubusercontent.com/kubestellar/kubestellar/${kubestellar_ref}/scripts/${script_name}" | bash -s -- "$@"
+    fi
+}
 
 # Function to check if a command exists
 command_exists() {
@@ -71,15 +112,9 @@ if ! dunsel=$(docker ps 2>&1); then
 fi
 echo "Container runtime is running."
 
-kubestellar_version=0.30.0
-echo -e "KubeStellar Version: ${kubestellar_version}"
-
 echo -e "Checking that pre-req softwares are installed..."
-if [ "$k8s_platform" == "kind" ]; then
-    curl -s https://raw.githubusercontent.com/kubestellar/kubestellar/v${kubestellar_version}/scripts/check_pre_req.sh | bash -s -- --assert -V kflex ocm helm kubectl docker kind
-else
-    curl -s https://raw.githubusercontent.com/kubestellar/kubestellar/v${kubestellar_version}/scripts/check_pre_req.sh | bash -s -- --assert -V kflex ocm helm kubectl docker k3d
-fi
+platform_tool="$k8s_platform"
+run_helper_script check_pre_req.sh --assert -V kflex ocm helm kubectl docker "$platform_tool"
 
 ##########################################
 cluster_clean_up() {
@@ -170,7 +205,7 @@ done
 
 echo -e "Creating KubeFlex cluster with SSL Passthrough"
 if [ "$k8s_platform" == "kind" ]; then
-    curl -s https://raw.githubusercontent.com/kubestellar/kubestellar/v${kubestellar_version}/scripts/create-kind-cluster-with-SSL-passthrough.sh | bash -s -- --name kubeflex --nosetcontext
+    run_helper_script create-kind-cluster-with-SSL-passthrough.sh --name kubeflex --nosetcontext
 else
     k3d cluster create -p "9443:443@loadbalancer" --k3s-arg "--disable=traefik@server:*" kubeflex
     kubectl wait --for=condition=Ready node --all --timeout=600s #Ensure both API server and nodes are ready
@@ -216,7 +251,7 @@ else var_flags=""
 fi
 
 helm upgrade --install ks-core oci://ghcr.io/kubestellar/kubestellar/core-chart \
-        --version $kubestellar_version \
+        --version "$kubestellar_version" \
         --set-json='ITSes=[{"name":"its1"}]' \
         --set-json='WDSes=[{"name":"wds1"},{"name":"wds2", "type":"host"}]' \
         --set-json='verbosity.default=5' \

--- a/scripts/create-demo-env-from-given-release.sh
+++ b/scripts/create-demo-env-from-given-release.sh
@@ -135,7 +135,7 @@ echo "Container runtime is running."
 
 echo -e "Checking that pre-req softwares are installed..."
 platform_tool="$k8s_platform"
-run_helper_script check_pre_req.sh --assert -V kflex ocm helm kubectl docker lsof "$platform_tool"
+run_helper_script check_pre_req.sh --assert -V kflex ocm helm kubectl docker "$platform_tool"
 
 ##########################################
 cluster_clean_up() {

--- a/scripts/create-demo-env-from-given-release.sh
+++ b/scripts/create-demo-env-from-given-release.sh
@@ -14,6 +14,7 @@
 # limitations under the License.
 
 set -e
+set -o pipefail
 
 # Script info
 SCRIPT_NAME="create-demo-env-from-given-release.sh"
@@ -87,7 +88,7 @@ run_helper_script() {
         bash "${SRC_DIR}/${script_name}" "$@"
     else
         echo "Fetching ${script_name} from GitHub (ref: ${kubestellar_ref})..."
-        curl -s "https://raw.githubusercontent.com/kubestellar/kubestellar/${kubestellar_ref}/scripts/${script_name}" | bash -s -- "$@"
+        curl -sSf "https://raw.githubusercontent.com/kubestellar/kubestellar/${kubestellar_ref}/scripts/${script_name}" | bash -s -- "$@"
     fi
 }
 

--- a/scripts/create-demo-env-from-given-release.sh
+++ b/scripts/create-demo-env-from-given-release.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Copyright 2024 The KubeStellar Authors.
+# Copyright 2026 The KubeStellar Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/scripts/create-demo-env-from-given-release.sh
+++ b/scripts/create-demo-env-from-given-release.sh
@@ -64,6 +64,14 @@ if [[ -z "$kubestellar_version" ]]; then
     exit 1
 fi
 
+# Validate version format to prevent arbitrary remote code execution
+# Allow SemVer-like versions: X.Y.Z with optional pre-release/build metadata
+if ! [[ "$kubestellar_version" =~ ^v?[0-9]+(\.[0-9]+){2}([+-][0-9A-Za-z.-]+)?$ ]]; then
+    echo "Error: invalid version format: $kubestellar_version" >&2
+    echo "Expected format: X.Y.Z or vX.Y.Z (optionally with pre-release/build metadata)" >&2
+    exit 1
+fi
+
 kubestellar_version="${kubestellar_version#v}"
 kubestellar_ref="v${kubestellar_version}"
 
@@ -131,7 +139,8 @@ run_helper_script check_pre_req.sh --assert -V kflex ocm helm kubectl docker lso
 
 ##########################################
 cluster_clean_up() {
-    if ! error_message=$(eval "$1" 2>&1); then
+    local cmd=("$@")
+    if ! error_message=$( "${cmd[@]}" 2>&1 ); then
         echo "clean up failed. Error:"
         echo "$error_message"
     fi
@@ -155,33 +164,41 @@ context_clean_up() {
 }
 
 checking_cluster() {
+    local cluster_name="$1"
+    local csr_timeout=300  # 5 minutes
+    local elapsed=0
     while IFS= read -r line; do
         # Check for the cluster name and "Pending" status
-        if echo "$line" | grep -q "$1" && echo "$line" | grep -q "Pending"; then
-            echo "Pending CSR for $1 has been found, approving..."
-            if clusteradm --context its1 accept --clusters "$1"; then
-                echo -e "\033[33m✔\033[0m CSR Approved for $1."
+        if echo "$line" | grep -q "$cluster_name" && echo "$line" | grep -q "Pending"; then
+            echo "Pending CSR for $cluster_name has been found, approving..."
+            if clusteradm --context its1 accept --clusters "$cluster_name"; then
+                echo -e "\033[33m✔\033[0m CSR Approved for $cluster_name."
                 return 0
             else
-                echo -e "\033[0;31mX\033[0m Failed to approve CSR for $1."
+                echo -e "\033[0;31mX\033[0m Failed to approve CSR for $cluster_name."
                 return 1
             fi
         fi
-    done < <(kubectl --context its1 get csr --watch)
+        ((elapsed++))
+        if (( elapsed > csr_timeout )); then
+            echo "ERROR: CSR for $cluster_name did not appear within ${csr_timeout}s" >&2
+            return 1
+        fi
+    done < <(timeout "$csr_timeout" kubectl --context its1 get csr --watch)
 }
 
 echo -e "\nStarting environment clean up..."
 echo -e "Starting cluster clean up..."
 
 if command_exists "k3d"; then
-    cluster_clean_up "k3d cluster delete kubeflex"
-    cluster_clean_up "k3d cluster delete cluster1"
-    cluster_clean_up "k3d cluster delete cluster2"
+    cluster_clean_up k3d cluster delete kubeflex
+    cluster_clean_up k3d cluster delete cluster1
+    cluster_clean_up k3d cluster delete cluster2
 fi
 if command_exists "kind"; then
-    cluster_clean_up "kind delete cluster --name kubeflex"
-    cluster_clean_up "kind delete cluster --name cluster1"
-    cluster_clean_up "kind delete cluster --name cluster2"
+    cluster_clean_up kind delete cluster --name kubeflex
+    cluster_clean_up kind delete cluster --name cluster1
+    cluster_clean_up kind delete cluster --name cluster2
 fi
 
 echo -e "\033[33m✔\033[0m Cluster space clean up has been completed"
@@ -196,7 +213,7 @@ echo -e "\033[33m✔\033[0m Context space clean up completed"
 echo -e "\nCreating two $k8s_platform clusters to serve as example WECs"
 clusters=(cluster1 cluster2)
 temp_dir=$(mktemp -d)
-trap "rm -rf $temp_dir" EXIT
+trap "rm -rf \"$temp_dir\"" EXIT
 for cluster in "${clusters[@]}"; do
     if {
       if [ "$k8s_platform" == "kind" ]; then
@@ -233,8 +250,8 @@ images=("ghcr.io/loft-sh/vcluster:0.16.4"
         "quay.io/kubestellar/postgresql:16.0.0-debian-11-r13")
 
 for image in "${images[@]}"; do
-    if ! docker inspect $image &> /dev/null; then
-        docker pull $image &
+    if ! docker inspect "$image" &> /dev/null; then
+        docker pull "$image" &
     fi
 done
 wait
@@ -289,9 +306,16 @@ echo -e "\nRegistering cluster 1 and 2 for remote access with KubeStellar Core..
 # set flags to "" if you have installed KubeStellar on an OpenShift cluster
 flags="--force-internal-endpoint-lookup"
 clusters=(cluster1 cluster2);
-if ! joincmd=$(clusteradm --context its1 get token | grep '^clusteradm join')
-then echo -e "\033[0;31mX\033[0m get token failed!\n" >&2; echo "$joincmd" >&2; false
-fi
+token_output=$(clusteradm --context its1 get token 2>&1) || {
+    echo -e "\033[0;31mX\033[0m get token failed!" >&2
+    echo "$token_output" >&2
+    false
+}
+joincmd=$(echo "$token_output" | grep '^clusteradm join') || {
+    echo -e "\033[0;31mX\033[0m clusteradm join command not found in token output!" >&2
+    echo "Token output: $token_output" >&2
+    false
+}
 for cluster in "${clusters[@]}"; do
    if log=$(${joincmd/<cluster_name>/${cluster}} -v=6 --context ${cluster} --singleton ${flags} 2>&1)
    then echo -e "\033[33m✔\033[0m clusteradm join of $cluster succeeded"
@@ -309,8 +333,8 @@ checking_cluster cluster2
 echo
 echo "Checking the new clusters are in the OCM inventory and label them"
 kubectl --context its1 get managedclusters
-kubectl --context its1 label managedcluster cluster1 location-group=edge name=cluster1
-kubectl --context its1 label managedcluster cluster2 location-group=edge name=cluster2
+kubectl --context its1 label managedcluster cluster1 location-group=edge name=cluster1 --overwrite
+kubectl --context its1 label managedcluster cluster2 location-group=edge name=cluster2 --overwrite
 
 echo
 echo Waiting for transport controller to create namespace customization-properties

--- a/scripts/create-demo-env-from-given-release.sh
+++ b/scripts/create-demo-env-from-given-release.sh
@@ -88,7 +88,11 @@ run_helper_script() {
         bash "${SRC_DIR}/${script_name}" "$@"
     else
         echo "Fetching ${script_name} from GitHub (ref: ${kubestellar_ref})..."
-        curl -sSf "https://raw.githubusercontent.com/kubestellar/kubestellar/${kubestellar_ref}/scripts/${script_name}" | bash -s -- "$@"
+        local tmp_script
+        tmp_script=$(mktemp)
+        trap 'rm -f "${tmp_script}"' RETURN
+        curl -sSf "https://raw.githubusercontent.com/kubestellar/kubestellar/${kubestellar_ref}/scripts/${script_name}" -o "${tmp_script}"
+        bash "${tmp_script}" "$@"
     fi
 }
 
@@ -100,10 +104,18 @@ command_exists() {
 # Function to check if a port is free
 wait_for_port_free() {
     local port=$1
-    while lsof -i $port >/dev/null 2>&1; do
+    while lsof -i "$port" >/dev/null 2>&1; do
         echo "Waiting for port $port to be free..."
         sleep 5
     done
+}
+
+get_host_arch() {
+    case "$(uname -m)" in
+        x86_64|amd64) echo amd64 ;;
+        aarch64|arm64) echo arm64 ;;
+        *) echo "$(uname -m)" ;;
+    esac
 }
 
 echo -e "Checking container runtime..."
@@ -115,7 +127,7 @@ echo "Container runtime is running."
 
 echo -e "Checking that pre-req softwares are installed..."
 platform_tool="$k8s_platform"
-run_helper_script check_pre_req.sh --assert -V kflex ocm helm kubectl docker "$platform_tool"
+run_helper_script check_pre_req.sh --assert -V kflex ocm helm kubectl docker lsof "$platform_tool"
 
 ##########################################
 cluster_clean_up() {
@@ -147,9 +159,7 @@ checking_cluster() {
         # Check for the cluster name and "Pending" status
         if echo "$line" | grep -q "$1" && echo "$line" | grep -q "Pending"; then
             echo "Pending CSR for $1 has been found, approving..."
-            clusteradm --context its1 accept --clusters "$1"
-
-            if [ $? -eq 0 ]; then
+            if clusteradm --context its1 accept --clusters "$1"; then
                 echo -e "\033[33m✔\033[0m CSR Approved for $1."
                 return 0
             else
@@ -236,7 +246,7 @@ for image in "${images[@]}"; do
         echo
         echo "Flatten container image $image to single architecture to work around https://github.com/kubernetes-sigs/kind/issues/3795 ..."
         echo "FROM $image" | docker build -t "$image" -f- "${temp_dir}/context"
-        if [[ "$(go env GOARCH)" != amd64 ]] && [[ "$image" =~ quay.io/open-cluster-management/ ]]; then
+        if [[ "$(get_host_arch)" != amd64 ]] && [[ "$image" =~ quay.io/open-cluster-management/ ]]; then
             echo "That InvalidBaseImagePlatform warning is expected because the original image is buggy"
         fi
         kind load docker-image "$image" --name kubeflex
@@ -276,7 +286,7 @@ echo -e "\033[33m✔\033[0m OCM hub is ready"
 
 echo -e "\nRegistering cluster 1 and 2 for remote access with KubeStellar Core..."
 
-: set flags to "" if you have installed KubeStellar on an OpenShift cluster
+# set flags to "" if you have installed KubeStellar on an OpenShift cluster
 flags="--force-internal-endpoint-lookup"
 clusters=(cluster1 cluster2);
 if ! joincmd=$(clusteradm --context its1 get token | grep '^clusteradm join')

--- a/scripts/create-demo-env-from-given-release.sh
+++ b/scripts/create-demo-env-from-given-release.sh
@@ -135,7 +135,7 @@ echo "Container runtime is running."
 
 echo -e "Checking that pre-req softwares are installed..."
 platform_tool="$k8s_platform"
-run_helper_script check_pre_req.sh --assert -V kflex ocm helm kubectl docker "$platform_tool"
+run_helper_script check_pre_req.sh --assert -V kflex ocm helm kubectl docker lsof timeout "$platform_tool"
 
 ##########################################
 cluster_clean_up() {
@@ -311,16 +311,31 @@ token_output=$(clusteradm --context its1 get token 2>&1) || {
     echo "$token_output" >&2
     false
 }
-joincmd=$(echo "$token_output" | grep '^clusteradm join') || {
+join_line=$(printf '%s\n' "$token_output" | grep -m 1 '^clusteradm join') || {
     echo -e "\033[0;31mX\033[0m clusteradm join command not found in token output!" >&2
     echo "Token output: $token_output" >&2
     false
 }
+read -r -a join_args <<< "$join_line"
+if [[ ${#join_args[@]} -lt 2 || "${join_args[0]}" != "clusteradm" || "${join_args[1]}" != "join" ]]; then
+    echo -e "\033[0;31mX\033[0m Unexpected join command format: $join_line" >&2
+    false
+fi
 for cluster in "${clusters[@]}"; do
-   if log=$(${joincmd/<cluster_name>/${cluster}} -v=6 --context ${cluster} --singleton ${flags} 2>&1)
-   then echo -e "\033[33m✔\033[0m clusteradm join of $cluster succeeded"
-   else echo -e "\033[0;31mX\033[0m clusteradm join of $cluster failed!" >&2; echo "$log" >&2; false
-   fi
+    join_cmd=("${join_args[@]}")
+    for i in "${!join_cmd[@]}"; do
+        join_cmd[i]="${join_cmd[i]//<cluster_name>/${cluster}}"
+    done
+    if [[ -n "$flags" ]]; then
+        join_cmd+=("$flags")
+    fi
+    if log=$("${join_cmd[@]}" -v=6 --context "${cluster}" --singleton 2>&1); then
+        echo -e "\033[33m✔\033[0m clusteradm join of $cluster succeeded"
+    else
+        echo -e "\033[0;31mX\033[0m clusteradm join of $cluster failed!" >&2
+        echo "$log" >&2
+        false
+    fi
 done
 
 echo -e "Checking that the CSR for cluster 1 and 2 appears..."

--- a/scripts/create-kubestellar-demo-env.sh
+++ b/scripts/create-kubestellar-demo-env.sh
@@ -79,7 +79,7 @@ echo "Container runtime is running."
 
 echo -e "KubeStellar Version: ${kubestellar_version}"
 
-SRC_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd 2>/dev/null || echo ".")"
+SRC_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd || echo ".")"
 
 echo -e "Checking that pre-req softwares are installed..."
 if [ -f "${SRC_DIR}/check_pre_req.sh" ]; then

--- a/scripts/create-kubestellar-demo-env.sh
+++ b/scripts/create-kubestellar-demo-env.sh
@@ -18,26 +18,35 @@ set -e
 # Script info
 SCRIPT_NAME="create-kubestellar-demo-env.sh"
 
-# Default Kubernetes platform parameter
+# Default parameters
 k8s_platform="kind"
+kubestellar_version="0.30.0"
+git_ref=""
 
 # Parse command-line arguments
 while [[ "$#" -gt 0 ]]; do
     case $1 in
         --platform) k8s_platform="$2"; shift ;;
+        --version) kubestellar_version="$2"; shift ;;
+        --git-ref) git_ref="$2"; shift ;;
         -X) set -x ;;
         -h|--help)
-            echo "Usage: ${SCRIPT_NAME} [--platform <kind|k3d>] [-X] [-h|--help]" >&2
+            echo "Usage: ${SCRIPT_NAME} [--platform <kind|k3d>] [--version <version>] [--git-ref <ref>] [-X] [-h|--help]" >&2
             exit 0
             ;;
         *)
             echo "Unknown parameter passed: $1" >&2
-            echo "Usage: ${SCRIPT_NAME} [--platform <kind|k3d>] [-X] [-h|--help]" >&2
+            echo "Usage: ${SCRIPT_NAME} [--platform <kind|k3d>] [--version <version>] [--git-ref <ref>] [-X] [-h|--help]" >&2
             exit 1
             ;;
     esac
     shift
 done
+
+# If git_ref is not specified, default to v${kubestellar_version}
+if [[ -z "$git_ref" ]]; then
+    git_ref="v${kubestellar_version}"
+fi
 
 if [[ "$k8s_platform" != "kind" && "$k8s_platform" != "k3d" ]]; then
     echo "Invalid platform specified: $k8s_platform"
@@ -68,14 +77,25 @@ if ! dunsel=$(docker ps 2>&1); then
 fi
 echo "Container runtime is running."
 
-kubestellar_version=0.30.0
 echo -e "KubeStellar Version: ${kubestellar_version}"
 
+SRC_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd 2>/dev/null || echo ".")"
+
 echo -e "Checking that pre-req softwares are installed..."
-if [ "$k8s_platform" == "kind" ]; then
-    curl -s https://raw.githubusercontent.com/kubestellar/kubestellar/v${kubestellar_version}/scripts/check_pre_req.sh | bash -s -- --assert -V kflex ocm helm kubectl docker kind
+if [ -f "${SRC_DIR}/check_pre_req.sh" ]; then
+    echo "Using local check_pre_req.sh"
+    if [ "$k8s_platform" == "kind" ]; then
+        bash "${SRC_DIR}/check_pre_req.sh" --assert -V kflex ocm helm kubectl docker kind
+    else
+        bash "${SRC_DIR}/check_pre_req.sh" --assert -V kflex ocm helm kubectl docker k3d
+    fi
 else
-    curl -s https://raw.githubusercontent.com/kubestellar/kubestellar/v${kubestellar_version}/scripts/check_pre_req.sh | bash -s -- --assert -V kflex ocm helm kubectl docker k3d
+    echo "Fetching check_pre_req.sh from GitHub (ref: ${git_ref})...."
+    if [ "$k8s_platform" == "kind" ]; then
+        curl -s "https://raw.githubusercontent.com/kubestellar/kubestellar/${git_ref}/scripts/check_pre_req.sh" | bash -s -- --assert -V kflex ocm helm kubectl docker kind
+    else
+        curl -s "https://raw.githubusercontent.com/kubestellar/kubestellar/${git_ref}/scripts/check_pre_req.sh" | bash -s -- --assert -V kflex ocm helm kubectl docker k3d
+    fi
 fi
 
 ##########################################
@@ -167,7 +187,13 @@ done
 
 echo -e "Creating KubeFlex cluster with SSL Passthrough"
 if [ "$k8s_platform" == "kind" ]; then
-    curl -s https://raw.githubusercontent.com/kubestellar/kubestellar/v${kubestellar_version}/scripts/create-kind-cluster-with-SSL-passthrough.sh | bash -s -- --name kubeflex --nosetcontext
+    if [ -f "${SRC_DIR}/create-kind-cluster-with-SSL-passthrough.sh" ]; then
+        echo "Using local create-kind-cluster-with-SSL-passthrough.sh"
+        bash "${SRC_DIR}/create-kind-cluster-with-SSL-passthrough.sh" --name kubeflex --nosetcontext
+    else
+        echo "Fetching create-kind-cluster-with-SSL-passthrough.sh from GitHub (ref: ${git_ref})..."
+        curl -s "https://raw.githubusercontent.com/kubestellar/kubestellar/${git_ref}/scripts/create-kind-cluster-with-SSL-passthrough.sh" | bash -s -- --name kubeflex --nosetcontext
+    fi
 else
     k3d cluster create -p "9443:443@loadbalancer" --k3s-arg "--disable=traefik@server:*" kubeflex
     kubectl wait --for=condition=Ready node --all --timeout=600s #Ensure both API server and nodes are ready

--- a/scripts/create-kubestellar-demo-env.sh
+++ b/scripts/create-kubestellar-demo-env.sh
@@ -50,6 +50,19 @@ echo "Please use create-demo-env-from-given-release.sh instead, which requires e
 
 echo "Selected Kubernetes platform: $k8s_platform"
 
+SRC_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+version_file="${SRC_DIR}/kubestellar-demo-env-version.sh"
+if [[ -f "${version_file}" ]]; then
+    # shellcheck disable=SC1090
+    source "${version_file}"
+else
+    kubestellar_version=0.30.0
+fi
+if [[ -z "${kubestellar_version:-}" ]]; then
+    echo "ERROR: KubeStellar version is not set." >&2
+    exit 1
+fi
+
 # Function to check if a command exists
 command_exists() {
     command -v "$1" >/dev/null 2>&1
@@ -71,7 +84,6 @@ if ! dunsel=$(docker ps 2>&1); then
 fi
 echo "Container runtime is running."
 
-kubestellar_version=0.30.0
 echo -e "KubeStellar Version: ${kubestellar_version}"
 
 echo -e "Checking that pre-req softwares are installed..."

--- a/scripts/create-kubestellar-demo-env.sh
+++ b/scripts/create-kubestellar-demo-env.sh
@@ -18,9 +18,6 @@ set -e
 # Script info
 SCRIPT_NAME="create-kubestellar-demo-env.sh"
 
-echo "WARNING: ${SCRIPT_NAME} is deprecated and will be removed in a future release." >&2
-echo "Please use create-demo-env-from-given-release.sh instead, which requires explicitly specifying the KubeStellar version via the --version option." >&2
-
 # Default Kubernetes platform parameter
 k8s_platform="kind"
 
@@ -47,6 +44,9 @@ if [[ "$k8s_platform" != "kind" && "$k8s_platform" != "k3d" ]]; then
     echo "Supported platforms are: kind, k3d"
     exit 1
 fi
+
+echo "WARNING: ${SCRIPT_NAME} is deprecated and will be removed in a future release." >&2
+echo "Please use create-demo-env-from-given-release.sh instead, which requires explicitly specifying the KubeStellar version via the --version option." >&2
 
 echo "Selected Kubernetes platform: $k8s_platform"
 

--- a/scripts/kubestellar-demo-env-version.sh
+++ b/scripts/kubestellar-demo-env-version.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+# Shared canonical KubeStellar version for demo environment scripts and tests.
+kubestellar_version="0.30.0"

--- a/test/e2e/ci/test-demo-env.sh
+++ b/test/e2e/ci/test-demo-env.sh
@@ -35,10 +35,18 @@ echo "Testing demo environment setup with platform: $platform"
 
 # Read a canonical version from a shared location instead of scraping it from the deprecated script.
 # This avoids the circular dependency and keeps the test valid after the deprecated script is removed.
+version_file="${scripts_dir}/kubestellar-demo-env-version.sh"
+if [[ ! -f "${version_file}" ]]; then
+    echo "ERROR: version file not found: ${version_file}" >&2
+    exit 1
+fi
 # shellcheck disable=SC1090
-source "${scripts_dir}/kubestellar-demo-env-version.sh"
+if ! source "${version_file}"; then
+    echo "ERROR: failed to source ${version_file}" >&2
+    exit 1
+fi
 if [[ -z "${kubestellar_version:-}" ]]; then
-    echo "ERROR: canonical KubeStellar version is not set in ${scripts_dir}/kubestellar-demo-env-version.sh" >&2
+    echo "ERROR: kubestellar_version is not set in ${version_file}" >&2
     exit 1
 fi
 

--- a/test/e2e/ci/test-demo-env.sh
+++ b/test/e2e/ci/test-demo-env.sh
@@ -44,7 +44,7 @@ fi
 
 # Test the demo environment creation script
 echo "Creating demo environment with $platform using version $kubestellar_version..."
-if ! "${scripts_dir}/create-demo-env-from-given-release.sh" --platform $platform --version "$kubestellar_version"; then
+if ! "${scripts_dir}/create-demo-env-from-given-release.sh" --platform "$platform" --version "$kubestellar_version"; then
     echo "ERROR: Demo environment creation script failed for $platform!"
     exit 1
 fi

--- a/test/e2e/ci/test-demo-env.sh
+++ b/test/e2e/ci/test-demo-env.sh
@@ -33,9 +33,13 @@ source "${common_srcs}/setup-shell.sh"
 
 echo "Testing demo environment setup with platform: $platform"
 
+# Get the version from the deprecated script to test the new script and safely strip quotes
+kubestellar_version=$(grep -E '^kubestellar_version=' "${scripts_dir}/create-kubestellar-demo-env.sh" | cut -d= -f2 | tr -d '"' | tr -d "'")
+
+
 # Test the demo environment creation script
-echo "Creating demo environment with $platform..."
-if ! "${scripts_dir}/create-kubestellar-demo-env.sh" --platform $platform; then
+echo "Creating demo environment with $platform using version $kubestellar_version..."
+if ! "${scripts_dir}/create-demo-env-from-given-release.sh" --platform $platform --version "$kubestellar_version"; then
     echo "ERROR: Demo environment creation script failed for $platform!"
     exit 1
 fi

--- a/test/e2e/ci/test-demo-env.sh
+++ b/test/e2e/ci/test-demo-env.sh
@@ -33,9 +33,14 @@ source "${common_srcs}/setup-shell.sh"
 
 echo "Testing demo environment setup with platform: $platform"
 
-# Get the version from the deprecated script to test the new script and safely strip quotes
-kubestellar_version=$(grep -E '^kubestellar_version=' "${scripts_dir}/create-kubestellar-demo-env.sh" | cut -d= -f2 | tr -d '"' | tr -d "'")
-
+# Read a canonical version from a shared location instead of scraping it from the deprecated script.
+# This avoids the circular dependency and keeps the test valid after the deprecated script is removed.
+# shellcheck disable=SC1090
+source "${scripts_dir}/kubestellar-demo-env-version.sh"
+if [[ -z "${kubestellar_version:-}" ]]; then
+    echo "ERROR: canonical KubeStellar version is not set in ${scripts_dir}/kubestellar-demo-env-version.sh" >&2
+    exit 1
+fi
 
 # Test the demo environment creation script
 echo "Creating demo environment with $platform using version $kubestellar_version..."


### PR DESCRIPTION
## Description
This PR addresses and resolves the structural, script execution, and versioning issues described in #3722. It introduces modern argument parsing and implements a local-first dependency resolution mechanism to prevent circular dependencies during execution.

### Changes Made
* **Modernized Argument Parsing:** Added flexible `--version <version>` and `--git-ref <ref>` command-line arguments.
  * `kubestellar_version` defaults to `0.30.0`.
  * `git_ref` dynamically defaults to `v${kubestellar_version}`, ensuring backward compatibility for users downloading and running the script via a direct `curl` from a released tag.
* **Local-First Script Execution:** Upgraded the script to dynamically identify its host directory (`SRC_DIR`).
  * If the helper scripts (`check_pre_req.sh` and `create-kind-cluster-with-SSL-passthrough.sh`) exist locally within the same directory, it executes them directly.
  * If they do not exist locally (e.g., when the script is run directly via `curl`), it safely falls back to fetching them from GitHub using the configured `--git-ref`.

### Issue Resolution
* **Stale Check Issue Resolved:** E2E CI runs (via `test/e2e/ci/test-demo-env.sh`) will now correctly utilize the local, modified versions of the helper scripts within the PR branch instead of pulling stale scripts from the main/released tags.
* **Circular Dependency Broken:** The script no longer strictly requires a release tag to already exist on GitHub prior to its execution. Automated workflows and developers can now run local copies seamlessly or pass a specific development branch/tag via `--git-ref`.

Fixes #3722