### PR TITLE
cleanup: Remove unused type alias workStatusON

### DIFF
--- a/pkg/status/status-controller.go
+++ b/pkg/status/status-controller.go
@@ -101,8 +101,6 @@ type workloadObjectRef struct{ util.ObjectIdentifier }
 // bindingRef is a workqueue item that references a Binding
 type bindingRef string
 
-type workStatusON cache.ObjectName
-
 // workStatusRef is a workqueue item that references a WorkStatus
 type workStatusRef struct {
 	// Name is the Name of the WorkStatus object


### PR DESCRIPTION
Remove the unused `workStatusON` type alias from `pkg/status/status-controller.go`.

The alias was defined as:

type workStatusON cache.ObjectName

but it is never referenced anywhere in the codebase. The package already uses `cache.ObjectName` directly in function signatures and related logic, making the alias redundant.

Type: Cleanup