### PR TITLE
🧹 cleanup: simplify boolean returns, propagate errors, and fix typos

### DIFF
--- a/cmd/controller-manager/main.go
+++ b/cmd/controller-manager/main.go
@@ -80,7 +80,7 @@ func main() {
 	pflag.StringVar(&itsName, "its-name", "", "name of the Inventory and Transport Space to connect to (empty string means to use the only one)")
 	pflag.StringVar(&wdsName, "wds-name", "", "name of the workload description space to connect to")
 	pflag.StringVar(&allowedGroupsString, "api-groups", "", "list of allowed api groups, comma separated. Empty string means all API groups are allowed")
-	pflag.StringSliceVar(&controllers, "controllers", []string{}, "list of controllers to be started by the controller manager, lower case and comma separated, e.g. 'binding,status'. If not specified (or emtpy list specifed), all controllers are started. Currently available controllers are 'binding' and 'status'.")
+	pflag.StringSliceVar(&controllers, "controllers", []string{}, "list of controllers to be started by the controller manager, lower case and comma separated, e.g. 'binding,status'. If not specified (or empty list specified), all controllers are started. Currently available controllers are 'binding' and 'status'.")
 	pflag.BoolVar(&enableLeaderElection, "leader-elect", false,
 		"Enable leader election for controller manager. "+
 			"Enabling this will ensure there is only one active controller manager.")
@@ -111,7 +111,7 @@ func main() {
 		strings.ToLower(binding.ControllerName),
 		strings.ToLower(status.ControllerName),
 	).IsSuperset(ctlrsToStart) {
-		setupLog.Error(fmt.Errorf("unkown controller specified"), "'controllers' flag has incorrect value")
+		setupLog.Error(fmt.Errorf("unknown controller specified"), "'controllers' flag has incorrect value")
 		os.Exit(1)
 	}
 

--- a/pkg/binding/bindingpolicy-resolver.go
+++ b/pkg/binding/bindingpolicy-resolver.go
@@ -351,11 +351,7 @@ func (resolver *bindingPolicyResolver) SetDestinations(bindingPolicyKey string,
 // ResolutionExists returns true if a resolution is associated with the
 // given bindingpolicy key.
 func (resolver *bindingPolicyResolver) ResolutionExists(bindingPolicyKey string) bool {
-	if resolver.getResolution(bindingPolicyKey) == nil {
-		return false
-	}
-
-	return true
+	return resolver.getResolution(bindingPolicyKey) != nil
 }
 
 // GetReportedStateRequestForObject returns four things.

--- a/pkg/binding/bindingpolicy.go
+++ b/pkg/binding/bindingpolicy.go
@@ -81,9 +81,9 @@ func (c *Controller) syncBindingPolicy(ctx context.Context, bindingPolicyName st
 		}
 
 		// set destinations and enqueue binding for syncing
-		// we can skip handling the error since the call to BindingPolicyResolver::NoteBindingPolicy above
-		// guarantees that an error won't be returned here
-		_ = c.bindingPolicyResolver.SetDestinations(bindingPolicy.GetName(), clusterSet)
+		if err := c.bindingPolicyResolver.SetDestinations(bindingPolicy.GetName(), clusterSet); err != nil {
+			return fmt.Errorf("failed to set destinations for %s: %w", bindingPolicy.GetName(), err)
+		}
 		logger.V(5).Info("Enqueued Binding for syncing, while handling BindingPolicy", "name", bindingPolicy.Name)
 		c.enqueueBinding(bindingPolicy.GetName())
 

--- a/pkg/binding/crd.go
+++ b/pkg/binding/crd.go
@@ -123,11 +123,7 @@ func (c *Controller) includedToWatch(r APIResource) bool {
 		Resource: r.resource.Name,
 	}
 
-	if isExcludedGroupResource(gr) {
-		return false
-	}
-
-	return true
+	return !isExcludedGroupResource(gr)
 }
 
 func crdEstablished(crd *apiextensionsv1.CustomResourceDefinition) bool {

--- a/pkg/util/object-identifier.go
+++ b/pkg/util/object-identifier.go
@@ -116,9 +116,6 @@ func IdentifierForCombinedStatus(name, ns string) ObjectIdentifier {
 }
 
 func gvkMatches(gvk schema.GroupVersionKind, group, version, kind string) bool {
-	if gvk.Group == group && (version == AnyVersion || gvk.Version == version) &&
-		gvk.Kind == kind {
-		return true
-	}
-	return false
+	return gvk.Group == group && (version == AnyVersion || gvk.Version == version) &&
+		gvk.Kind == kind
 }


### PR DESCRIPTION
## Summary

Perform a small cleanup pass across the codebase by simplifying boolean returns, removing silent error handling, and fixing user-facing typos.

## Changes

- Simplified boolean return patterns:
  - `pkg/binding/crd.go` (`includedToWatch`)
  - `pkg/binding/bindingpolicy-resolver.go` (`ResolutionExists`)
  - `pkg/util/object-identifier.go` (`gvkMatches`)
- Replaced a silently discarded error in `SetDestinations` with proper error propagation:
  - `pkg/binding/bindingpolicy.go`
- Fixed typos in controller-manager flag descriptions:
  - `emtpy` → `empty`
  - `specifed` → `specified`
  - `unkown` → `unknown`

## Impact

- Removes redundant branches and simplifies code paths.
- Prevents silent error suppression in destination handling.
- Improves clarity of CLI help text.
- No functional changes intended beyond proper error propagation.