### PR TITLE
🐛 fix(status): prevent status-controller from silently swallowing startup errors

### DIFF
--- a/pkg/status/status-controller.go
+++ b/pkg/status/status-controller.go
@@ -202,7 +202,11 @@ func (c *Controller) Start(parentCtx context.Context, workers int, cListers chan
 	ctx := klog.NewContext(parentCtx, logger)
 	errChan := make(chan error, 1)
 	go func() {
-		errChan <- c.run(ctx, workers, cListers)
+		err := c.run(ctx, workers, cListers)
+		if err != nil {
+			logger.Error(err, "status-controller failed")
+		}
+		errChan <- err
 	}()
 
 	// check for errors at startup, after all started we let it continue


### PR DESCRIPTION
## Summary
This PR fixes a bug in `pkg/status/status-controller.go` where initialization errors could be silently swallowed.

In `Controller.Start`, the main controller loop (`c.run`) is executed inside a goroutine, and any error is sent to a buffered `errChan`. The parent function waits up to 3 seconds for an error during startup. If `c.run` fails *after* 3 seconds, the error is sent to the channel but is never handled or logged, resulting in a silent failure. This PR adds a check inside the goroutine to log any error returned by `c.run` before sending it to the channel, ensuring delayed initialization failures are captured in the logs.

## Related issue(s)
N/A - bug fix
