### PR TITLE
refactor(util): prevent deadlock risks and add tests for ConcurrentMap

### DIFF
--- a/pkg/util/concurrent-map.go
+++ b/pkg/util/concurrent-map.go
@@ -82,17 +82,21 @@ func (mm *rwMutexMap[K, V]) Get(key K) (V, bool) {
 	return value, ok
 }
 
-// Iterator iterates over the map and calls the given function for each
-// key/value pair sequentially.
+// Iterator iterates over a snapshot of the map and calls the given function
+// for each key/value pair sequentially. This prevents deadlocks if the
+// yield function attempts to mutate the map or blocks execution.
 // If the given function returns an error, the iteration is stopped and
 // the error is returned.
-// During the iteration, the map must not be mutated by the given function.
-// If the map is mutated during the iteration, the behavior is undefined.
 func (mm *rwMutexMap[K, V]) Iterator(yield func(K, V) error) error {
 	mm.RLock()
-	defer mm.RUnlock()
-
+	// Take a snapshot of keys and values to release lock early
+	snapshot := make(map[K]V, len(mm.m))
 	for k, v := range mm.m {
+		snapshot[k] = v
+	}
+	mm.RUnlock()
+
+	for k, v := range snapshot {
 		if err := yield(k, v); err != nil {
 			return err
 		}

--- a/pkg/util/concurrent-map_test.go
+++ b/pkg/util/concurrent-map_test.go
@@ -1,0 +1,57 @@
+package util
+
+import (
+	"sync"
+	"testing"
+)
+
+// TestConcurrentMap_Basic verifies standard operations under parallel load.
+func TestConcurrentMap_Basic(t *testing.T) {
+	cm := NewConcurrentMap[string, int]()
+	var wg sync.WaitGroup
+
+	// Concurrent Writers
+	for i := 0; i < 50; i++ {
+		wg.Add(1)
+		go func(val int) {
+			defer wg.Done()
+			cm.Set("key", val)
+		}(i)
+	}
+
+	// Concurrent Readers
+	for i := 0; i < 50; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_, _ = cm.Get("key")
+			_ = cm.Len()
+		}()
+	}
+
+	wg.Wait()
+}
+
+// TestConcurrentMap_Iterator_SafeMutation ensures that calling mutation
+// methods within or alongside the iterator does not cause a deadlock.
+func TestConcurrentMap_Iterator_SafeMutation(t *testing.T) {
+	cm := NewConcurrentMap[string, int]()
+	cm.Set("key1", 100)
+	cm.Set("key2", 200)
+
+	err := cm.Iterator(func(k string, v int) error {
+		if k == "key1" {
+			// Simulating mutation during iteration (would deadlock previously)
+			cm.Set("key1_updated", 150)
+		}
+		return nil
+	})
+
+	if err != nil {
+		t.Fatalf("unexpected error during iteration: %v", err)
+	}
+
+	if _, ok := cm.Get("key1_updated"); !ok {
+		t.Error("expected key1_updated to be set successfully")
+	}
+}


### PR DESCRIPTION
PR Title: 🐛 refactor(util): prevent deadlock risks and add tests for ConcurrentMap

## Summary
This PR fixes a severe concurrency design defect in `pkg/util/concurrent-map.go` and adds critical missing unit test coverage for the package. 

Previously, the `Iterator` method executed the user-supplied `yield` callback while actively holding the package's internal read lock (`mm.RLock()`). If the callback invoked any write operation on the map (like `Set`) or encountered a blocking state, it triggered a deterministic deadlock. 

The updated routine isolates memory reading by copying keys and values safely into a short-lived local snapshot before yielding context control to the caller. 

Additionally, this PR includes:
- `TestConcurrentMap_Basic`: Verifies standard operations under parallel read/write load.
- `TestConcurrentMap_Iterator_SafeMutation`: Explicitly captures the deadlocking pattern and passes successfully with the new early-unlock snapshot layout.

Locally verified via `go fmt`, `go vet`, `go test -race`, and `golangci-lint run`.

## Related issue(s)

Fixes #