### PR TITLE
chore: remove commented-out dead code

### DIFF
--- a/cmd/kubectl-rbac-flatten/main.go
+++ b/cmd/kubectl-rbac-flatten/main.go
@@ -46,8 +46,6 @@ import (
 	"github.com/kubestellar/kubestellar/pkg/util"
 )
 
-//const noNamespace = "**"
-
 type NamespacedName = apimachtypes.NamespacedName
 
 func main() {

--- a/pkg/util/resources.go
+++ b/pkg/util/resources.go
@@ -23,7 +23,6 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 
 	"github.com/kubestellar/kubestellar/api/control/v1alpha1"
-	//"k8s.io/apiextensions-apiserver/pkg/apis/apiextensions"
 )
 
 // ParseAPIGroupsString takes a comma separated string list of api groups in the form of


### PR DESCRIPTION
## Summary
- Remove duplicate commented-out import in `pkg/util/resources.go`
- Remove unused commented-out constant `noNamespace` in `cmd/kubectl-rbac-flatten/main.go`

## Changes
| File | Change |
|------|--------|
| `pkg/util/resources.go:26` | Remove `//\t"k8s.io/apiextensions-apiserver/pkg/apis/apiextensions"` (duplicate of line 22) |
| `cmd/kubectl-rbac-flatten/main.go:49` | Remove `//const noNamespace = "**"` (unused dead code) |

## Test
- [x] No functional changes, only dead code removal
- [x] Verified the commented-out code is not referenced anywhere

Signed-off-by: Akanksha Trehun <magic-peach@users.noreply.github.com>