### PR TITLE
🐛 fix(controller): use ServerSideApply update strategy for ServiceAccount

### DIFF
--- a/pkg/transport/ocm-transport-controller/pkg/ocm.go
+++ b/pkg/transport/ocm-transport-controller/pkg/ocm.go
@@ -44,10 +44,16 @@ type ocm struct {
 }
 
 var createOnlyStrategy = workv1.UpdateStrategy{Type: workv1.UpdateStrategyTypeCreateOnly}
+// serverSideApplyStrategy uses ServerSideApply (SSA) because it ensures deterministic, declarative
+// updates and avoids conflict errors that can occur with CreateOrUpdate or Patch, particularly
+// for core resources like ServiceAccounts that controllers frequently reconcile.
+// The FieldManager name is set to clearly identify KubeStellar as the manager of these fields
+// for conflict resolution purposes.
 var serverSideApplyStrategy = workv1.UpdateStrategy{
 	Type: workv1.UpdateStrategyTypeServerSideApply,
 	ServerSideApply: &workv1.ServerSideApplyConfig{
-		Force: true,
+		Force:        true,
+		FieldManager: "kubestellar-transport-controller",
 	},
 }
 

--- a/pkg/transport/ocm-transport-controller/pkg/ocm.go
+++ b/pkg/transport/ocm-transport-controller/pkg/ocm.go
@@ -44,14 +44,20 @@ type ocm struct {
 }
 
 var createOnlyStrategy = workv1.UpdateStrategy{Type: workv1.UpdateStrategyTypeCreateOnly}
+var serverSideApplyStrategy = workv1.UpdateStrategy{
+	Type: workv1.UpdateStrategyTypeServerSideApply,
+	ServerSideApply: &workv1.ServerSideApplyConfig{
+		Force: true,
+	},
+}
 
 func (ocm *ocm) WrapObjects(wrapees []transport.Wrapee, kindToResource func(schema.GroupKind) string) runtime.Object {
 	manifests := make([]workv1.Manifest, len(wrapees))
 	var configs []workv1.ManifestConfigOption
 	for i, wrapee := range wrapees {
 		manifests[i].RawExtension = runtime.RawExtension{Object: wrapee.Object}
+		gvk := wrapee.Object.GroupVersionKind()
 		if wrapee.CreateOnly {
-			gvk := wrapee.Object.GroupVersionKind()
 			rsc := kindToResource(gvk.GroupKind())
 			configs = append(configs, workv1.ManifestConfigOption{
 				ResourceIdentifier: workv1.ResourceIdentifier{
@@ -61,6 +67,17 @@ func (ocm *ocm) WrapObjects(wrapees []transport.Wrapee, kindToResource func(sche
 					Name:      wrapee.Object.GetName(),
 				},
 				UpdateStrategy: &createOnlyStrategy,
+			})
+		} else if gvk.Group == "" && gvk.Kind == "ServiceAccount" {
+			rsc := kindToResource(gvk.GroupKind())
+			configs = append(configs, workv1.ManifestConfigOption{
+				ResourceIdentifier: workv1.ResourceIdentifier{
+					Group:     gvk.Group,
+					Resource:  rsc,
+					Namespace: wrapee.Object.GetNamespace(),
+					Name:      wrapee.Object.GetName(),
+				},
+				UpdateStrategy: &serverSideApplyStrategy,
 			})
 		}
 	}

--- a/pkg/transport/ocm-transport-controller/pkg/ocm_test.go
+++ b/pkg/transport/ocm-transport-controller/pkg/ocm_test.go
@@ -1,0 +1,76 @@
+package ocm
+
+import (
+	"testing"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	workv1 "open-cluster-management.io/api/work/v1"
+
+	"github.com/kubestellar/kubestellar/pkg/transport"
+)
+
+func TestWrapObjects_ServiceAccount(t *testing.T) {
+	ocm := NewOCMTransport()
+	
+	sa := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "v1",
+			"kind":       "ServiceAccount",
+			"metadata": map[string]interface{}{
+				"name":      "test-sa",
+				"namespace": "test-ns",
+			},
+		},
+	}
+
+	pod := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "v1",
+			"kind":       "Pod",
+			"metadata": map[string]interface{}{
+				"name":      "test-pod",
+				"namespace": "test-ns",
+			},
+		},
+	}
+
+	wrapees := []transport.Wrapee{
+		{Object: sa},
+		{Object: pod},
+	}
+
+	kindToResource := func(gk schema.GroupKind) string {
+		switch gk.Kind {
+		case "ServiceAccount":
+			return "serviceaccounts"
+		case "Pod":
+			return "pods"
+		default:
+			return "unknown"
+		}
+	}
+
+	manifestWorkObj := ocm.WrapObjects(wrapees, kindToResource)
+	manifestWork, ok := manifestWorkObj.(*workv1.ManifestWork)
+	if !ok {
+		t.Fatalf("expected ManifestWork, got %T", manifestWorkObj)
+	}
+
+	configs := manifestWork.Spec.ManifestConfigs
+	if len(configs) != 1 {
+		t.Fatalf("expected exactly 1 config option for ServiceAccount, got %d", len(configs))
+	}
+
+	config := configs[0]
+	if config.ResourceIdentifier.Resource != "serviceaccounts" || config.ResourceIdentifier.Name != "test-sa" {
+		t.Errorf("unexpected resource identifier: %v", config.ResourceIdentifier)
+	}
+
+	if config.UpdateStrategy == nil || config.UpdateStrategy.Type != workv1.UpdateStrategyTypeServerSideApply {
+		t.Errorf("expected ServerSideApply update strategy for ServiceAccount, got %v", config.UpdateStrategy)
+	}
+	if config.UpdateStrategy.ServerSideApply == nil || !config.UpdateStrategy.ServerSideApply.Force {
+		t.Errorf("expected Force: true in ServerSideApply strategy, got %v", config.UpdateStrategy.ServerSideApply)
+	}
+}

