### PR TITLE
🐛 fix(transport): resolve edge-mutation and lifecycle conflicts in OCM transport

### DIFF
--- a/pkg/transport/ocm-transport-controller/pkg/ocm.go
+++ b/pkg/transport/ocm-transport-controller/pkg/ocm.go
@@ -55,12 +55,17 @@ func (ocm *ocm) WrapObjects(wrapees []transport.Wrapee, kindToResource func(sche
 		rsc := kindToResource(gvk.GroupKind())
 
 		var ignorePaths []string
+		var conditionRules []workv1.ConditionRule
 		if gvk.Group == "batch" && gvk.Kind == "Job" {
 			ignorePaths = append(ignorePaths,
 				".spec.selector",
 				".spec.template.metadata.labels.controller-uid",
 				".spec.template.metadata.labels[\"batch.kubernetes.io/controller-uid\"]",
 			)
+			conditionRules = append(conditionRules, workv1.ConditionRule{
+				Condition: "Complete",
+				Type:      workv1.WellKnownConditionsType,
+			})
 		}
 
 		if annotationVal := wrapee.Object.GetAnnotations()["kubestellar.io/ignore-fields"]; annotationVal != "" {
@@ -82,15 +87,10 @@ func (ocm *ocm) WrapObjects(wrapees []transport.Wrapee, kindToResource func(sche
 				},
 				UpdateStrategy: &createOnlyStrategy,
 			})
-		} else if len(ignorePaths) > 0 {
-			configs = append(configs, workv1.ManifestConfigOption{
-				ResourceIdentifier: workv1.ResourceIdentifier{
-					Group:     gvk.Group,
-					Resource:  rsc,
-					Namespace: wrapee.Object.GetNamespace(),
-					Name:      wrapee.Object.GetName(),
-				},
-				UpdateStrategy: &workv1.UpdateStrategy{
+		} else if len(ignorePaths) > 0 || len(conditionRules) > 0 {
+			var updateStrategy *workv1.UpdateStrategy
+			if len(ignorePaths) > 0 {
+				updateStrategy = &workv1.UpdateStrategy{
 					Type: workv1.UpdateStrategyTypeServerSideApply,
 					ServerSideApply: &workv1.ServerSideApplyConfig{
 						FieldManager: workv1.DefaultFieldManager,
@@ -101,7 +101,18 @@ func (ocm *ocm) WrapObjects(wrapees []transport.Wrapee, kindToResource func(sche
 							},
 						},
 					},
+				}
+			}
+
+			configs = append(configs, workv1.ManifestConfigOption{
+				ResourceIdentifier: workv1.ResourceIdentifier{
+					Group:     gvk.Group,
+					Resource:  rsc,
+					Namespace: wrapee.Object.GetNamespace(),
+					Name:      wrapee.Object.GetName(),
 				},
+				UpdateStrategy: updateStrategy,
+				ConditionRules: conditionRules,
 			})
 		}
 	}

--- a/pkg/transport/ocm-transport-controller/pkg/ocm.go
+++ b/pkg/transport/ocm-transport-controller/pkg/ocm.go
@@ -80,7 +80,8 @@ func (ocm *ocm) WrapObjects(wrapees []transport.Wrapee, kindToResource func(sche
 								Condition: workv1.IgnoreFieldsConditionOnSpokePresent,
 								JSONPaths: []string{
 									".spec.selector",
-									".spec.template.metadata.labels",
+									".spec.template.metadata.labels.controller-uid",
+									".spec.template.metadata.labels[\"batch.kubernetes.io/controller-uid\"]",
 								},
 							},
 						},

--- a/pkg/transport/ocm-transport-controller/pkg/ocm.go
+++ b/pkg/transport/ocm-transport-controller/pkg/ocm.go
@@ -50,9 +50,10 @@ func (ocm *ocm) WrapObjects(wrapees []transport.Wrapee, kindToResource func(sche
 	var configs []workv1.ManifestConfigOption
 	for i, wrapee := range wrapees {
 		manifests[i].RawExtension = runtime.RawExtension{Object: wrapee.Object}
+		gvk := wrapee.Object.GroupVersionKind()
+		rsc := kindToResource(gvk.GroupKind())
+
 		if wrapee.CreateOnly {
-			gvk := wrapee.Object.GroupVersionKind()
-			rsc := kindToResource(gvk.GroupKind())
 			configs = append(configs, workv1.ManifestConfigOption{
 				ResourceIdentifier: workv1.ResourceIdentifier{
 					Group:     gvk.Group,
@@ -61,6 +62,30 @@ func (ocm *ocm) WrapObjects(wrapees []transport.Wrapee, kindToResource func(sche
 					Name:      wrapee.Object.GetName(),
 				},
 				UpdateStrategy: &createOnlyStrategy,
+			})
+		} else if gvk.Group == "batch" && gvk.Kind == "Job" {
+			configs = append(configs, workv1.ManifestConfigOption{
+				ResourceIdentifier: workv1.ResourceIdentifier{
+					Group:     gvk.Group,
+					Resource:  rsc,
+					Namespace: wrapee.Object.GetNamespace(),
+					Name:      wrapee.Object.GetName(),
+				},
+				UpdateStrategy: &workv1.UpdateStrategy{
+					Type: workv1.UpdateStrategyTypeServerSideApply,
+					ServerSideApply: &workv1.ServerSideApplyConfig{
+						FieldManager: workv1.DefaultFieldManager,
+						IgnoreFields: []workv1.IgnoreField{
+							{
+								Condition: workv1.IgnoreFieldsConditionOnSpokePresent,
+								JSONPaths: []string{
+									".spec.selector",
+									".spec.template.metadata.labels",
+								},
+							},
+						},
+					},
+				},
 			})
 		}
 	}

--- a/pkg/transport/ocm-transport-controller/pkg/ocm.go
+++ b/pkg/transport/ocm-transport-controller/pkg/ocm.go
@@ -18,6 +18,7 @@ package ocm
 
 import (
 	"fmt"
+	"strings"
 
 	workv1 "open-cluster-management.io/api/work/v1"
 
@@ -53,6 +54,24 @@ func (ocm *ocm) WrapObjects(wrapees []transport.Wrapee, kindToResource func(sche
 		gvk := wrapee.Object.GroupVersionKind()
 		rsc := kindToResource(gvk.GroupKind())
 
+		var ignorePaths []string
+		if gvk.Group == "batch" && gvk.Kind == "Job" {
+			ignorePaths = append(ignorePaths,
+				".spec.selector",
+				".spec.template.metadata.labels.controller-uid",
+				".spec.template.metadata.labels[\"batch.kubernetes.io/controller-uid\"]",
+			)
+		}
+
+		if annotationVal := wrapee.Object.GetAnnotations()["kubestellar.io/ignore-fields"]; annotationVal != "" {
+			parts := strings.Split(annotationVal, ",")
+			for _, p := range parts {
+				if trimmed := strings.TrimSpace(p); trimmed != "" {
+					ignorePaths = append(ignorePaths, trimmed)
+				}
+			}
+		}
+
 		if wrapee.CreateOnly {
 			configs = append(configs, workv1.ManifestConfigOption{
 				ResourceIdentifier: workv1.ResourceIdentifier{
@@ -63,7 +82,7 @@ func (ocm *ocm) WrapObjects(wrapees []transport.Wrapee, kindToResource func(sche
 				},
 				UpdateStrategy: &createOnlyStrategy,
 			})
-		} else if gvk.Group == "batch" && gvk.Kind == "Job" {
+		} else if len(ignorePaths) > 0 {
 			configs = append(configs, workv1.ManifestConfigOption{
 				ResourceIdentifier: workv1.ResourceIdentifier{
 					Group:     gvk.Group,
@@ -78,11 +97,7 @@ func (ocm *ocm) WrapObjects(wrapees []transport.Wrapee, kindToResource func(sche
 						IgnoreFields: []workv1.IgnoreField{
 							{
 								Condition: workv1.IgnoreFieldsConditionOnSpokePresent,
-								JSONPaths: []string{
-									".spec.selector",
-									".spec.template.metadata.labels.controller-uid",
-									".spec.template.metadata.labels[\"batch.kubernetes.io/controller-uid\"]",
-								},
+								JSONPaths: ignorePaths,
 							},
 						},
 					},

--- a/pkg/transport/ocm-transport-controller/pkg/ocm_test.go
+++ b/pkg/transport/ocm-transport-controller/pkg/ocm_test.go
@@ -59,8 +59,8 @@ func TestWrapObjects(t *testing.T) {
 	if jobConfig.UpdateStrategy == nil || jobConfig.UpdateStrategy.Type != workv1.UpdateStrategyTypeServerSideApply {
 		t.Errorf("expected ServerSideApply update strategy for Job, got %v", jobConfig.UpdateStrategy)
 	}
-	if len(jobConfig.UpdateStrategy.ServerSideApply.IgnoreFields) == 0 {
-		t.Errorf("expected IgnoreFields for Job")
+	if len(jobConfig.UpdateStrategy.ServerSideApply.IgnoreFields) == 0 || len(jobConfig.UpdateStrategy.ServerSideApply.IgnoreFields[0].JSONPaths) != 3 {
+		t.Errorf("expected 3 IgnoreFields for Job")
 	}
 
 	// Second config should be for CreateOnly deployment (wrapee3)

--- a/pkg/transport/ocm-transport-controller/pkg/ocm_test.go
+++ b/pkg/transport/ocm-transport-controller/pkg/ocm_test.go
@@ -72,6 +72,12 @@ func TestWrapObjects(t *testing.T) {
 	if len(jobConfig.UpdateStrategy.ServerSideApply.IgnoreFields) == 0 || len(jobConfig.UpdateStrategy.ServerSideApply.IgnoreFields[0].JSONPaths) != 3 {
 		t.Errorf("expected 3 IgnoreFields for Job")
 	}
+	if len(jobConfig.ConditionRules) != 1 {
+		t.Fatalf("expected 1 ConditionRule for Job, got %d", len(jobConfig.ConditionRules))
+	}
+	if jobConfig.ConditionRules[0].Condition != "Complete" || jobConfig.ConditionRules[0].Type != workv1.WellKnownConditionsType {
+		t.Errorf("expected WellKnownConditions Complete rule for Job, got %v", jobConfig.ConditionRules[0])
+	}
 
 	// Second config should be for CreateOnly deployment (wrapee3)
 	deployConfig := manifestWork.Spec.ManifestConfigs[1]

--- a/pkg/transport/ocm-transport-controller/pkg/ocm_test.go
+++ b/pkg/transport/ocm-transport-controller/pkg/ocm_test.go
@@ -1,0 +1,74 @@
+package ocm
+
+import (
+	"testing"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	workv1 "open-cluster-management.io/api/work/v1"
+
+	"github.com/kubestellar/kubestellar/pkg/transport"
+)
+
+func TestWrapObjects(t *testing.T) {
+	ocmTransport := NewOCMTransport()
+
+	// 1. Create a non-Job object that is NOT createOnly
+	configMap := &unstructured.Unstructured{}
+	configMap.SetGroupVersionKind(schema.GroupVersionKind{Group: "", Version: "v1", Kind: "ConfigMap"})
+	configMap.SetName("test-cm")
+	configMap.SetNamespace("default")
+	wrapee1 := transport.NewWrapee(configMap, false)
+
+	// 2. Create a Job object
+	job := &unstructured.Unstructured{}
+	job.SetGroupVersionKind(schema.GroupVersionKind{Group: "batch", Version: "v1", Kind: "Job"})
+	job.SetName("test-job")
+	job.SetNamespace("default")
+	wrapee2 := transport.NewWrapee(job, false)
+
+	// 3. Create a CreateOnly object
+	createOnlyObj := &unstructured.Unstructured{}
+	createOnlyObj.SetGroupVersionKind(schema.GroupVersionKind{Group: "apps", Version: "v1", Kind: "Deployment"})
+	createOnlyObj.SetName("test-deploy")
+	createOnlyObj.SetNamespace("default")
+	wrapee3 := transport.NewWrapee(createOnlyObj, true)
+
+	wrapees := []transport.Wrapee{wrapee1, wrapee2, wrapee3}
+
+	kindToResource := func(gk schema.GroupKind) string {
+		return gk.Kind + "s" // Simplistic mock
+	}
+
+	result := ocmTransport.WrapObjects(wrapees, kindToResource)
+
+	manifestWork, ok := result.(*workv1.ManifestWork)
+	if !ok {
+		t.Fatalf("expected *workv1.ManifestWork, got %T", result)
+	}
+
+	if len(manifestWork.Spec.ManifestConfigs) != 2 {
+		t.Fatalf("expected 2 manifest configs, got %d", len(manifestWork.Spec.ManifestConfigs))
+	}
+
+	// First config should be for Job (wrapee2)
+	jobConfig := manifestWork.Spec.ManifestConfigs[0]
+	if jobConfig.ResourceIdentifier.Resource != "Jobs" {
+		t.Errorf("expected Jobs resource, got %s", jobConfig.ResourceIdentifier.Resource)
+	}
+	if jobConfig.UpdateStrategy == nil || jobConfig.UpdateStrategy.Type != workv1.UpdateStrategyTypeServerSideApply {
+		t.Errorf("expected ServerSideApply update strategy for Job, got %v", jobConfig.UpdateStrategy)
+	}
+	if len(jobConfig.UpdateStrategy.ServerSideApply.IgnoreFields) == 0 {
+		t.Errorf("expected IgnoreFields for Job")
+	}
+
+	// Second config should be for CreateOnly deployment (wrapee3)
+	deployConfig := manifestWork.Spec.ManifestConfigs[1]
+	if deployConfig.ResourceIdentifier.Resource != "Deployments" {
+		t.Errorf("expected Deployments resource, got %s", deployConfig.ResourceIdentifier.Resource)
+	}
+	if deployConfig.UpdateStrategy == nil || deployConfig.UpdateStrategy.Type != workv1.UpdateStrategyTypeCreateOnly {
+		t.Errorf("expected CreateOnly update strategy for Deployment, got %v", deployConfig.UpdateStrategy)
+	}
+}

--- a/pkg/transport/ocm-transport-controller/pkg/ocm_test.go
+++ b/pkg/transport/ocm-transport-controller/pkg/ocm_test.go
@@ -34,7 +34,17 @@ func TestWrapObjects(t *testing.T) {
 	createOnlyObj.SetNamespace("default")
 	wrapee3 := transport.NewWrapee(createOnlyObj, true)
 
-	wrapees := []transport.Wrapee{wrapee1, wrapee2, wrapee3}
+	// 4. Create an object with the ignore-fields annotation
+	annotatedObj := &unstructured.Unstructured{}
+	annotatedObj.SetGroupVersionKind(schema.GroupVersionKind{Group: "apps", Version: "v1", Kind: "Deployment"})
+	annotatedObj.SetName("test-annotated")
+	annotatedObj.SetNamespace("default")
+	annotatedObj.SetAnnotations(map[string]string{
+		"kubestellar.io/ignore-fields": ".spec.replicas, .spec.template.metadata.labels",
+	})
+	wrapee4 := transport.NewWrapee(annotatedObj, false)
+
+	wrapees := []transport.Wrapee{wrapee1, wrapee2, wrapee3, wrapee4}
 
 	kindToResource := func(gk schema.GroupKind) string {
 		return gk.Kind + "s" // Simplistic mock
@@ -47,8 +57,8 @@ func TestWrapObjects(t *testing.T) {
 		t.Fatalf("expected *workv1.ManifestWork, got %T", result)
 	}
 
-	if len(manifestWork.Spec.ManifestConfigs) != 2 {
-		t.Fatalf("expected 2 manifest configs, got %d", len(manifestWork.Spec.ManifestConfigs))
+	if len(manifestWork.Spec.ManifestConfigs) != 3 {
+		t.Fatalf("expected 3 manifest configs, got %d", len(manifestWork.Spec.ManifestConfigs))
 	}
 
 	// First config should be for Job (wrapee2)
@@ -70,5 +80,23 @@ func TestWrapObjects(t *testing.T) {
 	}
 	if deployConfig.UpdateStrategy == nil || deployConfig.UpdateStrategy.Type != workv1.UpdateStrategyTypeCreateOnly {
 		t.Errorf("expected CreateOnly update strategy for Deployment, got %v", deployConfig.UpdateStrategy)
+	}
+
+	// Third config should be for annotated object (wrapee4)
+	annotatedConfig := manifestWork.Spec.ManifestConfigs[2]
+	if annotatedConfig.ResourceIdentifier.Resource != "Deployments" {
+		t.Errorf("expected Deployments resource, got %s", annotatedConfig.ResourceIdentifier.Resource)
+	}
+	if annotatedConfig.UpdateStrategy == nil || annotatedConfig.UpdateStrategy.Type != workv1.UpdateStrategyTypeServerSideApply {
+		t.Errorf("expected ServerSideApply update strategy for Annotated Obj, got %v", annotatedConfig.UpdateStrategy)
+	}
+	if len(annotatedConfig.UpdateStrategy.ServerSideApply.IgnoreFields) == 0 {
+		t.Fatalf("expected IgnoreFields for Annotated Obj")
+	}
+	if len(annotatedConfig.UpdateStrategy.ServerSideApply.IgnoreFields[0].JSONPaths) != 2 {
+		t.Errorf("expected 2 IgnoreFields for Annotated Obj, got %v", annotatedConfig.UpdateStrategy.ServerSideApply.IgnoreFields[0].JSONPaths)
+	}
+	if annotatedConfig.UpdateStrategy.ServerSideApply.IgnoreFields[0].JSONPaths[0] != ".spec.replicas" || annotatedConfig.UpdateStrategy.ServerSideApply.IgnoreFields[0].JSONPaths[1] != ".spec.template.metadata.labels" {
+		t.Errorf("unexpected IgnoreFields parsed: %v", annotatedConfig.UpdateStrategy.ServerSideApply.IgnoreFields[0].JSONPaths)
 	}
 }


### PR DESCRIPTION
## Summary

This PR utilizes native OCM features (`ServerSideApply`, `IgnoreFields`, and `ConditionRules`) to solve four critical edge-mutation and lifecycle bugs.

1. **Fixes immutable Job selector error on edge (#3960):** 
Currently, KubeStellar explicitly strips `controller-uid` and `.spec.selector` from a `batch/v1` `Job` prior to transport. Because the resulting payload lacks a selector, the OCM work-agent attempts to apply a `null` selector over the edge Job's auto-generated selector, which the Kubernetes API rejects (`field is immutable`). This PR hardcodes `IgnoreFields` for `.spec.selector` and the `controller-uid` labels to natively prevent this conflict.

2. **Fixes Job TTL infinite rerun loop (#3961):**
When a Job completes on the edge and is cleaned up by the TTL controller, OCM attempts to recreate it because the WDS object still exists, causing infinite executions. This PR injects a `WellKnownConditionsType` rule for the `Complete` condition on Jobs, instructing the OCM work-agent to stop updating/recreating the Job once it successfully completes.

3. **Adds dynamic `kubestellar.io/ignore-fields` annotation (#3959, #3962):**
To solve edge-controller ping-pong loops (such as an Edge HPA fighting with the Hub's desired `Deployment.spec.replicas`, or a Hub fighting with an Edge CSI provisioner over `PVC.spec.volumeName`), this PR introduces the `kubestellar.io/ignore-fields` annotation. If a user annotates an object with a comma-separated list of JSONPaths (e.g., `kubestellar.io/ignore-fields: ".spec.replicas, .spec.volumeName"`), the transport controller will automatically instruct the edge work-agent to ignore diffs on those fields.

## Related issue(s)

Fixes #3959
Fixes #3960
Fixes #3961
Fixes #3962
