### PR TITLE
fix(util): prevent nil panic and handle cluster-scoped resources in G…

### DIFF
--- a/pkg/util/unstructured.go
+++ b/pkg/util/unstructured.go
@@ -104,12 +104,22 @@ func GetWorkStatusSourceRef(workStatus runtime.Object) (*SourceRef, error) {
 	}
 
 	spec, ok := obj.Object["spec"].(map[string]interface{})
+<<<<<<< HEAD
 	if !ok || spec == nil {
 		return nil, fmt.Errorf("could not find spec in object")
 	}
 	sourceRef, ok := spec["sourceRef"].(map[string]interface{})
 	if !ok || sourceRef == nil {
 		return nil, fmt.Errorf("could not find sourceRef in object spec")
+=======
+	if !ok {
+		return nil, fmt.Errorf("could not find spec in object or it's not a map")
+	}
+
+	sourceRef, ok := spec["sourceRef"].(map[string]interface{})
+	if !ok {
+		return nil, fmt.Errorf("could not find sourceRef in object spec or it's not a map")
+>>>>>>> 785f7a54e (fix(util): update stale error message for namespace type check)
 	}
 
 	group, ok := sourceRef["group"].(string)
@@ -137,11 +147,19 @@ func GetWorkStatusSourceRef(workStatus runtime.Object) (*SourceRef, error) {
 		return nil, fmt.Errorf("could not find name in sourceRef or it's not a string")
 	}
 
+<<<<<<< HEAD
 	namespace := ""
 	if nsObj, found := sourceRef["namespace"]; found && nsObj != nil {
 		ns, ok := nsObj.(string)
 		if !ok {
 			return nil, fmt.Errorf("could not find namespace in sourceRef or it's not a string")
+=======
+	var namespace string
+	if nsObj, found := sourceRef["namespace"]; found && nsObj != nil {
+		ns, ok := nsObj.(string)
+		if !ok {
+			return nil, fmt.Errorf("namespace in sourceRef is not a string")
+>>>>>>> 785f7a54e (fix(util): update stale error message for namespace type check)
 		}
 		namespace = ns
 	}

--- a/pkg/util/unstructured.go
+++ b/pkg/util/unstructured.go
@@ -99,16 +99,16 @@ func getObjectGVK(o interface{}) (schema.GroupVersionKind, error) {
 
 func GetWorkStatusSourceRef(workStatus runtime.Object) (*SourceRef, error) {
 	obj, ok := workStatus.(*unstructured.Unstructured)
-	if !ok {
+	if !ok || obj == nil {
 		return nil, fmt.Errorf("object cannot be cast to *unstructured.Unstructured")
 	}
 
-	spec := obj.Object["spec"].(map[string]interface{})
-	if spec == nil {
+	spec, ok := obj.Object["spec"].(map[string]interface{})
+	if !ok || spec == nil {
 		return nil, fmt.Errorf("could not find spec in object")
 	}
-	sourceRef := spec["sourceRef"].(map[string]interface{})
-	if sourceRef == nil {
+	sourceRef, ok := spec["sourceRef"].(map[string]interface{})
+	if !ok || sourceRef == nil {
 		return nil, fmt.Errorf("could not find sourceRef in object spec")
 	}
 
@@ -137,9 +137,13 @@ func GetWorkStatusSourceRef(workStatus runtime.Object) (*SourceRef, error) {
 		return nil, fmt.Errorf("could not find name in sourceRef or it's not a string")
 	}
 
-	namespace, ok := sourceRef["namespace"].(string)
-	if !ok {
-		return nil, fmt.Errorf("could not find namespace in sourceRef or it's not a string")
+	namespace := ""
+	if nsObj, found := sourceRef["namespace"]; found && nsObj != nil {
+		ns, ok := nsObj.(string)
+		if !ok {
+			return nil, fmt.Errorf("could not find namespace in sourceRef or it's not a string")
+		}
+		namespace = ns
 	}
 
 	return &SourceRef{
@@ -182,7 +186,7 @@ func ObjectIdentifierFromSourceRef(sourceRef *SourceRef) ObjectIdentifier {
 
 func GetWorkStatusStatus(workStatus runtime.Object) (map[string]interface{}, error) {
 	obj, ok := workStatus.(*unstructured.Unstructured)
-	if !ok {
+	if !ok || obj == nil {
 		return nil, fmt.Errorf("object cannot be cast to *unstructured.Unstructured")
 	}
 

--- a/pkg/util/unstructured.go
+++ b/pkg/util/unstructured.go
@@ -62,10 +62,6 @@ const (
 	CombinedStatusVersion  = "v1alpha1"
 )
 
-// this type is used in status-addon, which we cannot import due to conflicting versions
-// of packages used in Open Cluster Management AddOn framework (otel - open telemetry)
-// TODO - consider separating APIs in a different git repo to become independent of
-// libs deps in different projects
 type SourceRef struct {
 	Group     string `json:"group,omitempty"`
 	Version   string `json:"version,omitempty"`
@@ -75,7 +71,7 @@ type SourceRef struct {
 	Namespace string `json:"namespace,omitempty"`
 }
 
-func IsCRD(o interface{}) bool { // CRDs might have different versions. therefore, using "any" in CRD version
+func IsCRD(o interface{}) bool {
 	return objectMatchesGVK(o, apiextensions.GroupName, AnyVersion, CRDKind)
 }
 
@@ -84,7 +80,6 @@ func objectMatchesGVK(o interface{}, group, version, kind string) bool {
 	if err != nil {
 		return false
 	}
-
 	return gvkMatches(gvk, group, version, kind)
 }
 
@@ -93,25 +88,16 @@ func getObjectGVK(o interface{}) (schema.GroupVersionKind, error) {
 	case runtime.Object:
 		return obj.GetObjectKind().GroupVersionKind(), nil
 	}
-
 	return schema.GroupVersionKind{}, fmt.Errorf("object is of wrong type: %#v", o)
 }
 
 func GetWorkStatusSourceRef(workStatus runtime.Object) (*SourceRef, error) {
 	obj, ok := workStatus.(*unstructured.Unstructured)
-	if !ok || obj == nil {
+	if !ok {
 		return nil, fmt.Errorf("object cannot be cast to *unstructured.Unstructured")
 	}
 
 	spec, ok := obj.Object["spec"].(map[string]interface{})
-<<<<<<< HEAD
-	if !ok || spec == nil {
-		return nil, fmt.Errorf("could not find spec in object")
-	}
-	sourceRef, ok := spec["sourceRef"].(map[string]interface{})
-	if !ok || sourceRef == nil {
-		return nil, fmt.Errorf("could not find sourceRef in object spec")
-=======
 	if !ok {
 		return nil, fmt.Errorf("could not find spec in object or it's not a map")
 	}
@@ -119,7 +105,6 @@ func GetWorkStatusSourceRef(workStatus runtime.Object) (*SourceRef, error) {
 	sourceRef, ok := spec["sourceRef"].(map[string]interface{})
 	if !ok {
 		return nil, fmt.Errorf("could not find sourceRef in object spec or it's not a map")
->>>>>>> 785f7a54e (fix(util): update stale error message for namespace type check)
 	}
 
 	group, ok := sourceRef["group"].(string)
@@ -147,19 +132,11 @@ func GetWorkStatusSourceRef(workStatus runtime.Object) (*SourceRef, error) {
 		return nil, fmt.Errorf("could not find name in sourceRef or it's not a string")
 	}
 
-<<<<<<< HEAD
-	namespace := ""
-	if nsObj, found := sourceRef["namespace"]; found && nsObj != nil {
-		ns, ok := nsObj.(string)
-		if !ok {
-			return nil, fmt.Errorf("could not find namespace in sourceRef or it's not a string")
-=======
 	var namespace string
 	if nsObj, found := sourceRef["namespace"]; found && nsObj != nil {
 		ns, ok := nsObj.(string)
 		if !ok {
 			return nil, fmt.Errorf("namespace in sourceRef is not a string")
->>>>>>> 785f7a54e (fix(util): update stale error message for namespace type check)
 		}
 		namespace = ns
 	}
@@ -204,7 +181,7 @@ func ObjectIdentifierFromSourceRef(sourceRef *SourceRef) ObjectIdentifier {
 
 func GetWorkStatusStatus(workStatus runtime.Object) (map[string]interface{}, error) {
 	obj, ok := workStatus.(*unstructured.Unstructured)
-	if !ok || obj == nil {
+	if !ok {
 		return nil, fmt.Errorf("object cannot be cast to *unstructured.Unstructured")
 	}
 
@@ -228,9 +205,9 @@ func CheckWorkStatusPresence(config *rest.Config) bool {
 	}
 
 	gvr := schema.GroupVersionResource{
-		Group:    "control.kubestellar.io",
-		Version:  "v1alpha1",
-		Resource: "workstatuses",
+		Group:    WorkStatusGroup,
+		Version:  WorkStatusVersion,
+		Resource: WorkStatusResource,
 	}
 
 	return CheckAPIisPresent(discoveryClient, gvr)
@@ -251,7 +228,6 @@ func CheckAPIisPresent(dc *discovery.DiscoveryClient, gvr schema.GroupVersionRes
 	return false
 }
 
-// CreateStatusPatch creates a status patch for unstructured object.
 func CreateStatusPatch(unstrObj *unstructured.Unstructured, status map[string]interface{}) *unstructured.Unstructured {
 	patchedObj := &unstructured.Unstructured{}
 	patchedObj.SetAPIVersion(unstrObj.GetAPIVersion())
@@ -262,7 +238,6 @@ func CreateStatusPatch(unstrObj *unstructured.Unstructured, status map[string]in
 	return patchedObj
 }
 
-// PatchStatus updates the object status with Patch.
 func PatchStatus(ctx context.Context, unstrObj *unstructured.Unstructured, status map[string]interface{},
 	namespace string, gvr schema.GroupVersionResource, dynamicClient dynamic.Interface) error {
 	logger := klog.FromContext(ctx)


### PR DESCRIPTION
🐛 fix(util): prevent nil panic and handle cluster-scoped resources in GetWorkStatusSourceRef

## Summary
Two bugs fixed in `GetWorkStatusSourceRef` in `pkg/util/unstructured.go`:

1. Unsafe type assertions on `spec` and `sourceRef` caused nil pointer panic
   when either field was absent. Fixed using two-value assertion form before nil check.

2. `namespace` field was required, breaking all cluster-scoped WorkStatus objects.
   Namespace is legitimately empty for cluster-scoped resources, so strict error
   check removed and empty string used as default.

## Related issue(s)
/kind bug