### PR TITLE
🌱 chore: remove unused code detected by staticcheck (U1000/SA4006)

### DIFF
--- a/pkg/binding/bindingpolicy-resolution.go
+++ b/pkg/binding/bindingpolicy-resolution.go
@@ -239,15 +239,6 @@ func (resolution *bindingPolicyResolution) matchesBindingSpec(bindingSpec *v1alp
 	return true
 }
 
-// getDestinationsList returns a sorted list of v1alpha1.Destination in the
-// resolution.
-func (resolution *bindingPolicyResolution) getDestinationsList() []v1alpha1.Destination {
-	resolution.RLock()
-	defer resolution.RUnlock()
-
-	return destinationsStringSetToSortedDestinations(resolution.destinations)
-}
-
 func (resolution *bindingPolicyResolution) getWorkloadReferences() []util.ObjectIdentifier {
 	resolution.RLock()
 	defer resolution.RUnlock()

--- a/pkg/binding/bindingpolicy.go
+++ b/pkg/binding/bindingpolicy.go
@@ -107,28 +107,6 @@ func (c *Controller) deleteResolutionForBindingPolicy(ctx context.Context, bindi
 	return nil
 }
 
-func (c *Controller) requeueSelectedWorkloadObjects(ctx context.Context, bindingPolicyName string) error {
-	if !c.bindingPolicyResolver.ResolutionExists(bindingPolicyName) {
-		return nil
-	}
-
-	// requeue all objects that are selected by the bindingpolicy (are in its resolution)
-	objectIdentifiers, err := c.bindingPolicyResolver.GetObjectIdentifiers(bindingPolicyName)
-	if err != nil {
-		return fmt.Errorf("failed to get object identifiers from bindingpolicy resolver for "+
-			"bindingpolicy %s: %w", bindingPolicyName, err)
-	}
-
-	logger := klog.FromContext(ctx)
-	for objIdentifier := range objectIdentifiers {
-		logger.V(5).Info("Enqueuing workload object due to change in BindingPolicy",
-			"objectIdentifier", objIdentifier, "bindingPolicyName", bindingPolicyName)
-		c.enqueueObjectIdentifier(objIdentifier)
-	}
-
-	return nil
-}
-
 func (c *Controller) evaluateBindingPoliciesForUpdate(ctx context.Context, clusterId string, oldLabels labels.Set, newLabels labels.Set) {
 	logger := klog.FromContext(ctx)
 

--- a/pkg/status/binding.go
+++ b/pkg/status/binding.go
@@ -69,7 +69,7 @@ func (c *Controller) syncBinding(ctx context.Context, key string) error {
 // missingSCs, a slice of the missing StatusCollector object name(s), must be sorted.
 func (c *Controller) createOrUpdateStatusCollectorAvailableCondition(ctx context.Context, bdg *v1alpha1.Binding, missingSCs []string) error {
 	// compose tentative condition where LastTransitionTime is TBD
-	conditionTentative := v1alpha1.BindingPolicyCondition{}
+	var conditionTentative v1alpha1.BindingPolicyCondition
 	if len(missingSCs) != 0 {
 		conditionTentative = v1alpha1.BindingPolicyCondition{
 			Type:    v1alpha1.TypeStatusCollectorsAvailable,

--- a/pkg/status/status-controller.go
+++ b/pkg/status/status-controller.go
@@ -101,8 +101,6 @@ type workloadObjectRef struct{ util.ObjectIdentifier }
 // bindingRef is a workqueue item that references a Binding
 type bindingRef string
 
-type workStatusON cache.ObjectName
-
 // workStatusRef is a workqueue item that references a WorkStatus
 type workStatusRef struct {
 	// Name is the Name of the WorkStatus object

--- a/test/performance/latency-controller/internal/controller/controller.go
+++ b/test/performance/latency-controller/internal/controller/controller.go
@@ -83,7 +83,6 @@ type GenericLatencyCollectorReconciler struct {
 	BindingPolicyName   string
 	DiscoveredResources []schema.GroupVersionKind
 	gvkToGVR            map[schema.GroupVersionKind]schema.GroupVersionResource
-	bindingCreated      time.Time
 
 	cache    map[string]*PerWorkloadCache
 	cacheMux sync.Mutex


### PR DESCRIPTION
## Summary

Remove unused types, functions, fields, and variables detected by `staticcheck` (U1000, SA4006). This is a non-functional cleanup PR that reduces dead code and improves maintainability.

| File | What was removed | Rule |
|------|-----------------|------|
| `pkg/binding/bindingpolicy-resolution.go` | Unused method `getDestinationsList` | U1000 |
| `pkg/binding/bindingpolicy.go` | Unused method `requeueSelectedWorkloadObjects` | U1000 |
| `pkg/status/status-controller.go` | Unused type alias `workStatusON` | U1000 |
| `pkg/status/binding.go` | Use `var` declaration for zero-value struct instead of composite literal | style |
| `test/performance/.../controller.go` | Unused struct field `bindingCreated` | U1000 |

No functional behavior changes. All removed symbols had zero references in the codebase.

## Related issue(s)

N/A — proactive cleanup of dead code detected by `staticcheck`.

cc @MikeSpreitzer @waltforme
