### PR TITLE
🐛 Fix recursive read-lock deadlock in compareCombinedStatus

### DIFF
--- a/pkg/status/combinedstatus-resolution.go
+++ b/pkg/status/combinedstatus-resolution.go
@@ -273,12 +273,22 @@ func (c *combinedStatusResolution) noteStatusCollectorAbsence(statusCollectorNam
 }
 
 // generateCombinedStatus calculates the combinedstatus from the statuscollector
-// data in the combinedstatus resolution.
+// data in the combinedstatus resolution. It acquires the read lock and delegates
+// to generateCombinedStatusReadLocked.
 func (c *combinedStatusResolution) generateCombinedStatus(bindingName string,
 	workloadObjectIdentifier util.ObjectIdentifier) *v1alpha1.CombinedStatus {
 	c.RLock()
 	defer c.RUnlock()
 
+	return c.generateCombinedStatusReadLocked(bindingName, workloadObjectIdentifier)
+}
+
+// generateCombinedStatusReadLocked calculates the combinedstatus from the
+// statuscollector data in the combinedstatus resolution. The caller must hold
+// at least the read lock, since sync.RWMutex is not reentrant and recursively
+// acquiring the read lock can deadlock if a writer is waiting.
+func (c *combinedStatusResolution) generateCombinedStatusReadLocked(bindingName string,
+	workloadObjectIdentifier util.ObjectIdentifier) *v1alpha1.CombinedStatus {
 	combinedStatus := &v1alpha1.CombinedStatus{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      c.Name,
@@ -318,7 +328,10 @@ func (c *combinedStatusResolution) compareCombinedStatus(status *v1alpha1.Combin
 	c.RLock()
 	defer c.RUnlock()
 
-	localCombinedStatus := c.generateCombinedStatus(bindingName, sourceObjectIdentifier)
+	// Use the read-locked helper: we already hold the read lock, and
+	// sync.RWMutex is not reentrant, so calling generateCombinedStatus (which
+	// re-acquires the read lock) here can deadlock if a writer is waiting.
+	localCombinedStatus := c.generateCombinedStatusReadLocked(bindingName, sourceObjectIdentifier)
 
 	// check labels
 	if !validateCombinedStatusLabels(status, bindingName, sourceObjectIdentifier) {

--- a/pkg/status/combinedstatus_deadlock_test.go
+++ b/pkg/status/combinedstatus_deadlock_test.go
@@ -1,0 +1,92 @@
+/*
+Copyright 2024 The KubeStellar Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package status
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/client-go/tools/cache"
+
+	"github.com/kubestellar/kubestellar/api/control/v1alpha1"
+	"github.com/kubestellar/kubestellar/pkg/util"
+)
+
+// TestCompareCombinedStatusNoRecursiveReadLock is a regression test for the
+// recursive read-lock deadlock (issue #3899). compareCombinedStatus held the
+// resolution's read lock and then called generateCombinedStatus, which
+// re-acquired the same read lock. sync.RWMutex is not reentrant: if a writer
+// calls Lock in the window between the two RLock calls, the second RLock blocks
+// behind the writer, which blocks behind the first reader -> deadlock.
+//
+// The test hammers compareCombinedStatus while a writer goroutine repeatedly
+// takes the write lock on the same resolution. On the buggy code this hangs; on
+// the fixed code it completes well within the timeout.
+func TestCompareCombinedStatusNoRecursiveReadLock(t *testing.T) {
+	res := &combinedStatusResolution{
+		Name:                      "cs",
+		StatusCollectorNameToData: map[string]*statusCollectorData{},
+		CollectionDestinations:    sets.New[string]("wec1"),
+	}
+
+	objID := util.ObjectIdentifier{
+		GVK:        schema.GroupVersionKind{Group: "apps", Version: "v1", Kind: "Deployment"},
+		Resource:   "deployments",
+		ObjectName: cache.NewObjectName("ns", "name"),
+	}
+	status := &v1alpha1.CombinedStatus{}
+
+	done := make(chan struct{})
+	stop := make(chan struct{})
+	var wg sync.WaitGroup
+
+	// Writer: contends for the write lock on the same resolution so a Lock can
+	// land between the two read-lock acquisitions of the old code path.
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+			}
+			res.Lock()
+			res.StatusCollectorNameToData["sc"] = nil
+			res.Unlock()
+		}
+	}()
+
+	// Readers: repeatedly run the compare path.
+	go func() {
+		for i := 0; i < 2000; i++ {
+			res.compareCombinedStatus(status, "bp", objID)
+		}
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		close(stop)
+		wg.Wait()
+	case <-time.After(15 * time.Second):
+		t.Fatal("compareCombinedStatus deadlocked: recursive read-lock with a waiting writer")
+	}
+}

--- a/pkg/status/combinedstatus_deadlock_test.go
+++ b/pkg/status/combinedstatus_deadlock_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package status
 
 import (
+	"runtime"
 	"sync"
 	"testing"
 	"time"
@@ -71,6 +72,10 @@ func TestCompareCombinedStatusNoRecursiveReadLock(t *testing.T) {
 			res.Lock()
 			res.StatusCollectorNameToData["sc"] = nil
 			res.Unlock()
+			// Yield so the reader goroutine gets scheduled between our
+			// Lock/Unlock cycles, keeping contention high without pegging a
+			// core in a tight spin loop.
+			runtime.Gosched()
 		}
 	}()
 
@@ -87,6 +92,9 @@ func TestCompareCombinedStatusNoRecursiveReadLock(t *testing.T) {
 		close(stop)
 		wg.Wait()
 	case <-time.After(15 * time.Second):
+		// Signal the writer to stop before failing so it does not keep
+		// spinning and interfere with other tests in the package.
+		close(stop)
 		t.Fatal("compareCombinedStatus deadlocked: recursive read-lock with a waiting writer")
 	}
 }


### PR DESCRIPTION
## Summary

`compareCombinedStatus` takes the resolution's read lock and, while holding it, calls `generateCombinedStatus`, which takes the same read lock again. `sync.RWMutex` is not reentrant — recursive read-locking is documented as unsafe. If a writer calls `Lock()` in the gap between the two `RLock()` calls, the writer blocks behind the first reader and the second `RLock()` blocks behind the writer, so the status controller goroutine parks permanently.

The fix pulls the body of `generateCombinedStatus` into an unlocked helper, `generateCombinedStatusReadLocked`, that assumes the caller already holds the lock. This matches the existing `handleSelectReadLocked` / `handleAggregationReadLocked` convention in the same file. `generateCombinedStatus` stays a thin wrapper that acquires the read lock once, and `compareCombinedStatus` calls the helper directly since it already holds the lock. No behavior change on the single-lock paths.

The regression test runs `compareCombinedStatus` in a loop while another goroutine contends for the same resolution's write lock. It deadlocks (times out) on the old code and passes on the fixed code; verified both ways locally, and `go test -race ./pkg/status/` is clean.

## Related issue(s)

Fixes #3899
