### PR TITLE
fix(status): prevent recursive read-lock deadlock in compareCombinedStatus

### DIFF
--- a/pkg/status/combinedstatus-resolution.go
+++ b/pkg/status/combinedstatus-resolution.go
@@ -273,12 +273,9 @@ func (c *combinedStatusResolution) noteStatusCollectorAbsence(statusCollectorNam
 }
 
 // generateCombinedStatus calculates the combinedstatus from the statuscollector
-// data in the combinedstatus resolution.
-func (c *combinedStatusResolution) generateCombinedStatus(bindingName string,
+// data in the combinedstatus resolution. Caller must hold at least the read lock.
+func (c *combinedStatusResolution) generateCombinedStatusLocked(bindingName string,
 	workloadObjectIdentifier util.ObjectIdentifier) *v1alpha1.CombinedStatus {
-	c.RLock()
-	defer c.RUnlock()
-
 	combinedStatus := &v1alpha1.CombinedStatus{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      c.Name,
@@ -313,12 +310,20 @@ func (c *combinedStatusResolution) generateCombinedStatus(bindingName string,
 	return addLabelsToCombinedStatus(combinedStatus, bindingName, workloadObjectIdentifier)
 }
 
+// generateCombinedStatus is the public entry point that acquires the read lock.
+func (c *combinedStatusResolution) generateCombinedStatus(bindingName string,
+	workloadObjectIdentifier util.ObjectIdentifier) *v1alpha1.CombinedStatus {
+	c.RLock()
+	defer c.RUnlock()
+	return c.generateCombinedStatusLocked(bindingName, workloadObjectIdentifier)
+}
+
 func (c *combinedStatusResolution) compareCombinedStatus(status *v1alpha1.CombinedStatus,
 	bindingName string, sourceObjectIdentifier util.ObjectIdentifier) *v1alpha1.CombinedStatus {
 	c.RLock()
 	defer c.RUnlock()
 
-	localCombinedStatus := c.generateCombinedStatus(bindingName, sourceObjectIdentifier)
+	localCombinedStatus := c.generateCombinedStatusLocked(bindingName, sourceObjectIdentifier)
 
 	// check labels
 	if !validateCombinedStatusLabels(status, bindingName, sourceObjectIdentifier) {


### PR DESCRIPTION
## Description

`compareCombinedStatus` in `pkg/status/combinedstatus-resolution.go` holds a read lock and then calls `generateCombinedStatus`, which acquires the same read lock again. Go's `sync.RWMutex` is not reentrant and recursive read-locking is explicitly unsafe — if a writer calls `Lock()` between the two `RLock()` calls, the reader blocks waiting for the writer, and the writer blocks waiting for the first reader to release, causing a deadlock.

## Fix

Split `generateCombinedStatus` into an unlocked `generateCombinedStatusLocked` helper that both functions call. `compareCombinedStatus` now acquires the lock once and calls the locked variant directly, avoiding the recursive acquisition. The public `generateCombinedStatus` method remains as a thin wrapper that acquires the read lock and delegates.

## Changes

- `pkg/status/combinedstatus-resolution.go`: Extract `generateCombinedStatusLocked` (no lock acquisition); `compareCombinedStatus` calls it directly under its own lock; `generateCombinedStatus` acquires lock and delegates.

## Related issue(s)

Fixes #3899

## Checklist

- [x] Code compiles correctly
- [x] Unit tests passing
- [ ] End-to-end tests passing

## Release Note

RELEASE NOTE: **FIX** Status controller no longer risks deadlock from recursive read-locking in combined status comparison.