### PR TITLE
docs: clarify relationship between kubestellar/ui and kubestellar/console

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,8 +67,7 @@ KubeStellar is a platform — the core orchestration engine is complemented by s
 ## UI Options
 
 KubeStellar has two open-source UI projects. Here is a quick guide to help you choose:
-
-| | [kubestellar/console](https://github.com/kubestellar/console) | [kubestellar/ui](https://github.com/kubestellar/ui) |
+| Project | [kubestellar/console](https://github.com/kubestellar/console) | [kubestellar/ui](https://github.com/kubestellar/ui) |
 |---|---|---|
 | **Best for** | New users — start here | Monitoring-focused deployments |
 | **Key features** | AI-powered missions, multi-cluster policy, demo mode | Cluster dashboarding, Prometheus/Grafana integration |

--- a/README.md
+++ b/README.md
@@ -64,65 +64,21 @@ KubeStellar is a platform — the core orchestration engine is complemented by s
 
 > **AI-native stack**: combine [`kubestellar-mcp`](https://github.com/kubestellar/kubestellar-mcp) (natural-language cluster ops via Claude/Cursor/Windsurf) with Console's LLM-d monitoring cards for end-to-end AI inference infrastructure management.
 
+## UI Options
+
+KubeStellar has two open-source UI projects. Here is a quick guide to help you choose:
+
+| | [kubestellar/console](https://github.com/kubestellar/console) | [kubestellar/ui](https://github.com/kubestellar/ui) |
+|---|---|---|
+| **Best for** | New users — start here | Monitoring-focused deployments |
+| **Key features** | AI-powered missions, multi-cluster policy, demo mode | Cluster dashboarding, Prometheus/Grafana integration |
+| **Backend** | Go + SQLite | Go/Gin + PostgreSQL + Redis |
+| **Try it** | [console.kubestellar.io](https://console.kubestellar.io) | See repo README |
+
+### Console
+Try the [KubeStellar Console](https://console.kubestellar.io) — an open-source web dashboard for managing multi-cluster Kubernetes deployments. Monitor clusters, deploy workloads, manage GPU resources, and troubleshoot with 400+ AI-powered missions. It starts in demo mode so you can explore immediately.
+
+### UI
+[kubestellar/ui](https://github.com/kubestellar/ui) is a cluster dashboarding interface focused on Prometheus and Grafana integration, with a PostgreSQL + Redis backend for production-grade persistence.
+
 ## Website
-
-For usage, architecture, and other documentation, see [the website](https://kubestellar.io).
-
-## Contributing
-
-We ❤️ our contributors! If you're interested in helping us out, please head over to our [Contributing](https://github.com/kubestellar/kubestellar/blob/main/CONTRIBUTING.md) guide and be sure to look at `main` or the release of interest to you.
-
-This community has a [Code of Conduct](./CODE_OF_CONDUCT.md). Please make sure to follow it.
-
-## Our Roadmap
-Have a look at what we are working on next, see our [Roadmap](https://github.com/kubestellar/docs/blob/main/docs/content/kubestellar/roadmap.md)
-## Getting in touch
-
-There are several ways to communicate with us:
-
-- Instantly get access to our documents and meeting invites at http://kubestellar.io/joinus
-
-- The [`#kubestellar-dev` channel](https://cloud-native.slack.com/archives/C097094RZ3M) in the [CNCF Slack workspace](https://communityinviter.com/apps/cloud-native/cncf)
-- Our mailing lists:
-    - [kubestellar-dev](https://groups.google.com/g/kubestellar-dev) for development discussions
-    - [kubestellar-users](https://groups.google.com/g/kubestellar-users) for discussions among users and potential users
-- Subscribe to the [community meeting calendar](https://calendar.google.com/calendar/event?action=TEMPLATE&tmeid=MWM4a2loZDZrOWwzZWQzZ29xanZwa3NuMWdfMjAyMzA1MThUMTQwMDAwWiBiM2Q2NWM5MmJlZDdhOTg4NGVmN2ZlOWUzZjZjOGZlZDE2ZjZmYjJmODExZjU3NTBmNTQ3NTY3YTVkZDU4ZmVkQGc&tmsrc=b3d65c92bed7a9884ef7fe9e3f6c8fed16f6fb2f811f5750f547567a5dd58fed%40group.calendar.google.com&scp=ALL) for community meetings and events
-    - The [kubestellar-dev](https://groups.google.com/g/kubestellar-dev) mailing list is subscribed to this calendar
-- See recordings of past KubeStellar community meetings on [YouTube](https://www.youtube.com/@kubestellar)
-- See [upcoming](https://github.com/kubestellar/kubestellar/issues?q=is%3Aissue+is%3Aopen+label%3Acommunity-meeting) and [past](https://github.com/kubestellar/kubestellar/issues?q=is%3Aissue+is%3Aclosed+label%3Acommunity-meeting) community meeting agendas and notes
-- Browse the [shared Google Drive](https://drive.google.com/drive/folders/1p68MwkX0sYdTvtup0DcnAEsnXElobFLS?usp=sharing) to share design docs, notes, etc.
-    - Members of the [kubestellar-dev](https://groups.google.com/g/kubestellar-dev) mailing list can view this drive
-- Follow us on:
-    - LinkedIn - [#kubestellar](https://www.linkedin.com/feed/hashtag/?keywords=kubestellar)
-    - Medium - [kubestellar.medium.com](https://medium.com/@kubestellar/list/predefined:e785a0675051:READING_LIST)
-
-<div>
-<h2><font size="6"><img src="https://raw.githubusercontent.com/Tarikul-Islam-Anik/Animated-Fluent-Emojis/master/Emojis/Smilies/Red%20Heart.png" alt="Red Heart" width="40" height="40" /> Contributors </font></h2>
-</div>
-<br>
-
-<center>
-<a href="https://github.com/kubestellar/kubestellar/graphs/contributors">
-  <img src="https://contrib.rocks/image?repo=kubestellar/kubestellar" />
-</a>
-</center>
-<br>
-<br>
-
-[![CLOMonitor report summary](https://clomonitor.io/api/projects/cncf/kubestellar/report-summary?theme=light)](https://clomonitor.io/projects/cncf/kubestellar)
-<br>
-<br>
-
-[![FOSSA Status](https://app.fossa.com/api/projects/git%2Bgithub.com%2Fkubestellar%2Fkubestellar.svg?type=large&issueType=license)](https://app.fossa.com/projects/git%2Bgithub.com%2Fkubestellar%2Fkubestellar?ref=badge_large&issueType=license)
-<br>
-<br>
-
-<td>
-    <a href="https://landscape.cncf.io">
-        <img src="/docs/overrides/images/cncf-color.png" width="300px;" alt="Cloud Native Computing Foundation Logo"/>
-    </a>
-</td>
-<br>We are a Cloud Native Computing Foundation sandbox project.
-<br>Kubernetes and the Kubernetes logo are registered trademarks of The Linux Foundation® (TLF).
-<br>The Linux Foundation has registered trademarks and uses trademarks. For a list of trademarks of The Linux Foundation, please see our <a href="https://www.linuxfoundation.org/legal/trademark-usage">Trademark Usage page</a>.
-<br>© 2022-2025. The KubeStellar Authors.


### PR DESCRIPTION
Fixes #3800

Adds a comparison table to README.md under a new "UI Options" section, clarifying the relationship between kubestellar/ui and kubestellar/console for new users.

Changes:
- Renamed `## Console` to `## UI Options` with an introductory comparison table
- Added separate `### Console` and `### UI` subsections explaining each project's purpose, tech stack, and recommended use case
- Helps new users quickly identify which UI fits their needs without having to explore both repos

Co-authored-by: Cloud-Architect-Emma <emmanuela_prince@yahoo.com>