### PR TITLE
Fix/status deepcopy informer cache corruption

### DIFF
--- a/pkg/status/workstatus.go
+++ b/pkg/status/workstatus.go
@@ -138,13 +138,13 @@ func (c *Controller) updateObjectStatus(ctx context.Context, objectIdentifier ut
 	}
 
 	if wantSingleton && !haveSingleton {
-		err = c.handleStatusReturnLabel(ctx, unstrObj, objectIdentifier.GVR(), true, util.BindingPolicyLabelSingletonStatusKey)
+		err = c.handleStatusReturnLabel(ctx, unstrObj, objectIdentifier.GVR(), true, util.BindingPolicyLabelSingletonStatusKey, false)
 		if err != nil {
 			return err
 		}
 	}
 	if wantMultiWEC && !haveMultiWEC {
-		err = c.handleStatusReturnLabel(ctx, unstrObj, objectIdentifier.GVR(), true, util.BindingPolicyLabelMultiWECStatusKey)
+		err = c.handleStatusReturnLabel(ctx, unstrObj, objectIdentifier.GVR(), true, util.BindingPolicyLabelMultiWECStatusKey, false)
 		if err != nil {
 			return err
 		}
@@ -155,6 +155,8 @@ func (c *Controller) updateObjectStatus(ctx context.Context, objectIdentifier ut
 	if apiequality.Semantic.DeepEqual(unstrObj.Object["status"], status) {
 		logger.V(5).Info("Workload object found to already have intended status", "objectIdentifier", objectIdentifier)
 	} else {
+		// DeepCopy before mutating to avoid corrupting the informer cache.
+		unstrObj = unstrObj.DeepCopy()
 		// set the status and update the object
 		unstrObj.Object["status"] = status
 
@@ -172,14 +174,14 @@ func (c *Controller) updateObjectStatus(ctx context.Context, objectIdentifier ut
 	}
 
 	if haveSingleton && !wantSingleton {
-		err = c.handleStatusReturnLabel(ctx, unstrObj, objectIdentifier.GVR(), false, util.BindingPolicyLabelSingletonStatusKey)
+		err = c.handleStatusReturnLabel(ctx, unstrObj, objectIdentifier.GVR(), false, util.BindingPolicyLabelSingletonStatusKey, true)
 		if err != nil {
 			return err
 		}
 	}
 
 	if haveMultiWEC && !wantMultiWEC {
-		err = c.handleStatusReturnLabel(ctx, unstrObj, objectIdentifier.GVR(), false, util.BindingPolicyLabelMultiWECStatusKey)
+		err = c.handleStatusReturnLabel(ctx, unstrObj, objectIdentifier.GVR(), false, util.BindingPolicyLabelMultiWECStatusKey, true)
 		if err != nil {
 			return err
 		}
@@ -189,7 +191,7 @@ func (c *Controller) updateObjectStatus(ctx context.Context, objectIdentifier ut
 }
 
 func (c *Controller) handleStatusReturnLabel(ctx context.Context, unstructuredObj *unstructured.Unstructured,
-	objGVR schema.GroupVersionResource, wantLabel bool, labelKey string) error {
+	objGVR schema.GroupVersionResource, wantLabel bool, labelKey string, alreadyCopied bool) error {
 
 	labels := unstructuredObj.GetLabels() // gets a copy of the labels
 	_, foundLabel := labels[labelKey]
@@ -206,7 +208,9 @@ func (c *Controller) handleStatusReturnLabel(ctx context.Context, unstructuredOb
 		message = fmt.Sprintf("Removed %s label from workload object", labelKey)
 		delete(labels, labelKey)
 	}
-	unstructuredObj = unstructuredObj.DeepCopy() // avoid mutating the original object
+	if !alreadyCopied {
+		unstructuredObj = unstructuredObj.DeepCopy() // avoid mutating the original object
+	}
 	unstructuredObj.SetLabels(labels)
 	namespace := unstructuredObj.GetNamespace()
 	rscIfc := util.DynamicForResource(c.wdsDynClient, objGVR, namespace)

--- a/pkg/status/workstatus_test.go
+++ b/pkg/status/workstatus_test.go
@@ -1,0 +1,234 @@
+/*
+Copyright 2024 The KubeStellar Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package status
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	appsv1 "k8s.io/api/apps/v1"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+	k8stesting "k8s.io/client-go/testing"
+	"k8s.io/client-go/tools/cache"
+
+	"github.com/kubestellar/kubestellar/pkg/util"
+)
+
+var testGVR = appsv1.SchemeGroupVersion.WithResource("deployments")
+
+var testGVK = appsv1.SchemeGroupVersion.WithKind("Deployment")
+
+func newTestUnstructured(namespace, name string, status map[string]interface{}) *unstructured.Unstructured {
+	obj := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": appsv1.SchemeGroupVersion.String(),
+			"kind":       "Deployment",
+			"metadata": map[string]interface{}{
+				"name":            name,
+				"namespace":       namespace,
+				"resourceVersion": "999",
+			},
+		},
+	}
+	if status != nil {
+		obj.Object["status"] = status
+	}
+	return obj
+}
+
+type fakeGenericLister struct {
+	obj runtime.Object
+}
+
+func (f *fakeGenericLister) List(selector labels.Selector) ([]runtime.Object, error) {
+	return []runtime.Object{f.obj}, nil
+}
+
+func (f *fakeGenericLister) Get(name string) (runtime.Object, error) {
+	return f.obj, nil
+}
+
+func (f *fakeGenericLister) ByNamespace(namespace string) cache.GenericNamespaceLister {
+	return f
+}
+
+func newFakeScheme() *runtime.Scheme {
+	scheme := runtime.NewScheme()
+	scheme.AddKnownTypeWithName(
+		schema.GroupVersionKind{Group: "apps", Version: "v1", Kind: "Deployment"},
+		&unstructured.Unstructured{},
+	)
+	scheme.AddKnownTypeWithName(
+		schema.GroupVersionKind{Group: "apps", Version: "v1", Kind: "DeploymentList"},
+		&unstructured.UnstructuredList{},
+	)
+	return scheme
+}
+
+func newTestObjectIdentifier(namespace, name string) util.ObjectIdentifier {
+	return util.ObjectIdentifier{
+		GVK:        testGVK,
+		Resource:   "deployments",
+		ObjectName: cache.NewObjectName(namespace, name),
+	}
+}
+
+func newTestListers(obj runtime.Object) util.ConcurrentMap[schema.GroupVersionResource, cache.GenericLister] {
+	listers := util.NewConcurrentMap[schema.GroupVersionResource, cache.GenericLister]()
+	listers.Set(testGVR, &fakeGenericLister{obj: obj})
+	return listers
+}
+
+func TestUpdateObjectStatus_DoesNotMutateInformerCacheOnUpdateFailure(t *testing.T) {
+	ctx := context.Background()
+
+	originalStatus := map[string]interface{}{
+		"replicas": int64(1),
+	}
+	originalStatusCopy := make(map[string]interface{}, len(originalStatus))
+	for k, v := range originalStatus {
+		originalStatusCopy[k] = v
+	}
+
+	cachedObj := newTestUnstructured("test-ns", "test-deploy", originalStatusCopy)
+
+	fakeDynClient := dynamicfake.NewSimpleDynamicClient(newFakeScheme(), cachedObj)
+
+	fakeDynClient.PrependReactor("update", "deployments", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		return true, nil, fmt.Errorf("simulated API server failure")
+	})
+
+	c := &Controller{wdsDynClient: fakeDynClient}
+	listers := newTestListers(cachedObj)
+	objectIdentifier := newTestObjectIdentifier("test-ns", "test-deploy")
+
+	newStatus := map[string]interface{}{
+		"replicas": int64(5),
+	}
+
+	err := c.updateObjectStatus(ctx, objectIdentifier, newStatus, listers, false)
+	if err == nil {
+		t.Fatal("expected an error when UpdateStatus fails, got nil")
+	}
+
+	actualStatus, _, _ := unstructured.NestedMap(cachedObj.Object, "status")
+	if !reflect.DeepEqual(actualStatus, originalStatus) {
+		t.Errorf(
+			"BUG: informer cache was mutated after UpdateStatus failure.\ngot:  %v\nwant: %v",
+			actualStatus,
+			originalStatus,
+		)
+	}
+}
+
+func TestUpdateObjectStatus_UpdatesStatusWhenDifferent(t *testing.T) {
+	ctx := context.Background()
+
+	cachedObj := newTestUnstructured("test-ns", "test-deploy", map[string]interface{}{
+		"replicas": int64(1),
+	})
+
+	fakeDynClient := dynamicfake.NewSimpleDynamicClient(newFakeScheme(), cachedObj)
+
+	updateCalled := false
+	fakeDynClient.PrependReactor("update", "deployments", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		if updateAction, ok := action.(k8stesting.UpdateAction); ok && updateAction.GetSubresource() == "status" {
+			updateCalled = true
+		}
+		return false, nil, nil
+	})
+
+	c := &Controller{wdsDynClient: fakeDynClient}
+	listers := newTestListers(cachedObj)
+	objectIdentifier := newTestObjectIdentifier("test-ns", "test-deploy")
+
+	err := c.updateObjectStatus(ctx, objectIdentifier, map[string]interface{}{"replicas": int64(5)}, listers, false)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if !updateCalled {
+		t.Error("expected UpdateStatus to be called when status differs, but it was not")
+	}
+}
+
+func TestUpdateObjectStatus_NoOpWhenStatusAlreadyMatches(t *testing.T) {
+	ctx := context.Background()
+
+	existingStatus := map[string]interface{}{
+		"replicas": int64(3),
+	}
+
+	cachedObj := newTestUnstructured("test-ns", "test-deploy", existingStatus)
+
+	fakeDynClient := dynamicfake.NewSimpleDynamicClient(newFakeScheme(), cachedObj)
+
+	statusUpdateCalled := false
+	fakeDynClient.PrependReactor("update", "deployments", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		// only flag if this is a status subresource update, not a label update
+		if action.(k8stesting.UpdateAction).GetSubresource() == "status" {
+			statusUpdateCalled = true
+		}
+		return false, nil, nil
+	})
+
+	c := &Controller{wdsDynClient: fakeDynClient}
+	listers := newTestListers(cachedObj)
+	objectIdentifier := newTestObjectIdentifier("test-ns", "test-deploy")
+
+	err := c.updateObjectStatus(ctx, objectIdentifier, existingStatus, listers, false)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if statusUpdateCalled {
+		t.Error("UpdateStatus subresource was called even though status had not changed")
+	}
+}
+
+func TestUpdateObjectStatus_NoOpWhenNilStatusAndNoLabel(t *testing.T) {
+	ctx := context.Background()
+
+	cachedObj := newTestUnstructured("test-ns", "test-deploy", nil)
+
+	fakeDynClient := dynamicfake.NewSimpleDynamicClient(newFakeScheme(), cachedObj)
+
+	updateCalled := false
+	fakeDynClient.PrependReactor("update", "deployments", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		updateCalled = true
+		return true, nil, nil
+	})
+
+	c := &Controller{wdsDynClient: fakeDynClient}
+	listers := newTestListers(cachedObj)
+	objectIdentifier := newTestObjectIdentifier("test-ns", "test-deploy")
+
+	err := c.updateObjectStatus(ctx, objectIdentifier, nil, listers, false)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if updateCalled {
+		t.Error("UpdateStatus was called when status was nil and no label present")
+	}
+}


### PR DESCRIPTION
### 🐛 Fix informer cache corruption in status package

#### Problem
In `pkg/status`, `updateObjectStatus` retrieved the workload object directly from the lister (backed by the informer cache) and mutated `unstrObj.Object["status"]` in-place before calling `UpdateStatus`. If `UpdateStatus` failed for any reason — network error, conflict, server unavailability — the informer cache was left permanently holding the incorrect status value.

On the next reconciliation, the controller would read this corrupted cached state, find the status already equal to the desired value, and silently skip the API update entirely — leaving the workload object in WDS with stale status until a full informer resync.

#### Fix
**DeepCopy before mutation (`workstatus.go`)**
Added `unstrObj = unstrObj.DeepCopy()` immediately before the status mutation in the `else` block, so the original cached object is never touched. If `UpdateStatus` fails, the cache remains intact and the next reconciliation correctly retries the update.

This mirrors the existing pattern in `handleStatusReturnLabel` in the same file, which already applied `DeepCopy` before mutating labels for exactly this reason. 

*(Note: The unrelated CEL inventory type mismatch fixes previously in this PR have been extracted into their own PR to keep this PR focused purely on the cache corruption issue.)*

#### Tests added (`workstatus_test.go`)
Test | Purpose
-- | --
TestUpdateObjectStatus_CacheNotMutatedOnFailure | Regression: proves informer cache is not mutated when UpdateStatus fails
TestUpdateObjectStatus_UpdatesStatusWhenDifferent | Happy path: status is correctly written to the API server when it differs
TestUpdateObjectStatus_NoUpdateWhenStatusMatches | Idempotency: no status subresource call is made when status already matches
TestUpdateObjectStatus_NilStatusNoLabel | No-op: nil status with no existing label results in no API call

