### PR TITLE
🌱 status: tighten CombinedStatus workstatus re-evaluation trigger

### DIFF
--- a/pkg/status/combinedstatus-resolution.go
+++ b/pkg/status/combinedstatus-resolution.go
@@ -182,20 +182,24 @@ func (c *combinedStatusResolution) setCollectionDestinations(destinationsSet set
 // and the specs in it are immutable.
 // The given map has an entry for every relevant StatusCollector name,
 // but a `nil` spec pointer if the collector does not exist now.
-// The function returns a tuple (removedSome, addedSome):
+// The function returns a tuple (removedSome, addedSome, evalNeeded):
 //
 // - removedSome: true if one or more statuscollectors were removed.
 //
 // - addedSome: true if one or more statuscollectors were added.
-func (c *combinedStatusResolution) setStatusCollectors(statusCollectorNameToSpec map[string]*v1alpha1.StatusCollectorSpec) (bool, bool) {
+//
+// - evalNeeded: true if workstatuses should be re-evaluated because an
+// evaluable statuscollector was added or its spec changed. Adding a
+// placeholder for a missing StatusCollector does not set evalNeeded.
+func (c *combinedStatusResolution) setStatusCollectors(statusCollectorNameToSpec map[string]*v1alpha1.StatusCollectorSpec) (bool, bool, bool) {
 	c.Lock()
 	defer c.Unlock()
 
-	removedSome, addedSome := false, false
+	removedSome, addedSome, evalNeeded := false, false, false
 
 	// remove entries for collectors that are not relevant anymore and update the
 	// statuscollector data that are. If one of the latter is updated, mark it as added
-	for statusCollectorName, statusCollectorData := range c.StatusCollectorNameToData {
+	for statusCollectorName, scData := range c.StatusCollectorNameToData {
 		statusCollectorSpec, ok := statusCollectorNameToSpec[statusCollectorName]
 		if !ok {
 			delete(c.StatusCollectorNameToData, statusCollectorName)
@@ -203,9 +207,22 @@ func (c *combinedStatusResolution) setStatusCollectors(statusCollectorNameToSpec
 			continue
 		}
 
-		if statusCollectorSpec != nil && (statusCollectorData == nil || !statusCollectorSpecsMatch(statusCollectorData.collectorSpec, statusCollectorSpec)) {
-			c.StatusCollectorNameToData[statusCollectorName].collectorSpec = statusCollectorSpec
+		if statusCollectorSpec == nil {
+			continue
+		}
+		if scData == nil {
+			c.StatusCollectorNameToData[statusCollectorName] = &statusCollectorData{
+				collectorSpec: statusCollectorSpec,
+				WECToData:     make(map[string]*workStatusData),
+			}
 			addedSome = true
+			evalNeeded = true
+			continue
+		}
+		if !statusCollectorSpecsMatch(scData.collectorSpec, statusCollectorSpec) {
+			scData.collectorSpec = statusCollectorSpec
+			addedSome = true
+			evalNeeded = true
 		}
 	}
 
@@ -219,13 +236,14 @@ func (c *combinedStatusResolution) setStatusCollectors(statusCollectorNameToSpec
 					collectorSpec: statusCollectorSpec,
 					WECToData:     make(map[string]*workStatusData),
 				}
+				evalNeeded = true
 			}
 
 			addedSome = true
 		}
 	}
 
-	return removedSome, addedSome
+	return removedSome, addedSome, evalNeeded
 }
 
 // updateStatusCollector updates the status collector data in the

--- a/pkg/status/combinedstatus-resolution.go
+++ b/pkg/status/combinedstatus-resolution.go
@@ -186,11 +186,11 @@ func (c *combinedStatusResolution) setCollectionDestinations(destinationsSet set
 //
 // - removedSome: true if one or more statuscollectors were removed.
 //
-// - addedSome: true if one or more statuscollectors were added.
+// - addedSome: true if one or more statuscollectors were added or updated.
 //
 // - evalNeeded: true if workstatuses should be re-evaluated because an
-// evaluable statuscollector was added or its spec changed. Adding a
-// placeholder for a missing StatusCollector does not set evalNeeded.
+// 	 evaluable statuscollector was added or its spec changed. Adding a
+// 	 placeholder for a missing StatusCollector does not set evalNeeded.
 func (c *combinedStatusResolution) setStatusCollectors(statusCollectorNameToSpec map[string]*v1alpha1.StatusCollectorSpec) (bool, bool, bool) {
 	c.Lock()
 	defer c.Unlock()

--- a/pkg/status/combinedstatus-resolver.go
+++ b/pkg/status/combinedstatus-resolver.go
@@ -264,7 +264,7 @@ func (c *combinedStatusResolver) NoteBindingResolution(ctx context.Context, bind
 		}
 
 		// update statuscollectors
-		removedCollectors, addedCollectors := csResolution.setStatusCollectors(c.statusCollectorNameToSpecFromCache(objectData.Modulation.StatusCollectors))
+		removedCollectors, addedCollectors, collectorsNeedEvaluation := csResolution.setStatusCollectors(c.statusCollectorNameToSpecFromCache(objectData.Modulation.StatusCollectors))
 
 		// update destinations
 		removedDestinations, newDestinationsSet := csResolution.setCollectionDestinations(destinationsSet)
@@ -272,6 +272,7 @@ func (c *combinedStatusResolver) NoteBindingResolution(ctx context.Context, bind
 		logger.V(5).Info("Updating CombinedStatus resolution", "binding", bindingName, "objectId", objectIdentifier,
 			"introduced", !exists,
 			"removedCollectors", removedCollectors, "addedCollectors", addedCollectors,
+			"collectorsNeedEvaluation", collectorsNeedEvaluation,
 			"removedDestinations", removedDestinations, "newDestinationsSet", newDestinationsSet)
 
 		// should queue the combinedstatus object for syncing if lost collectors / destinations
@@ -280,9 +281,9 @@ func (c *combinedStatusResolver) NoteBindingResolution(ctx context.Context, bind
 				objectIdentifier.ObjectName.Namespace))
 		}
 
-		// should evaluate workstatuses if added/updated collectors or added destinations
-		if addedCollectors || len(newDestinationsSet) > 0 {
-			workloadIdentifiersToEvaluate.Insert(objectIdentifier) // TODO: this can be optimized through tightening
+		// should evaluate workstatuses if evaluable collectors were added/updated or destinations were added
+		if collectorsNeedEvaluation || len(newDestinationsSet) > 0 {
+			workloadIdentifiersToEvaluate.Insert(objectIdentifier)
 		}
 		return nil
 	})


### PR DESCRIPTION
## Summary

- There was a TODO in NoteBindingResolution saying we could tighten when workstatus re-evaluation runs.... this PR implements that.
- Before.... adding a placeholder for a missing StatusCollector still triggered a full re-eval across all destinations, even though there was nothing real to evaluate yet. 
Now: we only re-run when an actual collector shows up, its spec changes, or a new destination is added...
Also fixed a small edge case where promoting a nil placeholder to a real collector could’ve hit a nil pointer,, we now create the collector data properly when the spec appears..

## Related issue(s)
 // TODO: this can be optimized through tightening - was given in codebase, this PR implements it.