### PR TITLE
🐛 Add error handling in CombinedStatus Resolver

### DIFF
--- a/pkg/status/binding.go
+++ b/pkg/status/binding.go
@@ -39,8 +39,11 @@ func (c *Controller) syncBinding(ctx context.Context, key string) error {
 	logger.V(5).Info("In syncBinding", "bindingName", key, "isDeleted", isDeleted, "resolutionIsNil", resolution == nil, "resolution", resolution, "resolutionType", fmt.Sprintf("%T", resolution))
 
 	// NoteBindingResolution does not use the resolution if isDeleted is true
-	changedCombinedStatuses := c.combinedStatusResolver.NoteBindingResolution(ctx, key, resolution, isDeleted,
+	changedCombinedStatuses, err := c.combinedStatusResolver.NoteBindingResolution(ctx, key, resolution, isDeleted,
 		c.workStatusIndexer, c.statusCollectorLister)
+	if err != nil {
+		return fmt.Errorf("failed to note binding resolution: %w", err)
+	}
 	for combinedStatus := range changedCombinedStatuses {
 		logger.V(5).Info("Enqueuing CombinedStatus due to sync of Binding", "combinedStatus", combinedStatus.ObjectName, "bindingName", key)
 		c.workqueue.AddAfter(combinedStatusRef(combinedStatus.ObjectName.AsNamespacedName().String()), queueingDelay)

--- a/pkg/status/combinedstatus-queryables.go
+++ b/pkg/status/combinedstatus-queryables.go
@@ -24,7 +24,6 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	runtime2 "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/client-go/tools/cache"
 
 	"github.com/kubestellar/kubestellar/pkg/util"
@@ -32,7 +31,7 @@ import (
 
 // getCombinedContentMap returns a map of content for the given workstatus.
 func getCombinedContentMap(listersConcurrentMap util.ConcurrentMap[schema.GroupVersionResource, cache.GenericLister],
-	workStatus *workStatus, resolution *combinedStatusResolution) map[string]interface{} {
+	workStatus *workStatus, resolution *combinedStatusResolution) (map[string]interface{}, error) {
 
 	// betting on `combinedStatusResolution::queryingContentRequirements` being faster
 	// than fetching content that is not required.
@@ -44,8 +43,8 @@ func getCombinedContentMap(listersConcurrentMap util.ConcurrentMap[schema.GroupV
 	if sourceObjectRequired {
 		objMap, err := getObjectMetaAndSpec(listersConcurrentMap, workStatus.SourceObjectIdentifier)
 		if err != nil {
-			runtime2.HandleError(fmt.Errorf("failed to get meta & spec for source object %s: %w",
-				workStatus.SourceObjectIdentifier, err))
+			return nil, fmt.Errorf("failed to get meta & spec for source object %s: %w",
+				workStatus.SourceObjectIdentifier, err)
 		}
 
 		content[sourceObjectKey] = objMap
@@ -63,7 +62,7 @@ func getCombinedContentMap(listersConcurrentMap util.ConcurrentMap[schema.GroupV
 		content[propagationMetaKey] = propagateMetaForWorkStatus(workStatus, resolution)
 	}
 
-	return content
+	return content, nil
 }
 
 // getObjectMetaAndSpec fetches the metadata and spec of the object associated

--- a/pkg/status/combinedstatus-resolution.go
+++ b/pkg/status/combinedstatus-resolution.go
@@ -1006,7 +1006,7 @@ func calculateCombinedFieldAggregation(combinedFieldNamedAgg v1alpha1.NamedAggre
 
 // getCombinedFieldSubject returns the subject of the combinedField evaluation.
 // If the subject does not conform to the expected type, the function logs an
-// error and returns nil. TODO: handle errors
+// error using klog and returns nil.
 // The given `row` map has domain = name of a NamedAggregator,
 // domain = evaluated value (before aggregation, of course) for a given WEC.
 func getCombinedFieldSubject(combinedFieldNamedAgg v1alpha1.NamedAggregator, row map[string]ref.Val) (*float64, string) {
@@ -1066,11 +1066,15 @@ func getCombinedFieldSubject(combinedFieldNamedAgg v1alpha1.NamedAggregator, row
 	case string:
 		f, err := strconv.ParseFloat(v, 64)
 		if err != nil {
-			return nil, "failed to parse combinedField subject as a float: " + err.Error()
+			errStr := "failed to parse combinedField subject as a float: " + err.Error()
+			klog.ErrorS(err, "Failed to parse combinedField subject as float", "aggregator", combinedFieldNamedAgg.Name)
+			return nil, errStr
 		}
 		return &f, ""
 	default:
-		return nil, fmt.Sprintf("combinedField subject has unexpected type %T", evalValue)
+		errStr := fmt.Sprintf("combinedField subject has unexpected type %T", evalValue)
+		klog.ErrorS(errors.New(errStr), "combinedField subject has unexpected type", "aggregator", combinedFieldNamedAgg.Name, "type", fmt.Sprintf("%T", evalValue))
+		return nil, errStr
 	}
 }
 

--- a/pkg/status/combinedstatus-resolver.go
+++ b/pkg/status/combinedstatus-resolver.go
@@ -66,7 +66,7 @@ type CombinedStatusResolver interface {
 	// that should be queued for syncing.
 	NoteBindingResolution(ctx context.Context, bindingName string, bindingResolution binding.Resolution, deleted bool,
 		workStatusIndexer cache.Indexer,
-		statusCollectorLister controllisters.StatusCollectorLister) sets.Set[util.ObjectIdentifier]
+		statusCollectorLister controllisters.StatusCollectorLister) (sets.Set[util.ObjectIdentifier], error)
 
 	// NoteStatusCollector notes a statuscollector's spec.
 	// The statuscollector is cached on the resolver's level, and is updated
@@ -82,14 +82,14 @@ type CombinedStatusResolver interface {
 	// that should be queued for syncing, respectively.
 	NoteStatusCollector(ctx context.Context, statusCollector *v1alpha1.StatusCollector, deleted bool,
 		workStatusIndexer cache.Indexer,
-	) (sets.Set[util.ObjectIdentifier], sets.Set[string])
+	) (sets.Set[util.ObjectIdentifier], sets.Set[string], error)
 
 	// NoteWorkStatus notes a workstatus in the combinedstatus resolutions
 	// associated with its source workload object.
 	//
 	// The returned set contains the identifiers of combinedstatus objects
 	// that should be queued for syncing.
-	NoteWorkStatus(ctx context.Context, workStatus *workStatus) sets.Set[util.ObjectIdentifier]
+	NoteWorkStatus(ctx context.Context, workStatus *workStatus) (sets.Set[util.ObjectIdentifier], error)
 
 	// ResolutionExists returns true if a combinedstatus resolution is
 	// associated with the given name. The name is expected to follow the
@@ -192,7 +192,7 @@ func (c *combinedStatusResolver) CompareCombinedStatus(bindingName string,
 // that should be queued for syncing.
 func (c *combinedStatusResolver) NoteBindingResolution(ctx context.Context, bindingName string, bindingResolution binding.Resolution,
 	deleted bool, workStatusIndexer cache.Indexer,
-	statusCollectorLister controllisters.StatusCollectorLister) sets.Set[util.ObjectIdentifier] {
+	statusCollectorLister controllisters.StatusCollectorLister) (sets.Set[util.ObjectIdentifier], error) {
 	logger := klog.FromContext(ctx)
 	c.Lock()
 	defer c.Unlock()
@@ -203,7 +203,7 @@ func (c *combinedStatusResolver) NoteBindingResolution(ctx context.Context, bind
 	// (1)
 	if deleted {
 		logger.V(3).Info("Deleting CombinedStatus resolutions for Binding", "name", bindingName)
-		return c.deleteResolutionsForBindingWriteLocked(bindingName)
+		return c.deleteResolutionsForBindingWriteLocked(bindingName), nil
 	} else {
 		logger.V(3).Info("Noting non-deleted resolutions for Binding", "name", bindingName, "bindingResolution", bindingResolution)
 	}
@@ -289,12 +289,15 @@ func (c *combinedStatusResolver) NoteBindingResolution(ctx context.Context, bind
 
 	// evaluate workstatuses associated with members of workloadIdentifiersToEvaluate and return the combinedstatus
 	// identifiers that should be queued for syncing
-	dueToEvaluation := c.evaluateWorkStatusesPerBindingReadLocked(ctx, bindingName,
+	dueToEvaluation, err := c.evaluateWorkStatusesPerBindingReadLocked(ctx, bindingName,
 		workloadIdentifiersToEvaluate, destinationsSet, workStatusIndexer)
+	if err != nil {
+		return nil, err
+	}
 	logger.V(5).Info("After evaluateWorkStatusesPerBindingReadLocked", "binding", bindingName,
 		"workloadIdentifiersToEvaluate", util.K8sSet4Log(workloadIdentifiersToEvaluate),
 		"dueToEvaluation", util.K8sSet4Log(dueToEvaluation))
-	return combinedStatusIdentifiersToQueue.Union(dueToEvaluation)
+	return combinedStatusIdentifiersToQueue.Union(dueToEvaluation), nil
 }
 
 // deleteResolutionsForBindingWriteLocked deletes all combinedstatus resolutions associated with the given binding name.
@@ -327,8 +330,7 @@ func (c *combinedStatusResolver) deleteResolutionsForBindingWriteLocked(bindingN
 //
 // The returned set contains the identifiers of combinedstatus objects
 // that should be queued for syncing.
-// TODO: handle errors
-func (c *combinedStatusResolver) NoteWorkStatus(ctx context.Context, workStatus *workStatus) sets.Set[util.ObjectIdentifier] {
+func (c *combinedStatusResolver) NoteWorkStatus(ctx context.Context, workStatus *workStatus) (sets.Set[util.ObjectIdentifier], error) {
 	c.RLock()
 	defer c.RUnlock()
 	logger := klog.FromContext(ctx)
@@ -343,7 +345,10 @@ func (c *combinedStatusResolver) NoteWorkStatus(ctx context.Context, workStatus 
 			continue
 		}
 
-		content := getCombinedContentMap(c.wdsListers, workStatus, resolution)
+		content, err := getCombinedContentMap(c.wdsListers, workStatus, resolution)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get combined content map for binding %s and workload object %v: %w", bindingName, workStatus.SourceObjectIdentifier, err)
+		}
 
 		// this call logs errors, but does not return them for now
 		if resolution.evaluateWorkStatus(ctx, c.celEvaluator, workStatus.SourceObjectIdentifier, bindingName, workStatus.WECName, content) {
@@ -355,7 +360,7 @@ func (c *combinedStatusResolver) NoteWorkStatus(ctx context.Context, workStatus 
 	}
 	logger.V(5).Info("Done considering bindingResolutions", "workStatusRef", workStatus.workStatusRef, "statusLen", len(workStatus.status), "count", len(c.bindingNameToResolutions))
 
-	return combinedStatusIdentifiersToQueue
+	return combinedStatusIdentifiersToQueue, nil
 }
 
 // NoteStatusCollector notes a statuscollector's spec.
@@ -372,7 +377,7 @@ func (c *combinedStatusResolver) NoteWorkStatus(ctx context.Context, workStatus 
 // that should be queued for syncing, respectively.
 func (c *combinedStatusResolver) NoteStatusCollector(
 	ctx context.Context, statusCollector *v1alpha1.StatusCollector, deleted bool, workStatusIndexer cache.Indexer,
-) (sets.Set[util.ObjectIdentifier], sets.Set[string]) {
+) (sets.Set[util.ObjectIdentifier], sets.Set[string], error) {
 	logger := klog.FromContext(ctx)
 	c.Lock()
 	defer c.Unlock()
@@ -380,7 +385,7 @@ func (c *combinedStatusResolver) NoteStatusCollector(
 	currentSpec := c.statusCollectorNameToSpec[statusCollector.Name]
 	if !deleted && currentSpec != nil && statusCollectorSpecsMatch(currentSpec, &statusCollector.Spec) {
 		logger.V(5).Info("No change in StatusCollector", "name", statusCollector.Name)
-		return nil, nil // already cached and the spec has not changed
+		return nil, nil, nil // already cached and the spec has not changed
 	}
 	logger.V(5).Info("Noting StatusCollector", "name", statusCollector.Name, "numBindings", len(c.bindingNameToResolutions), "deleted", deleted)
 
@@ -403,9 +408,13 @@ func (c *combinedStatusResolver) NoteStatusCollector(
 
 			if resolution.updateStatusCollector(statusCollector.Name, &statusCollector.Spec) { // true if changed
 				// evaluate ALL workstatuses associated with the (binding, workload object) pair
-				combinedStatusIdentifiersToQueue.Insert(c.evaluateWorkStatusesPerBindingReadLocked(ctx, bindingName,
+				evalSet, err := c.evaluateWorkStatusesPerBindingReadLocked(ctx, bindingName,
 					sets.New(workloadObjectIdentifier), resolution.CollectionDestinations,
-					workStatusIndexer).UnsortedList()...)
+					workStatusIndexer)
+				if err != nil {
+					return nil, nil, err
+				}
+				combinedStatusIdentifiersToQueue.Insert(evalSet.UnsortedList()...)
 				bindingNamesToQueue.Insert(bindingName)
 			}
 		}
@@ -417,7 +426,7 @@ func (c *combinedStatusResolver) NoteStatusCollector(
 		delete(c.statusCollectorNameToSpec, statusCollector.Name)
 	}
 
-	return combinedStatusIdentifiersToQueue, bindingNamesToQueue
+	return combinedStatusIdentifiersToQueue, bindingNamesToQueue, nil
 }
 
 // ResolutionExists returns true if a combinedstatus resolution is
@@ -473,7 +482,7 @@ func (c *combinedStatusResolver) MissingStatusCollectors(bindingName string) []s
 // The method is expected to be called with the read lock held.
 func (c *combinedStatusResolver) evaluateWorkStatusesPerBindingReadLocked(ctx context.Context, bindingName string,
 	workloadObjIdentifiersToEvaluate sets.Set[util.ObjectIdentifier], destinations sets.Set[string],
-	workStatusIndexer cache.Indexer) sets.Set[util.ObjectIdentifier] {
+	workStatusIndexer cache.Indexer) (sets.Set[util.ObjectIdentifier], error) {
 	combinedStatusesToQueue := sets.Set[util.ObjectIdentifier]{}
 	logger := klog.FromContext(ctx)
 
@@ -516,7 +525,10 @@ func (c *combinedStatusResolver) evaluateWorkStatusesPerBindingReadLocked(ctx co
 			}
 
 			csResolution := c.bindingNameToResolutions[bindingName][workStat.SourceObjectIdentifier]
-			content := getCombinedContentMap(c.wdsListers, workStat, csResolution)
+			content, err := getCombinedContentMap(c.wdsListers, workStat, csResolution)
+			if err != nil {
+				return nil, fmt.Errorf("failed to get combined content map for binding %s and workload object %v: %w", bindingName, workStat.SourceObjectIdentifier, err)
+			}
 
 			// evaluate workstatus
 			if csResolution.evaluateWorkStatus(ctx, c.celEvaluator, workloadObjIdentifier, bindingName, workStat.WECName, content) {
@@ -526,7 +538,7 @@ func (c *combinedStatusResolver) evaluateWorkStatusesPerBindingReadLocked(ctx co
 		}
 	}
 
-	return combinedStatusesToQueue
+	return combinedStatusesToQueue, nil
 }
 
 func statusCollectorSpecsMatch(spec1, spec2 *v1alpha1.StatusCollectorSpec) bool {

--- a/pkg/status/combinedstatus-resolver_test.go
+++ b/pkg/status/combinedstatus-resolver_test.go
@@ -1,0 +1,192 @@
+/*
+Copyright 2024 The KubeStellar Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package status
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	celtypes "github.com/google/cel-go/common/types"
+	"github.com/google/cel-go/common/types/ref"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/tools/cache"
+
+	"github.com/kubestellar/kubestellar/api/control/v1alpha1"
+	"github.com/kubestellar/kubestellar/pkg/util"
+)
+
+func TestGetCombinedFieldSubject_ErrorHandling(t *testing.T) {
+	tests := []struct {
+		name        string
+		aggregator  v1alpha1.NamedAggregator
+		row         map[string]ref.Val
+		expectedVal *float64
+		expectedErr string
+	}{
+		{
+			name: "Success - float value",
+			aggregator: v1alpha1.NamedAggregator{
+				Name: "test-agg",
+				Type: v1alpha1.AggregatorTypeSum,
+			},
+			row: map[string]ref.Val{
+				"test-agg": celtypes.Double(12.34),
+			},
+			expectedVal: func() *float64 { f := 12.34; return &f }(),
+			expectedErr: "",
+		},
+		{
+			name: "Success - int value",
+			aggregator: v1alpha1.NamedAggregator{
+				Name: "test-agg",
+				Type: v1alpha1.AggregatorTypeSum,
+			},
+			row: map[string]ref.Val{
+				"test-agg": celtypes.Int(42),
+			},
+			expectedVal: func() *float64 { f := 42.0; return &f }(),
+			expectedErr: "",
+		},
+		{
+			name: "Success - parsable string value",
+			aggregator: v1alpha1.NamedAggregator{
+				Name: "test-agg",
+				Type: v1alpha1.AggregatorTypeSum,
+			},
+			row: map[string]ref.Val{
+				"test-agg": celtypes.String("123.45"),
+			},
+			expectedVal: func() *float64 { f := 123.45; return &f }(),
+			expectedErr: "",
+		},
+		{
+			name: "Failure - unparsable string value",
+			aggregator: v1alpha1.NamedAggregator{
+				Name: "test-agg",
+				Type: v1alpha1.AggregatorTypeSum,
+			},
+			row: map[string]ref.Val{
+				"test-agg": celtypes.String("not-a-number"),
+			},
+			expectedVal: nil,
+			expectedErr: "failed to parse combinedField subject as a float",
+		},
+		{
+			name: "Failure - unexpected type",
+			aggregator: v1alpha1.NamedAggregator{
+				Name: "test-agg",
+				Type: v1alpha1.AggregatorTypeSum,
+			},
+			row: map[string]ref.Val{
+				"test-agg": celtypes.False,
+			},
+			expectedVal: nil,
+			expectedErr: "combinedField subject has unexpected type bool",
+		},
+		{
+			name: "Nil evaluation returns nil without error",
+			aggregator: v1alpha1.NamedAggregator{
+				Name: "test-agg",
+				Type: v1alpha1.AggregatorTypeSum,
+			},
+			row:         map[string]ref.Val{},
+			expectedVal: nil,
+			expectedErr: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			val, errStr := getCombinedFieldSubject(tt.aggregator, tt.row)
+			if tt.expectedErr == "" {
+				if errStr != "" {
+					t.Errorf("expected no error, got: %s", errStr)
+				}
+				if tt.expectedVal == nil {
+					if val != nil {
+						t.Errorf("expected nil value, got: %v", *val)
+					}
+				} else {
+					if val == nil || *val != *tt.expectedVal {
+						t.Errorf("expected value %v, got: %v", *tt.expectedVal, val)
+					}
+				}
+			} else {
+				if errStr == "" || !strings.Contains(errStr, tt.expectedErr) {
+					t.Errorf("expected error containing %q, got: %q", tt.expectedErr, errStr)
+				}
+				if val != nil {
+					t.Errorf("expected nil value on error, got: %v", val)
+				}
+			}
+		})
+	}
+}
+
+func TestNoteWorkStatus_ErrorHandling(t *testing.T) {
+	// Setup a resolver with a fake/empty listers map to trigger getCombinedContentMap errors
+	listers := util.NewConcurrentMap[schema.GroupVersionResource, cache.GenericLister]()
+	resolver := NewCombinedStatusResolver(nil, listers)
+
+	r := resolver.(*combinedStatusResolver)
+
+	objID := util.ObjectIdentifier{
+		GVK: schema.GroupVersionKind{Group: "apps", Version: "v1", Kind: "Deployment"},
+		ObjectName: cache.ObjectName{
+			Namespace: "default",
+			Name:      "my-deploy",
+		},
+	}
+
+	r.bindingNameToResolutions["binding1"] = map[util.ObjectIdentifier]*combinedStatusResolution{
+		objID: {
+			Name: "cs-name",
+			StatusCollectorNameToData: map[string]*statusCollectorData{
+				"sc1": {
+					collectorSpec: &v1alpha1.StatusCollectorSpec{
+						// sourceObjectRequired=true triggers getObjectMetaAndSpec
+						Select: []v1alpha1.NamedExpression{
+							{
+								Name: "col1",
+								Def:  "obj.metadata.name",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	ws := &workStatus{
+		workStatusRef: workStatusRef{
+			Name:                   "ws-name",
+			WECName:                "wec1",
+			SourceObjectIdentifier: objID,
+		},
+	}
+
+	// We expect NoteWorkStatus to fail because the GVR lister is missing from listers
+	_, err := r.NoteWorkStatus(context.Background(), ws)
+	if err == nil {
+		t.Fatal("expected NoteWorkStatus to return an error due to missing lister, but got nil")
+	}
+	expectedErr := "failed to get combined content map"
+	if !strings.Contains(err.Error(), expectedErr) {
+		t.Errorf("expected error containing %q, got: %v", expectedErr, err)
+	}
+}

--- a/pkg/status/statuscollector.go
+++ b/pkg/status/statuscollector.go
@@ -57,7 +57,10 @@ func (c *Controller) syncStatusCollector(ctx context.Context, ref string) error 
 		}
 	}
 
-	combinedStatusSet, bindingNameSet := c.combinedStatusResolver.NoteStatusCollector(ctx, statusCollector, isDeleted, c.workStatusIndexer)
+	combinedStatusSet, bindingNameSet, err := c.combinedStatusResolver.NoteStatusCollector(ctx, statusCollector, isDeleted, c.workStatusIndexer)
+	if err != nil {
+		return fmt.Errorf("failed to note status collector: %w", err)
+	}
 	for combinedStatus := range combinedStatusSet {
 		logger.V(5).Info("Enqueuing reference to CombinedStatus while syncing StatusCollector", "combinedStatusRef", combinedStatus.ObjectName, "statusCollectorName", ref)
 		c.workqueue.AddAfter(combinedStatusRef(combinedStatus.ObjectName.AsNamespacedName().String()), queueingDelay)

--- a/pkg/status/workstatus.go
+++ b/pkg/status/workstatus.go
@@ -75,7 +75,10 @@ func (c *Controller) syncWorkStatus(ctx context.Context, ref workStatusRef) erro
 		workStatus.lastUpdateTime = getObjectStatusLastUpdateTime(obj.(metav1.Object))
 	}
 
-	combinedStatusSet := c.combinedStatusResolver.NoteWorkStatus(ctx, workStatus) // nil .status is equivalent to deleted
+	combinedStatusSet, err := c.combinedStatusResolver.NoteWorkStatus(ctx, workStatus) // nil .status is equivalent to deleted
+	if err != nil {
+		return fmt.Errorf("failed to note workstatus: %w", err)
+	}
 	for combinedStatus := range combinedStatusSet {
 		logger.V(5).Info("Enqueuing reference to CombinedStatus while syncing WorkStatus", "combinedStatusRef", combinedStatus.ObjectName, "workStatusRef", ref)
 		c.workqueue.AddAfter(combinedStatusRef(combinedStatus.ObjectName.AsNamespacedName().String()), queueingDelay)


### PR DESCRIPTION
## Summary

- Remove the TODO comment in `pkg/status/combinedstatus-resolver.go` and `pkg/status/combinedstatus-resolution.go` regarding error handling.
- Propagate errors returned by `getCombinedContentMap` (when fetching source object metadata & spec) to `NoteWorkStatus`, `NoteStatusCollector`, `NoteBindingResolution`.
- Propagate these errors to workstatus, statuscollector, and binding controller sync reconciliation loops to trigger retry on transient system errors.
- Log error conditions (such as invalid types or unparsable string inputs in `getCombinedFieldSubject`) using the existing klog framework.
- Add unit tests in `pkg/status/combinedstatus-resolver_test.go` covering error paths for `getCombinedFieldSubject` and `NoteWorkStatus`.

## Related issue(s)

Fixes #3884
