### PR TITLE
Support Wildcards [*] and Array Traversal in Custom JSONPath Parser

### DIFF
--- a/pkg/jsonpath/eval.go
+++ b/pkg/jsonpath/eval.go
@@ -75,20 +75,61 @@ func (fn FieldNode) Remove() {
 	delete(fn.Object, fn.Key)
 }
 
+// ArrayItemNode is an element of a JSON array
+type ArrayItemNode struct {
+	Slice []any
+	Index int
+}
+
+var _ Node = ArrayItemNode{}
+
+func (an ArrayItemNode) Get() (JSONValue, bool) {
+	if an.Index < 0 || an.Index >= len(an.Slice) {
+		return nil, false
+	}
+	return an.Slice[an.Index], true
+}
+
+func (an ArrayItemNode) Remove() {
+	if an.Index >= 0 && an.Index < len(an.Slice) {
+		an.Slice[an.Index] = nil
+	}
+}
+
 // QueryValue applies `query` to `node`, invoking `yield` on each
 // of the nodes that the query produces, in a context where the document
 // root is `root`.
 func QueryValue(query Query, node Node, yield func(Node)) {
-	for _, fieldName := range query {
-		objA, ok := node.Get()
-		if !ok {
-			return
-		}
-		objM, ok := objA.(map[string]any)
-		if !ok {
-			return
-		}
-		node = FieldNode{objM, fieldName}
+	queryValueHelper(query, node, yield)
+}
+
+func queryValueHelper(query Query, node Node, yield func(Node)) {
+	if len(query) == 0 {
+		yield(node)
+		return
 	}
-	yield(node)
+
+	segment := query[0]
+	val, ok := node.Get()
+	if !ok {
+		return
+	}
+
+	if segment.Kind == SegmentKindField {
+		objM, ok := val.(map[string]any)
+		if !ok {
+			return
+		}
+		nextNode := FieldNode{Object: objM, Key: segment.Name}
+		queryValueHelper(query[1:], nextNode, yield)
+	} else if segment.Kind == SegmentKindWildcard {
+		sliceVal, ok := val.([]any)
+		if !ok {
+			return
+		}
+		for i := range sliceVal {
+			nextNode := ArrayItemNode{Slice: sliceVal, Index: i}
+			queryValueHelper(query[1:], nextNode, yield)
+		}
+	}
 }

--- a/pkg/jsonpath/eval_test.go
+++ b/pkg/jsonpath/eval_test.go
@@ -44,6 +44,63 @@ func TestEval(t *testing.T) {
 	if !jsonEqualities.DeepEqual(expected, actual) {
 		t.Errorf("Expected %#v, got %#v", expected, actual)
 	}
+
+	// Test with arrays and wildcard
+	var root2 RootNode
+	err = json.Unmarshal([]byte(`{
+		"spec": {
+			"resources": {
+				"GenericItems": [
+					{"generictemplate": {"metadata": {"resourceVersion": "123", "name": "item1"}}},
+					{"generictemplate": {"metadata": {"resourceVersion": "456", "name": "item2"}}}
+				]
+			}
+		}
+	}`), &root2.Value)
+	if err != nil {
+		t.Fatalf("Failed to parse doc2, err=%s", err.Error())
+	}
+
+	expected = []JSONValue{"123", "456"}
+	actual = GetQuery(&root2, "$.spec.resources.GenericItems[*].generictemplate.metadata.resourceVersion")
+	if !jsonEqualities.DeepEqual(expected, actual) {
+		t.Errorf("Expected %#v, got %#v", expected, actual)
+	}
+
+	// Test with dot-wildcard as well
+	actual = GetQuery(&root2, "$.spec.resources.GenericItems.*.generictemplate.metadata.resourceVersion")
+	if !jsonEqualities.DeepEqual(expected, actual) {
+		t.Errorf("Expected %#v, got %#v", expected, actual)
+	}
+
+	// Test Remove using wildcard
+	query, err := ParseQuery("$.spec.resources.GenericItems[*].generictemplate.metadata.resourceVersion")
+	if err != nil {
+		t.Fatalf("Failed to parse remove query, err=%s", err.Error())
+	}
+	QueryValue(query, &root2, func(node Node) {
+		node.Remove()
+	})
+
+	// Verify that the fields were removed
+	var expectedDoc any
+	err = json.Unmarshal([]byte(`{
+		"spec": {
+			"resources": {
+				"GenericItems": [
+					{"generictemplate": {"metadata": {"name": "item1"}}},
+					{"generictemplate": {"metadata": {"name": "item2"}}}
+				]
+			}
+		}
+	}`), &expectedDoc)
+	if err != nil {
+		t.Fatalf("Failed to parse expectedDoc, err=%s", err.Error())
+	}
+
+	if !jsonEqualities.DeepEqual(expectedDoc, *root2.Value) {
+		t.Errorf("After Remove, expected %#v, got %#v", expectedDoc, *root2.Value)
+	}
 }
 
 var jsonEqualities = k8sreflect.Equalities{}

--- a/pkg/jsonpath/lexer.go
+++ b/pkg/jsonpath/lexer.go
@@ -25,9 +25,22 @@ import (
 	js_ast "github.com/dop251/goja/ast"
 )
 
+type SegmentKind int
+
+const (
+	SegmentKindField SegmentKind = iota
+	SegmentKindWildcard
+)
+
+type Segment struct {
+	Kind SegmentKind
+	Name string
+}
+
 // Query represents a parsed query in a very restricted subset of JSONPath (RFC 9535).
-// The only supported segment functionality is selecting one definite member of a JSON object.
-type Query []string
+// Supported segment functionality is selecting one definite member of a JSON object or
+// traversing all items of an array (wildcard).
+type Query []Segment
 
 // ParseQuery parses a very restricted form of JSONPath expression into a Query.
 // This parser only accepts segments of the form `.name` or `[string]`.
@@ -93,31 +106,50 @@ func (lxr *Lexer) ScanQuery() (Query, error) {
 			if err := lxr.advance(); err != nil {
 				return query, err
 			}
-			if !isNameFirst(lxr.chr) {
-				return query, fmt.Errorf("syntax error at %d: expected member-name-shorthand, got %q", lxr.chrPos, lxr.chr)
-			}
-			if next, err := lxr.nextIdentifier(); err != nil {
-				return query, err
+			if lxr.chr == '*' {
+				if err := lxr.advance(); err != nil {
+					return query, err
+				}
+				query = append(query, Segment{Kind: SegmentKindWildcard})
 			} else {
-				query = append(query, next)
+				if !isNameFirst(lxr.chr) {
+					return query, fmt.Errorf("syntax error at %d: expected member-name-shorthand or wildcard, got %q", lxr.chrPos, lxr.chr)
+				}
+				if next, err := lxr.nextIdentifier(); err != nil {
+					return query, err
+				} else {
+					query = append(query, Segment{Kind: SegmentKindField, Name: next})
+				}
 			}
 		} else if lxr.chr == '[' {
 			if err := lxr.advance(); err != nil {
 				return query, err
 			}
-			if lxr.chr != '"' {
-				return query, fmt.Errorf("syntax error at %d: expected open quote, got %q", lxr.chrPos, lxr.chr)
-			}
-			if next, err := lxr.nextString(); err != nil {
-				return query, err
+			if lxr.chr == '*' {
+				if err := lxr.advance(); err != nil {
+					return query, err
+				}
+				if lxr.chr != ']' {
+					return query, fmt.Errorf("syntax error at %d: missing close bracket, got %q", lxr.chrPos, lxr.chr)
+				}
+				if err := lxr.advance(); err != nil {
+					return query, err
+				}
+				query = append(query, Segment{Kind: SegmentKindWildcard})
+			} else if lxr.chr == '"' {
+				if next, err := lxr.nextString(); err != nil {
+					return query, err
+				} else {
+					query = append(query, Segment{Kind: SegmentKindField, Name: next})
+				}
+				if lxr.chr != ']' {
+					return query, fmt.Errorf("syntax error at %d: missing close bracket, got %q", lxr.chrPos, lxr.chr)
+				}
+				if err := lxr.advance(); err != nil {
+					return query, err
+				}
 			} else {
-				query = append(query, next)
-			}
-			if lxr.chr != ']' {
-				return query, fmt.Errorf("syntax error at %d: missing close bracket, got %q", lxr.chrPos, lxr.chr)
-			}
-			if err := lxr.advance(); err != nil {
-				return query, err
+				return query, fmt.Errorf("syntax error at %d: expected open quote or wildcard, got %q", lxr.chrPos, lxr.chr)
 			}
 		} else {
 			break

--- a/pkg/jsonpath/lexer_test.go
+++ b/pkg/jsonpath/lexer_test.go
@@ -24,7 +24,7 @@ func TestLexer(t *testing.T) {
 CaseLoop:
 	for _, testCase := range []struct {
 		source  string
-		results []string
+		results []Segment
 		goodEnd func(error) bool
 	}{
 		{"", nil, badEnd},
@@ -32,20 +32,41 @@ CaseLoop:
 			nil,
 			badEnd},
 		{`$.xyz`,
-			[]string{"xyz"},
+			[]Segment{{Kind: SegmentKindField, Name: "xyz"}},
 			cleanEOF},
 		{`$["foo.bar/baz"]`,
-			[]string{"foo.bar/baz"},
+			[]Segment{{Kind: SegmentKindField, Name: "foo.bar/baz"}},
 			cleanEOF},
 		{`$["foo.bar/baz"].zork`,
-			[]string{"foo.bar/baz", "zork"},
+			[]Segment{{Kind: SegmentKindField, Name: "foo.bar/baz"}, {Kind: SegmentKindField, Name: "zork"}},
 			cleanEOF},
 		{`$.zot["foo.bar/baz"]`,
-			[]string{"zot", "foo.bar/baz"},
+			[]Segment{{Kind: SegmentKindField, Name: "zot"}, {Kind: SegmentKindField, Name: "foo.bar/baz"}},
 			cleanEOF},
 		{`$.`, nil, badEnd},
 		{`$[`, nil, badEnd},
 		{`$[]`, nil, badEnd},
+		{`$.spec.resources.GenericItems[*].generictemplate.metadata.resourceVersion`,
+			[]Segment{
+				{Kind: SegmentKindField, Name: "spec"},
+				{Kind: SegmentKindField, Name: "resources"},
+				{Kind: SegmentKindField, Name: "GenericItems"},
+				{Kind: SegmentKindWildcard},
+				{Kind: SegmentKindField, Name: "generictemplate"},
+				{Kind: SegmentKindField, Name: "metadata"},
+				{Kind: SegmentKindField, Name: "resourceVersion"},
+			},
+			cleanEOF},
+		{`$.spec.resources.GenericItems.*.metadata.resourceVersion`,
+			[]Segment{
+				{Kind: SegmentKindField, Name: "spec"},
+				{Kind: SegmentKindField, Name: "resources"},
+				{Kind: SegmentKindField, Name: "GenericItems"},
+				{Kind: SegmentKindWildcard},
+				{Kind: SegmentKindField, Name: "metadata"},
+				{Kind: SegmentKindField, Name: "resourceVersion"},
+			},
+			cleanEOF},
 	} {
 		query, err := ParseQuery(testCase.source)
 		for idx, good := range testCase.results {
@@ -54,7 +75,7 @@ CaseLoop:
 				continue
 			}
 			if query[idx] != good {
-				t.Errorf("For source %q, segment %d is %q but expected token %q", testCase.source, idx, query[idx], good)
+				t.Errorf("For source %q, segment %d is %#v but expected %#v", testCase.source, idx, query[idx], good)
 				continue CaseLoop
 			}
 		}

--- a/pkg/transport/generic/generic_transport_controller_test.go
+++ b/pkg/transport/generic/generic_transport_controller_test.go
@@ -162,6 +162,19 @@ func (rg *generator) generateObject() mrObjRsc {
 					APIVersion: "apps/v1",
 				},
 				MaxReplicas: 2,
+				Metrics: []k8sautoscalingapiv2.MetricSpec{
+					{
+						Type: k8sautoscalingapiv2.PodsMetricSourceType,
+						Pods: &k8sautoscalingapiv2.PodsMetricSource{
+							Metric: k8sautoscalingapiv2.MetricIdentifier{
+								Name: "cpu-limit",
+							},
+							Target: k8sautoscalingapiv2.MetricTarget{
+								Type: k8sautoscalingapiv2.AverageValueMetricType,
+							},
+						},
+					},
+				},
 			},
 		}, "horizontalpodautoscalers"}
 	}
