### PR TITLE
🐛 fix(transport): stop removeFinalizer from mutating informer-cache Binding objects

### DIFF
--- a/pkg/transport/generic/generic_transport_controller.go
+++ b/pkg/transport/generic/generic_transport_controller.go
@@ -1224,25 +1224,24 @@ func addFinalizer(binding *v1alpha1.Binding, finalizer string) (*v1alpha1.Bindin
 // removeFinalizer accepts Binding object and removes the provided finalizer if present.
 // It returns the updated (or not) Binding and an indication of whether it updated the object's list of finalizers.
 func removeFinalizer(binding *v1alpha1.Binding, finalizer string) (*v1alpha1.Binding, bool) {
-	finalizersList := binding.GetFinalizers()
-	length := len(finalizersList)
-
-	index := 0
-	for i := 0; i < length; i++ {
-		if finalizersList[i] == finalizer {
-			continue
-		}
-		finalizersList[index] = finalizersList[i]
-		index++
-	}
-	if length == index { // finalizer wasn't found, no need to remove
+	finalizers := binding.GetFinalizers()
+	if !slices.Contains(finalizers, finalizer) { // finalizer wasn't found, no need to remove
 		return binding, false
 	}
 	// otherwise, finalizer was found and has to be removed.
 	// objects returned from a BindingLister must be treated as read-only.
 	// Therefore, create a deep copy before updating the object.
 	updatedBinding := binding.DeepCopy()
-	updatedBinding.SetFinalizers(finalizersList[:index])
+	updatedFinalizers := updatedBinding.GetFinalizers()
+	index := 0
+	for _, item := range updatedFinalizers {
+		if item == finalizer {
+			continue
+		}
+		updatedFinalizers[index] = item
+		index++
+	}
+	updatedBinding.SetFinalizers(updatedFinalizers[:index])
 	return updatedBinding, true
 }
 

--- a/pkg/transport/generic/generic_transport_controller_test.go
+++ b/pkg/transport/generic/generic_transport_controller_test.go
@@ -438,3 +438,57 @@ func TestGenericController(t *testing.T) {
 		logger.Info("Success", "objects", len(objs), "numExpected", len(transport.expect))
 	}
 }
+
+func TestRemoveFinalizer(t *testing.T) {
+	newBinding := func(finalizers []string) *ksapi.Binding {
+		return &ksapi.Binding{ObjectMeta: metav1.ObjectMeta{Name: "binding", Finalizers: finalizers}}
+	}
+	original := []string{"keep-1", "remove-me", "keep-2", "keep-3"}
+
+	t.Run("removes finalizer without mutating input", func(t *testing.T) {
+		binding := newBinding(append([]string(nil), original...))
+		wantFinalizers := []string{"keep-1", "keep-2", "keep-3"}
+
+		updated, changed := removeFinalizer(binding, "remove-me")
+		if !changed {
+			t.Fatal("expected changed == true")
+		}
+		if !apiequality.Semantic.DeepEqual(updated.Finalizers, wantFinalizers) {
+			t.Fatalf("expected finalizers %v, got %v", wantFinalizers, updated.Finalizers)
+		}
+		// The original (informer-cache) object must remain untouched.
+		if !apiequality.Semantic.DeepEqual(binding.Finalizers, original) {
+			t.Fatalf("original object was mutated: %v", binding.Finalizers)
+		}
+	})
+
+	t.Run("removing last finalizer", func(t *testing.T) {
+		binding := newBinding([]string{"only"})
+
+		updated, changed := removeFinalizer(binding, "only")
+		if !changed {
+			t.Fatal("expected changed == true")
+		}
+		if len(updated.Finalizers) != 0 {
+			t.Fatalf("expected empty finalizers, got %v", updated.Finalizers)
+		}
+		if len(binding.Finalizers) != 1 {
+			t.Fatalf("original object was mutated: %v", binding.Finalizers)
+		}
+	})
+
+	t.Run("finalizer not present returns unchanged", func(t *testing.T) {
+		binding := newBinding([]string{"keep-1", "keep-2"})
+
+		updated, changed := removeFinalizer(binding, "not-there")
+		if changed {
+			t.Fatal("expected changed == false")
+		}
+		if updated != binding {
+			t.Fatal("expected the same object to be returned")
+		}
+		if !apiequality.Semantic.DeepEqual(binding.Finalizers, []string{"keep-1", "keep-2"}) {
+			t.Fatalf("original object was mutated: %v", binding.Finalizers)
+		}
+	})
+}


### PR DESCRIPTION
**What this PR does / why we need it:**

`removeFinalizer` in `pkg/transport/generic/generic_transport_controller.go` compacts the finalizers slice **in place** and only creates a deep copy afterwards:

```go
finalizersList := binding.GetFinalizers()  // backing array of the cache object
...
finalizersList[index] = finalizersList[i]  // ← mutates the cache object
...
updatedBinding := binding.DeepCopy()       // ← too late
```

`GetFinalizers()` returns the underlying slice of the object handed in, and that object comes straight from the informer's `BindingLister`. The file's own `addFinalizer` documents the invariant: *"objects returned from a BindingLister must be treated as read-only"* — and correctly deep-copies **first**. `removeFinalizer` violates the same invariant:

- Removing `"B"` from `["A","B","C"]` leaves the shared cache object holding `["A","C","C"]` — silent corruption of the informer cache.
- Multiple workers reading the same cached `Binding` concurrently can race on the shared backing array.

**The fix:**

Check for the finalizer's presence **without mutating** (using `slices.Contains`), then `DeepCopy()` first and compact the copy's own slice — mirroring `addFinalizer`. The returned result is identical to before; only the (buggy) in-place mutation of the input is gone.

**Tests added:**

`TestRemoveFinalizer` with subtests:
- removes a middle finalizer without mutating the input object
- removes the last remaining finalizer
- finalizer-not-present returns the same object, unchanged

**Verified** the test fails against the old implementation (it reports `original object was mutated: [keep-1 keep-2 keep-3 keep-3]`) and passes with the fix, clean under `-race`.

**Special notes for your reviewer:**

None.