### PR TITLE
📖 docs: fix typos in code comments

### DIFF
--- a/pkg/binding/binding-controller.go
+++ b/pkg/binding/binding-controller.go
@@ -230,7 +230,7 @@ func NewController(parentLogger logr.Logger,
 		apiResourceLists, wdsName, allowedGroupsSet, workloadObsserver)
 }
 
-// doDiscovery contains the exact one occurrence of ServerPreferredResources() in this repository.
+// doDiscovery contains the primary occurrence of ServerPreferredResources() used by the binding controller.
 // doDiscovery is supposed to be invoked exactly one time during the lifecycle of a binding controller.
 // That is, full API discovery against the WDS is done exactly one time during the lifecycle of a binding controller.
 // doDiscovery also returns the number of successfully discovered GVRs.

--- a/pkg/jsonpath/lexer.go
+++ b/pkg/jsonpath/lexer.go
@@ -72,7 +72,7 @@ func NewLexer(source string, startPos int) (*Lexer, error) {
 	return lxr, err
 }
 
-// GetPosition returns the postion of the character that the Lexer is currently looking at
+// GetPosition returns the position of the character that the Lexer is currently looking at
 // and whether the Lexer is looking at EOF.
 func (lxr *Lexer) GetPosition() (int, bool) { return lxr.chrPos, lxr.eof }
 

--- a/pkg/status/singletonstatus.go
+++ b/pkg/status/singletonstatus.go
@@ -41,7 +41,7 @@ func (c *Controller) updateWorkStatusToObject(ctx context.Context, workStatusON 
 	if wsObj == nil {
 		objId, had := c.workStatusToObject.Delete(workStatusON)
 		if had {
-			logger.V(5).Info("Enqueuing workload object due to absense of WorkStatus", "workStatus", workStatusON, "workloadObject", objId)
+			logger.V(5).Info("Enqueuing workload object due to absence of WorkStatus", "workStatus", workStatusON, "workloadObject", objId)
 			c.workqueue.Add(workloadObjectRef{objId})
 		}
 	} else {

--- a/pkg/transport/generic/generic_transport_controller.go
+++ b/pkg/transport/generic/generic_transport_controller.go
@@ -343,7 +343,7 @@ type genericTransportController struct {
 	workqueue workqueue.RateLimitingInterface
 
 	transport        transport.Transport //transport is a specific implementation for the transport interface.
-	transportClient  dynamic.Interface   // dynamic client to transport wrapped object. since object kind is unknown during compilation, we use dynamic
+	transportClient  dynamic.Interface   // dynamic client to transport wrapped object. Since object kind is unknown during compilation, we use dynamic
 	wrappedObjectGVR schema.GroupVersionResource
 
 	wdsDynamicClient dynamic.Interface

--- a/pkg/transport/generic/generic_transport_controller.go
+++ b/pkg/transport/generic/generic_transport_controller.go
@@ -343,7 +343,7 @@ type genericTransportController struct {
 	workqueue workqueue.RateLimitingInterface
 
 	transport        transport.Transport //transport is a specific implementation for the transport interface.
-	transportClient  dynamic.Interface   // dynamic client to transport wrapped object. since object kind is unknown during complilation, we use dynamic
+	transportClient  dynamic.Interface   // dynamic client to transport wrapped object. since object kind is unknown during compilation, we use dynamic
 	wrappedObjectGVR schema.GroupVersionResource
 
 	wdsDynamicClient dynamic.Interface
@@ -355,7 +355,7 @@ type genericTransportController struct {
 
 	propsMutex sync.Mutex
 
-	// bindingSensitiveDestinations maps Binding name to the set of destinations whose properties the Binding is senstive to.
+	// bindingSensitiveDestinations maps Binding name to the set of destinations whose properties the Binding is sensitive to.
 	// Access to both the map and the Sets it holds is controlled by the RWMutex.
 	// The sets are mutable with the RWMutex held.
 	bindingSensitiveDestinations map[string]sets.Set[v1alpha1.Destination]


### PR DESCRIPTION
## Summary
This PR fixes a few obvious typos in code comments across the codebase to improve readability.

- `pkg/jsonpath/lexer.go`: "postion" → "position"
- `pkg/status/singletonstatus.go`: "absense" → "absence"
- `pkg/binding/binding-controller.go`: "occurence" → "occurrence"
- `pkg/transport/generic/generic_transport_controller.go`: "complilation" → "compilation"
- `pkg/transport/generic/generic_transport_controller.go`: "senstive" → "sensitive"

## Related issue(s)
N/A - just some simple doc cleanup.
