### PR TITLE
🐛 fix(status): use DynType for inventory CEL variable

### DIFF
--- a/pkg/status/cel-evaluator.go
+++ b/pkg/status/cel-evaluator.go
@@ -52,11 +52,11 @@ func newCELEvaluator() (*celEvaluator, error) {
 	env, err := cel.NewEnv(
 		cel.Variable(sourceObjectKey, cel.MapType(cel.StringType, cel.DynType)),
 		cel.Variable(returnedKey, cel.MapType(cel.StringType, cel.DynType)),
-		cel.Variable(inventoryKey, cel.MapType(cel.StringType, cel.StringType)),
+		cel.Variable(inventoryKey, cel.MapType(cel.StringType, cel.DynType)),
 		cel.Variable(propagationMetaKey, cel.MapType(cel.StringType, cel.DynType)),
 	)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create CEL environment: %v", err)
+		return nil, fmt.Errorf("failed to create CEL environment: %w", err)
 	}
 
 	return &celEvaluator{env: env}, nil

--- a/pkg/status/cel-evaluator_test.go
+++ b/pkg/status/cel-evaluator_test.go
@@ -1,0 +1,87 @@
+/*
+Copyright 2024 The KubeStellar Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package status
+
+import (
+	"testing"
+
+	"github.com/kubestellar/kubestellar/api/control/v1alpha1"
+)
+
+func TestInventoryWithNonStringValue(t *testing.T) {
+	evaluator, err := newCELEvaluator()
+	if err != nil {
+		t.Fatalf("failed to create evaluator: %v", err)
+	}
+
+	// inventory values are not always strings; they can carry numeric
+	// fields such as CPU count or memory. This expression was rejected
+	// before the fix because inventory was typed as map[string]string.
+	expr := v1alpha1.Expression(`inventory["cpu"] == 4`)
+
+	err = evaluator.CheckExpression(&expr)
+	if err != nil {
+		t.Fatalf("CheckExpression rejected a valid expression: %v", err)
+	}
+
+	objMap := map[string]interface{}{
+		sourceObjectKey:    map[string]interface{}{},
+		returnedKey:        map[string]interface{}{},
+		inventoryKey:       map[string]interface{}{"cpu": int64(4)},
+		propagationMetaKey: map[string]interface{}{},
+	}
+
+	result, err := evaluator.Evaluate(expr, objMap)
+	if err != nil {
+		t.Fatalf("Evaluate failed: %v", err)
+	}
+
+	if result.Value() != true {
+		t.Errorf("expected true, got %v", result.Value())
+	}
+}
+
+func TestInventoryWithStringValueStillWorks(t *testing.T) {
+	evaluator, err := newCELEvaluator()
+	if err != nil {
+		t.Fatalf("failed to create evaluator: %v", err)
+	}
+
+	// existing string-only inventory users must not be broken by the fix.
+	expr := v1alpha1.Expression(`inventory["region"] == "us-east-1"`)
+
+	err = evaluator.CheckExpression(&expr)
+	if err != nil {
+		t.Fatalf("CheckExpression rejected a valid expression: %v", err)
+	}
+
+	objMap := map[string]interface{}{
+		sourceObjectKey:    map[string]interface{}{},
+		returnedKey:        map[string]interface{}{},
+		inventoryKey:       map[string]interface{}{"region": "us-east-1"},
+		propagationMetaKey: map[string]interface{}{},
+	}
+
+	result, err := evaluator.Evaluate(expr, objMap)
+	if err != nil {
+		t.Fatalf("Evaluate failed: %v", err)
+	}
+
+	if result.Value() != true {
+		t.Errorf("expected true, got %v", result.Value())
+	}
+}

--- a/pkg/status/cel-evaluator_test.go
+++ b/pkg/status/cel-evaluator_test.go
@@ -50,8 +50,8 @@ func TestInventoryWithNonStringValue(t *testing.T) {
 		t.Fatalf("Evaluate failed: %v", err)
 	}
 
-	if result.Value() != true {
-		t.Errorf("expected true, got %v", result.Value())
+	if val, ok := result.Value().(bool); !ok || !val {
+		t.Errorf("expected bool true, got type %T value %v", result.Value(), result.Value())
 	}
 }
 
@@ -81,7 +81,7 @@ func TestInventoryWithStringValueStillWorks(t *testing.T) {
 		t.Fatalf("Evaluate failed: %v", err)
 	}
 
-	if result.Value() != true {
-		t.Errorf("expected true, got %v", result.Value())
+	if val, ok := result.Value().(bool); !ok || !val {
+		t.Errorf("expected bool true, got type %T value %v", result.Value(), result.Value())
 	}
 }


### PR DESCRIPTION
## Summary
Fixes `CheckExpression` in the CEL evaluator to use `DynType` instead of `StringType` for the inventory variable, which allows non-string values to be properly evaluated.
Also updates the tests in `cel-evaluator_test.go` to explicitly assert that the result is a boolean type, providing more informative error messages if the evaluation returns an unexpected type.

## Related issue(s)
N/A
