### PR TITLE
🌱 Remove dead code and redundant boolean logic flagged by staticcheck

### DIFF
--- a/pkg/binding/bindingpolicy-resolution.go
+++ b/pkg/binding/bindingpolicy-resolution.go
@@ -239,15 +239,6 @@ func (resolution *bindingPolicyResolution) matchesBindingSpec(bindingSpec *v1alp
 	return true
 }
 
-// getDestinationsList returns a sorted list of v1alpha1.Destination in the
-// resolution.
-func (resolution *bindingPolicyResolution) getDestinationsList() []v1alpha1.Destination {
-	resolution.RLock()
-	defer resolution.RUnlock()
-
-	return destinationsStringSetToSortedDestinations(resolution.destinations)
-}
-
 func (resolution *bindingPolicyResolution) getWorkloadReferences() []util.ObjectIdentifier {
 	resolution.RLock()
 	defer resolution.RUnlock()

--- a/pkg/binding/bindingpolicy-resolver.go
+++ b/pkg/binding/bindingpolicy-resolver.go
@@ -351,11 +351,7 @@ func (resolver *bindingPolicyResolver) SetDestinations(bindingPolicyKey string,
 // ResolutionExists returns true if a resolution is associated with the
 // given bindingpolicy key.
 func (resolver *bindingPolicyResolver) ResolutionExists(bindingPolicyKey string) bool {
-	if resolver.getResolution(bindingPolicyKey) == nil {
-		return false
-	}
-
-	return true
+	return resolver.getResolution(bindingPolicyKey) != nil
 }
 
 // GetReportedStateRequestForObject returns four things.

--- a/pkg/binding/bindingpolicy.go
+++ b/pkg/binding/bindingpolicy.go
@@ -107,28 +107,6 @@ func (c *Controller) deleteResolutionForBindingPolicy(ctx context.Context, bindi
 	return nil
 }
 
-func (c *Controller) requeueSelectedWorkloadObjects(ctx context.Context, bindingPolicyName string) error {
-	if !c.bindingPolicyResolver.ResolutionExists(bindingPolicyName) {
-		return nil
-	}
-
-	// requeue all objects that are selected by the bindingpolicy (are in its resolution)
-	objectIdentifiers, err := c.bindingPolicyResolver.GetObjectIdentifiers(bindingPolicyName)
-	if err != nil {
-		return fmt.Errorf("failed to get object identifiers from bindingpolicy resolver for "+
-			"bindingpolicy %s: %w", bindingPolicyName, err)
-	}
-
-	logger := klog.FromContext(ctx)
-	for objIdentifier := range objectIdentifiers {
-		logger.V(5).Info("Enqueuing workload object due to change in BindingPolicy",
-			"objectIdentifier", objIdentifier, "bindingPolicyName", bindingPolicyName)
-		c.enqueueObjectIdentifier(objIdentifier)
-	}
-
-	return nil
-}
-
 func (c *Controller) evaluateBindingPoliciesForUpdate(ctx context.Context, clusterId string, oldLabels labels.Set, newLabels labels.Set) {
 	logger := klog.FromContext(ctx)
 

--- a/pkg/binding/crd.go
+++ b/pkg/binding/crd.go
@@ -123,11 +123,7 @@ func (c *Controller) includedToWatch(r APIResource) bool {
 		Resource: r.resource.Name,
 	}
 
-	if isExcludedGroupResource(gr) {
-		return false
-	}
-
-	return true
+	return !isExcludedGroupResource(gr)
 }
 
 func crdEstablished(crd *apiextensionsv1.CustomResourceDefinition) bool {

--- a/pkg/status/binding.go
+++ b/pkg/status/binding.go
@@ -69,7 +69,7 @@ func (c *Controller) syncBinding(ctx context.Context, key string) error {
 // missingSCs, a slice of the missing StatusCollector object name(s), must be sorted.
 func (c *Controller) createOrUpdateStatusCollectorAvailableCondition(ctx context.Context, bdg *v1alpha1.Binding, missingSCs []string) error {
 	// compose tentative condition where LastTransitionTime is TBD
-	conditionTentative := v1alpha1.BindingPolicyCondition{}
+	var conditionTentative v1alpha1.BindingPolicyCondition
 	if len(missingSCs) != 0 {
 		conditionTentative = v1alpha1.BindingPolicyCondition{
 			Type:    v1alpha1.TypeStatusCollectorsAvailable,

--- a/pkg/status/status-controller.go
+++ b/pkg/status/status-controller.go
@@ -101,8 +101,6 @@ type workloadObjectRef struct{ util.ObjectIdentifier }
 // bindingRef is a workqueue item that references a Binding
 type bindingRef string
 
-type workStatusON cache.ObjectName
-
 // workStatusRef is a workqueue item that references a WorkStatus
 type workStatusRef struct {
 	// Name is the Name of the WorkStatus object


### PR DESCRIPTION
## Summary

Fixes #3880

staticcheck flags several pieces of dead code and redundant logic in `pkg/binding` and `pkg/status` (the deprecated workqueue findings are handled separately in #3878). This PR resolves all of them:

- **Delete `(*bindingPolicyResolution).getDestinationsList`** (`bindingpolicy-resolution.go`) — no callers anywhere, including tests.
- **Delete `(*Controller).requeueSelectedWorkloadObjects`** (`bindingpolicy.go`) — no callers.
- **Delete `type workStatusON cache.ObjectName`** (`status-controller.go`) — never used; the `workStatusON` locals in `singletonstatus.go` are plain `cache.ObjectName` values, not this type.
- **`ResolutionExists`** (`bindingpolicy-resolver.go`) and the CRD relevance check (`crd.go`) — collapse `if cond { return false }; return true` into direct boolean returns (S1008).
- **`createOrUpdateStatusCollectorAvailableCondition`** (`status/binding.go`) — declare `conditionTentative` without an initializer since both branches unconditionally assign it (SA4006).

Net: 3 insertions, 44 deletions, no behavior change.

## Testing

- `go build ./...` — clean
- `go test ./pkg/...` — all packages pass
- `staticcheck ./pkg/...` — zero remaining U1000/S1008/SA4006 findings (only the SA1019 deprecations addressed by #3878 remain)