### PR TITLE
fix(controller-manager): resolve exponential backoff and graceful shu…

### DIFF
--- a/cmd/controller-manager/main.go
+++ b/cmd/controller-manager/main.go
@@ -80,7 +80,7 @@ func main() {
 	pflag.StringVar(&itsName, "its-name", "", "name of the Inventory and Transport Space to connect to (empty string means to use the only one)")
 	pflag.StringVar(&wdsName, "wds-name", "", "name of the workload description space to connect to")
 	pflag.StringVar(&allowedGroupsString, "api-groups", "", "list of allowed api groups, comma separated. Empty string means all API groups are allowed")
-	pflag.StringSliceVar(&controllers, "controllers", []string{}, "list of controllers to be started by the controller manager, lower case and comma separated, e.g. 'binding,status'. If not specified (or emtpy list specifed), all controllers are started. Currently available controllers are 'binding' and 'status'.")
+	pflag.StringSliceVar(&controllers, "controllers", []string{}, "list of controllers to be started by the controller manager, lower case and comma separated, e.g. 'binding,status'. If not specified (or empty list specified), all controllers are started. Currently available controllers are 'binding' and 'status'.")
 	pflag.BoolVar(&enableLeaderElection, "leader-elect", false,
 		"Enable leader election for controller manager. "+
 			"Enabling this will ensure there is only one active controller manager.")
@@ -111,7 +111,7 @@ func main() {
 		strings.ToLower(binding.ControllerName),
 		strings.ToLower(status.ControllerName),
 	).IsSuperset(ctlrsToStart) {
-		setupLog.Error(fmt.Errorf("unkown controller specified"), "'controllers' flag has incorrect value")
+		setupLog.Error(fmt.Errorf("unknown controller specified"), "'controllers' flag has incorrect value")
 		os.Exit(1)
 	}
 
@@ -180,7 +180,6 @@ func main() {
 			if (i & (i - 1)) == 0 {
 				setupLog.Info("Not creating status controller yet because WorkStatus is not defined in the ITS")
 			}
-			i++
 			time.Sleep(15 * time.Second)
 		}
 		setupLog.Info("Creating controller", "name", status.ControllerName)
@@ -213,7 +212,7 @@ func main() {
 		}
 	}
 
-	select {}
+	<-ctx.Done()
 }
 
 // workloadEventRelay implements binding.WorkloadEventHandler and relays the notifications


### PR DESCRIPTION
🐛 fix(controller-manager): resolve exponential backoff and graceful shutdown bugs

## Summary
This PR addresses two structural bugs in the controller-manager initialization (`cmd/controller-manager/main.go`), as well as a few typos in the flags and error handling:

**1. Status Controller Exponential Backoff Bug**
The loop waiting for the `WorkStatus` add-on attempts to log its status using a power-of-2 bitwise check `(i & (i - 1)) == 0`. However, the loop counter `i` was being incremented both in the `for` statement and inside the loop block. This caused `i` to only evaluate as odd numbers (1, 3, 5, 7...), meaning the exponential backoff log would never trigger after the first iteration. Removed the redundant `i++` to restore the intended behavior.

**2. Graceful Shutdown Bug**
The `main` function previously ended with a blocking `select {}`, ignoring the initialized OS signal context. Replaced this with `<-ctx.Done()` to allow the controller manager to shut down cleanly upon receiving termination signals.

*(Note: Also fixed a few minor spelling errors caught by golangci-lint: `emtpy` -> `empty`, `specifed` -> `specified`, `unkown` -> `unknown`)*

## Related issue(s)

Fixes #