### PR TITLE
🐛 fix(kubectl-rbac-flatten): prevent non-resource rules from expanding to all resources

### DIFF
--- a/cmd/kubectl-rbac-flatten/README.md
+++ b/cmd/kubectl-rbac-flatten/README.md
@@ -34,7 +34,8 @@ object, role-ism, and binding --- with the exception of wildcards.
 
     A non-resource URL path is just the path part of a URL; the schema
     and authority of the authorized URL are implicitly those of the
-    apiserver.
+    apiserver. Note that rules defining only `NonResourceURLs` (like `system:discovery`)
+    apply exclusively to those paths and will not be expanded against API resources.
 
     An API object is identified by a "resource", "object name"
     (misnamed "ResourceName" in the RBAC API), and possibly

--- a/cmd/kubectl-rbac-flatten/main.go
+++ b/cmd/kubectl-rbac-flatten/main.go
@@ -313,6 +313,18 @@ func getFlat(ctx context.Context, client auth_client.RbacV1Interface, rscMap res
 		complainCS, complainNR := false, false
 		complainedResources := sets.New[metav1.GroupResource]()
 		for ruleIdx, rule := range rules {
+			if len(rule.NonResourceURLs) > 0 {
+				pr := PolicyRule{
+					Verbs:            verbFilter.FilterSlice(rule.Verbs, true),
+					NonResourcePaths: rule.NonResourceURLs,
+				}
+				for _, subj := range subjects {
+					if subjFilter.Passes(subj) {
+						ans = append(ans, Tuple{Binding: source, RoleInCluster: roleInCluster, RoleName: roleName, Subject: subj, Rule: pr})
+					}
+				}
+				continue
+			}
 			ruledResources := composeRuleResources(rscMap, rule.APIGroups, rule.Resources)
 			if len(ruledResources) == 0 {
 				complainNR = true

--- a/cmd/kubectl-rbac-flatten/main_test.go
+++ b/cmd/kubectl-rbac-flatten/main_test.go
@@ -1,0 +1,65 @@
+package main
+
+import (
+	"context"
+	"testing"
+
+	rbac "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	fakeclientset "k8s.io/client-go/kubernetes/fake"
+
+	"github.com/kubestellar/kubestellar/pkg/util"
+)
+
+func TestGetFlatNonResourceURLs(t *testing.T) {
+	client := fakeclientset.NewSimpleClientset(&rbac.ClusterRole{
+		ObjectMeta: metav1.ObjectMeta{Name: "system:discovery"},
+		Rules: []rbac.PolicyRule{
+			{
+				Verbs:           []string{"get"},
+				NonResourceURLs: []string{"/api", "/api/*"},
+			},
+		},
+	}, &rbac.ClusterRoleBinding{
+		ObjectMeta: metav1.ObjectMeta{Name: "system:discovery"},
+		RoleRef: rbac.RoleRef{
+			APIGroup: "rbac.authorization.k8s.io",
+			Kind:     "ClusterRole",
+			Name:     "system:discovery",
+		},
+		Subjects: []rbac.Subject{
+			{
+				Kind:     "Group",
+				Name:     "system:authenticated",
+				APIGroup: "rbac.authorization.k8s.io",
+			},
+		},
+	})
+
+	rscMap := make(resourceMap)
+
+	subjFilter := subjectFilter{
+		UserName:       util.StringFilter{AllPass: true},
+		UserGroup:      util.StringFilter{AllPass: true},
+		ServiceAccount: util.StringFilter{AllPass: true},
+	}
+	verbFilter := util.StringFilter{AllPass: true}
+	rscFilter := util.StringFilter{AllPass: true}
+
+	flat, errs := getFlat(context.Background(), client.RbacV1(), rscMap, subjFilter, verbFilter, rscFilter)
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+
+	if len(flat) != 1 {
+		t.Fatalf("expected 1 flat tuple, got %d", len(flat))
+	}
+
+	tuple := flat[0]
+	if len(tuple.Rule.NonResourcePaths) != 2 || tuple.Rule.NonResourcePaths[0] != "/api" {
+		t.Errorf("unexpected non-resource paths: %v", tuple.Rule.NonResourcePaths)
+	}
+	if len(tuple.Rule.Resources) > 0 {
+		t.Errorf("expected 0 resources for non-resource rule, got %d", len(tuple.Rule.Resources))
+	}
+}


### PR DESCRIPTION
## Summary
Fixes `kubectl-rbac-flatten` to correctly handle RBAC rules that only contain `nonResourceURLs` (such as the default `system:discovery` ClusterRole). Previously, these rules caused the tool to default to wildcard `*` resources due to empty `APIGroups` and `Resources`, falsely reporting cluster-wide access.
This adds an explicit check for `len(rule.NonResourceURLs) > 0` to map the non-resource paths and safely bypass the wildcard resource expansion.

## Related issue(s)
N/A
