### PR TITLE
🐛 bug: fix objectIsQueried infinite loop on embedded-then-standalone matches

### DIFF
--- a/pkg/status/combinedstatus-resolution.go
+++ b/pkg/status/combinedstatus-resolution.go
@@ -1225,19 +1225,23 @@ func sortedStringSlice(s []string) []string {
 // That means, it must not be surrounded by alphanumeric characters.
 // query is assumed to be non-nil.
 func objectIsQueried(query *string, obj string) bool {
-	idx := 0
+	base := 0
 
 	for {
-		idx = strings.Index((*query)[idx:], obj) // slices share the same storage, therefore efficient
-		if idx == -1 {
+		// strings.Index returns a relative offset within (*query)[base:], so we
+		// must add base to get the absolute position before passing it to
+		// isWholeWord (which operates on the original string).
+		rel := strings.Index((*query)[base:], obj)
+		if rel == -1 {
 			return false
 		}
 
-		if isWholeWord(query, idx, len(obj)) {
+		abs := base + rel
+		if isWholeWord(query, abs, len(obj)) {
 			return true
 		}
 
-		idx += len(obj)
+		base = abs + len(obj)
 	}
 }
 

--- a/pkg/status/objectisqueried_test.go
+++ b/pkg/status/objectisqueried_test.go
@@ -1,0 +1,89 @@
+/*
+Copyright 2024 The KubeStellar Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Regression test for the objectIsQueried infinite loop (issue #3848).
+// Before the fix, inputs where the first occurrence of obj is an embedded
+// prefix of a longer word caused an infinite loop: strings.Index returns a
+// relative offset within the sliced substring, but the original code used it
+// as an absolute index for isWholeWord, so the search oscillated between two
+// wrong positions forever.
+package status
+
+import "testing"
+
+func TestObjectIsQueried(t *testing.T) {
+	cases := []struct {
+		query string
+		obj   string
+		want  bool
+	}{
+		// Whole-word occurrences
+		{"select foo from bar", "foo", true},
+		{"foo", "foo", true},
+		// Not a whole word (embedded inside another word)
+		{"foobar", "foo", false},
+		{"barfoo", "foo", false},
+		// Surrounded by punctuation (not alphanumeric) — still a match
+		{"(foo)", "foo", true},
+		// Key regression case: first occurrence embedded, second standalone.
+		// The original code looped forever on this input.
+		{"foobar foo", "foo", true},
+		// Object not present at all
+		{"select bar from baz", "qux", false},
+		// Empty query
+		{"", "foo", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.query+"/"+tc.obj, func(t *testing.T) {
+			q := tc.query
+			got := objectIsQueried(&q, tc.obj)
+			if got != tc.want {
+				t.Errorf("objectIsQueried(%q, %q) = %v, want %v", tc.query, tc.obj, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestIsWholeWord(t *testing.T) {
+	cases := []struct {
+		s      string
+		idx    int
+		length int
+		want   bool
+	}{
+		// "foo" alone at position 0
+		{"foo", 0, 3, true},
+		// "foo" at start followed by space
+		{"foo bar", 0, 3, true},
+		// "foo" embedded in "foobar"
+		{"foobar", 0, 3, false},
+		// "foo" at the end preceded by letter
+		{"barfoo", 3, 3, false},
+		// "foo" in "(foo)"
+		{"(foo)", 1, 3, true},
+		// "bar" in "bar,baz"
+		{"bar,baz", 0, 3, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.s, func(t *testing.T) {
+			s := tc.s
+			got := isWholeWord(&s, tc.idx, tc.length)
+			if got != tc.want {
+				t.Errorf("isWholeWord(%q, %d, %d) = %v, want %v", tc.s, tc.idx, tc.length, got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Bug

`objectIsQueried` in `pkg/status/combinedstatus-resolution.go` enters an
infinite loop whenever a queried field name first appears as an embedded
prefix of a longer token and then appears as a standalone whole-word token
later in the same query string (e.g. query `"foobar foo"`, field `"foo"`).

The function slices the query string before searching:

```go
idx = strings.Index((*query)[idx:], obj)   // returns RELATIVE offset
isWholeWord(query, idx, len(obj))           // but treats it as ABSOLUTE
idx += len(obj)
```

`strings.Index` returns the offset within the **sub-slice** starting at `idx`,
not within the original string. When the search window starts at absolute
position 3 and `strings.Index` returns 4 (relative), the code sets `idx = 4`
instead of `3 + 4 = 7`. The `isWholeWord` check then inspects the wrong
character, rejects the match, advances to 7, where `strings.Index` returns 0
(relative), sending `idx` back to 0, and the cycle repeats indefinitely.

**Impact:** any StatusCollector query where a field name is a prefix of another
identifier causes the status controller goroutine for that collector to hang
permanently, silently stalling CombinedStatus updates for the affected workload.

## Fix

Track `base` (absolute window start) and `rel` (relative result from
`strings.Index`) separately; compute the absolute position as `abs = base + rel`:

```go
rel := strings.Index((*query)[base:], obj)
if rel == -1 {
    return false
}
abs := base + rel
if isWholeWord(query, abs, len(obj)) {
    return true
}
base = abs + len(obj)
```

**Changed file:** `pkg/status/combinedstatus-resolution.go` — `objectIsQueried` function only.

## Regression test

`pkg/status/objectisqueried_test.go` — new file, two test functions:

- `TestObjectIsQueried` — 8 table-driven cases including the key regression
  case `"foobar foo" / "foo"` that hangs forever on the buggy code.
- `TestIsWholeWord` — 6 cases covering boundary conditions for the helper.

## How to run

No cluster, controller, or Kubernetes infrastructure needed:

```bash
go test ./pkg/status/... -run 'TestObjectIsQueried|TestIsWholeWord' -v -timeout 30s
```

Expected result: 14 subtests, all `--- PASS`, completing in under 5 seconds.

To verify the bug is real, revert the `objectIsQueried` change and re-run with
`-timeout 15s` — the test panics with `test timed out` in the
`foobar_foo/foo` subtest.

## Notes

- No other production code was modified.
- If maintainers prefer, the regression test can instead be added to an
  existing test file in `pkg/status`.

Fixes #3848
