### PR TITLE
🐛 fix(binding): respect context and ListOptions in CRD informers

### DIFF
--- a/pkg/binding/crd.go
+++ b/pkg/binding/crd.go
@@ -156,10 +156,10 @@ func (c *Controller) startInformersForNewAPIResources(ctx context.Context, toSta
 		informer := cache.NewSharedIndexInformer(
 			&cache.ListWatch{
 				ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
-					return c.dynamicClient.Resource(gvr).List(context.TODO(), metav1.ListOptions{})
+					return c.dynamicClient.Resource(gvr).List(ctx, options)
 				},
 				WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
-					return c.dynamicClient.Resource(gvr).Watch(context.TODO(), metav1.ListOptions{})
+					return c.dynamicClient.Resource(gvr).Watch(ctx, options)
 				},
 			},
 			nil,


### PR DESCRIPTION
## Summary
This PR fixes two critical issues in the dynamic informer creation logic within `pkg/binding/crd.go`:

1. **Context Ignored**: The `ListFunc` and `WatchFunc` closures mistakenly used `context.TODO()` instead of the `ctx` passed to `startInformersForNewAPIResources`. This prevented the informers from properly respecting cancellation signals (e.g. during graceful shutdown of the controller manager).
2. **ListOptions Ignored**: The closures also ignored the `options metav1.ListOptions` provided by the informer framework (which contains the ResourceVersion to resume watches from) and instead passed an empty `metav1.ListOptions{}`. This caused the informers to perform inefficient full re-lists instead of resuming from their last known state.

Both are resolved by passing the correct `ctx` and `options` variables to the client calls.

## Related issue(s)
N/A - bug fix
