### PR TITLE
fix(controllers): fix tombstone unwrapping panics and ignored ListOptions in informers

### DIFF
--- a/pkg/binding/crd.go
+++ b/pkg/binding/crd.go
@@ -152,10 +152,10 @@ func (c *Controller) startInformersForNewAPIResources(ctx context.Context, toSta
 		informer := cache.NewSharedIndexInformer(
 			&cache.ListWatch{
 				ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
-					return c.dynamicClient.Resource(gvr).List(context.TODO(), metav1.ListOptions{})
+					return c.dynamicClient.Resource(gvr).List(context.TODO(), options)
 				},
 				WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
-					return c.dynamicClient.Resource(gvr).Watch(context.TODO(), metav1.ListOptions{})
+					return c.dynamicClient.Resource(gvr).Watch(context.TODO(), options)
 				},
 			},
 			nil,

--- a/pkg/transport/generic/generic_transport_controller.go
+++ b/pkg/transport/generic/generic_transport_controller.go
@@ -198,7 +198,7 @@ func NewTransportControllerForWrappedObjectGVR(ctx context.Context,
 		},
 		UpdateFunc: func(_, new interface{}) { transportController.handleBinding(new, "update") },
 		DeleteFunc: func(obj any) {
-			if dfsu, is := obj.(*cache.DeletedFinalStateUnknown); is {
+			if dfsu, is := obj.(cache.DeletedFinalStateUnknown); is {
 				obj = dfsu.Obj
 			}
 			transportController.handleBinding(obj, "delete")
@@ -234,7 +234,7 @@ func NewTransportControllerForWrappedObjectGVR(ctx context.Context,
 			transportController.handleWrappedObject(new, "update")
 		},
 		DeleteFunc: func(obj any) {
-			if dfsu, is := obj.(*cache.DeletedFinalStateUnknown); is {
+			if dfsu, is := obj.(cache.DeletedFinalStateUnknown); is {
 				obj = dfsu.Obj
 			}
 			transportController.handleWrappedObject(obj, "delete")
@@ -250,7 +250,7 @@ func NewTransportControllerForWrappedObjectGVR(ctx context.Context,
 			transportController.handlePropertiesEvent(new, "update")
 		},
 		DeleteFunc: func(obj any) {
-			if dfsu, is := obj.(*cache.DeletedFinalStateUnknown); is {
+			if dfsu, is := obj.(cache.DeletedFinalStateUnknown); is {
 				obj = dfsu.Obj
 			}
 			transportController.handlePropertiesEvent(obj, "delete")
@@ -266,7 +266,7 @@ func NewTransportControllerForWrappedObjectGVR(ctx context.Context,
 			transportController.handlePropertiesEvent(new, "update")
 		},
 		DeleteFunc: func(obj any) {
-			if dfsu, is := obj.(*cache.DeletedFinalStateUnknown); is {
+			if dfsu, is := obj.(cache.DeletedFinalStateUnknown); is {
 				obj = dfsu.Obj
 			}
 			transportController.handlePropertiesEvent(obj, "delete")


### PR DESCRIPTION
### Summary of Changes

This PR addresses two real bugs in controller informer event handling and watch resumption:

1. **Fix runtime panic on tombstone unwrapping in `generic_transport_controller.go`**
   - Four `DeleteFunc` event handlers previously attempted a pointer type assertion to `*cache.DeletedFinalStateUnknown`.
   - In `k8s.io/client-go/tools/cache`, `DeletedFinalStateUnknown` is constructed and passed as a value struct, not a pointer. Because the pointer type assertion always evaluated to `false`, object unwrapping failed whenever a tombstone was received (e.g., deletion occurring while the informer was disconnected). The tombstone wrapper was passed directly into `handleBinding`, `handleWrappedObject`, and `handlePropertiesEvent`, resulting in a runtime panic upon type assertion (e.g., `obj.(*v1alpha1.Binding)` or `obj.(metav1.Object)`).
   - This change updates the assertions to value checks (`obj.(cache.DeletedFinalStateUnknown)`), matching standard client-go usage and the adjacent `customTransformInformer` handler in the same file.

2. **Honor `ListOptions` parameter in dynamic CRD informer (`crd.go`)**
   - The `ListFunc` and `WatchFunc` implementations for dynamic CRD informers previously ignored the `options metav1.ListOptions` parameter provided by `cache.NewSharedIndexInformer`, passing an empty `metav1.ListOptions{}` instead.
   - During watch resumptions or relist operations, client-go sets critical parameters in `options`, most notably `ResourceVersion`. Passing an empty option struct caused watches to lose resource version continuity upon reconnection.
   - This fix ensures the provided `options` argument is properly forwarded to `.List(...)` and `.Watch(...)`.

### Verification
- Checked with `go vet ./...`.
- Confirmed all unit tests in `pkg/...` compile and pass cleanly.