### PR TITLE
fix(binding): prevent deadlocks in bindingpolicy resolver

### DIFF
--- a/pkg/binding/bindingpolicy-resolver.go
+++ b/pkg/binding/bindingpolicy-resolver.go
@@ -387,9 +387,6 @@ func (resolver *bindingPolicyResolver) GetReportedStateRequestForObject(objId ut
 }
 
 func (resolver *bindingPolicyResolver) GetSingletonReportedStateRequestsForBinding(bindingPolicyKey string) []SingletonReportedStateReturnStatus {
-	resolver.RWMutex.RLock()
-	defer resolver.RWMutex.RUnlock()
-
 	resolution := resolver.getResolution(bindingPolicyKey)
 	if resolution == nil {
 		return nil
@@ -407,9 +404,9 @@ func (resolver *bindingPolicyResolver) GetSingletonReportedStateRequestsForBindi
 // if it exists.
 func (resolver *bindingPolicyResolver) DeleteResolution(bindingPolicyKey string) {
 	resolver.Lock() // lock for modifying map
-	defer resolver.Unlock()
-
 	delete(resolver.bindingPolicyToResolution, bindingPolicyKey)
+	resolver.Unlock()
+
 	resolver.broker.NotifyBindingPolicyCallbacks(bindingPolicyKey)
 }
 


### PR DESCRIPTION
### Summary of Changes

This PR addresses two concurrency deadlock vulnerabilities in `bindingPolicyResolver`:

1. **Reentrant Read Lock Deadlock (`GetSingletonReportedStateRequestsForBinding`)**:
   - `GetSingletonReportedStateRequestsForBinding` previously acquired a read lock on the resolver (`resolver.RWMutex.RLock()`), and then called `resolver.getResolution`, which internally acquired the same read lock again. 
   - In Go, `sync.RWMutex` is susceptible to a reentrant read lock deadlock if a writer requests a lock between the first and second read lock acquisitions. Removing the outer, redundant lock prevents this issue while maintaining thread safety.

2. **Callback Deadlock (`DeleteResolution`)**:
   - `DeleteResolution` held a write lock on the resolver (`resolver.Lock()`) while synchronously executing `resolver.broker.NotifyBindingPolicyCallbacks`.
   - Executing callbacks while holding a write lock is a known anti-pattern in Go, as callbacks frequently call back into the same component (to fetch the latest state, e.g. via `ResolutionExists` or `GetReportedStateRequestForObject`), attempting to acquire a read lock. This would immediately deadlock because the writer lock is still held. 
   - The fix releases the write lock immediately after mutating the map, before invoking the callback broker.

### Verification
- Checked with `go vet ./...`.