### PR TITLE
fix(status): prevent panic from unhashable groupBy values

### DIFF
--- a/pkg/status/combinedstatus-resolution.go
+++ b/pkg/status/combinedstatus-resolution.go
@@ -797,7 +797,7 @@ func handleAggregationReadLocked(scName string, scData *statusCollectorData) *v1
 	// 		Where the N-values tuple is the string concatenation of the assigned numbers
 	// 		separated by commas, ordered by the groupBy expressions in scData.GroupBy slice.
 	generator := 0
-	ValueToNumber := map[any]int{}
+	ValueToNumber := map[string]int{}
 	idToAggregationGroup := map[string]*aggregationGroup{}
 
 	if len(scData.collectorSpec.GroupBy) == 0 && len(scData.WECToData) == 0 {
@@ -826,10 +826,13 @@ func handleAggregationReadLocked(scName string, scData *statusCollectorData) *v1
 		for _, groupByNamedExp := range scData.collectorSpec.GroupBy {
 			groupByValue := wsData.groupByEval[groupByNamedExp.Name]
 
-			// ensure unique number mapping for the value
-			uid, exists := ValueToNumber[groupByValue.Value()]
+			// Use string representation as key to handle composite types
+			// (lists, maps) which are not comparable and would panic when
+			// used as map keys.
+			groupByKey := fmt.Sprintf("%v", groupByValue.Value())
+			uid, exists := ValueToNumber[groupByKey]
 			if !exists {
-				ValueToNumber[groupByValue.Value()] = generator
+				ValueToNumber[groupByKey] = generator
 				uid = generator
 				generator++
 			}


### PR DESCRIPTION
## Description

A StatusCollector whose `groupBy` expression evaluates to a composite value (a list or a map) crashes the status controller with `panic: hash of unhashable type`. The CEL evaluation result was used directly as a `map[any]int` key, and Go maps require comparable keys — slices and maps are not comparable.

## Fix

Convert the `groupBy` value to its string representation (`fmt.Sprintf("%v", ...)`) before using it as a map key. This handles all CEL return types safely, including composite types like `[]interface{}` and `map[string]interface{}`. The map type is changed from `map[any]int` to `map[string]int`.

## Changes

- `pkg/status/combinedstatus-resolution.go`: Use `fmt.Sprintf("%v", groupByValue.Value())` as the map key in `handleAggregationReadLocked` instead of `groupByValue.Value()` directly.

## Related issue(s)

Fixes #3897

## Checklist

- [x] Code compiles correctly
- [x] Unit tests passing
- [ ] End-to-end tests passing

## Release Note

RELEASE NOTE: **FIX** Status controller no longer panics when a groupBy expression returns a composite type (list or map).