### PR TITLE
fix: correct typos in Go source code comments

### DIFF
--- a/pkg/binding/binding-controller.go
+++ b/pkg/binding/binding-controller.go
@@ -230,7 +230,7 @@ func NewController(parentLogger logr.Logger,
 		apiResourceLists, wdsName, allowedGroupsSet, workloadObsserver)
 }
 
-// doDiscovery contains the exact one occurence of ServerPreferredResources() in this repository.
+// doDiscovery contains the exact one occurrence of ServerPreferredResources() in this repository.
 // doDiscovery is supposed to be invoked exactly one time during the lifecycle of a binding controller.
 // That is, full API discovery against the WDS is done exactly one time during the lifecycle of a binding controller.
 // doDiscovery also returns the number of successfully discovered GVRs.

--- a/pkg/status/multiwec-status.go
+++ b/pkg/status/multiwec-status.go
@@ -86,7 +86,7 @@ func (c *Controller) handleMultiWEC(ctx context.Context, wObjID util.ObjectIdent
 		return nil
 	}
 
-	// Aggregate for known kind that Kubestellar handle specially which are mainly kind available as built-in healthchecks for Argocd
+	// Aggregate for known kinds that KubeStellar handles specially, which are mainly kinds available as built-in healthchecks for ArgoCD
 	var aggregatedStatus map[string]any
 	var errAggregate error
 


### PR DESCRIPTION
## Summary
- Fix `occurence` → `occurrence` in `pkg/binding/binding-controller.go`
- Fix `Argocd` → `ArgoCD` and `Kubestellar handle` → `KubeStellar handles` in `pkg/status/multiwec-status.go`

## Changes
| File | Before | After |
|------|--------|-------|
| `pkg/binding/binding-controller.go:233` | `occurence` | `occurrence` |
| `pkg/status/multiwec-status.go:89` | `Kubestellar handle...Argocd` | `KubeStellar handles...ArgoCD` |

## Test
- [x] No code changes, only comment/documentation fixes
- [x] Verified each fix addresses actual typos

Signed-off-by: Akanksha Trehun <magic-peach@users.noreply.github.com>