### PR TITLE
📖 docs: add missing godocs in pkg/util

### DIFF
--- a/pkg/util/string-filter.go
+++ b/pkg/util/string-filter.go
@@ -30,15 +30,18 @@ type StringFilterOptions struct {
 	Literals  []string
 }
 
+// NewStringFilterOptions creates a StringFilterOptions initialized with the provided literals.
 func NewStringFilterOptions(literals ...string) StringFilterOptions {
 	return StringFilterOptions{Literals: literals}
 }
 
+// SeparateBySpacesToo enables space-separation parsing and returns the modified StringFilterOptions.
 func (sfo StringFilterOptions) SeparateBySpacesToo() StringFilterOptions {
 	sfo.SpacesToo = true
 	return sfo
 }
 
+// AddToFlags binds the literals in this StringFilterOptions to a flag in the provided FlagSet.
 func (sfo *StringFilterOptions) AddToFlags(flagSet *pflag.FlagSet, flagName, what string) {
 	sep := "comma"
 	if sfo.SpacesToo {
@@ -53,6 +56,7 @@ type StringFilter struct {
 	Literals sets.Set[string]
 }
 
+// ToFilter converts the options into a StringFilter and returns whether any literals were provided.
 func (sfo StringFilterOptions) ToFilter() (StringFilter, bool) {
 	gotSome := len(sfo.Literals) > 0
 	ansSet := sets.New[string]()
@@ -77,10 +81,12 @@ func (sfo StringFilterOptions) ToFilter() (StringFilter, bool) {
 	return StringFilter{Literals: ansSet}, gotSome
 }
 
+// Passes returns true if the candidate string matches the filter criteria or if the filter allows all.
 func (sf *StringFilter) Passes(candidate string, passStar bool) bool {
 	return sf.AllPass || passStar && candidate == "*" || sf.Literals.Has(candidate)
 }
 
+// FilterSlice filters a slice of candidate strings, returning only those that pass the filter criteria.
 func (sf *StringFilter) FilterSlice(candidates []string, passStar bool) []string {
 	ans := make([]string, 0, len(candidates))
 	for _, candidate := range candidates {

--- a/pkg/util/string-filter.go
+++ b/pkg/util/string-filter.go
@@ -87,6 +87,8 @@ func (sf *StringFilter) Passes(candidate string, passStar bool) bool {
 }
 
 // FilterSlice filters a slice of candidate strings, returning only those that pass the filter criteria.
+// It iterates through each candidate and applies the StringFilter predicate to determine inclusion.
+// (as evaluated by the Passes predicate).
 func (sf *StringFilter) FilterSlice(candidates []string, passStar bool) []string {
 	ans := make([]string, 0, len(candidates))
 	for _, candidate := range candidates {

--- a/pkg/util/unstructured.go
+++ b/pkg/util/unstructured.go
@@ -71,6 +71,7 @@ type SourceRef struct {
 	Namespace string `json:"namespace,omitempty"`
 }
 
+// IsCRD returns true if the object is a CustomResourceDefinition.
 func IsCRD(o interface{}) bool {
 	return objectMatchesGVK(o, apiextensions.GroupName, AnyVersion, CRDKind)
 }
@@ -91,6 +92,7 @@ func getObjectGVK(o interface{}) (schema.GroupVersionKind, error) {
 	return schema.GroupVersionKind{}, fmt.Errorf("object is of wrong type: %#v", o)
 }
 
+// GetWorkStatusSourceRef extracts the sourceRef from a WorkStatus unstructured object.
 func GetWorkStatusSourceRef(workStatus runtime.Object) (*SourceRef, error) {
 	obj, ok := workStatus.(*unstructured.Unstructured)
 	if !ok {
@@ -151,11 +153,13 @@ func GetWorkStatusSourceRef(workStatus runtime.Object) (*SourceRef, error) {
 	}, nil
 }
 
+// KeyFromSourceRefAndWecName creates a unique string key from a SourceRef and a WEC name.
 func KeyFromSourceRefAndWecName(sourceRef *SourceRef, wecName string) string {
 	return fmt.Sprintf("%s/%s/%s/%s/%s/%s", sourceRef.Group, sourceRef.Version, sourceRef.Resource,
 		sourceRef.Kind, sourceRef.Name, wecName)
 }
 
+// SourceRefFromObjectIdentifier creates a SourceRef corresponding to an ObjectIdentifier.
 func SourceRefFromObjectIdentifier(objIdentifier ObjectIdentifier) *SourceRef {
 	return &SourceRef{
 		Group:     objIdentifier.GVK.Group,
@@ -167,6 +171,7 @@ func SourceRefFromObjectIdentifier(objIdentifier ObjectIdentifier) *SourceRef {
 	}
 }
 
+// ObjectIdentifierFromSourceRef creates an ObjectIdentifier from a SourceRef.
 func ObjectIdentifierFromSourceRef(sourceRef *SourceRef) ObjectIdentifier {
 	return ObjectIdentifier{
 		GVK: schema.GroupVersionKind{
@@ -179,6 +184,7 @@ func ObjectIdentifierFromSourceRef(sourceRef *SourceRef) ObjectIdentifier {
 	}
 }
 
+// GetWorkStatusStatus extracts the status subresource map from a WorkStatus runtime object.
 func GetWorkStatusStatus(workStatus runtime.Object) (map[string]interface{}, error) {
 	obj, ok := workStatus.(*unstructured.Unstructured)
 	if !ok {
@@ -198,6 +204,7 @@ func GetWorkStatusStatus(workStatus runtime.Object) (map[string]interface{}, err
 	return status, nil
 }
 
+// CheckWorkStatusPresence checks if the WorkStatus API resource is present in the cluster.
 func CheckWorkStatusPresence(config *rest.Config) bool {
 	discoveryClient, err := discovery.NewDiscoveryClientForConfig(config)
 	if err != nil {
@@ -213,6 +220,7 @@ func CheckWorkStatusPresence(config *rest.Config) bool {
 	return CheckAPIisPresent(discoveryClient, gvr)
 }
 
+// CheckAPIisPresent checks if the specified GroupVersionResource is present via discovery.
 func CheckAPIisPresent(dc *discovery.DiscoveryClient, gvr schema.GroupVersionResource) bool {
 	resourceList, err := dc.ServerResourcesForGroupVersion(gvr.GroupVersion().String())
 	if err != nil {
@@ -228,6 +236,7 @@ func CheckAPIisPresent(dc *discovery.DiscoveryClient, gvr schema.GroupVersionRes
 	return false
 }
 
+// CreateStatusPatch creates an unstructured patch containing only the APIVersion, Kind, Name, Namespace, and status.
 func CreateStatusPatch(unstrObj *unstructured.Unstructured, status map[string]interface{}) *unstructured.Unstructured {
 	patchedObj := &unstructured.Unstructured{}
 	patchedObj.SetAPIVersion(unstrObj.GetAPIVersion())
@@ -238,6 +247,7 @@ func CreateStatusPatch(unstrObj *unstructured.Unstructured, status map[string]in
 	return patchedObj
 }
 
+// PatchStatus applies a status patch to an unstructured object using the provided dynamic client.
 func PatchStatus(ctx context.Context, unstrObj *unstructured.Unstructured, status map[string]interface{},
 	namespace string, gvr schema.GroupVersionResource, dynamicClient dynamic.Interface) error {
 	logger := klog.FromContext(ctx)
@@ -260,6 +270,7 @@ func PatchStatus(ctx context.Context, unstrObj *unstructured.Unstructured, statu
 	return err
 }
 
+// DynamicForResource returns a DynamicResourceInterface for the given GroupVersionResource and namespace.
 func DynamicForResource(dynClient dynamic.Interface, gvr schema.GroupVersionResource, namespace string) dynamic.ResourceInterface {
 	nsblIfc := dynClient.Resource(gvr)
 	if namespace == metav1.NamespaceNone {

--- a/pkg/util/unstructured.go
+++ b/pkg/util/unstructured.go
@@ -270,7 +270,8 @@ func PatchStatus(ctx context.Context, unstrObj *unstructured.Unstructured, statu
 	return err
 }
 
-// DynamicForResource returns a DynamicResourceInterface for the given GroupVersionResource and namespace.
+// DynamicForResource provides a convenient helper to obtain a dynamic.ResourceInterface.
+// It exists to avoid repetitive client setup and namespace handling logic across controllers.
 func DynamicForResource(dynClient dynamic.Interface, gvr schema.GroupVersionResource, namespace string) dynamic.ResourceInterface {
 	nsblIfc := dynClient.Resource(gvr)
 	if namespace == metav1.NamespaceNone {


### PR DESCRIPTION
## Summary
This PR adds missing standard godoc comments to all exported functions in `pkg/util/unstructured.go` and `pkg/util/string-filter.go`. 

This satisfies standard Go linting rules and continues the cleanup effort of the `pkg/util` package to ensure it is properly documented and maintainable.

## Related issue(s)
N/A - codebase documentation cleanup
