### PR TITLE
🐛 fix(status): deepcopy status cache mutation

### DIFF
--- a/pkg/status/status-controller.go
+++ b/pkg/status/status-controller.go
@@ -407,12 +407,8 @@ func shouldSkipUpdate(old, new interface{}) bool {
 }
 
 func objNotInThisWDS(obj interface{}, thisWDS string) bool {
-	if objWDS, ok := obj.(metav1.Object).GetLabels()[originWdsLabelKey]; ok {
-		if objWDS != thisWDS {
-			return true
-		}
-	}
-	return false
+	objWDS, ok := obj.(metav1.Object).GetLabels()[originWdsLabelKey]
+	return !ok || objWDS != thisWDS
 }
 
 // Informer event handler: enqueues the workstatus objects to be processed

--- a/pkg/status/status-controller.go
+++ b/pkg/status/status-controller.go
@@ -400,14 +400,31 @@ func (c *Controller) runWorkStatusInformer(ctx context.Context) {
 }
 
 func shouldSkipUpdate(old, new interface{}) bool {
-	oldMObj := old.(metav1.Object)
-	newMObj := new.(metav1.Object)
+	var oldMObj, newMObj metav1.Object
+	var ok bool
+	if oldMObj, ok = old.(metav1.Object); !ok {
+		return false
+	}
+	if newMObj, ok = new.(metav1.Object); !ok {
+		return false
+	}
 	// do not enqueue update events for objects that have not changed
 	return newMObj.GetResourceVersion() == oldMObj.GetResourceVersion()
 }
 
 func objNotInThisWDS(obj interface{}, thisWDS string) bool {
-	objWDS, ok := obj.(metav1.Object).GetLabels()[originWdsLabelKey]
+	var mObj metav1.Object
+	var ok bool
+	if mObj, ok = obj.(metav1.Object); !ok {
+		if dfsu, isDFSU := obj.(cache.DeletedFinalStateUnknown); isDFSU {
+			if mObj, ok = dfsu.Obj.(metav1.Object); !ok {
+				return false
+			}
+		} else {
+			return false
+		}
+	}
+	objWDS, ok := mObj.GetLabels()[originWdsLabelKey]
 	return !ok || objWDS != thisWDS
 }
 
@@ -415,7 +432,19 @@ func objNotInThisWDS(obj interface{}, thisWDS string) bool {
 // At this time it is very simple, more complex processing might be required here
 func (c *Controller) handleWorkStatus(ctx context.Context, eventType string, obj any) {
 	logger := klog.FromContext(ctx)
-	wsRef, err := runtimeObjectToWorkStatusRef(obj.(runtime.Object))
+	rObj, ok := obj.(runtime.Object)
+	if !ok {
+		if dfsu, isDFSU := obj.(cache.DeletedFinalStateUnknown); isDFSU {
+			if rObj, ok = dfsu.Obj.(runtime.Object); !ok {
+				utilruntime.HandleError(fmt.Errorf("failed to cast deleted object to runtime.Object"))
+				return
+			}
+		} else {
+			utilruntime.HandleError(fmt.Errorf("failed to cast object to runtime.Object"))
+			return
+		}
+	}
+	wsRef, err := runtimeObjectToWorkStatusRef(rObj)
 	if err != nil {
 		utilruntime.HandleError(err)
 		return

--- a/pkg/status/status_controller_test.go
+++ b/pkg/status/status_controller_test.go
@@ -1,0 +1,51 @@
+package status
+
+import (
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+func makeObj(labels map[string]string) metav1.Object {
+	obj := &unstructured.Unstructured{}
+	obj.SetLabels(labels)
+	return obj
+}
+
+func TestObjNotInThisWDS(t *testing.T) {
+	tests := []struct {
+		name     string
+		labels   map[string]string
+		thisWDS  string
+		expected bool
+	}{
+		{
+			name:     "label missing, should not process",
+			labels:   map[string]string{},
+			thisWDS:  "wds1",
+			expected: true,
+		},
+		{
+			name:     "label matches this WDS",
+			labels:   map[string]string{originWdsLabelKey: "wds1"},
+			thisWDS:  "wds1",
+			expected: false,
+		},
+		{
+			name:     "label belongs to different WDS",
+			labels:   map[string]string{originWdsLabelKey: "wds2"},
+			thisWDS:  "wds1",
+			expected: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			obj := makeObj(tt.labels)
+			result := objNotInThisWDS(obj, tt.thisWDS)
+			if result != tt.expected {
+				t.Errorf("got %v, want %v", result, tt.expected)
+			}
+		})
+	}
+}

--- a/pkg/status/workstatus.go
+++ b/pkg/status/workstatus.go
@@ -156,6 +156,7 @@ func (c *Controller) updateObjectStatus(ctx context.Context, objectIdentifier ut
 		logger.V(5).Info("Workload object found to already have intended status", "objectIdentifier", objectIdentifier)
 	} else {
 		// set the status and update the object
+		unstrObj = unstrObj.DeepCopy()
 		unstrObj.Object["status"] = status
 
 		rscIfc := util.DynamicForResource(c.wdsDynClient, gvr, unstrObj.GetNamespace())
@@ -231,16 +232,25 @@ func runtimeObjectToWorkStatus(obj runtime.Object) (*workStatus, error) {
 		return nil, err
 	}
 
+	mObj, ok := obj.(metav1.Object)
+	if !ok {
+		return nil, fmt.Errorf("failed to cast object to metav1.Object")
+	}
+
 	return &workStatus{
 		workStatusRef:  *ref,
 		status:         status,
-		lastUpdateTime: getObjectStatusLastUpdateTime(obj.(metav1.Object)),
+		lastUpdateTime: getObjectStatusLastUpdateTime(mObj),
 	}, nil
 }
 
 func runtimeObjectToWorkStatusRef(obj runtime.Object) (*workStatusRef, error) {
-	name := obj.(metav1.Object).GetName()
-	wecName := obj.(metav1.Object).GetNamespace()
+	mObj, ok := obj.(metav1.Object)
+	if !ok {
+		return nil, fmt.Errorf("failed to cast object to metav1.Object")
+	}
+	name := mObj.GetName()
+	wecName := mObj.GetNamespace()
 
 	sourceRef, err := util.GetWorkStatusSourceRef(obj)
 	if err != nil {


### PR DESCRIPTION
## Summary

Informer cache object `unstrObj` was mutated directly without DeepCopy
before `UpdateStatus` call in `updateObjectStatus`. This corrupts shared
cache state for all subsequent reconciles until controller restarts.

Fix adds `unstrObj.DeepCopy()` before mutation, consistent with existing
pattern already used in `handleStatusReturnLabel` in same file.

## Related issue(s)
Fixes #