### PR TITLE
📖 docs: add missing godocs in pkg/controller and pkg/ocm

### DIFF
--- a/pkg/controller/run.go
+++ b/pkg/controller/run.go
@@ -31,6 +31,7 @@ import (
 	ksopts "github.com/kubestellar/kubestellar/options"
 )
 
+// InitialContext creates a new root context and sets up signal handling to cancel it.
 func InitialContext() (context.Context, func()) {
 	ctx, cancel := context.WithCancel(context.Background())
 	sigChan := make(chan os.Signal, 2)
@@ -44,6 +45,7 @@ func InitialContext() (context.Context, func()) {
 	return ctx, cancel
 }
 
+// Start initializes auxiliary services like health probes, metrics, and profiling for the controller.
 func Start(ctx context.Context, processOpts ksopts.ProcessOptions) {
 	logger := klog.FromContext(ctx)
 	if processOpts.HealthProbeBindAddr != "" {
@@ -75,6 +77,7 @@ func Start(ctx context.Context, processOpts ksopts.ProcessOptions) {
 	}()
 }
 
+// HappyDumbHandler is a simple HTTP handler that always returns an "ok" response.
 func HappyDumbHandler(resp http.ResponseWriter, req *http.Request) {
 	resp.Write([]byte("ok\r\n"))
 }

--- a/pkg/ocm/ocm.go
+++ b/pkg/ocm/ocm.go
@@ -28,6 +28,7 @@ import (
 	ksmetrics "github.com/kubestellar/kubestellar/pkg/metrics"
 )
 
+// FindClustersBySelectors retrieves a set of managed cluster names that match any of the provided label selectors.
 func FindClustersBySelectors(ctx context.Context, client ksmetrics.ClientModNamespace[*managedclusterapi.ManagedCluster, *managedclusterapi.ManagedClusterList], selectors []metav1.LabelSelector) (sets.Set[string], error) {
 	// in order to support OR between label selectors in a straightforward manner, we perform List for each selector.
 	// additionally, to support complex selectors (such as set selectors), we avoid conversion to maps.


### PR DESCRIPTION
## Summary
This PR adds missing standard godoc comments to exported functions in `pkg/controller` and `pkg/ocm`.

This continues the effort from recent PRs to resolve linter warnings regarding missing godocs on exported functions, improving codebase readability and maintainability.

## Related issue(s)
N/A - codebase documentation cleanup
