### PR TITLE
📖 docs: add Tuna OS to ADOPTERS.md

### DIFF
--- a/ADOPTERS.md
+++ b/ADOPTERS.md
@@ -6,4 +6,5 @@ Listed below are organizations that have adopted KubeStellar in one way or anoth
 | Organization  | Description | Maturity Level | Further Information |
 | ------------- | ------------- | --- | --- |
 | Cornell University | Workload orchestration for the Software-Defined Farm (SDF) System | Workload Integration | [SDF Repo](https://github.com/Cornell-CIDA-Dev/Software-Defined-Farm) |
+| [Tuna OS](https://github.com/tuna-os) | Contributing idle GPU capacity to the Hive network via the KubeStellar Hive Console, backed by a self-hosted Qwen3.6-27B model on a Talos Linux K8s cluster | Compute Contribution | |
 | ------------- | ------------- | --- | --- |

--- a/ADOPTERS.md
+++ b/ADOPTERS.md
@@ -6,5 +6,5 @@ Listed below are organizations that have adopted KubeStellar in one way or anoth
 | Organization  | Description | Maturity Level | Further Information |
 | ------------- | ------------- | --- | --- |
 | Cornell University | Workload orchestration for the Software-Defined Farm (SDF) System | Workload Integration | [SDF Repo](https://github.com/Cornell-CIDA-Dev/Software-Defined-Farm) |
-| [Tuna OS](https://github.com/tuna-os) | Contributing idle GPU capacity to the Hive network via the KubeStellar Hive Console, backed by a self-hosted Qwen3.6-27B model on a Talos Linux K8s cluster | Compute Contribution | |
+| [Tuna OS](https://github.com/tuna-os) | Contributing idle GPU capacity to the Hive network via the KubeStellar Hive Console, backed by a self-hosted Qwen3.6-27B model on a Talos Linux K8s cluster | Compute Contribution | — |
 | ------------- | ------------- | --- | --- |


### PR DESCRIPTION
Adds Tuna OS to the ADOPTERS.md as a KubeStellar Hive Console adopter.

Tuna OS contributes idle GPU compute to the upstream Hive network via the KubeStellar Hive Console, backed by a self-hosted Qwen3.6-27B model on a Talos Linux K8s cluster.