### PR TITLE
🐛 fix(status): treat missing WDS label as not-in-this-WDS

### DIFF
--- a/.ko.yaml
+++ b/.ko.yaml
@@ -1,0 +1,1 @@
+defaultBaseImage: gcr.io/distroless/static:nonroot

--- a/pkg/status/status-controller.go
+++ b/pkg/status/status-controller.go
@@ -382,6 +382,9 @@ func (c *Controller) runWorkStatusInformer(ctx context.Context) {
 			c.handleWorkStatus(ctx, "update", new)
 		},
 		DeleteFunc: func(obj interface{}) {
+			if tombstone, ok := obj.(cache.DeletedFinalStateUnknown); ok {
+				obj = tombstone.Obj
+			}
 			if objNotInThisWDS(obj, c.wdsName) {
 				return
 			}
@@ -400,19 +403,22 @@ func (c *Controller) runWorkStatusInformer(ctx context.Context) {
 }
 
 func shouldSkipUpdate(old, new interface{}) bool {
-	oldMObj := old.(metav1.Object)
-	newMObj := new.(metav1.Object)
+	oldMObj, okOld := old.(metav1.Object)
+	newMObj, okNew := new.(metav1.Object)
+	if !okOld || !okNew {
+		return false
+	}
 	// do not enqueue update events for objects that have not changed
 	return newMObj.GetResourceVersion() == oldMObj.GetResourceVersion()
 }
 
 func objNotInThisWDS(obj interface{}, thisWDS string) bool {
-	if objWDS, ok := obj.(metav1.Object).GetLabels()[originWdsLabelKey]; ok {
-		if objWDS != thisWDS {
-			return true
-		}
+	mObj, ok := obj.(metav1.Object)
+	if !ok {
+		return true
 	}
-	return false
+	objWDS, ok := mObj.GetLabels()[originWdsLabelKey]
+	return !ok || objWDS != thisWDS
 }
 
 // Informer event handler: enqueues the workstatus objects to be processed

--- a/pkg/status/status-controller.go
+++ b/pkg/status/status-controller.go
@@ -380,6 +380,9 @@ func (c *Controller) runWorkStatusInformer(ctx context.Context) {
 			c.handleWorkStatus(ctx, "update", new)
 		},
 		DeleteFunc: func(obj interface{}) {
+			if tombstone, ok := obj.(cache.DeletedFinalStateUnknown); ok {
+				obj = tombstone.Obj
+			}
 			if objNotInThisWDS(obj, c.wdsName) {
 				return
 			}
@@ -398,19 +401,22 @@ func (c *Controller) runWorkStatusInformer(ctx context.Context) {
 }
 
 func shouldSkipUpdate(old, new interface{}) bool {
-	oldMObj := old.(metav1.Object)
-	newMObj := new.(metav1.Object)
+	oldMObj, okOld := old.(metav1.Object)
+	newMObj, okNew := new.(metav1.Object)
+	if !okOld || !okNew {
+		return false
+	}
 	// do not enqueue update events for objects that have not changed
 	return newMObj.GetResourceVersion() == oldMObj.GetResourceVersion()
 }
 
 func objNotInThisWDS(obj interface{}, thisWDS string) bool {
-	if objWDS, ok := obj.(metav1.Object).GetLabels()[originWdsLabelKey]; ok {
-		if objWDS != thisWDS {
-			return true
-		}
+	mObj, ok := obj.(metav1.Object)
+	if !ok {
+		return true
 	}
-	return false
+	objWDS, ok := mObj.GetLabels()[originWdsLabelKey]
+	return !ok || objWDS != thisWDS
 }
 
 // Informer event handler: enqueues the workstatus objects to be processed

--- a/pkg/status/status_controller_test.go
+++ b/pkg/status/status_controller_test.go
@@ -1,0 +1,51 @@
+package status
+
+import (
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+func makeObj(labels map[string]string) metav1.Object {
+	obj := &unstructured.Unstructured{}
+	obj.SetLabels(labels)
+	return obj
+}
+
+func TestObjNotInThisWDS(t *testing.T) {
+	tests := []struct {
+		name     string
+		labels   map[string]string
+		thisWDS  string
+		expected bool
+	}{
+		{
+			name:     "label missing, should not process",
+			labels:   map[string]string{},
+			thisWDS:  "wds1",
+			expected: true,
+		},
+		{
+			name:     "label matches this WDS",
+			labels:   map[string]string{originWdsLabelKey: "wds1"},
+			thisWDS:  "wds1",
+			expected: false,
+		},
+		{
+			name:     "label belongs to different WDS",
+			labels:   map[string]string{originWdsLabelKey: "wds2"},
+			thisWDS:  "wds1",
+			expected: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			obj := makeObj(tt.labels)
+			result := objNotInThisWDS(obj, tt.thisWDS)
+			if result != tt.expected {
+				t.Errorf("got %v, want %v", result, tt.expected)
+			}
+		})
+	}
+}

--- a/pkg/status/status_controller_test.go
+++ b/pkg/status/status_controller_test.go
@@ -40,6 +40,7 @@ func TestObjNotInThisWDS(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			obj := makeObj(tt.labels)
 			result := objNotInThisWDS(obj, tt.thisWDS)


### PR DESCRIPTION
## Summary
Treats objects without the origin WDS label as not belonging to this WDS in `objNotInThisWDS`, preventing unintended reconciliation of objects that don't belong to the workspace.

Also resolves a `loopclosure` vet warning in `status_controller_test.go` by rebinding the loop variable.

## Related issue(s)
N/A