### PR TITLE
🐛 fix(util): prevent panic from unsafe metav1.Object assertion

### DIFF
--- a/pkg/util/gvk-obj-ref.go
+++ b/pkg/util/gvk-obj-ref.go
@@ -35,12 +35,16 @@ func (ref GKObjRef) String() string {
 // RefToRuntimeObj creates a GVKObjRef to a runtime.Object.
 func RefToRuntimeObj(obj runtime.Object) GKObjRef {
 	gvk := obj.GetObjectKind().GroupVersionKind()
-	mObj := obj.(metav1.Object)
+	var namespace, name string
+	if mObj, ok := obj.(metav1.Object); ok {
+		namespace = mObj.GetNamespace()
+		name = mObj.GetName()
+	}
 	ans := GKObjRef{
 		GK: gvk.GroupKind(),
 		OR: klog.ObjectRef{
-			Namespace: mObj.GetNamespace(),
-			Name:      mObj.GetName(),
+			Namespace: namespace,
+			Name:      name,
 		},
 	}
 	return ans


### PR DESCRIPTION
## Summary

This PR hardens the object identifier utility against panics caused by unconditionally casting arbitrary runtime objects to `metav1.Object`.

**Changes:**
- Update `RefToRuntimeObj` in `pkg/util/gvk-obj-ref.go` to use the safe comma-ok idiom before accessing `GetName()` and `GetNamespace()`, preventing a crash if a non-standard runtime object is processed.


## Related issue(s)

Fixes #