### PR TITLE
🐛 Reject BindingPolicy and Binding names longer than 63 characters at admission

### DIFF
--- a/api/control/v1alpha1/types.go
+++ b/api/control/v1alpha1/types.go
@@ -68,6 +68,7 @@ const PropertyConfigMapNamespace = "customization-properties"
 // +kubebuilder:printcolumn:name="TYPE",type="string",JSONPath=".spec.type"
 // +kubebuilder:printcolumn:name="AGE",type="date",JSONPath=".metadata.creationTimestamp"
 // +kubebuilder:resource:scope=Cluster,shortName={bp}
+// +kubebuilder:validation:XValidation:rule="size(self.metadata.name) <= 63",message="metadata.name must be at most 63 characters, because it is used as a label value on the transport objects"
 type BindingPolicy struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
@@ -287,6 +288,7 @@ type BindingPolicyList struct {
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
 // +kubebuilder:resource:scope=Cluster,shortName={bdg}
+// +kubebuilder:validation:XValidation:rule="size(self.metadata.name) <= 63",message="metadata.name must be at most 63 characters, because it is used as a label value on the transport objects"
 type Binding struct {
 	metav1.TypeMeta `json:",inline"`
 	// Standard object metadata.

--- a/config/crd/bases/control.kubestellar.io_bindingpolicies.yaml
+++ b/config/crd/bases/control.kubestellar.io_bindingpolicies.yaml
@@ -386,6 +386,10 @@ spec:
             - observedGeneration
             type: object
         type: object
+        x-kubernetes-validations:
+        - message: metadata.name must be at most 63 characters, because it is used
+            as a label value on the transport objects
+          rule: size(self.metadata.name) <= 63
     served: true
     storage: true
     subresources:

--- a/config/crd/bases/control.kubestellar.io_bindings.yaml
+++ b/config/crd/bases/control.kubestellar.io_bindings.yaml
@@ -342,6 +342,10 @@ spec:
             - observedGeneration
             type: object
         type: object
+        x-kubernetes-validations:
+        - message: metadata.name must be at most 63 characters, because it is used
+            as a label value on the transport objects
+          rule: size(self.metadata.name) <= 63
     served: true
     storage: true
     subresources:

--- a/pkg/crd/files/crds.yaml
+++ b/pkg/crd/files/crds.yaml
@@ -402,6 +402,10 @@ spec:
             - observedGeneration
             type: object
         type: object
+        x-kubernetes-validations:
+        - message: metadata.name must be at most 63 characters, because it is used
+            as a label value on the transport objects
+          rule: size(self.metadata.name) <= 63
     served: true
     storage: true
     subresources:
@@ -750,6 +754,10 @@ spec:
             - observedGeneration
             type: object
         type: object
+        x-kubernetes-validations:
+        - message: metadata.name must be at most 63 characters, because it is used
+            as a label value on the transport objects
+          rule: size(self.metadata.name) <= 63
     served: true
     storage: true
     subresources:


### PR DESCRIPTION
## Problem

Fixes #3871.

A BindingPolicy (and its Binding) with a `metadata.name` of 64+ characters is accepted by the API server, but nothing ever propagates to the WECs and the user gets no feedback. The root cause is that the generic transport controller stamps the Binding's name onto every wrapped transport object as a **label value**:

- `pkg/transport/generic/generic_transport_controller.go` sets `transport.kubestellar.io/originOwnerReferenceBindingKey: <binding-name>` on each wrapped object, and
- the same label is used in the list selectors the controller relies on to find and prune its wrapped objects.

Kubernetes label values are capped at 63 characters, so the ITS API server rejects every wrapped-object create for such a Binding, and the downsync silently halts — exactly the behavior reported in the issue.

## Solution

Fail fast at admission instead of failing silently downstream. This PR adds a CEL validation rule (`size(self.metadata.name) <= 63`) to the `BindingPolicy` and `Binding` CRDs via kubebuilder markers on the API types, so the API server rejects over-long names at create time with a message that explains why:

```
The BindingPolicy "aaa…(64)" is invalid: <nil>: Invalid value: "object": metadata.name must be at most 63 characters, because it is used as a label value on the transport objects
```

The name-as-label-value scheme is load-bearing (it is how the controller tracks its wrapped objects across the ITS), so relaxing the transport side instead — e.g. hashing long names — would change the on-the-wire label scheme and break tracking of existing wrapped objects on upgrade. Since no BindingPolicy with a 64+ character name can propagate anything today, tightening validation does not break any working configuration.

Both CRDs get the rule because the transport controller consumes Bindings regardless of who created them; validating only BindingPolicy would leave directly-created Bindings with the same silent failure.

## Changes

- `api/control/v1alpha1/types.go`: `+kubebuilder:validation:XValidation` marker on `BindingPolicy` and `Binding`
- `config/crd/bases/…bindingpolicies.yaml`, `config/crd/bases/…bindings.yaml`, `pkg/crd/files/crds.yaml`: regenerated with `make manifests` (controller-gen v0.17.3)

## Testing and validation

- `go build ./...` and `go test ./pkg/crd/... ./api/...` pass.
- Verified end to end against a kind cluster with the regenerated CRDs applied:
  - a 63-character BindingPolicy name is **accepted** (created successfully),
  - a 64-character BindingPolicy name is **rejected** with the message above,
  - a 64-character Binding name is **rejected** with the same message.

## Documentation

The docs tree is currently being restructured (`docs/content/direct` no longer exists on `main`), so no doc page was updated; the validation message itself states the reason for the limit. Happy to add a note wherever the naming guidance lands.