### PR TITLE
docs: fix duplicated word in common setup introduction

### DIFF
--- a/oldocs/common-setup-intro.md
+++ b/oldocs/common-setup-intro.md
@@ -1,6 +1,6 @@
 # KubeStellar Hub Setup
 
-This document is is excerpted from [our example scenarios](examples.md) document to show two ways of deploying the kubestellar hub (core) components to create the "common setup" used by those examples.
+This document is excerpted from [our example scenarios](examples.md) document to show two ways of deploying the kubestellar hub (core) components to create the "common setup" used by those examples.
 
 
 ## Common Setup


### PR DESCRIPTION
Fix a typo in oldocs/common-setup-intro.md where 'is' was duplicated ('This document is is excerpted' -> 'This document is excerpted').