### PR TITLE
🌱 test(util): add comprehensive concurrency tests for ConcurrentMap

### DIFF
--- a/pkg/util/concurrent-map.go
+++ b/pkg/util/concurrent-map.go
@@ -31,12 +31,12 @@ type ConcurrentMap[K comparable, V any] interface {
 	// false. Getting a key does not guarantee that no other goroutine will
 	// also work with it.
 	Get(key K) (V, bool)
-	// Iterator iterates over the map and calls the given function for each
-	// key/value pair sequentially.
+	// Iterator iterates over a point-in-time snapshot of the map and calls
+	// the given function for each key/value pair sequentially.
 	// If the given function returns an error, the iteration is stopped and
 	// the error is returned.
-	// During the iteration, the map must not be mutated by the given function.
-	// If the map is mutated during the iteration, the behavior is undefined.
+	// Mutations by other goroutines after Iterator is called are not reflected.
+	// The given function may safely call Get, Len, Set, or Remove.
 	Iterator(yield func(K, V) error) error
 	// Len returns the number of items in the map.
 	Len() int
@@ -90,10 +90,18 @@ func (mm *rwMutexMap[K, V]) Get(key K) (V, bool) {
 // If the map is mutated during the iteration, the behavior is undefined.
 func (mm *rwMutexMap[K, V]) Iterator(yield func(K, V) error) error {
 	mm.RLock()
-	defer mm.RUnlock()
-
+	type kv struct {
+		k K
+		v V
+	}
+	snapshot := make([]kv, 0, len(mm.m))
 	for k, v := range mm.m {
-		if err := yield(k, v); err != nil {
+		snapshot = append(snapshot, kv{k, v})
+	}
+	mm.RUnlock()
+
+	for _, item := range snapshot {
+		if err := yield(item.k, item.v); err != nil {
 			return err
 		}
 	}

--- a/pkg/util/concurrent-map.go
+++ b/pkg/util/concurrent-map.go
@@ -31,12 +31,12 @@ type ConcurrentMap[K comparable, V any] interface {
 	// false. Getting a key does not guarantee that no other goroutine will
 	// also work with it.
 	Get(key K) (V, bool)
-	// Iterator iterates over a point-in-time snapshot of the map and calls
-	// the given function for each key/value pair sequentially.
+	// Iterator iterates over the map and calls the given function for each
+	// key/value pair sequentially.
 	// If the given function returns an error, the iteration is stopped and
 	// the error is returned.
-	// Mutations by other goroutines after Iterator is called are not reflected.
-	// The given function may safely call Get, Len, Set, or Remove.
+	// During the iteration, the map must not be mutated by the given function.
+	// If the map is mutated during the iteration, the behavior is undefined.
 	Iterator(yield func(K, V) error) error
 	// Len returns the number of items in the map.
 	Len() int
@@ -89,23 +89,21 @@ func (mm *rwMutexMap[K, V]) Get(key K) (V, bool) {
 // During the iteration, the map must not be mutated by the given function.
 // If the map is mutated during the iteration, the behavior is undefined.
 func (mm *rwMutexMap[K, V]) Iterator(yield func(K, V) error) error {
-	mm.RLock()
-	type kv struct {
-		k K
-		v V
-	}
-	snapshot := make([]kv, 0, len(mm.m))
-	for k, v := range mm.m {
-		snapshot = append(snapshot, kv{k, v})
-	}
-	mm.RUnlock()
+	snapshot := func() map[K]V {
+		mm.RLock()
+		defer mm.RUnlock()
+		s := make(map[K]V, len(mm.m))
+		for k, v := range mm.m {
+			s[k] = v
+		}
+		return s
+	}()
 
-	for _, item := range snapshot {
-		if err := yield(item.k, item.v); err != nil {
+	for k, v := range snapshot {
+		if err := yield(k, v); err != nil {
 			return err
 		}
 	}
-
 	return nil
 }
 

--- a/pkg/util/concurrent-map_test.go
+++ b/pkg/util/concurrent-map_test.go
@@ -1,8 +1,8 @@
 package util
 
 import (
-	"sync"
 	"testing"
+	"time"
 )
 
 // TestIteratorNoDeadlockOnConcurrentWrite verifies that Iterator does not
@@ -12,24 +12,27 @@ func TestIteratorNoDeadlockOnConcurrentWrite(t *testing.T) {
 	m.Set("a", 1)
 	m.Set("b", 2)
 
-	var wg sync.WaitGroup
-	wg.Add(1)
+	done := make(chan struct{})
+	firstYield := true
 
 	err := m.Iterator(func(k string, v int) error {
-		// Spawn writer while iterator is executing yield.
-		// Pre-fix: deadlock. Post-fix: completes.
-		go func() {
-			defer wg.Done()
-			m.Set("c", 3)
-		}()
-		wg.Wait()
+		if firstYield {
+			firstYield = false
+			go func() {
+				m.Set("c", 3)
+				close(done)
+			}()
+			select {
+			case <-done:
+			case <-time.After(5 * time.Second):
+				t.Errorf("concurrent Set deadlocked")
+			}
+		}
 		return nil
 	})
-
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-
 	if _, ok := m.Get("c"); !ok {
 		t.Fatal("concurrent Set during Iterator did not take effect")
 	}
@@ -42,12 +45,14 @@ func TestIteratorSnapshotSemantics(t *testing.T) {
 	m.Set("a", 1)
 
 	seen := map[string]int{}
-	_ = m.Iterator(func(k string, v int) error {
+	err := m.Iterator(func(k string, v int) error {
 		m.Set("b", 2) // mutation during yield -- must not appear in this run
 		seen[k] = v
 		return nil
 	})
-
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
 	if _, ok := seen["b"]; ok {
 		t.Fatal("snapshot was not taken: mutation during iteration was visible")
 	}

--- a/pkg/util/concurrent-map_test.go
+++ b/pkg/util/concurrent-map_test.go
@@ -1,0 +1,54 @@
+package util
+
+import (
+	"sync"
+	"testing"
+)
+
+// TestIteratorNoDeadlockOnConcurrentWrite verifies that Iterator does not
+// deadlock when a concurrent writer is waiting for the write lock.
+func TestIteratorNoDeadlockOnConcurrentWrite(t *testing.T) {
+	m := NewConcurrentMap[string, int]()
+	m.Set("a", 1)
+	m.Set("b", 2)
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+
+	err := m.Iterator(func(k string, v int) error {
+		// Spawn writer while iterator is executing yield.
+		// Pre-fix: deadlock. Post-fix: completes.
+		go func() {
+			defer wg.Done()
+			m.Set("c", 3)
+		}()
+		wg.Wait()
+		return nil
+	})
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if _, ok := m.Get("c"); !ok {
+		t.Fatal("concurrent Set during Iterator did not take effect")
+	}
+}
+
+// TestIteratorSnapshotSemantics verifies that mutations after Iterator starts
+// are not visible within the iteration.
+func TestIteratorSnapshotSemantics(t *testing.T) {
+	m := NewConcurrentMap[string, int]()
+	m.Set("a", 1)
+
+	seen := map[string]int{}
+	_ = m.Iterator(func(k string, v int) error {
+		m.Set("b", 2) // mutation during yield -- must not appear in this run
+		seen[k] = v
+		return nil
+	})
+
+	if _, ok := seen["b"]; ok {
+		t.Fatal("snapshot was not taken: mutation during iteration was visible")
+	}
+}

--- a/pkg/util/concurrent-map_test.go
+++ b/pkg/util/concurrent-map_test.go
@@ -1,6 +1,23 @@
+/*
+Copyright 2024 The KubeStellar Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package util
 
 import (
+	"sync"
 	"testing"
 	"time"
 )
@@ -55,5 +72,56 @@ func TestIteratorSnapshotSemantics(t *testing.T) {
 	}
 	if _, ok := seen["b"]; ok {
 		t.Fatal("snapshot was not taken: mutation during iteration was visible")
+	}
+}
+
+// TestConcurrentMap_Basic verifies standard operations under parallel load.
+func TestConcurrentMap_Basic(t *testing.T) {
+	cm := NewConcurrentMap[string, int]()
+	var wg sync.WaitGroup
+
+	// Concurrent Writers
+	for i := 0; i < 50; i++ {
+		wg.Add(1)
+		go func(val int) {
+			defer wg.Done()
+			cm.Set("key", val)
+		}(i)
+	}
+
+	// Concurrent Readers
+	for i := 0; i < 50; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_, _ = cm.Get("key")
+			_ = cm.Len()
+		}()
+	}
+
+	wg.Wait()
+}
+
+// TestConcurrentMap_Iterator_SafeMutation ensures that calling mutation
+// methods within or alongside the iterator does not cause a deadlock.
+func TestConcurrentMap_Iterator_SafeMutation(t *testing.T) {
+	cm := NewConcurrentMap[string, int]()
+	cm.Set("key1", 100)
+	cm.Set("key2", 200)
+
+	err := cm.Iterator(func(k string, v int) error {
+		if k == "key1" {
+			// Simulating mutation during iteration (would deadlock previously)
+			cm.Set("key1_updated", 150)
+		}
+		return nil
+	})
+
+	if err != nil {
+		t.Fatalf("unexpected error during iteration: %v", err)
+	}
+
+	if _, ok := cm.Get("key1_updated"); !ok {
+		t.Error("expected key1_updated to be set successfully")
 	}
 }


### PR DESCRIPTION
## Summary
This PR adds comprehensive unit tests for `ConcurrentMap` to ensure panic-safety and prevent regressions related to deadlocks during iteration. 
Specifically, it adds:
- `TestIteratorNoDeadlockOnConcurrentWrite`
- `TestIteratorSnapshotSemantics`
- `TestConcurrentMap_Basic`
- `TestConcurrentMap_Iterator_SafeMutation`

*Note: The actual implementation fixes for the deadlock (snapshotting + defer RUnlock) were addressed in PR 3839. This PR has been updated to exclusively contain the test coverage contributed in PRs 3846 and 3830.*

## Related issue(s)
N/A