@@ -373,7 +386,15 @@ func TestGenericController(t *testing.T) {
 	}
 	bindingCase := gen.generateBindingCase("b1", objs)
 	logger.V(3).Info("Generated bindingCase", "case", bindingCase)
-	wdsKsObjs := []runtime.Object{bindingCase.Binding, ct}
+	ct2 := &ksapi.CustomTransform{
+		TypeMeta:   metav1.TypeMeta{APIVersion: ksapi.GroupVersion.String(), Kind: "CustomTransform"},
+		ObjectMeta: metav1.ObjectMeta{Name: "test-ct2"},
+		Spec: ksapi.CustomTransformSpec{
+			APIGroup: k8sautoscalingapiv2.SchemeGroupVersion.Group,
+			Resource: "horizontalpodautoscalers",
+			Remove:   []string{`$.spec.metrics[*].pods.metric.name`},
+		}}
+	wdsKsObjs := []runtime.Object{bindingCase.Binding, ct, ct2}
 	wdsKsClientFake := ksclientfake.NewSimpleClientset(wdsKsObjs...)
 	wdsKsInformerFactory := ksinformers.NewSharedInformerFactory(wdsKsClientFake, 0*time.Minute)
 	wdsDynamicClient := dynamicfake.NewSimpleDynamicClient(scheme, wdsK8sObjs...)


### PR DESCRIPTION
## Summary
This PR extends the `jsonpath` package parser and evaluator to support wildcard segments `.*` and `[*]`. It introduces recursive array/slice traversal and defines `ArrayItemNode` to represent slice elements, enabling `Remove()` on fields inside items of slices.

## Related issue(s)
Fixes #3965

## Changes
- Modified `lexer.go` to parse dot-wildcard (`.*`) and bracket-wildcard (`[*]`), returning `Query` as a slice of `Segment`s.
- Modified `eval.go` to implement `ArrayItemNode` and a recursive `QueryValue` helper that traverses slice elements when encountering a wildcard.
- Updated `lexer_test.go` and `eval_test.go` with unit tests for wildcard selections and removal.
- Added integration test inside `generic_transport_controller_test.go` to verify array-level field stripping.

## Testing
- Ran unit tests `go test ./pkg/jsonpath/...` (passed).
- Ran integration tests `go test ./pkg/transport/generic/...` (passed).
