### PR TITLE
🐛 fix(cmd): replace formatless fmt.Errorf with errors.New

### DIFF
--- a/cmd/controller-manager/main.go
+++ b/cmd/controller-manager/main.go
@@ -20,8 +20,8 @@ package main
 // to ensure that exec-entrypoint and run can make use of them.
 
 import (
+	"errors"
 	"flag"
-	"fmt"
 	"os"
 	"strings"
 	"time"
@@ -111,7 +111,7 @@ func main() {
 		strings.ToLower(binding.ControllerName),
 		strings.ToLower(status.ControllerName),
 	).IsSuperset(ctlrsToStart) {
-		setupLog.Error(fmt.Errorf("unknown controller specified"), "'controllers' flag has incorrect value")
+		setupLog.Error(errors.New("unknown controller specified"), "'controllers' flag has incorrect value")
 		os.Exit(1)
 	}
 

--- a/pkg/status/combinedstatus-resolution.go
+++ b/pkg/status/combinedstatus-resolution.go
@@ -1154,8 +1154,12 @@ func valueEqual(a, b *v1alpha1.Value) bool {
 		return *a.Bool == *b.Bool
 	case v1alpha1.TypeObject:
 		var v1, v2 interface{}
-		json.Unmarshal([]byte(a.Object.Raw), &v1)
-		json.Unmarshal([]byte(b.Object.Raw), &v2)
+		if err := json.Unmarshal([]byte(a.Object.Raw), &v1); err != nil {
+			return false
+		}
+		if err := json.Unmarshal([]byte(b.Object.Raw), &v2); err != nil {
+			return false
+		}
 		return reflect.DeepEqual(v1, v2)
 	case v1alpha1.TypeNull:
 		return true


### PR DESCRIPTION
## Summary

This PR replaces a formatless `fmt.Errorf` call with `errors.New` in the controller-manager setup logs. Using `fmt.Errorf` without formatting verbs incurs unnecessary parsing overhead and is flagged as an anti-pattern by Go linters (`go vet` / `staticcheck`). 




## Related issue(s)

Fixes #