### PR TITLE
🌱 chore: replace deprecated wait.PollImmediate with wait.PollUntilContextTimeout (SA1019)

### DIFF
--- a/test/integration/argocd/argocd_test.go
+++ b/test/integration/argocd/argocd_test.go
@@ -120,7 +120,7 @@ func TestArgoCDClusterSecretIsCreated(t *testing.T) {
 	// Poll every 2 seconds for up to 60 seconds waiting for the Secret to be created
 	// This gives KubeStellar controllers time to reconcile and create the Argo CD cluster Secret
 	t.Logf("Waiting for Argo CD cluster Secret to be created: %s/%s", argoCDNamespace, secretName)
-	err = wait.PollImmediate(2*time.Second, 60*time.Second, func() (bool, error) {
+	err = wait.PollUntilContextTimeout(ctx, 2*time.Second, 60*time.Second, true, func(ctx context.Context) (bool, error) {
 		// Try to get the Secret from the argocd namespace
 		secret, err := clientset.CoreV1().Secrets(argoCDNamespace).Get(ctx, secretName, metav1.GetOptions{})
 		if err != nil {


### PR DESCRIPTION
## Summary

Replace deprecated `wait.PollImmediate` with `wait.PollUntilContextTimeout` in `test/integration/argocd/argocd_test.go`.

`wait.PollImmediate` is deprecated (SA1019) since `k8s.io/apimachinery` v0.27. The replacement `wait.PollUntilContextTimeout` is the idiomatic alternative that properly respects context cancellation.

| File | Before | After | Rule |
|------|--------|-------|------|
| `test/integration/argocd/argocd_test.go` | `wait.PollImmediate(...)` | `wait.PollUntilContextTimeout(ctx, ...)` | SA1019 |

No functional behavior changes (the `true` flag in `PollUntilContextTimeout` preserves the original immediate execution semantics).

## Related issue(s)

N/A — proactive cleanup of deprecated API usage detected by `staticcheck`.

cc @MikeSpreitzer @waltforme
