### PR TITLE
📖 docs: add missing godocs in pkg/metrics and pkg/client

### DIFF
--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -29,6 +29,7 @@ import (
 	controlv1alpha1 "github.com/kubestellar/kubestellar/api/control/v1alpha1"
 )
 
+// GetClient creates and returns a new controller-runtime client with the required schemes registered.
 func GetClient() *client.Client {
 	logger := klog.Background().WithName("client")
 

--- a/pkg/metrics/client.go
+++ b/pkg/metrics/client.go
@@ -64,18 +64,21 @@ func GVRString(gvr schema.GroupVersionResource) string {
 
 type RegisterFn = func(k8smetrics.Registerable) error
 
+// Must panics if the provided error is not nil.
 func Must(err error) {
 	if err != nil {
 		panic(err)
 	}
 }
 
+// MustRegister calls Register on each provided item and panics on error.
 func MustRegister(reg RegisterFn, registerable ...interface{ Register(RegisterFn) error }) {
 	for _, ra := range registerable {
 		Must(ra.Register(reg))
 	}
 }
 
+// MustRegisterAbles registers multiple k8smetrics.Registerable items and panics on error.
 func MustRegisterAbles(reg RegisterFn, registerable ...k8smetrics.Registerable) {
 	for _, ra := range registerable {
 		Must(reg(ra))
@@ -108,6 +111,7 @@ type clientResourceMetrics struct {
 
 var _ MultiSpaceClientMetrics = &multiSpaceClientMetrics{}
 
+// NewMultiSpaceClientMetrics creates a new multiSpaceClientMetrics for tracking API call latency.
 func NewMultiSpaceClientMetrics() *multiSpaceClientMetrics {
 	return &multiSpaceClientMetrics{
 		CallLatency: k8smetrics.NewHistogramVec(&k8smetrics.HistogramOpts{
@@ -151,6 +155,7 @@ func (crm *clientResourceMetrics) ResourceRecord(method string, err error, laten
 	crm.Base.Record(crm.Resource, method, err, latency)
 }
 
+// ErrorShort returns a concise string representation of an error for metrics tagging.
 func ErrorShort(err error) string {
 	if err == nil {
 		return ""

--- a/pkg/metrics/sampler.go
+++ b/pkg/metrics/sampler.go
@@ -31,6 +31,7 @@ type Sampler interface {
 	Register(RegisterFn) error
 }
 
+// NewSampler creates a Sampler that evaluates the read function to produce a gauge value.
 func NewSampler(read func() float64, opts *k8smetrics.KubeOpts) Sampler {
 	return &sampler{
 		Read:  read,
@@ -38,6 +39,7 @@ func NewSampler(read func() float64, opts *k8smetrics.KubeOpts) Sampler {
 	}
 }
 
+// NewListLenSampler creates a Sampler that reports the length of a slice returned by getList.
 func NewListLenSampler[Elt any](getList func() []Elt, opts *k8smetrics.KubeOpts) Sampler {
 	return NewSampler(func() float64 { return float64(len(getList())) }, opts)
 }

--- a/pkg/metrics/wrap_client.go
+++ b/pkg/metrics/wrap_client.go
@@ -109,10 +109,12 @@ type wrappedClientMetrics[Single MRObject, List runtime.Object] struct {
 
 var _ MeasuredClientModNamespace[MRObject, MRObject] = &wrappedClientMetrics[MRObject, MRObject]{}
 
+// NewWrappedBasicClusterScopedClient creates a measured BasicClientModNamespace for a cluster-scoped resource.
 func NewWrappedBasicClusterScopedClient[Single MRObject, List runtime.Object](cm ClientMetrics, gvr schema.GroupVersionResource, inner BasicClientModNamespace[Single, List]) MeasuredBasicClientModNamespace[Single, List] {
 	return &wrappedBasicClientMetrics[Single, List]{cm.ResourceMetrics(gvr), inner}
 }
 
+// NewWrappedClusterScopedClient creates a measured ClientModNamespace for a cluster-scoped resource.
 func NewWrappedClusterScopedClient[Single MRObject, List runtime.Object](cm ClientMetrics, gvr schema.GroupVersionResource, inner ClientModNamespace[Single, List]) MeasuredClientModNamespace[Single, List] {
 	return &wrappedClientMetrics[Single, List]{
 		wrappedBasicClientMetrics: wrappedBasicClientMetrics[Single, List]{cm.ResourceMetrics(gvr), inner},
@@ -120,6 +122,7 @@ func NewWrappedClusterScopedClient[Single MRObject, List runtime.Object](cm Clie
 	}
 }
 
+// NewWrappedBasicNamespacedClient creates a measured BasicNamespacedClient for a namespace-scoped resource.
 func NewWrappedBasicNamespacedClient[Single MRObject, List runtime.Object](cm ClientMetrics, gvr schema.GroupVersionResource, namespaceFn func(string) BasicClientModNamespace[Single, List]) MeasuredBasicNamespacedClient[Single, List] {
 	return &wrappedBasicNamespacingMetrics[Single, List]{
 		namespaceFn:           namespaceFn,
@@ -127,6 +130,7 @@ func NewWrappedBasicNamespacedClient[Single MRObject, List runtime.Object](cm Cl
 	}
 }
 
+// NewWrappedNamespacedClient creates a measured NamespacedClient for a namespace-scoped resource.
 func NewWrappedNamespacedClient[Single MRObject, List runtime.Object](cm ClientMetrics, gvr schema.GroupVersionResource, namespaceFn func(string) ClientModNamespace[Single, List]) MeasuredNamespacedClient[Single, List] {
 	return &wrappedNamespacingMetrics[Single, List]{
 		wrappedBasicNamespacingMetrics: wrappedBasicNamespacingMetrics[Single, List]{cm.ResourceMetrics(gvr), func(ns string) BasicClientModNamespace[Single, List] { return namespaceFn(ns) }},

--- a/pkg/metrics/wrap_dynamic.go
+++ b/pkg/metrics/wrap_dynamic.go
@@ -48,6 +48,7 @@ type wrappedDynamicModNamespace struct {
 	Inner dynamic.ResourceInterface
 }
 
+// NewWrappedDynamicClient wraps a dynamic client to provide metrics for API calls.
 func NewWrappedDynamicClient(clientMetrics ClientMetrics, inner dynamic.Interface) MeasuredDynamicClient {
 	return &wrappedDynamicClient{
 		Inner:         inner,


### PR DESCRIPTION
## Summary
This PR adds missing standard godoc comments to exported functions in `pkg/metrics` and `pkg/client`.

This satisfies standard Go linting rules and continues the cleanup effort to ensure the codebase is properly documented and maintainable.

## Related issue(s)
N/A - codebase documentation cleanup
