### PR TITLE
fix: remove dead code and simplify redundant boolean logic

### DIFF
--- a/pkg/binding/bindingpolicy-resolution.go
+++ b/pkg/binding/bindingpolicy-resolution.go
@@ -239,15 +239,6 @@ func (resolution *bindingPolicyResolution) matchesBindingSpec(bindingSpec *v1alp
 	return true
 }
 
-// getDestinationsList returns a sorted list of v1alpha1.Destination in the
-// resolution.
-func (resolution *bindingPolicyResolution) getDestinationsList() []v1alpha1.Destination {
-	resolution.RLock()
-	defer resolution.RUnlock()
-
-	return destinationsStringSetToSortedDestinations(resolution.destinations)
-}
-
 func (resolution *bindingPolicyResolution) getWorkloadReferences() []util.ObjectIdentifier {
 	resolution.RLock()
 	defer resolution.RUnlock()

--- a/pkg/binding/bindingpolicy-resolver.go
+++ b/pkg/binding/bindingpolicy-resolver.go
@@ -351,11 +351,7 @@ func (resolver *bindingPolicyResolver) SetDestinations(bindingPolicyKey string,
 // ResolutionExists returns true if a resolution is associated with the
 // given bindingpolicy key.
 func (resolver *bindingPolicyResolver) ResolutionExists(bindingPolicyKey string) bool {
-	if resolver.getResolution(bindingPolicyKey) == nil {
-		return false
-	}
-
-	return true
+	return resolver.getResolution(bindingPolicyKey) != nil
 }
 
 // GetReportedStateRequestForObject returns four things.

--- a/pkg/binding/bindingpolicy.go
+++ b/pkg/binding/bindingpolicy.go
@@ -107,28 +107,6 @@ func (c *Controller) deleteResolutionForBindingPolicy(ctx context.Context, bindi
 	return nil
 }
 
-func (c *Controller) requeueSelectedWorkloadObjects(ctx context.Context, bindingPolicyName string) error {
-	if !c.bindingPolicyResolver.ResolutionExists(bindingPolicyName) {
-		return nil
-	}
-
-	// requeue all objects that are selected by the bindingpolicy (are in its resolution)
-	objectIdentifiers, err := c.bindingPolicyResolver.GetObjectIdentifiers(bindingPolicyName)
-	if err != nil {
-		return fmt.Errorf("failed to get object identifiers from bindingpolicy resolver for "+
-			"bindingpolicy %s: %w", bindingPolicyName, err)
-	}
-
-	logger := klog.FromContext(ctx)
-	for objIdentifier := range objectIdentifiers {
-		logger.V(5).Info("Enqueuing workload object due to change in BindingPolicy",
-			"objectIdentifier", objIdentifier, "bindingPolicyName", bindingPolicyName)
-		c.enqueueObjectIdentifier(objIdentifier)
-	}
-
-	return nil
-}
-
 func (c *Controller) evaluateBindingPoliciesForUpdate(ctx context.Context, clusterId string, oldLabels labels.Set, newLabels labels.Set) {
 	logger := klog.FromContext(ctx)
 

--- a/pkg/binding/crd.go
+++ b/pkg/binding/crd.go
@@ -123,11 +123,7 @@ func (c *Controller) includedToWatch(r APIResource) bool {
 		Resource: r.resource.Name,
 	}
 
-	if isExcludedGroupResource(gr) {
-		return false
-	}
-
-	return true
+	return !isExcludedGroupResource(gr)
 }
 
 func crdEstablished(crd *apiextensionsv1.CustomResourceDefinition) bool {

--- a/pkg/status/binding.go
+++ b/pkg/status/binding.go
@@ -69,7 +69,7 @@ func (c *Controller) syncBinding(ctx context.Context, key string) error {
 // missingSCs, a slice of the missing StatusCollector object name(s), must be sorted.
 func (c *Controller) createOrUpdateStatusCollectorAvailableCondition(ctx context.Context, bdg *v1alpha1.Binding, missingSCs []string) error {
 	// compose tentative condition where LastTransitionTime is TBD
-	conditionTentative := v1alpha1.BindingPolicyCondition{}
+	var conditionTentative v1alpha1.BindingPolicyCondition
 	if len(missingSCs) != 0 {
 		conditionTentative = v1alpha1.BindingPolicyCondition{
 			Type:    v1alpha1.TypeStatusCollectorsAvailable,

--- a/pkg/status/status-controller.go
+++ b/pkg/status/status-controller.go
@@ -101,8 +101,6 @@ type workloadObjectRef struct{ util.ObjectIdentifier }
 // bindingRef is a workqueue item that references a Binding
 type bindingRef string
 
-type workStatusON cache.ObjectName
-
 // workStatusRef is a workqueue item that references a WorkStatus
 type workStatusRef struct {
 	// Name is the Name of the WorkStatus object


### PR DESCRIPTION
## Summary

Remove unused functions, types, and assignments flagged by staticcheck, and simplify redundant boolean expressions.

Fixes #3880

## Changes

- **Remove unused `getDestinationsList` method** (`pkg/binding/bindingpolicy-resolution.go`): Dead code with no callers.
- **Remove unused `requeueSelectedWorkloadObjects` method** (`pkg/binding/bindingpolicy.go`): Dead code with no callers.
- **Remove unused `workStatusON` type** (`pkg/status/status-controller.go`): Dead code never used as a type.
- **Simplify `ResolutionExists`** (`pkg/binding/bindingpolicy-resolver.go`): Replace `if x == nil { return false }; return true` with `return x != nil`.
- **Simplify `includedToWatch`** (`pkg/binding/crd.go`): Replace `if cond { return false }; return true` with `return !cond`.
- **Remove unused initial assignment** (`pkg/status/binding.go`): `conditionTentative` was initialized to zero value then immediately overwritten in both branches.

## Testing

- Build compiles cleanly
- `go vet` passes
- No behavior changes (dead code removal and expression simplification only)