### PR TITLE
Replace panic() with proper error handling in HTTP server startup

### DIFF
--- a/cmd/controller-manager/main.go
+++ b/cmd/controller-manager/main.go
@@ -115,10 +115,12 @@ func main() {
 		os.Exit(1)
 	}
 
-	if err := ksctlr.Start(ctx, processOpts); err != nil {
-		setupLog.Error(err, "error starting HTTP servers")
-		os.Exit(1)
-	}
+	go func() {
+		if err := ksctlr.Start(ctx, processOpts); err != nil {
+			setupLog.Error(err, "error running HTTP servers")
+			os.Exit(1)
+		}
+	}()
 
 	spacesClientMetrics := ksmetrics.NewMultiSpaceClientMetrics()
 	ksmetrics.MustRegister(legacyregistry.Register, spacesClientMetrics)

--- a/cmd/controller-manager/main.go
+++ b/cmd/controller-manager/main.go
@@ -115,7 +115,10 @@ func main() {
 		os.Exit(1)
 	}
 
-	ksctlr.Start(ctx, processOpts)
+	if err := ksctlr.Start(ctx, processOpts); err != nil {
+		setupLog.Error(err, "error starting HTTP servers")
+		os.Exit(1)
+	}
 
 	spacesClientMetrics := ksmetrics.NewMultiSpaceClientMetrics()
 	ksmetrics.MustRegister(legacyregistry.Register, spacesClientMetrics)

--- a/pkg/controller/run.go
+++ b/pkg/controller/run.go
@@ -18,10 +18,12 @@ package controller
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 	"os"
 	"os/signal"
 	"syscall"
+	"time"
 
 	"k8s.io/apiserver/pkg/server/mux"
 	"k8s.io/apiserver/pkg/server/routes"
@@ -44,35 +46,80 @@ func InitialContext() (context.Context, func()) {
 	return ctx, cancel
 }
 
