### PR TITLE
fix(status): prevent infinite loop in objectIsQueried

### DIFF
--- a/pkg/status/combinedstatus-resolution.go
+++ b/pkg/status/combinedstatus-resolution.go
@@ -1228,16 +1228,17 @@ func objectIsQueried(query *string, obj string) bool {
 	idx := 0
 
 	for {
-		idx = strings.Index((*query)[idx:], obj) // slices share the same storage, therefore efficient
-		if idx == -1 {
+		rel := strings.Index((*query)[idx:], obj) // relative offset within the slice
+		if rel == -1 {
 			return false
 		}
 
-		if isWholeWord(query, idx, len(obj)) {
+		abs := idx + rel // convert to absolute index in the original string
+		if isWholeWord(query, abs, len(obj)) {
 			return true
 		}
 
-		idx += len(obj)
+		idx = abs + len(obj)
 	}
 }
 

--- a/pkg/status/combinedstatus-resolution_test.go
+++ b/pkg/status/combinedstatus-resolution_test.go
@@ -1,0 +1,91 @@
+/*
+Copyright 2024 The KubeStellar Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package status
+
+import (
+	"testing"
+)
+
+func TestObjectIsQueried(t *testing.T) {
+	tests := []struct {
+		name   string
+		query  string
+		obj    string
+		expect bool
+	}{
+		{
+			name:   "exact match",
+			query:  "foo",
+			obj:    "foo",
+			expect: true,
+		},
+		{
+			name:   "infinite loop regression: embedded prefix then standalone",
+			query:  "foobar foo",
+			obj:    "foo",
+			expect: true,
+		},
+		{
+			name:   "embedded only, no standalone",
+			query:  "foobar baz",
+			obj:    "foo",
+			expect: false,
+		},
+		{
+			name:   "embedded only, no standalone anywhere",
+			query:  "foobar bazfoo qux",
+			obj:    "foo",
+			expect: false,
+		},
+		{
+			name:   "standalone at start",
+			query:  "foo bar baz",
+			obj:    "foo",
+			expect: true,
+		},
+		{
+			name:   "standalone at end",
+			query:  "bar baz foo",
+			obj:    "foo",
+			expect: true,
+		},
+		{
+			name:   "not found",
+			query:  "bar baz qux",
+			obj:    "foo",
+			expect: false,
+		},
+		{
+			name:   "empty query",
+			query:  "",
+			obj:    "foo",
+			expect: false,
+		},
+		{
+			name:   "embedded prefix then standalone after many words",
+			query:  "xyzfoo abc def foo",
+			obj:    "foo",
+			expect: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := objectIsQueried(&tt.query, tt.obj)
+			if result != tt.expect {
+				t.Errorf("objectIsQueried(%q, %q) = %v, want %v", tt.query, tt.obj, result, tt.expect)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Fix a bug where `objectIsQueried` could enter an infinite CPU spin when a queried field name first appears as an embedded prefix of a longer token and then also as a standalone whole-word token later in the same string.

Fixes #3848

## Root Cause

`strings.Index((*query)[idx:], obj)` returns a **relative** offset to the slice `(*query)[idx:]`, but the code was using that relative value as an **absolute** index into the original string when calling `isWholeWord`. After a non-whole-word match, the search would restart from the wrong position, potentially looping forever.

## Fix

Convert the relative offset to an absolute index (`abs = idx + rel`) before passing it to `isWholeWord`, and advance the search position correctly (`idx = abs + len(obj)`).

## Testing

- Added `TestObjectIsQueried` with 9 test cases covering:
  - The exact regression case from the issue (`"foobar foo"` searching for `"foo"`)
  - Exact match, standalone at start/end, embedded-only, not found, empty query
- All tests pass