### PR TITLE
docs: fix broken README links in console docs

### DIFF
--- a/docs/content/console/klaude-console-overview.md
+++ b/docs/content/console/klaude-console-overview.md
@@ -48,7 +48,7 @@ For production use, the console requires:
 1. **KKC Agent**: A local agent that connects to your kubeconfig
 2. **Backend API**: The KKC API server running on port 8080
 
-See the [setup guide](README.md) for detailed installation instructions.
+See the [setup guide](https://github.com/kubestellar/console#local-install-self-host) for detailed installation instructions.
 
 ## Architecture
 

--- a/docs/content/console/klaude-console-updates.md
+++ b/docs/content/console/klaude-console-updates.md
@@ -147,6 +147,6 @@ npm install && npm run build
 
 For update-related issues:
 
-- Check the [troubleshooting guide](README.md#troubleshooting)
+- Check the [troubleshooting guide](https://github.com/kubestellar/console/blob/main/docs/troubleshooting.md)
 - Search [GitHub Issues](https://github.com/kubestellar/console/issues)
 - Ask in the [KubeStellar Slack](https://kubestellar.io/community)


### PR DESCRIPTION
Both console doc pages link to a README.md that does not exist in docs/content/console, so the setup guide and troubleshooting links are broken on the site. Point them to the console repo install section and its troubleshooting doc.