### PR TITLE
🐛 fix(binding): prevent double-close panic on informer stopper channels

### DIFF
--- a/pkg/binding/binding-controller.go
+++ b/pkg/binding/binding-controller.go
@@ -464,9 +464,13 @@ func (c *Controller) run(ctx context.Context, workers int, cListers chan interfa
 				// run the informer
 				// we need to be able to stop informers for APIs (CRDs) that are removed
 				// after startup, therefore we use a stopper channel for each informer
-				// instead than informerFactory.Start(ctx.Done())
+				// instead than informerFactory.Start(ctx.Done()).
+				// Do NOT use defer close(stopper) here: defer runs when run() returns, not
+				// at the end of the loop iteration. If syncCRD already closed a stopper
+				// for a removed CRD, the deferred close would fire again on shutdown and
+				// panic with "close of closed channel". Stoppers are closed either by
+				// syncCRD (for individual CRD removal) or by the shutdown goroutine below.
 				stopper := make(chan struct{})
-				defer close(stopper)
 				c.stoppers.Set(gvr, stopper)
 				go informer.Run(stopper)
 			}
@@ -504,10 +508,23 @@ func (c *Controller) run(ctx context.Context, workers int, cListers chan interfa
 	c.logger.Info("Started workers")
 	c.initializedTs = time.Now()
 
+	// Wait for context cancellation, then close all remaining stoppers.
+	// We use safeClose to avoid panics due to concurrent close operations.
 	<-ctx.Done()
 	c.logger.Info("Shutting down workers")
+	c.stoppers.Iterator(func(_ schema.GroupVersionResource, stopper chan struct{}) error {
+		safeClose(stopper)
+		return nil
+	})
 
 	return nil
+}
+
+func safeClose(ch chan struct{}) {
+	defer func() {
+		recover()
+	}()
+	close(ch)
 }
 
 func (c *Controller) setupManagedClustersInformer(ctx context.Context) error {

--- a/pkg/binding/binding-controller.go
+++ b/pkg/binding/binding-controller.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"reflect"
 	"slices"
+	"sync"
 	"time"
 
 	"github.com/go-logr/logr"
@@ -145,7 +146,7 @@ type Controller struct {
 	apiResourceLists []*metav1.APIResourceList
 	listers          util.ConcurrentMap[schema.GroupVersionResource, cache.GenericLister]
 	informers        util.ConcurrentMap[schema.GroupVersionResource, cache.SharedIndexInformer]
-	stoppers         util.ConcurrentMap[schema.GroupVersionResource, chan struct{}]
+	stoppers         util.ConcurrentMap[schema.GroupVersionResource, *Stopper]
 
 	bindingPolicyResolver BindingPolicyResolver
 
@@ -320,7 +321,7 @@ func makeController(logger logr.Logger,
 		apiResourceLists:            apiResourceLists,
 		listers:                     util.NewConcurrentMap[schema.GroupVersionResource, cache.GenericLister](),
 		informers:                   util.NewConcurrentMap[schema.GroupVersionResource, cache.SharedIndexInformer](),
-		stoppers:                    util.NewConcurrentMap[schema.GroupVersionResource, chan struct{}](),
+		stoppers:                    util.NewConcurrentMap[schema.GroupVersionResource, *Stopper](),
 		bindingPolicyResolver:       NewBindingPolicyResolver(),
 		workqueue:                   workqueue.NewRateLimitingQueueWithConfig(ratelimiter, workqueue.RateLimitingQueueConfig{Name: ControllerName + "-" + wdsName}),
 		allowedGroupsSet:            allowedGroupsSet,
@@ -470,9 +471,9 @@ func (c *Controller) run(ctx context.Context, workers int, cListers chan interfa
 				// for a removed CRD, the deferred close would fire again on shutdown and
 				// panic with "close of closed channel". Stoppers are closed either by
 				// syncCRD (for individual CRD removal) or by the shutdown goroutine below.
-				stopper := make(chan struct{})
+				stopper := NewStopper()
 				c.stoppers.Set(gvr, stopper)
-				go informer.Run(stopper)
+				go informer.Run(stopper.C)
 			}
 		}
 	}
@@ -509,22 +510,33 @@ func (c *Controller) run(ctx context.Context, workers int, cListers chan interfa
 	c.initializedTs = time.Now()
 
 	// Wait for context cancellation, then close all remaining stoppers.
-	// We use safeClose to avoid panics due to concurrent close operations.
+	// We use Stopper's Stop() to avoid panics due to concurrent close operations.
 	<-ctx.Done()
 	c.logger.Info("Shutting down workers")
-	c.stoppers.Iterator(func(_ schema.GroupVersionResource, stopper chan struct{}) error {
-		safeClose(stopper)
+	c.stoppers.Iterator(func(_ schema.GroupVersionResource, stopper *Stopper) error {
+		stopper.Stop()
 		return nil
 	})
 
 	return nil
 }
 
-func safeClose(ch chan struct{}) {
-	defer func() {
-		recover()
-	}()
-	close(ch)
+// Stopper wraps a channel with sync.Once to ensure it is safely closed exactly once.
+type Stopper struct {
+	C    chan struct{}
+	once sync.Once
+}
+
+func (s *Stopper) Stop() {
+	s.once.Do(func() {
+		close(s.C)
+	})
+}
+
+func NewStopper() *Stopper {
+	return &Stopper{
+		C: make(chan struct{}),
+	}
 }
 
 func (c *Controller) setupManagedClustersInformer(ctx context.Context) error {

--- a/pkg/binding/crd.go
+++ b/pkg/binding/crd.go
@@ -97,10 +97,10 @@ func (c *Controller) syncCRD(ctx context.Context, objIdentifier util.ObjectIdent
 		stopper, ok := c.stoppers.Get(gvr)
 		if !ok {
 			logger.V(5).Info("Informer is already absent.", "gvr", gvr)
-		} else {
+				} else {
 			logger.V(2).Info("API should not be watched, ensuring the informer's absence.", "gvr", gvr)
 			// close channel
-			close(stopper)
+			safeClose(stopper)
 		}
 		// remove entries for gvr
 		c.informers.Remove(gvr)

--- a/pkg/binding/crd.go
+++ b/pkg/binding/crd.go
@@ -97,10 +97,10 @@ func (c *Controller) syncCRD(ctx context.Context, objIdentifier util.ObjectIdent
 		stopper, ok := c.stoppers.Get(gvr)
 		if !ok {
 			logger.V(5).Info("Informer is already absent.", "gvr", gvr)
-				} else {
+		} else {
 			logger.V(2).Info("API should not be watched, ensuring the informer's absence.", "gvr", gvr)
-			// close channel
-			safeClose(stopper)
+			// close the stopper channel to stop the informer
+			stopper.Stop()
 		}
 		// remove entries for gvr
 		c.informers.Remove(gvr)
@@ -197,13 +197,13 @@ func (c *Controller) startInformersForNewAPIResources(ctx context.Context, toSta
 		c.listers.Set(gvr, cache.NewGenericLister(informer.GetIndexer(), gvr.GroupResource()))
 
 		// add the stopper since it necessarily does not exist
-		stopper := make(chan struct{})
+		stopper := NewStopper()
 		logger.V(3).Info("Setting stopper", "gvr", gvr)
 		c.stoppers.Set(gvr, stopper)
 
 		// add the informer since it necessarily does not exist
 		logger.V(3).Info("Setting and running informer", "gvr", gvr)
 		c.informers.Set(gvr, informer)
-		go informer.Run(stopper)
+		go informer.Run(stopper.C)
 	}
 }


### PR DESCRIPTION
## Summary
Prevents a "close of closed channel" panic on informer stopper channels. 
Previously, a `defer close(stopper)` was used inside a loop within `run()`, but deferred calls execute when the function returns, not at the end of the loop. If `syncCRD` already closed a stopper for a removed CRD, the deferred close would fire again on shutdown, causing a panic. 
This fix removes the defer and explicitly safely closes any remaining stoppers during shutdown.

## Related issue(s)
N/A