-func Start(ctx context.Context, processOpts ksopts.ProcessOptions) {
+func Start(ctx context.Context, processOpts ksopts.ProcessOptions) error {
 	logger := klog.FromContext(ctx)
+	errChan := make(chan error, 3)
+	var servers []*http.Server
+
+	// Start health probe server if address is configured
 	if processOpts.HealthProbeBindAddr != "" {
+		healthServer := &http.Server{
+			Addr:    processOpts.HealthProbeBindAddr,
+			Handler: http.HandlerFunc(HappyDumbHandler),
+		}
+		servers = append(servers, healthServer)
+
 		go func() {
-			err := http.ListenAndServe(processOpts.HealthProbeBindAddr, http.HandlerFunc(HappyDumbHandler))
-			if err != nil {
-				logger.Error(err, "Failed to serve health probes", "bindAddress", processOpts.HealthProbeBindAddr)
-				panic(err)
+			logger.Info("Starting health probe server", "bindAddress", processOpts.HealthProbeBindAddr)
+			if err := healthServer.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+				errChan <- fmt.Errorf("health probe server failed: %w", err)
 			}
 		}()
-
 	}
+
+	// Start Prometheus metrics server
+	metricsServer := &http.Server{
+		Addr:    processOpts.MetricsBindAddr,
+		Handler: legacyregistry.Handler(),
+	}
+	servers = append(servers, metricsServer)
+
 	go func() {
-		err := http.ListenAndServe(processOpts.MetricsBindAddr, legacyregistry.Handler())
-		if err != nil {
-			logger.Error(err, "Failed to serve Prometheus metrics", "bindAddress", processOpts.MetricsBindAddr)
-			panic(err)
+		logger.Info("Starting Prometheus metrics server", "bindAddress", processOpts.MetricsBindAddr)
+		if err := metricsServer.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+			errChan <- fmt.Errorf("Prometheus metrics server failed: %w", err)
 		}
 	}()
 
+	// Start pprof debug server
 	mymux := mux.NewPathRecorderMux("debug")
 	routes.Profiling{}.Install(mymux)
+	pprofServer := &http.Server{
+		Addr:    processOpts.PProfBindAddr,
+		Handler: mymux,
+	}
+	servers = append(servers, pprofServer)
+
 	go func() {
-		err := http.ListenAndServe(processOpts.PProfBindAddr, mymux)
-		if err != nil {
-			logger.Error(err, "Failure in serving /debug/pprof", "bindAddress", processOpts.PProfBindAddr)
-			panic(err)
+		logger.Info("Starting pprof debug server", "bindAddress", processOpts.PProfBindAddr)
+		if err := pprofServer.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+			errChan <- fmt.Errorf("pprof debug server failed: %w", err)
 		}
 	}()
+
+	// Handle graceful shutdown on context cancellation
+	go func() {
+		<-ctx.Done()
+		logger.Info("Shutting down HTTP servers gracefully")
+		for _, server := range servers {
+			shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			defer cancel()
+			if err := server.Shutdown(shutdownCtx); err != nil {
+				logger.Error(err, "Error shutting down server", "address", server.Addr)
+			}
+		}
+	}()
+
+	// Wait for any server error or context cancellation
+	select {
+	case err := <-errChan:
+		logger.Error(err, "HTTP server failed, initiating shutdown")
+		// Cancel context to trigger graceful shutdown
+		return err
+	case <-ctx.Done():
+		logger.Info("Context cancelled, HTTP servers shutting down")
+		return ctx.Err()
+	}
 }
 
 func HappyDumbHandler(resp http.ResponseWriter, req *http.Request) {

--- a/pkg/controller/run.go
+++ b/pkg/controller/run.go
@@ -113,8 +113,14 @@ func Start(ctx context.Context, processOpts ksopts.ProcessOptions) error {
 	// Wait for any server error or context cancellation
 	select {
 	case err := <-errChan:
-		logger.Error(err, "HTTP server failed, initiating shutdown")
-		// Cancel context to trigger graceful shutdown
+		logger.Error(err, "HTTP server failed; shutting down")
+		for _, server := range servers {
+			shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			if shutdownErr := server.Shutdown(shutdownCtx); shutdownErr != nil {
+				logger.Error(shutdownErr, "Error shutting down server", "address", server.Addr)
+			}
+			cancel()
+		}
 		return err
 	case <-ctx.Done():
 		logger.Info("Context cancelled, HTTP servers shutting down")

--- a/pkg/controller/run.go
+++ b/pkg/controller/run.go
@@ -103,11 +103,12 @@ func Start(ctx context.Context, processOpts ksopts.ProcessOptions) error {
 		logger.Info("Shutting down HTTP servers gracefully")
 		for _, server := range servers {
 			shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-			defer cancel()
 			if err := server.Shutdown(shutdownCtx); err != nil {
 				logger.Error(err, "Error shutting down server", "address", server.Addr)
 			}
+			cancel()
 		}
+		logger.Error(fmt.Errorf("context cancelled"), "Context cancelled, HTTP servers shutting down")
 	}()
 
 	// Wait for any server error or context cancellation
@@ -124,7 +125,7 @@ func Start(ctx context.Context, processOpts ksopts.ProcessOptions) error {
 		return err
 	case <-ctx.Done():
 		logger.Info("Context cancelled, HTTP servers shutting down")
-		return ctx.Err()
+		return nil
 	}
 }
 

--- a/pkg/transport/generic/cmd/generic-main.go
+++ b/pkg/transport/generic/cmd/generic-main.go
@@ -72,7 +72,12 @@ func GenericMain(transportImplementation transport.Transport) {
 		logger.Info("Command line flag", "name", flg.Name, "value", flg.Value) // log all arguments
 	})
 
-	ksctlr.Start(ctx, options.ProcessOptions)
+	go func() {
+		if err := ksctlr.Start(ctx, options.ProcessOptions); err != nil {
+			logger.Error(err, "error running HTTP servers")
+			klog.FlushAndExit(klog.ExitFlushTimeout, 1)
+		}
+	}()
 
 	// get the config for WDS
 	wdsRestConfig, err := options.WdsClientOptions.ToRESTConfig()


### PR DESCRIPTION
This PR replaces panic() calls with proper error handling in the HTTP server startup code in run.go. The previous implementation would crash the entire process when HTTP servers failed to start, which is not suitable for production environments.

## Problem
The Start() function used panic() when HTTP servers (health probe, metrics, pprof) failed to start. This caused immediate process crashes without:

1.Graceful shutdown
2.Error propagation to callers
3.Opportunity for error recovery
4.Proper cleanup of resources

## Changes
Modified run.go:
1.Changed Start() signature to return error instead of void
2.Replaced http.ListenAndServe() with http.Server instances for proper lifecycle management
3.Added error channel to communicate goroutine errors to the caller
4.Implemented graceful shutdown on context cancellation with 5-second timeout
5.Replaced all panic(err) calls with proper error propagation
6.Added informative logging for server startup and shutdown
Updated main.go:
1/Modified the call to ksctlr.Start() to handle the returned error
2.Added error logging and graceful exit if HTTP servers fail to start

#3914 