--- a/pkg/transport/ocm-transport-controller/pkg/ocm_test.go
+++ b/pkg/transport/ocm-transport-controller/pkg/ocm_test.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2024 The KubeStellar Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package ocm
 
 import (
@@ -12,7 +28,7 @@ import (
 
 func TestWrapObjects_ServiceAccount(t *testing.T) {
 	ocm := NewOCMTransport()
-	
+
 	sa := &unstructured.Unstructured{
 		Object: map[string]interface{}{
 			"apiVersion": "v1",
@@ -72,5 +88,8 @@ func TestWrapObjects_ServiceAccount(t *testing.T) {
 	}
 	if config.UpdateStrategy.ServerSideApply == nil || !config.UpdateStrategy.ServerSideApply.Force {
 		t.Errorf("expected Force: true in ServerSideApply strategy, got %v", config.UpdateStrategy.ServerSideApply)
+	}
+	if config.UpdateStrategy.ServerSideApply.FieldManager != "kubestellar-transport-controller" {
+		t.Errorf("expected FieldManager: kubestellar-transport-controller in ServerSideApply strategy, got %v", config.UpdateStrategy.ServerSideApply.FieldManager)
 	}
 }

--- a/pkg/util/resources.go
+++ b/pkg/util/resources.go
@@ -23,7 +23,6 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 
 	"github.com/kubestellar/kubestellar/api/control/v1alpha1"
-	//"k8s.io/apiextensions-apiserver/pkg/apis/apiextensions"
 )
 
 // ParseAPIGroupsString takes a comma separated string list of api groups in the form of


### PR DESCRIPTION
## Summary
Updates the create/update strategy for `ServiceAccount` resources to use `ServerSideApply`. This ensures deterministic behavior and prevents conflicts when updating the resource, aligning it with best practices for controller resource management.

## Related issue(s)
Fixes #3870
