### PR TITLE
Add ignore patterns for agent artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,13 @@ local-chart/
 # word counts
 /counts
 
+# Agent-generated operational artifacts
+*_log.md
+*-diagnosis.md
+*-summary.txt
+pr.md
+reviewer_log.md
+
 # Core Chart generated dependencies
 core-chart/Chart.lock
 core-chart/charts/


### PR DESCRIPTION
﻿## Summary

Adds `.gitignore` coverage for agent-generated operational artifacts like scan logs, diagnosis notes, release summaries, and temporary PR notes. This mirrors the pattern from the recent `kubestellar/console` cleanup so these files do not get committed here by accident.

## Related issue(s)

Fixes #3819

## Validation

Ran `git check-ignore -v` for the filenames from the console incident:

- `cron_scan_log.md`
- `release-failure-diagnosis.md`
- `release-failure-summary.txt`
- `pr.md`
- `reviewer_log.md`
- `notes.log`
