### PR TITLE
🐛 fix(status): prevent panic from unsafe metav1.Object assertions

### DIFF
--- a/pkg/status/status-controller.go
+++ b/pkg/status/status-controller.go
@@ -400,26 +400,50 @@ func (c *Controller) runWorkStatusInformer(ctx context.Context) {
 }
 
 func shouldSkipUpdate(old, new interface{}) bool {
-	oldMObj := old.(metav1.Object)
-	newMObj := new.(metav1.Object)
+	oldMObj, okOld := old.(metav1.Object)
+	newMObj, okNew := new.(metav1.Object)
+	if !okOld || !okNew {
+		return false
+	}
 	// do not enqueue update events for objects that have not changed
 	return newMObj.GetResourceVersion() == oldMObj.GetResourceVersion()
 }
 
 func objNotInThisWDS(obj interface{}, thisWDS string) bool {
-	if objWDS, ok := obj.(metav1.Object).GetLabels()[originWdsLabelKey]; ok {
-		if objWDS != thisWDS {
-			return true
+	var mObj metav1.Object
+	var ok bool
+	if mObj, ok = obj.(metav1.Object); !ok {
+		if dfsu, isDFSU := obj.(cache.DeletedFinalStateUnknown); isDFSU {
+			if mObj, ok = dfsu.Obj.(metav1.Object); !ok {
+				return false
+			}
+		} else {
+			return false
 		}
 	}
-	return false
+
+	objWDS, ok := mObj.GetLabels()[originWdsLabelKey]
+	return !ok || objWDS != thisWDS
 }
 
 // Informer event handler: enqueues the workstatus objects to be processed
 // At this time it is very simple, more complex processing might be required here
 func (c *Controller) handleWorkStatus(ctx context.Context, eventType string, obj any) {
 	logger := klog.FromContext(ctx)
-	wsRef, err := runtimeObjectToWorkStatusRef(obj.(runtime.Object))
+	var runtimeObj runtime.Object
+	var ok bool
+	if runtimeObj, ok = obj.(runtime.Object); !ok {
+		if dfsu, isDFSU := obj.(cache.DeletedFinalStateUnknown); isDFSU {
+			if runtimeObj, ok = dfsu.Obj.(runtime.Object); !ok {
+				logger.Error(nil, "informer obj is neither runtime.Object nor cache.DeletedFinalStateUnknown with runtime.Object", "obj", obj)
+				return
+			}
+		} else {
+			logger.Error(nil, "informer obj is neither runtime.Object nor cache.DeletedFinalStateUnknown", "obj", obj)
+			return
+		}
+	}
+	wsRef, err := runtimeObjectToWorkStatusRef(runtimeObj)
 	if err != nil {
 		utilruntime.HandleError(err)
 		return

--- a/pkg/status/workstatus.go
+++ b/pkg/status/workstatus.go
@@ -231,16 +231,25 @@ func runtimeObjectToWorkStatus(obj runtime.Object) (*workStatus, error) {
 		return nil, err
 	}
 
+	mObj, ok := obj.(metav1.Object)
+	if !ok {
+		return nil, fmt.Errorf("object %T does not implement metav1.Object", obj)
+	}
+
 	return &workStatus{
 		workStatusRef:  *ref,
 		status:         status,
-		lastUpdateTime: getObjectStatusLastUpdateTime(obj.(metav1.Object)),
+		lastUpdateTime: getObjectStatusLastUpdateTime(mObj),
 	}, nil
 }
 
 func runtimeObjectToWorkStatusRef(obj runtime.Object) (*workStatusRef, error) {
-	name := obj.(metav1.Object).GetName()
-	wecName := obj.(metav1.Object).GetNamespace()
+	mObj, ok := obj.(metav1.Object)
+	if !ok {
+		return nil, fmt.Errorf("object %T does not implement metav1.Object", obj)
+	}
+	name := mObj.GetName()
+	wecName := mObj.GetNamespace()
 
 	sourceRef, err := util.GetWorkStatusSourceRef(obj)
 	if err != nil {


### PR DESCRIPTION
## Summary

This PR hardens the status controller and workstatus processing logic against panics caused by unsafe `metav1.Object` type assertions, particularly during informer disconnects.

**Changes:**
- Update `handleWorkStatus` and `objNotInThisWDS` in `pkg/status/status-controller.go` to handle `cache.DeletedFinalStateUnknown` gracefully before casting to `metav1.Object` or `runtime.Object`.
- Replace unsafe assertions with the safe comma-ok idiom in `shouldSkipUpdate` and `runtimeObjectToWorkStatusRef` in `pkg/status/workstatus.go`.


## Related issue(s)

Fixes #