### PR TITLE
🐛 fix(status): correct combined-field AVG/MIN/MAX aggregation over missing subjects

### DIFF
--- a/pkg/status/combinedstatus-resolution.go
+++ b/pkg/status/combinedstatus-resolution.go
@@ -938,28 +938,33 @@ func calculateCombinedFieldAggregation(combinedFieldNamedAgg v1alpha1.NamedAggre
 		}
 		numStr = strconv.FormatFloat(sum, 'g', -1, 64)
 	case v1alpha1.AggregatorTypeAvg:
-		var avg float64 = math.NaN()
-		if count := len(rows); count > 0 {
-			sum := 0.0
-			for dest, row := range rows {
-				subject, err1 := getCombinedFieldSubject(combinedFieldNamedAgg, row)
-				if err1 != "" {
-					if errStr == "" {
-						errStr = fmt.Sprintf("for WEC %s, %s", dest.ClusterId, err1)
-					}
+		avg := math.NaN()
+		sum := 0.0
+		count := 0
+		for dest, row := range rows {
+			subject, err1 := getCombinedFieldSubject(combinedFieldNamedAgg, row)
+			if err1 != "" {
+				if errStr == "" {
+					errStr = fmt.Sprintf("for WEC %s, %s", dest.ClusterId, err1)
 				}
-				if subject == nil {
-					continue
-				}
-				sum += *subject
 			}
-			avg = sum / float64(count)
+			if subject == nil {
+				continue
+			}
+			sum += *subject
+			count++
+		}
+		if count == 0 {
+			if errStr == "" {
+				errStr = "no values to average"
+			}
 		} else {
-			errStr = "no values to average"
+			avg = sum / float64(count)
 		}
 		numStr = strconv.FormatFloat(avg, 'g', -1, 64)
 	case v1alpha1.AggregatorTypeMin:
 		min := math.Inf(1)
+		count := 0
 		for dest, row := range rows {
 			subject, err1 := getCombinedFieldSubject(combinedFieldNamedAgg, row)
 			if err1 != "" {
@@ -970,13 +975,18 @@ func calculateCombinedFieldAggregation(combinedFieldNamedAgg v1alpha1.NamedAggre
 			if subject == nil {
 				continue
 			}
+			count++
 			if *subject < min {
 				min = *subject
 			}
 		}
+		if count == 0 && errStr == "" {
+			errStr = "no values to take minimum of"
+		}
 		numStr = strconv.FormatFloat(min, 'g', -1, 64)
 	case v1alpha1.AggregatorTypeMax:
 		max := math.Inf(-1)
+		count := 0
 		for dest, row := range rows {
 			subject, err1 := getCombinedFieldSubject(combinedFieldNamedAgg, row)
 			if err1 != "" {
@@ -987,9 +997,13 @@ func calculateCombinedFieldAggregation(combinedFieldNamedAgg v1alpha1.NamedAggre
 			if subject == nil {
 				continue
 			}
+			count++
 			if *subject > max {
 				max = *subject
 			}
+		}
+		if count == 0 && errStr == "" {
+			errStr = "no values to take maximum of"
 		}
 		numStr = strconv.FormatFloat(max, 'g', -1, 64)
 	default:

--- a/pkg/status/combinedstatus-resolution_test.go
+++ b/pkg/status/combinedstatus-resolution_test.go
@@ -1,0 +1,121 @@
+/*
+Copyright 2026 The KubeStellar Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package status
+
+import (
+	"testing"
+
+	celtypes "github.com/google/cel-go/common/types"
+	"github.com/google/cel-go/common/types/ref"
+
+	"github.com/kubestellar/kubestellar/api/control/v1alpha1"
+)
+
+func namedAgg(aggType v1alpha1.AggregatorType) v1alpha1.NamedAggregator {
+	return v1alpha1.NamedAggregator{Name: "field", Type: aggType}
+}
+
+func rowFragmentWith(subject ref.Val) rowFragment {
+	if subject == nil {
+		return rowFragment{}
+	}
+	return rowFragment{"field": subject}
+}
+
+func destination(clusterId string) v1alpha1.Destination {
+	return v1alpha1.Destination{ClusterId: clusterId}
+}
+
+func TestCalculateCombinedFieldAggregation(t *testing.T) {
+	testCases := []struct {
+		name    string
+		agg     v1alpha1.NamedAggregator
+		rows    map[v1alpha1.Destination]rowFragment
+		wantNum string
+		wantErr string
+	}{
+		{
+			name:    "COUNT counts all rows",
+			agg:     namedAgg(v1alpha1.AggregatorTypeCount),
+			rows:    map[v1alpha1.Destination]rowFragment{destination("w1"): rowFragmentWith(celtypes.Int(5)), destination("w2"): rowFragmentWith(celtypes.Int(7))},
+			wantNum: "2",
+		},
+		{
+			name:    "SUM skips rows without a subject",
+			agg:     namedAgg(v1alpha1.AggregatorTypeSum),
+			rows:    map[v1alpha1.Destination]rowFragment{destination("w1"): rowFragmentWith(celtypes.Int(5)), destination("w2"): rowFragmentWith(nil)},
+			wantNum: "5",
+		},
+		{
+			name:    "AVG uses the number of valid subjects as the denominator",
+			agg:     namedAgg(v1alpha1.AggregatorTypeAvg),
+			rows:    map[v1alpha1.Destination]rowFragment{destination("w1"): rowFragmentWith(celtypes.Int(5)), destination("w2"): rowFragmentWith(celtypes.Int(5)), destination("w3"): rowFragmentWith(nil)},
+			wantNum: "5",
+		},
+		{
+			name:    "AVG of no valid subjects reports an error",
+			agg:     namedAgg(v1alpha1.AggregatorTypeAvg),
+			rows:    map[v1alpha1.Destination]rowFragment{destination("w1"): rowFragmentWith(nil), destination("w2"): rowFragmentWith(nil)},
+			wantNum: "NaN",
+			wantErr: "no values to average",
+		},
+		{
+			name:    "MIN ignores rows without a subject",
+			agg:     namedAgg(v1alpha1.AggregatorTypeMin),
+			rows:    map[v1alpha1.Destination]rowFragment{destination("w1"): rowFragmentWith(celtypes.Int(9)), destination("w2"): rowFragmentWith(celtypes.Int(3)), destination("w3"): rowFragmentWith(nil)},
+			wantNum: "3",
+		},
+		{
+			name:    "MIN of no valid subjects reports an error instead of +Inf",
+			agg:     namedAgg(v1alpha1.AggregatorTypeMin),
+			rows:    map[v1alpha1.Destination]rowFragment{destination("w1"): rowFragmentWith(nil)},
+			wantNum: "+Inf",
+			wantErr: "no values to take minimum of",
+		},
+		{
+			name:    "MAX ignores rows without a subject",
+			agg:     namedAgg(v1alpha1.AggregatorTypeMax),
+			rows:    map[v1alpha1.Destination]rowFragment{destination("w1"): rowFragmentWith(celtypes.Int(9)), destination("w2"): rowFragmentWith(celtypes.Int(3)), destination("w3"): rowFragmentWith(nil)},
+			wantNum: "9",
+		},
+		{
+			name:    "MAX of no valid subjects reports an error instead of -Inf",
+			agg:     namedAgg(v1alpha1.AggregatorTypeMax),
+			rows:    map[v1alpha1.Destination]rowFragment{destination("w1"): rowFragmentWith(nil)},
+			wantNum: "-Inf",
+			wantErr: "no values to take maximum of",
+		},
+		{
+			name:    "aggregation over string subjects parsed as floats",
+			agg:     namedAgg(v1alpha1.AggregatorTypeSum),
+			rows:    map[v1alpha1.Destination]rowFragment{destination("w1"): rowFragmentWith(celtypes.String("2.5")), destination("w2"): rowFragmentWith(celtypes.String("0.5"))},
+			wantNum: "3",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			value, errStr := calculateCombinedFieldAggregation(tc.agg, tc.rows)
+			if value.Number == nil || *value.Number != tc.wantNum {
+				t.Fatalf("expected number %q, got %v", tc.wantNum, value.Number)
+			}
+			if errStr != tc.wantErr {
+				t.Fatalf("expected error %q, got %q", tc.wantErr, errStr)
+			}
+		})
+	}
+}


### PR DESCRIPTION
**What this PR does / why we need it:**

`calculateCombinedFieldAggregation` in `pkg/status/combinedstatus-resolution.go` mishandles rows whose combined-field subject is missing or non-numeric (`getCombinedFieldSubject` returns `nil` for those):

1. **AVG divides by the wrong denominator.** It divides the sum by `len(rows)` instead of the number of valid subjects, so missing values skew the average down (e.g. three rows with two valid values `5`,`5` produced `10/3 ≈ 3.33` instead of `5`).
2. **MIN / MAX report `+Inf` / `-Inf`** when no row has a valid subject, because the `math.Inf` sentinels are formatted and returned as the aggregate with no error.
3. **AVG with rows but no valid subject returned `0`** (with an empty error) instead of an error.

**The fix:**

- Count only rows with a valid subject for the AVG denominator.
- When MIN/MAX/AVG have nothing to aggregate, report a `no values to ...` error (mirroring the existing `no values to average` handling) instead of emitting a meaningless numeric sentinel. A more specific per-WEC parse error, when present, is preserved.

**Tests added:**

`TestCalculateCombinedFieldAggregation` covers all five aggregator types (COUNT, SUM, AVG, MIN, MAX), including missing subjects, string subjects parsed as floats, and the all-missing cases for AVG/MIN/MAX.

**Verified** the new tests fail against the old implementation (the AVG denominator, all-missing AVG, MIN `+Inf`, and MAX `-Inf` cases) and pass with the fix, clean under `-race`.

**Special notes for your reviewer:**

None.