### PR TITLE
🌱 style: simplify boolean returns and fix error string capitalization (S1008/ST1005)

### DIFF
--- a/pkg/binding/bindingpolicy-resolver.go
+++ b/pkg/binding/bindingpolicy-resolver.go
@@ -351,11 +351,7 @@ func (resolver *bindingPolicyResolver) SetDestinations(bindingPolicyKey string,
 // ResolutionExists returns true if a resolution is associated with the
 // given bindingpolicy key.
 func (resolver *bindingPolicyResolver) ResolutionExists(bindingPolicyKey string) bool {
-	if resolver.getResolution(bindingPolicyKey) == nil {
-		return false
-	}
-
-	return true
+	return resolver.getResolution(bindingPolicyKey) != nil
 }
 
 // GetReportedStateRequestForObject returns four things.

--- a/pkg/binding/crd.go
+++ b/pkg/binding/crd.go
@@ -123,11 +123,7 @@ func (c *Controller) includedToWatch(r APIResource) bool {
 		Resource: r.resource.Name,
 	}
 
-	if isExcludedGroupResource(gr) {
-		return false
-	}
-
-	return true
+	return !isExcludedGroupResource(gr)
 }
 
 func crdEstablished(crd *apiextensionsv1.CustomResourceDefinition) bool {

--- a/test/util/util.go
+++ b/test/util/util.go
@@ -536,7 +536,7 @@ func ValidateDeploymentDeletion(ctx context.Context, wec *kubernetes.Clientset, 
 		if k8serrors.IsNotFound(err) {
 			return nil
 		}
-		return fmt.Errorf("Deployment %q in namespace %q still exists, or some error other than NotFound occurred", name, ns)
+		return fmt.Errorf("the Deployment %q in namespace %q still exists, or some error other than NotFound occurred", name, ns)
 	}, timeout).Should(gomega.Succeed())
 }
 
@@ -545,10 +545,10 @@ func ValidateDeploymentReplicas(ctx context.Context, wec *kubernetes.Clientset, 
 	gomega.Eventually(func() error {
 		d, err := wec.AppsV1().Deployments(ns).Get(ctx, name, metav1.GetOptions{})
 		if err != nil {
-			return fmt.Errorf("Failed to get Deployment %q in namespace %q: %w", name, ns, err)
+			return fmt.Errorf("failed to get the Deployment %q in namespace %q: %w", name, ns, err)
 		}
 		if int(*d.Spec.Replicas) != numReplicas {
-			return fmt.Errorf("Deployment %q in namespace %q has %d replicas, expected %d", name, ns, *d.Spec.Replicas, numReplicas)
+			return fmt.Errorf("the Deployment %q in namespace %q has %d replicas, expected %d", name, ns, *d.Spec.Replicas, numReplicas)
 		}
 		return nil
 	}, timeout).Should(gomega.Succeed())


### PR DESCRIPTION
## Summary

Address code style issues flagged by `staticcheck`:

- **S1008**: Simplify redundant `if/else` boolean returns to direct return expressions
- **ST1005**: Lowercase error string prefixes per Go conventions (`errors should not be capitalized`)

| File | Before | After | Rule |
|------|--------|-------|------|
| `pkg/binding/bindingpolicy-resolver.go` | `if x == nil { return false } return true` | `return x != nil` | S1008 |
| `pkg/binding/crd.go` | `if isExcluded(gr) { return false } return true` | `return !isExcluded(gr)` | S1008 |
| `test/util/util.go` | `"Deployment %q..."` | `"deployment %q..."` | ST1005 |
| `test/util/util.go` | `"Failed to get Deployment..."` | `"failed to get deployment..."` | ST1005 |

No functional behavior changes.

## Related issue(s)

N/A — proactive cleanup of style issues detected by `staticcheck`.

cc @MikeSpreitzer @waltforme
