### PR TITLE
fix: correct typos in documentation

### DIFF
--- a/monitoring/README.md
+++ b/monitoring/README.md
@@ -184,7 +184,7 @@ a) API Server Monitoring: input into the following text boxes.
 
     <img src="images/apiserver-monitoring.png" width="60%" height="80%" title="apiserver-monitoring"> 
 
-To monitor a WDS space (e.g., wds1) use the following combination of `NS/APIService` parameters: `NS: wds1-system` and `APIService: wds1`. Likewise, to monitor a ITS space (e.g., its1): `NS: its1-system` and `APIService: vcluster`
+To monitor a WDS space (e.g., wds1) use the following combination of `NS/APIService` parameters: `NS: wds1-system` and `APIService: wds1`. Likewise, to monitor an ITS space (e.g., its1): `NS: its1-system` and `APIService: vcluster`
 
 **Note**: 
 - You can also use the following combination of `NS/APIService` values to monitor the apiserver of the hosting cluster or a WEC cluster: `NS: default` and `APIService: apiserver`
@@ -258,7 +258,7 @@ To monitor the KubeStellar controllers in a WDS space (e.g., wds1) or ITS space 
 - `NS: wds1-system` and `KSController: kubestellar-controller-manager-metrics-service`
 - `NS: wds1-system` and `KSController: ks-transport-controller`
 
-Likewise, to monitor the KubeStellar controller in a ITS space and WEC (e.g., its1): `NS: its1-system` and `KSController: status-addon-controller` & `NS: open-cluster-management-agent-addon` and `KSController: status-agent-controller`.
+Likewise, to monitor the KubeStellar controller in an ITS space and WEC (e.g., its1): `NS: its1-system` and `KSController: status-addon-controller` & `NS: open-cluster-management-agent-addon` and `KSController: status-agent-controller`.
 
 Note: 
 - Use the following commands to obtain the IP address of the KubeStellar controllers in the WDS (e.g., `wds1`) and ITS (e.g., `its1-system`) spaces and WEC (e.g.,`cluster1`):

--- a/test/e2e/performance/README.md
+++ b/test/e2e/performance/README.md
@@ -1,7 +1,7 @@
 # Kubestellar performance regression testing
 This is a simple performance test that aims to identify major regressions. 
 
-The test adds a deployment to the WDS and measures the cumulative time it takes to create the WDS workload object, the Binding object, the ManifestWork object, and the deployment object on the WEC. The starting time is just prior to adding the workload to the WDS and the end time is just after the object is observed on the WEC. The timings are obtained from the objects creation timestamp which have seconds granularity. We expect this test to run on VMs and and anything below seconds is likely just noise. 
+The test adds a deployment to the WDS and measures the cumulative time it takes to create the WDS workload object, the Binding object, the ManifestWork object, and the deployment object on the WEC. The starting time is just prior to adding the workload to the WDS and the end time is just after the object is observed on the WEC. The timings are obtained from the objects' creation timestamp which have seconds granularity. We expect this test to run on VMs and anything below seconds is likely just noise.
 
 This is what the results look like:
 

--- a/test/scale-infra/INSTRUCTIONS.md
+++ b/test/scale-infra/INSTRUCTIONS.md
@@ -48,7 +48,7 @@ As an alternative to the quick-start deployment bootstrapping instructions, you 
     ansible-playbook -i .data/${REGION}_${VPC}/hosts_core deploy_ks_core.yaml --ssh-common-args="-o StrictHostKeyChecking=no" -e "region=$REGION vpc_name=$VPC cluster_name=$CLUSTER_NAME ks_release=$KS_RELEASE"
     ```
 
-    You can use the variable `ks_release` to specify the KubeStellar release. Kubestellar is deployed using the [KS helmchart](https://github.com/kubestellar/kubestellar/tree/release-0.26.0/core-chart) configured with a ITS of type host. 
+    You can use the variable `ks_release` to specify the KubeStellar release. Kubestellar is deployed using the [KS helm chart](https://github.com/kubestellar/kubestellar/tree/release-0.26.0/core-chart) configured with an ITS of type host.
 
     Upon completion of the script's execution, a kubeconfig file is generated at `.data/${REGION}_${VPC}/admin.conf` to access the Kubernetes cluster and the control plane components for KubeStellar, for example:
     
@@ -156,7 +156,7 @@ As an alternative to the quick-start deployment bootstrapping instructions, you 
     ansible-playbook -i .data/${REGION}_${VPC}/hosts_wec deploy_ks_wec.yaml --ssh-common-args="-o StrictHostKeyChecking=no" -e "region=$REGION vpc_name=$VPC num_wecs=1"
     ```
 
