### PR TITLE
🌱 Add golangci-lint Configuration for Additional Linters

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,5 +1,6 @@
 version: "2"
 linters:
+  default: none
   enable:
     - asciicheck
     - bidichk
@@ -11,6 +12,10 @@ linters:
     - nilerr
     - nolintlint
     - unconvert
+    - govet
+    - staticcheck
+    - ineffassign
+    - unused
   settings:
     misspell:
       ignore-rules:
@@ -26,6 +31,16 @@ linters:
       - third_party$
       - builtin$
       - examples$
+    rules:
+      - linters:
+          - staticcheck
+        text: "SA1019:"
+      - linters:
+          - staticcheck
+        text: "ST"
+      - linters:
+          - staticcheck
+        text: "QF"
 formatters:
   enable:
     - gofmt

--- a/Makefile
+++ b/Makefile
@@ -62,7 +62,7 @@ else
 INSTALL_GOBIN=$(shell go env GOBIN)
 endif
 
-GOLANGCI_LINT_VER := v1.50.1
+GOLANGCI_LINT_VER := v2.4.0
 GOLANGCI_LINT_BIN := golangci-lint
 GOLANGCI_LINT := $(TOOLS_GOBIN_DIR)/$(GOLANGCI_LINT_BIN)-$(GOLANGCI_LINT_VER)
 
@@ -278,7 +278,7 @@ $(ENVTEST): $(LOCALBIN)
 	test -s $(LOCALBIN)/setup-envtest || GOBIN=$(LOCALBIN) go install sigs.k8s.io/controller-runtime/tools/setup-envtest@latest
 
 $(GOLANGCI_LINT):
-	GOBIN=$(TOOLS_GOBIN_DIR) $(GO_INSTALL) github.com/golangci/golangci-lint/cmd/golangci-lint $(GOLANGCI_LINT_BIN) $(GOLANGCI_LINT_VER)
+	GOBIN=$(TOOLS_GOBIN_DIR) $(GO_INSTALL) github.com/golangci/golangci-lint/v2/cmd/golangci-lint $(GOLANGCI_LINT_BIN) $(GOLANGCI_LINT_VER)
 
 $(STATICCHECK):
 	GOBIN=$(TOOLS_GOBIN_DIR) $(GO_INSTALL) honnef.co/go/tools/cmd/staticcheck $(STATICCHECK_BIN) $(STATICCHECK_VER)

--- a/pkg/binding/bindingpolicy-resolution.go
+++ b/pkg/binding/bindingpolicy-resolution.go
@@ -239,15 +239,6 @@ func (resolution *bindingPolicyResolution) matchesBindingSpec(bindingSpec *v1alp
 	return true
 }
 
