### PR TITLE
Fix panic on tombstone delete events in generic transport controller

### DIFF
--- a/pkg/transport/generic/generic_transport_controller.go
+++ b/pkg/transport/generic/generic_transport_controller.go
@@ -198,10 +198,7 @@ func NewTransportControllerForWrappedObjectGVR(ctx context.Context,
 		},
 		UpdateFunc: func(_, new interface{}) { transportController.handleBinding(new, "update") },
 		DeleteFunc: func(obj any) {
-			if dfsu, is := obj.(*cache.DeletedFinalStateUnknown); is {
-				obj = dfsu.Obj
-			}
-			transportController.handleBinding(obj, "delete")
+			transportController.handleBinding(tombstoneObject(obj), "delete")
 			transportController.bindingSampler.Prod()
 		},
 	})
@@ -213,10 +210,7 @@ func NewTransportControllerForWrappedObjectGVR(ctx context.Context,
 		},
 		UpdateFunc: func(_, obj any) { transportController.handleCustomTransform(obj, "update") },
 		DeleteFunc: func(obj any) {
-			if deletedStateUnknown, ok := obj.(cache.DeletedFinalStateUnknown); ok {
-				obj = deletedStateUnknown.Obj
-			}
-			transportController.handleCustomTransform(obj, "delete")
+			transportController.handleCustomTransform(tombstoneObject(obj), "delete")
 			transportController.transformSampler.Prod()
 		},
 	})
@@ -234,10 +228,7 @@ func NewTransportControllerForWrappedObjectGVR(ctx context.Context,
 			transportController.handleWrappedObject(new, "update")
 		},
 		DeleteFunc: func(obj any) {
-			if dfsu, is := obj.(*cache.DeletedFinalStateUnknown); is {
-				obj = dfsu.Obj
-			}
-			transportController.handleWrappedObject(obj, "delete")
+			transportController.handleWrappedObject(tombstoneObject(obj), "delete")
 			transportController.wrappedSampler.Prod()
 		},
 	})
@@ -250,10 +241,7 @@ func NewTransportControllerForWrappedObjectGVR(ctx context.Context,
 			transportController.handlePropertiesEvent(new, "update")
 		},
 		DeleteFunc: func(obj any) {
-			if dfsu, is := obj.(*cache.DeletedFinalStateUnknown); is {
-				obj = dfsu.Obj
-			}
-			transportController.handlePropertiesEvent(obj, "delete")
+			transportController.handlePropertiesEvent(tombstoneObject(obj), "delete")
 			transportController.wecSampler.Prod()
 		},
 	})
@@ -266,10 +254,7 @@ func NewTransportControllerForWrappedObjectGVR(ctx context.Context,
 			transportController.handlePropertiesEvent(new, "update")
 		},
 		DeleteFunc: func(obj any) {
-			if dfsu, is := obj.(*cache.DeletedFinalStateUnknown); is {
-				obj = dfsu.Obj
-			}
-			transportController.handlePropertiesEvent(obj, "delete")
+			transportController.handlePropertiesEvent(tombstoneObject(obj), "delete")
 			transportController.propMapSampler.Prod()
 		},
 	})
