### PR TITLE
🌱 - Add CODEOWNERS File for Automated PR Review Assignment

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,20 @@
+# GitHub CODEOWNERS File
+# Automatically assign reviewers based on which files are modified in a PR.
+# https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-codeowners
+
+# Default owners for all files in the repository
+*                   @MikeSpreitzer @KPRoche @pdettori @clubanderson @dumb0002 @waltforme
+
+# Component-specific code owners
+/pkg/binding/       @MikeSpreitzer @KPRoche @pdettori @clubanderson @dumb0002 @waltforme
+/pkg/status/        @MikeSpreitzer @KPRoche @pdettori @clubanderson @dumb0002 @waltforme
+/pkg/transport/     @MikeSpreitzer @KPRoche @pdettori @clubanderson @dumb0002 @waltforme
+/monitoring/        @MikeSpreitzer @KPRoche @pdettori @clubanderson @dumb0002 @waltforme
+/core-chart/        @MikeSpreitzer @KPRoche @pdettori @clubanderson @dumb0002 @waltforme
+
+# Documentation
+/docs/              @MikeSpreitzer @KPRoche @pdettori @clubanderson @dumb0002 @waltforme
+/docs/to-be-deleted/ @MikeSpreitzer @ezrasilvera @pdettori @clubanderson @dumb0002 @waltforme
+
+# Scripts and Tooling
+/hack/              @MikeSpreitzer @ezrasilvera @pdettori @clubanderson @dumb0002 @waltforme

--- a/issue_description.md
+++ b/issue_description.md
@@ -1,0 +1,16 @@
+## Description
+The repository currently uses a Prow `OWNERS` file, but lacks a GitHub-native `CODEOWNERS` configuration. Adding a `.github/CODEOWNERS` file will automatically assign reviewers based on which files are modified in a pull request. This improves reviewer assignment automation and speeds up the PR review cycle.
+
+## Proposed Changes
+- Create a `.github/CODEOWNERS` file at the root.
+- Map directories to appropriate maintainers (based on the root `OWNERS`, `hack/OWNERS`, and `docs/to-be-deleted/OWNERS`).
+- Explicitly cover key directories:
+  - `pkg/binding/`
+  - `pkg/status/`
+  - `pkg/transport/`
+  - `docs/`
+  - `monitoring/`
+  - `core-chart/`
+
+## Goal
+Automate GitHub PR reviewer assignments by mapping file and directory patterns to the project maintainers.

--- a/pr_description.md
+++ b/pr_description.md
@@ -1,0 +1,20 @@
+## Summary
+This PR adds a GitHub-native `.github/CODEOWNERS` file to automate reviewer assignments for pull requests. The directory mapping is based on the existing root `OWNERS`, `hack/OWNERS`, and `docs/to-be-deleted/OWNERS` files, and covers key project areas as specified in the issue.
+
+## Related issue(s)
+Fixes #3952
+
+## Changes
+- Created `.github/CODEOWNERS` file mapping files and directories to the project maintainers.
+- Covered key areas:
+  - `pkg/binding/`
+  - `pkg/status/`
+  - `pkg/transport/`
+  - `docs/`
+  - `monitoring/`
+  - `core-chart/`
+- Included specific mappings for `/hack/` and `/docs/to-be-deleted/` utilizing the additional maintainers defined in their respective `OWNERS` configurations.
+
+## Testing
+- Verified that all Github handles listed exist and are exactly corresponding to the `OWNERS` files.
+- Confirmed correct matching rules for `CODEOWNERS` syntax.


### PR DESCRIPTION
## Summary
This PR adds a GitHub-native `.github/CODEOWNERS` file to automate reviewer assignments for pull requests. The directory mapping is based on the existing root `OWNERS`, `hack/OWNERS`, and `docs/to-be-deleted/OWNERS` files, and covers key project areas as specified in the issue.

## Related issue(s)
Fixes #3952

## Changes
- Created `.github/CODEOWNERS` file mapping files and directories to the project maintainers.
- Covered key areas:
  - `pkg/binding/`
  - `pkg/status/`
  - `pkg/transport/`
  - `docs/`
  - `monitoring/`
  - `core-chart/`
- Included specific mappings for `/hack/` and `/docs/to-be-deleted/` utilizing the additional maintainers defined in their respective `OWNERS` configurations.

## Testing
- Verified that all Github handles listed exist and are exactly corresponding to the `OWNERS` files.
- Confirmed correct matching rules for `CODEOWNERS` syntax.
