### PR TITLE
refactor: simplify redundant code patterns

### DIFF
--- a/pkg/binding/binding-controller.go
+++ b/pkg/binding/binding-controller.go
@@ -630,11 +630,7 @@ func shouldSkipUpdate(old, new interface{}) bool {
 	oldMObj := old.(metav1.Object)
 	newMObj := new.(metav1.Object)
 	// do not enqueue update events for objects that have not changed
-	if newMObj.GetResourceVersion() == oldMObj.GetResourceVersion() {
-		return true
-	}
-
-	return false
+	return newMObj.GetResourceVersion() == oldMObj.GetResourceVersion()
 }
 
 // We only start informers on resources that support both watch and list

--- a/pkg/binding/binding.go
+++ b/pkg/binding/binding.go
@@ -157,9 +157,8 @@ func (c *Controller) updateOrCreateBinding(ctx context.Context, bdg *v1alpha1.Bi
 
 			logger.V(2).Info("created binding", "name", bdg.GetName(), "resourceVersion", bdgEcho.ResourceVersion)
 			return nil
-		} else {
-			return fmt.Errorf("failed to update binding: %w", err)
 		}
+		return fmt.Errorf("failed to update binding: %w", err)
 	}
 
 	logger.V(2).Info("updated binding", "name", bdg.GetName(), "resourceVersion", bdgEcho.ResourceVersion)

--- a/pkg/binding/bindingpolicy-resolver.go
+++ b/pkg/binding/bindingpolicy-resolver.go
@@ -351,11 +351,7 @@ func (resolver *bindingPolicyResolver) SetDestinations(bindingPolicyKey string,
 // ResolutionExists returns true if a resolution is associated with the
 // given bindingpolicy key.
 func (resolver *bindingPolicyResolver) ResolutionExists(bindingPolicyKey string) bool {
-	if resolver.getResolution(bindingPolicyKey) == nil {
-		return false
-	}
-
-	return true
+	return resolver.getResolution(bindingPolicyKey) != nil
 }
 
 // GetReportedStateRequestForObject returns four things.

--- a/pkg/status/status-controller.go
+++ b/pkg/status/status-controller.go
@@ -56,7 +56,7 @@ const (
 	originWdsLabelKey   = "transport.kubestellar.io/originWdsName"
 )
 
-// Controller watches workstatues and checks whether the corresponding
+// Controller watches WorkStatuses and checks whether the corresponding
 // workload object asks for the singleton status returning. If yes,
 // the full status will be copied to the workload object in WDS.
 type Controller struct {

--- a/pkg/status/statuscollector.go
+++ b/pkg/status/statuscollector.go
@@ -153,10 +153,9 @@ func (c *Controller) updateStatusCollectorErrors(ctx context.Context, statusColl
 			logger.V(4).Info("StatusCollector not found (status updating skipped)",
 				"ns", statusCollector.Namespace, "name", statusCollector.Name)
 			return nil
-		} else {
-			return fmt.Errorf("failed to update StatusCollector status (ns, name = %s, %s): %w",
-				statusCollector.Namespace, statusCollector.Name, err)
 		}
+		return fmt.Errorf("failed to update StatusCollector status (ns, name = %s, %s): %w",
+			statusCollector.Namespace, statusCollector.Name, err)
 	}
 
 	logger.V(2).Info("Updated StatusCollector status", "ns", statusCollector.Namespace,


### PR DESCRIPTION
## Summary
- Remove redundant `else` after `return` in `binding.go` and `statuscollector.go`
- Simplify `ResolutionExists` to single return statement
- Simplify `shouldSkipUpdate` to single return statement
- Fix `workstatues` typo to `WorkStatuses` in status-controller.go

## Changes
| File | Change |
|------|--------|
| `pkg/binding/binding.go:160` | Remove redundant `else` block |
| `pkg/status/statuscollector.go:156` | Remove redundant `else` block |
| `pkg/binding/bindingpolicy-resolver.go:353` | Simplify to `return resolver.getResolution(bindingPolicyKey) != nil` |
| `pkg/binding/binding-controller.go:633` | Simplify to `return newMObj.GetResourceVersion() == oldMObj.GetResourceVersion()` |
| `pkg/status/status-controller.go:59` | Fix `workstatues` → `WorkStatuses` |

## Test
- [x] No functional changes, only code simplification and typo fix
- [x] Verified all simplifications preserve existing behavior

Signed-off-by: Akanksha Trehun <magic-peach@users.noreply.github.com>