-// getDestinationsList returns a sorted list of v1alpha1.Destination in the
-// resolution.
-func (resolution *bindingPolicyResolution) getDestinationsList() []v1alpha1.Destination {
-	resolution.RLock()
-	defer resolution.RUnlock()
-
-	return destinationsStringSetToSortedDestinations(resolution.destinations)
-}
-
 func (resolution *bindingPolicyResolution) getWorkloadReferences() []util.ObjectIdentifier {
 	resolution.RLock()
 	defer resolution.RUnlock()

--- a/pkg/binding/bindingpolicy-resolver.go
+++ b/pkg/binding/bindingpolicy-resolver.go
@@ -351,11 +351,7 @@ func (resolver *bindingPolicyResolver) SetDestinations(bindingPolicyKey string,
 // ResolutionExists returns true if a resolution is associated with the
 // given bindingpolicy key.
 func (resolver *bindingPolicyResolver) ResolutionExists(bindingPolicyKey string) bool {
-	if resolver.getResolution(bindingPolicyKey) == nil {
-		return false
-	}
-
-	return true
+	return resolver.getResolution(bindingPolicyKey) != nil
 }
 
 // GetReportedStateRequestForObject returns four things.

--- a/pkg/binding/bindingpolicy.go
+++ b/pkg/binding/bindingpolicy.go
@@ -107,28 +107,6 @@ func (c *Controller) deleteResolutionForBindingPolicy(ctx context.Context, bindi
 	return nil
 }
 
-func (c *Controller) requeueSelectedWorkloadObjects(ctx context.Context, bindingPolicyName string) error {
-	if !c.bindingPolicyResolver.ResolutionExists(bindingPolicyName) {
-		return nil
-	}
-
-	// requeue all objects that are selected by the bindingpolicy (are in its resolution)
-	objectIdentifiers, err := c.bindingPolicyResolver.GetObjectIdentifiers(bindingPolicyName)
-	if err != nil {
-		return fmt.Errorf("failed to get object identifiers from bindingpolicy resolver for "+
-			"bindingpolicy %s: %w", bindingPolicyName, err)
-	}
-
-	logger := klog.FromContext(ctx)
-	for objIdentifier := range objectIdentifiers {
-		logger.V(5).Info("Enqueuing workload object due to change in BindingPolicy",
-			"objectIdentifier", objIdentifier, "bindingPolicyName", bindingPolicyName)
-		c.enqueueObjectIdentifier(objIdentifier)
-	}
-
-	return nil
-}
-
 func (c *Controller) evaluateBindingPoliciesForUpdate(ctx context.Context, clusterId string, oldLabels labels.Set, newLabels labels.Set) {
 	logger := klog.FromContext(ctx)
 

--- a/pkg/binding/crd.go
+++ b/pkg/binding/crd.go
@@ -123,11 +123,7 @@ func (c *Controller) includedToWatch(r APIResource) bool {
 		Resource: r.resource.Name,
 	}
 
-	if isExcludedGroupResource(gr) {
-		return false
-	}
-
-	return true
+	return !isExcludedGroupResource(gr)
 }
 
 func crdEstablished(crd *apiextensionsv1.CustomResourceDefinition) bool {

--- a/pkg/status/binding.go
+++ b/pkg/status/binding.go
@@ -69,7 +69,7 @@ func (c *Controller) syncBinding(ctx context.Context, key string) error {
 // missingSCs, a slice of the missing StatusCollector object name(s), must be sorted.
 func (c *Controller) createOrUpdateStatusCollectorAvailableCondition(ctx context.Context, bdg *v1alpha1.Binding, missingSCs []string) error {
 	// compose tentative condition where LastTransitionTime is TBD
-	conditionTentative := v1alpha1.BindingPolicyCondition{}
+	var conditionTentative v1alpha1.BindingPolicyCondition
 	if len(missingSCs) != 0 {
 		conditionTentative = v1alpha1.BindingPolicyCondition{
 			Type:    v1alpha1.TypeStatusCollectorsAvailable,

--- a/pkg/status/status-controller.go
+++ b/pkg/status/status-controller.go
@@ -101,8 +101,6 @@ type workloadObjectRef struct{ util.ObjectIdentifier }
 // bindingRef is a workqueue item that references a Binding
 type bindingRef string
 
-type workStatusON cache.ObjectName
-
 // workStatusRef is a workqueue item that references a WorkStatus
 type workStatusRef struct {
 	// Name is the Name of the WorkStatus object

--- a/test/performance/latency-controller/internal/controller/controller.go
+++ b/test/performance/latency-controller/internal/controller/controller.go
@@ -83,7 +83,6 @@ type GenericLatencyCollectorReconciler struct {
 	BindingPolicyName   string
 	DiscoveredResources []schema.GroupVersionKind
 	gvkToGVR            map[schema.GroupVersionKind]schema.GroupVersionResource
-	bindingCreated      time.Time
 
 	cache    map[string]*PerWorkloadCache
 	cacheMux sync.Mutex


### PR DESCRIPTION
## Summary
This PR adds configuration for recommended Kubernetes static analysis linters (`govet`, `staticcheck`, `ineffassign`, and `unused`) in `.golangci.yaml` (updated for v2 format). It also resolves all code issues surfaced by these linters across the codebase (unused code, ineffectual assignments, and returns that can be simplified).

Exclusion rules are added to suppress deprecated API warnings (`SA1019`) and style/quickfix warnings (`ST`/`QF`) from `staticcheck` to keep the linting focused and actionable.

## Related issue(s)
Fixes # (Issue 5)

## Changes
- **Configuration**:
  - Updated `.golangci.yaml` to `version: "2"` configuration with `default: none`, explicitly enabling the recommended linters.
  - Added exclusion rules for `SA1019`, `ST`, and `QF` prefixes in `staticcheck` settings.
  - Updated the `Makefile` to define and build `golangci-lint` `v2.4.0` using the correct module path.
- **Code Fixes**:
  - `pkg/status/binding.go`: Fixed ineffectual assignment to `conditionTentative`.
  - `pkg/binding/bindingpolicy-resolution.go`: Removed unused `getDestinationsList` function.
  - `pkg/binding/bindingpolicy.go`: Removed unused `requeueSelectedWorkloadObjects` function.
  - `pkg/status/status-controller.go`: Removed unused `workStatusON` type alias.
  - `test/performance/latency-controller/internal/controller/controller.go`: Removed unused `bindingCreated` field.
  - `pkg/binding/bindingpolicy-resolver.go` & `pkg/binding/crd.go`: Simplified boolean returns as suggested by `gosimple` (`S1008`).

## Testing
- Installed and ran `golangci-lint` v2.4.0 locally with the updated config; verified it passes successfully with no new linter warnings.
- Ran package unit tests (`go test ./pkg/...`); verified all tests compile and pass.

## Checklist
- [x] Recommended linters added to `.golangci.yaml`
- [x] Unused code, style issues, and ineffectual assignments resolved
- [x] Linter suppressions documented and configured for deprecated warnings
- [x] Unit tests verified and passing
