### PR TITLE
docs: add GitHub Discussions contact link

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ There are several ways to communicate with us:
 
 - Instantly get access to our documents and meeting invites at http://kubestellar.io/joinus
 
+- Join [GitHub Discussions](https://github.com/kubestellar/kubestellar/discussions) for questions, ideas, and show-and-tell
 - The [`#kubestellar-dev` channel](https://cloud-native.slack.com/archives/C097094RZ3M) in the [CNCF Slack workspace](https://communityinviter.com/apps/cloud-native/cncf)
 - Our mailing lists:
     - [kubestellar-dev](https://groups.google.com/g/kubestellar-dev) for development discussions


### PR DESCRIPTION
## Summary

Adds GitHub Discussions to the README contact list so visitors have an easy place for questions, ideas, and show-and-tell.

## Related issue(s)

Fixes #3823

## Testing

- Ran `git diff --check -- README.md docs/to-be-deleted/content/readme.md`