-    Use the input paramater `num_wecs` to specify the number of kind clusters to be created for each WEC Hosting Instances. The above command creates kind WEC clusters and connects them to the KubeStellar core cluster created in step 1. Furthermore, it attaches a [KWOK](https://github.com/kubernetes-sigs/kwok) fake node to each kind cluster.
+    Use the input parameter `num_wecs` to specify the number of kind clusters to be created for each WEC Hosting Instances. The above command creates kind WEC clusters and connects them to the KubeStellar core cluster created in step 1. Furthermore, it attaches a [KWOK](https://github.com/kubernetes-sigs/kwok) fake node to each kind cluster.
 
 
     c) Access the WEC kind clusters from Ansible control machine:

--- a/test/scale-infra/README.md
+++ b/test/scale-infra/README.md
@@ -58,7 +58,7 @@ Starting from a local directory containing the git repo, do the following:
     ./deploy_ks_cp_infra.sh --cluster-name $CLUSTER_NAME --region $REGION --vpc-name $VPC --k8s-num-workers $NUM_WORKER_NODES --instances-type $EC2_INSTANCE_TYPE --aws-key-name $EC2_SSH_PUBLIC_KEY --arch $ARCH --ec2-image-id $EC2_AMI --ks-release $KS_RELEASE
     ```
 
-    The above command creates the required AWS infrastructure including a VPC, security groups and EC2 instances. Then, it creates a Kubernetes cluster deployed using Kubeadm. Lastly, it deploys the KubeStellar core components. You can use the flag `--ks-release` to specify the KubeStellar release. Kubestellar is deployed using the [KS helmchart](https://github.com/kubestellar/kubestellar/tree/release-0.26.0/core-chart) configured with a ITS of type host. 
+    The above command creates the required AWS infrastructure including a VPC, security groups and EC2 instances. Then, it creates a Kubernetes cluster deployed using Kubeadm. Lastly, it deploys the KubeStellar core components. You can use the flag `--ks-release` to specify the KubeStellar release. Kubestellar is deployed using the [KS helm chart](https://github.com/kubestellar/kubestellar/tree/release-0.26.0/core-chart) configured with an ITS of type host.
 
     Use the flag `--vpc-name` to specify the name for the [AWS virtual private cloud](https://docs.aws.amazon.com/vpc/latest/userguide/what-is-amazon-vpc.html) to deploy your infrastructure in a logically isolated virtual network: *We highly advise utilizing a unique name or the AWS IAM user ID as the identifier for your VPC*. Furthermore, use the flag `--ec2-image-id` to specify the [Amazon machine image ID](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/AMIs.html), keeping in mind that it is region-specific.
 
@@ -176,7 +176,7 @@ Starting from a local directory containing the git repo, do the following:
     ansible-playbook -i .data/${REGION}_${VPC}/hosts_wec deploy_ks_wec.yaml --ssh-common-args="-o StrictHostKeyChecking=no" -e "region=$REGION vpc_name=$VPC num_wecs=1"
     ```
 
-    Use the input paramater `num_wecs` to specify the number of kind clusters to be created for each WEC Hosting Instances. The above command creates kind WEC clusters and connects them to the KubeStellar core cluster created in step 1. Furthermore, it attaches a [KWOK](https://github.com/kubernetes-sigs/kwok) fake node to each kind cluster. 
+    Use the input parameter `num_wecs` to specify the number of kind clusters to be created for each WEC Hosting Instances. The above command creates kind WEC clusters and connects them to the KubeStellar core cluster created in step 1. Furthermore, it attaches a [KWOK](https://github.com/kubernetes-sigs/kwok) fake node to each kind cluster.
 
     c) Access the WEC kind clusters from Ansible control machine:
 


### PR DESCRIPTION
## Summary
- Fix `paramater` → `parameter` in scale-infra docs
- Fix `a ITS` → `an ITS` in scale-infra and monitoring docs
- Fix `helmchart` → `helm chart` in scale-infra docs
- Fix `objects creation` → `objects' creation` in performance README
- Fix duplicate `and and` in performance README

## Changes
| File | Fix |
|------|-----|
| `test/scale-infra/INSTRUCTIONS.md:159` | `paramater` → `parameter` |
| `test/scale-infra/README.md:179` | `paramater` → `parameter` |
| `test/scale-infra/INSTRUCTIONS.md:51` | `a ITS` → `an ITS`, `helmchart` → `helm chart` |
| `test/scale-infra/README.md:61` | `a ITS` → `an ITS`, `helmchart` → `helm chart` |
| `test/e2e/performance/README.md:4` | `objects creation` → `objects' creation`, `and and` → `and` |
| `monitoring/README.md:187` | `a ITS` → `an ITS` |
| `monitoring/README.md:261` | `a ITS` → `an ITS` |

## Test
- [x] No code changes, only documentation fixes
- [x] Verified each fix addresses actual typos

Signed-off-by: Akanksha Trehun <magic-peach@users.noreply.github.com>