### PR TITLE
📖 docs: add missing godocs in pkg/abstract and pkg/ctrlutil

### DIFF
--- a/pkg/abstract/map-lock.go
+++ b/pkg/abstract/map-lock.go
@@ -31,6 +31,7 @@ type MapToLockedLocker[Key, Val any] struct {
 
 var _ MapToLocked[func() int, func() bool] = &MapToLockedLocker[func() int, func() bool]{}
 
+// NewMapToLockedLocker creates a MapToLockedLocker wrapping an inner MapToLocked with the provided mutex.
 func NewMapToLockedLocker[Key, Val any](mutex *sync.RWMutex, inner MapToLocked[Key, Val]) *MapToLockedLocker[Key, Val] {
 	if mutex == nil {
 		mutex = &sync.RWMutex{}

--- a/pkg/abstract/map-to-comparable.go
+++ b/pkg/abstract/map-to-comparable.go
@@ -35,6 +35,7 @@ type IndexedMapToComparable[Key, Val comparable] struct {
 	reverse MutableMap[Val, sets.Set[Key]]
 }
 
+// NewPrimitiveMapToComparable creates an IndexedMapToComparable using built-in maps for underlying storage.
 func NewPrimitiveMapToComparable[Key, Val comparable]() *IndexedMapToComparable[Key, Val] {
 	return &IndexedMapToComparable[Key, Val]{
 		forward: AsPrimitiveMap(map[Key]Val{}),
@@ -95,6 +96,7 @@ type LockedMapToComparable[Key, Val comparable] struct {
 	inverse MapToLocked[Val, sets.Set[Key]]
 }
 
+// NewLockedMapToComparable creates a thread-safe LockedMapToComparable wrapping a MutableMapToComparable.
 func NewLockedMapToComparable[Key, Val comparable](lock *sync.RWMutex, inner MutableMapToComparable[Key, Val]) *LockedMapToComparable[Key, Val] {
 	if lock == nil {
 		lock = new(sync.RWMutex)

--- a/pkg/abstract/primitive-map-ops.go
+++ b/pkg/abstract/primitive-map-ops.go
@@ -34,6 +34,7 @@ func PrimitiveMapHas[Key comparable, Val any](rep map[Key]Val) func(Key) bool {
 	}
 }
 
+// DropOK11 wraps a function that returns (value, bool) into one that just returns the value.
 func DropOK11[Domain1, Range1 any](base func(Domain1) (Range1, bool)) func(Domain1) Range1 {
 	return func(dom1 Domain1) Range1 {
 		rng1, _ := base(dom1)
@@ -41,6 +42,7 @@ func DropOK11[Domain1, Range1 any](base func(Domain1) (Range1, bool)) func(Domai
 	}
 }
 
+// PrimitiveMapEqual compares two primitive maps for equality.
 func PrimitiveMapEqual[Key, Val comparable](map1, map2 map[Key]Val) bool {
 	if len(map1) != len(map2) {
 		return false
@@ -75,6 +77,7 @@ func PrimitiveMapSafeValMap[Key comparable, Val, Mapped any](lock *sync.RWMutex,
 	return PrimitiveMapValMap(source, mapper)
 }
 
+// PrimitiveMapKeySlice returns a slice containing all keys from the provided map.
 func PrimitiveMapKeySlice[Key comparable, Val any](rep map[Key]Val) []Key {
 	keys := make([]Key, 0, len(rep))
 	for key := range rep {

--- a/pkg/abstract/slices.go
+++ b/pkg/abstract/slices.go
@@ -44,6 +44,7 @@ func NewSliceByFilter[Elt any](input []Elt, good func(Elt) bool) []Elt {
 	return newSlice
 }
 
+// SliceMap creates a new slice by applying a function to each element of the input slice.
 func SliceMap[Domain, Range any](slice []Domain, fn func(Domain) Range) []Range {
 	if slice == nil {
 		return nil
@@ -55,6 +56,7 @@ func SliceMap[Domain, Range any](slice []Domain, fn func(Domain) Range) []Range 
 	return ans
 }
 
+// SliceToPrimitiveMap creates a map from a slice using the provided key and value functions.
 func SliceToPrimitiveMap[Domain, Range any, Key comparable](slice []Domain, keyFn func(Domain) Key,
 	ValFn func(Domain) Range) map[Key]Range {
 	if slice == nil {
@@ -68,6 +70,7 @@ func SliceToPrimitiveMap[Domain, Range any, Key comparable](slice []Domain, keyF
 	return ans
 }
 
+// SliceMapToK8sSet creates a Kubernetes sets.Set from a slice using a mapping function.
 func SliceMapToK8sSet[Domain any, Range comparable](slice []Domain, fn func(Domain) Range) sets.Set[Range] {
 	if slice == nil {
 		return nil

--- a/pkg/ctrlutil/kubeconfig.go
+++ b/pkg/ctrlutil/kubeconfig.go
@@ -47,10 +47,12 @@ const (
 	ErrMultipleControlPlanes = "more than one control plane of type %s was found and no name was specified"
 )
 
+// GetWDSKubeconfig retrieves the REST config and name for a Workload Description Space (WDS) control plane.
 func GetWDSKubeconfig(logger logr.Logger, wdsName string) (*rest.Config, string, error) {
 	return getRestConfig(logger, wdsName, ControlPlaneTypeWDS)
 }
 
+// GetITSKubeconfig retrieves the REST config and name for an Inventory and Transport Space (ITS) control plane.
 func GetITSKubeconfig(logger logr.Logger, itsName string) (*rest.Config, string, error) {
 	return getRestConfig(logger, itsName, ControlPlaneTypeITS)
 }


### PR DESCRIPTION
## Summary
This PR adds missing standard godoc comments to exported functions in `pkg/abstract` and `pkg/ctrlutil`.

This continues the effort from recent PRs to resolve linter warnings regarding missing godocs on exported functions, improving codebase readability and maintainability.

## Related issue(s)
N/A - codebase documentation cleanup
