### PR TITLE
fix: use WorkStatus constants in CheckWorkStatusPresence

### DIFF
--- a/pkg/util/unstructured.go
+++ b/pkg/util/unstructured.go
@@ -206,9 +206,9 @@ func CheckWorkStatusPresence(config *rest.Config) bool {
 	}
 
 	gvr := schema.GroupVersionResource{
-		Group:    "control.kubestellar.io",
-		Version:  "v1alpha1",
-		Resource: "workstatuses",
+		Group:    WorkStatusGroup,
+		Version:  WorkStatusVersion,
+		Resource: WorkStatusResource,
 	}
 
 	return CheckAPIisPresent(discoveryClient, gvr)


### PR DESCRIPTION
🐛 fix: use WorkStatus constants in CheckWorkStatusPresence

## Summary
`CheckWorkStatusPresence` hardcodes GVR strings `"control.kubestellar.io"`,
`"v1alpha1"`, `"workstatuses"` instead of using constants `WorkStatusGroup`,
`WorkStatusVersion`, `WorkStatusResource` already defined in the same file.

If any constant changes, `CheckWorkStatusPresence` silently diverges and
returns `false` with no error logged, breaking WorkStatus feature detection.

Fix replaces hardcoded strings with existing constants.

## Related issue(s)
N/A