### PR TITLE
🐛 Fix panic on groupBy expression returning a list or map

### DIFF
--- a/pkg/status/aggregation_groupby_test.go
+++ b/pkg/status/aggregation_groupby_test.go
@@ -1,0 +1,112 @@
+/*
+Copyright 2024 The KubeStellar Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package status
+
+import (
+	"testing"
+
+	celtypes "github.com/google/cel-go/common/types"
+	"github.com/google/cel-go/common/types/ref"
+
+	"github.com/kubestellar/kubestellar/api/control/v1alpha1"
+)
+
+func nativeToRefVal(native any) ref.Val {
+	return celtypes.DefaultTypeAdapter.NativeToValue(native)
+}
+
+// scDataGroupingByList builds a statusCollectorData that groups by a single
+// expression whose evaluated value is a list (a composite, non-comparable
+// value). Each WEC's groupBy value is provided by wecToList.
+func scDataGroupingByList(wecToList map[string][]any) *statusCollectorData {
+	wecToData := map[string]*workStatusData{}
+	for wec, list := range wecToList {
+		wecToData[wec] = &workStatusData{
+			groupByEval:        rowFragment{"g": nativeToRefVal(list)},
+			combinedFieldsEval: rowFragment{"count": nil},
+		}
+	}
+	return &statusCollectorData{
+		collectorSpec: &v1alpha1.StatusCollectorSpec{
+			GroupBy: []v1alpha1.NamedExpression{{Name: "g", Def: "obj.spec.list"}},
+			CombinedFields: []v1alpha1.NamedAggregator{
+				{Name: "count", Type: v1alpha1.AggregatorTypeCount},
+			},
+		},
+		WECToData: wecToData,
+	}
+}
+
+// TestHandleAggregationGroupByComposite verifies that a groupBy value that is a
+// composite (list) type does not panic and that equal values are grouped
+// together while distinct values are grouped apart. Before the fix, the raw
+// composite value was used as a map key and this panicked with
+// "hash of unhashable type".
+func TestHandleAggregationGroupByComposite(t *testing.T) {
+	// wec1 and wec2 share the same list value; wec3 differs. Expect 2 groups.
+	sc := scDataGroupingByList(map[string][]any{
+		"wec1": {"a", "b"},
+		"wec2": {"a", "b"},
+		"wec3": {"a", "c"},
+	})
+
+	var result *v1alpha1.NamedStatusCombination
+	func() {
+		defer func() {
+			if r := recover(); r != nil {
+				t.Fatalf("handleAggregationReadLocked panicked on composite groupBy value: %v", r)
+			}
+		}()
+		result = handleAggregationReadLocked("sc", sc)
+	}()
+
+	if result == nil {
+		t.Fatal("expected a NamedStatusCombination, got nil")
+	}
+	if got := len(result.Rows); got != 2 {
+		t.Fatalf("expected 2 groups (two WECs share a value, one differs), got %d rows", got)
+	}
+}
+
+// TestGroupByValueKey checks the key helper directly: scalars keep distinct
+// keys by type and value, composites are reduced to a stable JSON key, and
+// equal composites collide while different ones do not.
+func TestGroupByValueKey(t *testing.T) {
+	if groupByValueKey(nil) != "null" {
+		t.Error("nil value should key to \"null\"")
+	}
+
+	listAB1 := groupByValueKey(nativeToRefVal([]any{"a", "b"}))
+	listAB2 := groupByValueKey(nativeToRefVal([]any{"a", "b"}))
+	listAC := groupByValueKey(nativeToRefVal([]any{"a", "c"}))
+	if listAB1 != listAB2 {
+		t.Errorf("equal lists should produce equal keys: %q vs %q", listAB1, listAB2)
+	}
+	if listAB1 == listAC {
+		t.Errorf("different lists should produce different keys, both were %q", listAB1)
+	}
+
+	mapKey := groupByValueKey(nativeToRefVal(map[string]any{"x": 1}))
+	if mapKey == listAB1 {
+		t.Error("a map and a list should not share a key")
+	}
+
+	// A string scalar "a,b" must not collide with the list ["a","b"].
+	if groupByValueKey(nativeToRefVal("a,b")) == listAB1 {
+		t.Error("scalar string should not collide with a list key")
+	}
+}

--- a/pkg/status/combinedstatus-resolution.go
+++ b/pkg/status/combinedstatus-resolution.go
@@ -781,6 +781,33 @@ func refValToValue(val ref.Val) v1alpha1.Value {
 	}
 }
 
+// groupByValueKey reduces a groupBy evaluation result to a stable string that
+// can be used as a map key. Scalars are formatted directly; composite values
+// (lists/maps), which are not comparable and cannot be used as map keys, are
+// reduced to their JSON encoding. Two evaluations that produce equal values
+// yield the same key, so grouping semantics are preserved.
+func groupByValueKey(val ref.Val) string {
+	if val == nil {
+		return "null"
+	}
+
+	native := val.Value()
+	switch native.(type) {
+	case string, bool,
+		int, int8, int16, int32, int64,
+		uint, uint8, uint16, uint32, uint64,
+		float32, float64:
+		return fmt.Sprintf("%T:%v", native, native)
+	default:
+		if encoded, err := json.Marshal(native); err == nil {
+			return "json:" + string(encoded)
+		}
+		// Fall back to a Go-syntax representation if the value is not
+		// JSON-encodable, rather than using it directly as a map key.
+		return fmt.Sprintf("gosyntax:%#v", native)
+	}
+}
+
 // handleAggregationReadLocked handles the aggregation of the statuscollector
 // data. This means that the function evaluates the groupBy expressions and the
 // combinedFields expressions against the possibly filtered workstatuses and
@@ -797,7 +824,7 @@ func handleAggregationReadLocked(scName string, scData *statusCollectorData) *v1
 	// 		Where the N-values tuple is the string concatenation of the assigned numbers
 	// 		separated by commas, ordered by the groupBy expressions in scData.GroupBy slice.
 	generator := 0
-	ValueToNumber := map[any]int{}
+	ValueToNumber := map[string]int{}
 	idToAggregationGroup := map[string]*aggregationGroup{}
 
 	if len(scData.collectorSpec.GroupBy) == 0 && len(scData.WECToData) == 0 {
@@ -826,10 +853,14 @@ func handleAggregationReadLocked(scName string, scData *statusCollectorData) *v1
 		for _, groupByNamedExp := range scData.collectorSpec.GroupBy {
 			groupByValue := wsData.groupByEval[groupByNamedExp.Name]
 
-			// ensure unique number mapping for the value
-			uid, exists := ValueToNumber[groupByValue.Value()]
+			// ensure unique number mapping for the value. The value is reduced to
+			// a stable string key first: a groupBy expression may evaluate to a
+			// composite (list/map) value, which is not comparable and would panic
+			// if used directly as a map key.
+			valueKey := groupByValueKey(groupByValue)
+			uid, exists := ValueToNumber[valueKey]
 			if !exists {
-				ValueToNumber[groupByValue.Value()] = generator
+				ValueToNumber[valueKey] = generator
 				uid = generator
 				generator++
 			}


### PR DESCRIPTION
## Summary

A StatusCollector whose `groupBy` expression evaluates to a composite value (a list or a map) crashes the status controller with `panic: hash of unhashable type`.

In `handleAggregationReadLocked` the evaluated groupBy value was used directly as a key in a `map[any]int`:

```go
ValueToNumber := map[any]int{}
...
uid, exists := ValueToNumber[groupByValue.Value()]
```

`groupByValue.Value()` is the native Go value of the CEL evaluation. For a list or map that is a `[]interface{}` / `map[string]interface{}`, which is not comparable, so indexing the map panics. Validation doesn't catch it either: groupBy expressions are checked against a CEL environment where `obj` is `map[string]DynType`, so something like `obj.spec.containers` type-checks fine and only fails later at evaluation time. Because that happens inside a workqueue worker and the offending StatusCollector stays in the cache, the controller crash-loops.

The fix reduces each groupBy value to a stable string key before the unique-number mapping. Scalars are keyed by their type and value; composite values are keyed by their JSON encoding, which mirrors how `refValToValue` already renders composite values downstream. Equal values still land in the same group and distinct values stay apart, so grouping behaviour is unchanged for the scalar cases that worked before.

## Testing

- Added `aggregation_groupby_test.go`: one test drives `handleAggregationReadLocked` with a list-valued groupBy across three WECs (two sharing a value, one differing) and asserts no panic plus the expected two groups; another exercises the key helper directly (equal composites collide, different composites and scalars don't). Reverting the fix makes the first test panic with `hash of unhashable type: []interface {}`, so it genuinely guards the regression.
- `go build ./...`, `go vet ./pkg/status/...`, and `go test ./pkg/status/...` all pass.

## Related issue(s)

Fixes #3897
