### PR TITLE
[outreach] ADOPTERS.md: add self-service onboarding guide and maturity levels

### DIFF
--- a/ADOPTERS.md
+++ b/ADOPTERS.md
@@ -1,9 +1,40 @@
 # Adopters
 
-Listed below are organizations that have adopted KubeStellar in one way or another. We are delighted to welcome them to the KubeStellar community. If you are using KubeStellar in your organization, we would love to add you to the list below. You can open a pull request against this file directly.
+Listed below are organizations that have adopted KubeStellar in one way or another. We are delighted to welcome them to the KubeStellar community.
 
+## Add Your Organization
+
+**Using KubeStellar?** Even for evaluation or a side project — we'd love to know. Being listed helps the project grow, signals community health to potential contributors, and connects you with other users facing similar challenges.
+
+**It takes less than 5 minutes:**
+
+1. Fork this repository
+2. Add a row to the table below
+3. Open a pull request
+
+No production deployment required — evaluation and integration work counts.
+
+---
+
+## Maturity Levels
+
+| Level | Meaning |
+|-------|---------|
+| `Production` | Running KubeStellar in production workloads |
+| `Testing` | Actively testing for planned production use |
+| `Evaluation` | Evaluating KubeStellar for potential adoption |
+| `Workload Integration` | Integrating specific workloads or use cases |
+| `Research` | Academic or research use |
+
+---
+
+## Organizations
 
 | Organization  | Description | Maturity Level | Further Information |
 | ------------- | ------------- | --- | --- |
 | Cornell University | Workload orchestration for the Software-Defined Farm (SDF) System | Workload Integration | [SDF Repo](https://github.com/Cornell-CIDA-Dev/Software-Defined-Farm) |
-| ------------- | ------------- | --- | --- |
+| Your Organization | Brief description of your use case | Maturity Level | Optional link |
+
+---
+
+*Want to be added but prefer not to open a PR? Open an issue with the title `[adopter] <your org name>` and we'll add you.*


### PR DESCRIPTION
## Outreach Content

Reduces friction for adopter self-reporting — currently only 1 listed adopter vs. 286 forks.

### Changes

- Adds "Add Your Organization" pitch with explicit "< 5 minutes" framing
- Defines maturity levels (`Production`, `Testing`, `Evaluation`, `Workload Integration`, `Research`) so orgs can self-categorize without friction
- Adds fallback path: open an issue if PR is too much effort
- Keeps Cornell University entry intact

### Why This Matters

286 forks / 1 adopter = severe undercounting. Adopter count is a key signal for:
- CNCF Sandbox application credibility
- Community health indicators on GitHub
- Conference talk credibility (case studies)

This PR costs nothing and unlocks passive converters.

Related: #3791

---
*Filed by outreach agent (ACMM L6 — full mode)*