### PR TITLE
🐛 fix(status): handle json.Unmarshal errors in TypeObject equality

### DIFF
--- a/pkg/status/combinedstatus-resolution.go
+++ b/pkg/status/combinedstatus-resolution.go
@@ -1154,8 +1154,12 @@ func valueEqual(a, b *v1alpha1.Value) bool {
 		return *a.Bool == *b.Bool
 	case v1alpha1.TypeObject:
 		var v1, v2 interface{}
-		json.Unmarshal([]byte(a.Object.Raw), &v1)
-		json.Unmarshal([]byte(b.Object.Raw), &v2)
+		if err := json.Unmarshal([]byte(a.Object.Raw), &v1); err != nil {
+			return false
+		}
+		if err := json.Unmarshal([]byte(b.Object.Raw), &v2); err != nil {
+			return false
+		}
 		return reflect.DeepEqual(v1, v2)
 	case v1alpha1.TypeNull:
 		return true

--- a/pkg/status/combinedstatus-resolution.go
+++ b/pkg/status/combinedstatus-resolution.go
@@ -1154,10 +1154,10 @@ func valueEqual(a, b *v1alpha1.Value) bool {
 		return *a.Bool == *b.Bool
 	case v1alpha1.TypeObject:
 		var v1, v2 interface{}
-		if err := json.Unmarshal([]byte(a.Object.Raw), &v1); err != nil {
+		if err := json.Unmarshal(a.Object.Raw, &v1); err != nil {
 			return false
 		}
-		if err := json.Unmarshal([]byte(b.Object.Raw), &v2); err != nil {
+		if err := json.Unmarshal(b.Object.Raw, &v2); err != nil {
 			return false
 		}
 		return reflect.DeepEqual(v1, v2)


### PR DESCRIPTION
## Summary

This PR adds error checking for `json.Unmarshal` calls within the `valueEqual` function in `combinedstatus-resolution.go`. Previously, unhandled unmarshal errors could lead to inaccurate evaluation of `TypeObject` equality by mistakenly comparing zero values. 



## Related issue(s)

Fixes #