### PR TITLE
fix: resolve deadlock in Iterator when yield calls Get

### DIFF
--- a/pkg/util/concurrent-map.go
+++ b/pkg/util/concurrent-map.go
@@ -90,14 +90,17 @@ func (mm *rwMutexMap[K, V]) Get(key K) (V, bool) {
 // If the map is mutated during the iteration, the behavior is undefined.
 func (mm *rwMutexMap[K, V]) Iterator(yield func(K, V) error) error {
 	mm.RLock()
-	defer mm.RUnlock()
-
+	snapshot := make(map[K]V, len(mm.m))
 	for k, v := range mm.m {
+		snapshot[k] = v
+	}
+	mm.RUnlock()
+
+	for k, v := range snapshot {
 		if err := yield(k, v); err != nil {
 			return err
 		}
 	}
-
 	return nil
 }
 

--- a/pkg/util/concurrent-map_test.go
+++ b/pkg/util/concurrent-map_test.go
@@ -1,0 +1,29 @@
+package util
+
+import (
+	"testing"
+	"time"
+)
+
+func TestIteratorNoDeadlock(t *testing.T) {
+	m := NewConcurrentMap[string, string]()
+	m.Set("a", "1")
+
+	done := make(chan struct{})
+	go func() {
+		err := m.Iterator(func(k, v string) error {
+			m.Get(k)
+			return nil
+		})
+		if err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("deadlock detected")
+	}
+}


### PR DESCRIPTION
🐛 fix: resolve deadlock in Iterator when yield calls Get

SUMMARY
Iterator held RLock. yield call Get. Get try RLock again.
RWMutex not reentrant. Program hang forever. No panic. No error.

Fix: copy map under lock. Release lock. Walk copy.
yield run outside lock. Safe now.

Test added. Prove deadlock before. Pass after.
RELATED ISSUE
Fixes #