### PR TITLE
🐛 fix(transport): remove fmt.Sprintf anti-pattern from structured logger

### DIFF
--- a/pkg/transport/generic/generic_transport_controller.go
+++ b/pkg/transport/generic/generic_transport_controller.go
@@ -1083,7 +1083,7 @@ func (c *genericTransportController) propagateWrappedObjectToClusters(ctx contex
 			} else {
 				gloss, err := c.transport.UnwrapObjects(currentWrappedObject, kindToResource)
 				if err != nil {
-					logger.Error(err, fmt.Sprintf("Failed to unwrap %#v", currentWrappedObject))
+					logger.Error(err, "Failed to unwrap", "object", currentWrappedObject)
 				}
 				desiredGeneration := task.ObjU.GetAnnotations()[originOwnerGenerationAnnotation]
 				actualGeneration := currentWrappedObject.GetAnnotations()[originOwnerGenerationAnnotation]


### PR DESCRIPTION
## Summary
This PR fixes a structured logging anti-pattern in the generic transport controller (`pkg/transport/generic/generic_transport_controller.go`).

Currently, an error log on unwrapping failure uses `fmt.Sprintf` directly inside the log message:
`logger.Error(err, fmt.Sprintf("Failed to unwrap %#v", currentWrappedObject))`

This dynamic string defeats the purpose of structured logging (such as `logr` or `klog`), making log messages impossible to index or query efficiently in downstream aggregators. This PR fixes the call by passing the object as a structured key-value pair instead:
`logger.Error(err, "Failed to unwrap", "object", currentWrappedObject)`

## Related issue(s)
N/A - bug fix