@@ -371,6 +356,18 @@ type genericTransportController struct {
 // enqueueBinding takes an Binding resource and
 // converts it into a namespace/name string which is put onto the workqueue.
 // This func *shouldn't* handle any resource other than Binding.
+// tombstoneObject unwraps the object reported by an informer's delete event.
+// On a delete, the informer may deliver the final object directly or, if that
+// object was missed and reconstructed from a re-list, a cache.DeletedFinalStateUnknown
+// holding it. client-go always passes the tombstone by value (see
+// cache.DeltaFIFO), so the assertion must be on the value type, not a pointer.
+func tombstoneObject(obj any) any {
+	if tombstone, ok := obj.(cache.DeletedFinalStateUnknown); ok {
+		return tombstone.Obj
+	}
+	return obj
+}
+
 func (c *genericTransportController) handleBinding(obj interface{}, event string) {
 	binding := obj.(*v1alpha1.Binding)
 	c.logger.V(5).Info("Enqueuing reference to Binding due to informer event about that Binding", "name", binding.Name, "resourceVersion", binding.ResourceVersion, "event", event)

--- a/pkg/transport/generic/tombstone_test.go
+++ b/pkg/transport/generic/tombstone_test.go
@@ -1,0 +1,126 @@
+/*
+Copyright 2024 The KubeStellar Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package transport
+
+import (
+	"testing"
+
+	"github.com/go-logr/logr"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/util/workqueue"
+
+	"github.com/kubestellar/kubestellar/api/control/v1alpha1"
+)
+
+// newTestController returns a controller wired with just the fields the delete
+// handlers touch: a logger and a workqueue to observe enqueues.
+func newTestController() *genericTransportController {
+	return &genericTransportController{
+		logger:    logr.Discard(),
+		workqueue: workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "test"),
+	}
+}
+
+// drainKeys returns every key currently sitting in the workqueue.
+func drainKeys(t *testing.T, q workqueue.RateLimitingInterface) []any {
+	t.Helper()
+	keys := []any{}
+	for q.Len() > 0 {
+		key, shutdown := q.Get()
+		if shutdown {
+			break
+		}
+		keys = append(keys, key)
+		q.Done(key)
+	}
+	return keys
+}
+
+// TestDeleteHandlersUnwrapTombstone verifies that the informer delete handlers
+// accept a cache.DeletedFinalStateUnknown tombstone and enqueue the embedded
+// object instead of panicking. client-go delivers tombstones by value, so a
+// pointer type assertion (*cache.DeletedFinalStateUnknown) silently fails to
+// match and lets the raw tombstone reach the typed cast below, which panics.
+func TestDeleteHandlersUnwrapTombstone(t *testing.T) {
+	binding := &v1alpha1.Binding{ObjectMeta: metav1.ObjectMeta{Name: "binding-1"}}
+	wrapped := &unstructured.Unstructured{}
+	wrapped.SetName("mw-1")
+	wrapped.SetLabels(map[string]string{originOwnerReferenceLabel: "owner-binding"})
+
+	tests := []struct {
+		name    string
+		invoke  func(c *genericTransportController, obj any)
+		obj     any
+		wantKey any
+	}{
+		{
+			name:    "binding direct",
+			invoke:  func(c *genericTransportController, obj any) { c.handleBinding(tombstoneObject(obj), "delete") },
+			obj:     binding,
+			wantKey: "binding-1",
+		},
+		{
+			name:    "binding tombstone",
+			invoke:  func(c *genericTransportController, obj any) { c.handleBinding(tombstoneObject(obj), "delete") },
+			obj:     cache.DeletedFinalStateUnknown{Key: "binding-1", Obj: binding},
+			wantKey: "binding-1",
+		},
+		{
+			name:    "wrapped object direct",
+			invoke:  func(c *genericTransportController, obj any) { c.handleWrappedObject(tombstoneObject(obj), "delete") },
+			obj:     wrapped,
+			wantKey: "owner-binding",
+		},
+		{
+			name:    "wrapped object tombstone",
+			invoke:  func(c *genericTransportController, obj any) { c.handleWrappedObject(tombstoneObject(obj), "delete") },
+			obj:     cache.DeletedFinalStateUnknown{Key: "mw-1", Obj: wrapped},
+			wantKey: "owner-binding",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			c := newTestController()
+			defer c.workqueue.ShutDown()
+
+			// Would panic before the fix for the tombstone cases.
+			tc.invoke(c, tc.obj)
+
+			keys := drainKeys(t, c.workqueue)
+			if len(keys) != 1 || keys[0] != tc.wantKey {
+				t.Fatalf("expected workqueue to contain %q, got %v", tc.wantKey, keys)
+			}
+		})
+	}
+}
+
+// TestTombstoneObject checks the unwrap helper in isolation.
+func TestTombstoneObject(t *testing.T) {
+	binding := &v1alpha1.Binding{ObjectMeta: metav1.ObjectMeta{Name: "b"}}
+
+	if got := tombstoneObject(binding); got != binding {
+		t.Errorf("expected a non-tombstone value to pass through unchanged")
+	}
+
+	tombstone := cache.DeletedFinalStateUnknown{Key: "b", Obj: binding}
+	if got := tombstoneObject(tombstone); got != binding {
+		t.Errorf("expected tombstone to be unwrapped to its embedded object, got %#v", got)
+	}
+}


### PR DESCRIPTION
## Summary

Four of the five informer `DeleteFunc` handlers in the generic transport controller asserted the delete-event tombstone as `obj.(*cache.DeletedFinalStateUnknown)` (a pointer). client-go always delivers the tombstone by value (`DeletedFinalStateUnknown{k, deletedObj}` from `DeltaFIFO`), so the pointer assertion never matched. The unmodified tombstone then reached the typed cast inside the handler and panicked the controller goroutine — `handleBinding` casts to `*v1alpha1.Binding`, `handleWrappedObject`/`handlePropertiesEvent` cast to `metav1.Object`.

The `CustomTransform` handler already used the value form, so the handlers had drifted. This consolidates the unwrap into a single `tombstoneObject` helper and uses it in all five delete handlers, so the assertion lives in one place.

Same root cause as #2383 (binding controller) and #2052 (an earlier transport panic).

## Testing

- Added `tombstone_test.go` covering both delivery paths (direct object and `DeletedFinalStateUnknown`) for the binding and wrapped-object handlers, plus the helper itself. Reverting to the old pointer assertion makes the tombstone cases panic with `interface conversion: interface {} is cache.DeletedFinalStateUnknown, not *v1alpha1.Binding`, which the test catches.
- `go test ./pkg/transport/...`, `go vet ./pkg/transport/...`, and `go build ./...` all pass.

## Related issue(s)

Fixes #3857
