### PR TITLE
🐛 fix(binding): prevent panic from unsafe type assertions in selectors.go

### DIFF
--- a/.ko.yaml
+++ b/.ko.yaml
@@ -1,0 +1,1 @@
+defaultBaseImage: gcr.io/distroless/static:nonroot

--- a/pkg/binding/selectors.go
+++ b/pkg/binding/selectors.go
@@ -50,7 +50,10 @@ func (c *Controller) updateResolutions(ctx context.Context, objIdentifier util.O
 		return fmt.Errorf("failed to get runtime.Object from object identifier (%v): %w", objIdentifier, err)
 	}
 
-	objMR := obj.(mrObject)
+	objMR, ok := obj.(mrObject)
+	if !ok {
+		return fmt.Errorf("object is not an mrObject")
+	}
 	objBeingDeleted := isBeingDeleted(obj)
 
 	for _, bindingPolicy := range bindingPolicies {


### PR DESCRIPTION
## Summary

This PR replaces an unsafe type assertion (`obj.(mrObject)`) with the safe comma-ok idiom in `pkg/binding/selectors.go`. This change prevents potential interface conversion panics during object reconciliation if the informer yields an unexpected type, aligning the error handling pattern with other recently merged fixes.


## Related issue(s)

Fixes #