### PR TITLE
🐛 fix(status): preserve existing status on transient WorkStatus errors

### DIFF
--- a/pkg/status/multiwec-status.go
+++ b/pkg/status/multiwec-status.go
@@ -53,15 +53,18 @@ func (c *Controller) handleMultiWEC(ctx context.Context, wObjID util.ObjectIdent
 
 	// collect status
 	statuses := make([]map[string]any, 0, len(wsObjects))
+	fetchErrors := 0
 	for _, wsON := range wsObjects {
 		wsObj, err := c.workStatusLister.ByNamespace(wsON.Namespace).Get(wsON.Name)
 		if err != nil {
 			logger.V(4).Info("Failed to get WorkStatus", "workStatus", wsON, "error", err)
+			fetchErrors++
 			continue
 		}
 		status, err := util.GetWorkStatusStatus(wsObj)
 		if err != nil {
 			logger.V(4).Info("Failed to extract status from WorkStatus", "workStatus", wsON, "error", err)
+			fetchErrors++
 			continue
 		}
 		if status == nil {
@@ -71,6 +74,11 @@ func (c *Controller) handleMultiWEC(ctx context.Context, wObjID util.ObjectIdent
 	}
 
 	if len(statuses) == 0 {
+		if fetchErrors > 0 {
+			logger.V(4).Info("All WorkStatus fetches failed, preserving existing status",
+				"object", wObjID, "wsObjects", len(wsObjects), "fetchErrors", fetchErrors)
+			return nil
+		}
 		if err := c.updateObjectStatus(ctx, wObjID, nil, c.listers, true); err != nil {
 			return err
 		}

--- a/pkg/status/multiwec-status.go
+++ b/pkg/status/multiwec-status.go
@@ -53,18 +53,18 @@ func (c *Controller) handleMultiWEC(ctx context.Context, wObjID util.ObjectIdent
 
 	// collect status
 	statuses := make([]map[string]any, 0, len(wsObjects))
-	fetchErrors := 0
+	workStatusReadErrors := 0
 	for _, wsON := range wsObjects {
 		wsObj, err := c.workStatusLister.ByNamespace(wsON.Namespace).Get(wsON.Name)
 		if err != nil {
 			logger.V(4).Info("Failed to get WorkStatus", "workStatus", wsON, "error", err)
-			fetchErrors++
+			workStatusReadErrors++
 			continue
 		}
 		status, err := util.GetWorkStatusStatus(wsObj)
 		if err != nil {
 			logger.V(4).Info("Failed to extract status from WorkStatus", "workStatus", wsON, "error", err)
-			fetchErrors++
+			workStatusReadErrors++
 			continue
 		}
 		if status == nil {
@@ -74,9 +74,9 @@ func (c *Controller) handleMultiWEC(ctx context.Context, wObjID util.ObjectIdent
 	}
 
 	if len(statuses) == 0 {
-		if fetchErrors > 0 {
-			logger.V(4).Info("All WorkStatus fetches failed, preserving existing status",
-				"object", wObjID, "wsObjects", len(wsObjects), "fetchErrors", fetchErrors)
+		if workStatusReadErrors == len(wsObjects) {
+			logger.V(4).Info("No statuses collected due to WorkStatus read/extract errors; preserving existing status",
+				"object", wObjID, "wsObjects", len(wsObjects), "readErrors", workStatusReadErrors)
 			return nil
 		}
 		if err := c.updateObjectStatus(ctx, wObjID, nil, c.listers, true); err != nil {


### PR DESCRIPTION
## Summary
Fixes the logic in `multiwec-status` to only preserve the existing status if *all* WorkStatus reads or extractions failed. Previously, the condition `fetchErrors > 0` would preserve stale status even if some reads were successful.
Also renames `fetchErrors` to `workStatusReadErrors` for clarity and updates the corresponding log message.

## Related issue(s)
N/A
