### PR TITLE
fix: remove stale empty key sets from reverse index map

### DIFF
--- a/pkg/abstract/map-to-comparable.go
+++ b/pkg/abstract/map-to-comparable.go
@@ -61,6 +61,9 @@ func (imc *IndexedMapToComparable[Key, Val]) Put(key Key, val Val) (Val, bool) {
 	if had {
 		oldKeys, _ := imc.reverse.Get(oldVal)
 		oldKeys.Delete(key)
+		if oldKeys.Len() == 0 {
+			imc.reverse.Delete(oldVal)
+		}
 	}
 	valKeys, hadVal := imc.reverse.Get(val)
 	if hadVal {
@@ -77,6 +80,9 @@ func (imc *IndexedMapToComparable[Key, Val]) Delete(key Key) (Val, bool) {
 	if had {
 		oldKeys, _ := imc.reverse.Get(oldVal)
 		oldKeys.Delete(key)
+		if oldKeys.Len() == 0 {
+			imc.reverse.Delete(oldVal)
+		}
 	}
 	return oldVal, had
 }

--- a/pkg/abstract/map-to-comparable_test.go
+++ b/pkg/abstract/map-to-comparable_test.go
@@ -87,6 +87,65 @@ func FuzzTestLockedMapToComparable(f *testing.F) {
 		}
 	})
 }
+func TestIndexedMapToComparableNoStaleReverseEntries(t *testing.T) {
+	for _, testCase := range []struct {
+		name string
+		run  func(imc *IndexedMapToComparable[string, string])
+	}{
+		{
+			name: "delete-removes-reverse-entry",
+			run: func(imc *IndexedMapToComparable[string, string]) {
+				imc.Put("a", "x")
+				imc.Delete("a")
+			},
+		},
+		{
+			name: "reassign-removes-old-reverse-entry",
+			run: func(imc *IndexedMapToComparable[string, string]) {
+				imc.Put("a", "x")
+				imc.Put("b", "x")
+				imc.Put("a", "y")
+				imc.Delete("b")
+				imc.Delete("a")
+			},
+		},
+		{
+			name: "reassign-leaves-shared-reverse-entry",
+			run: func(imc *IndexedMapToComparable[string, string]) {
+				imc.Put("a", "x")
+				imc.Put("b", "x")
+				imc.Put("a", "y")
+			},
+		},
+		{
+			name: "reput-same-value-keeps-reverse-entry",
+			run: func(imc *IndexedMapToComparable[string, string]) {
+				imc.Put("a", "x")
+				imc.Put("a", "x")
+			},
+		},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			imc := NewPrimitiveMapToComparable[string, string]()
+			testCase.run(imc)
+			imc.Iterate2(func(key, val string) error {
+				imc.ReadInverse().ContGet(val, func(reverseKeys sets.Set[string]) {
+					if !reverseKeys.Has(key) {
+						t.Errorf("forward entry %q:%q not in reverse keys %v", key, val, reverseKeys)
+					}
+				})
+				return nil
+			})
+			imc.ReadInverse().Iterate2(func(val string, keys sets.Set[string]) error {
+				if keys.Len() == 0 {
+					t.Errorf("reverse has stale empty key set for value %q", val)
+				}
+				return nil
+			})
+		})
+	}
+}
+
 func mtcCheckConsistency(t *testing.T, mtc MutableMapToComparable[int, int]) {
 	inverse := mtc.ReadInverse()
 	mtc.Iterate2(func(key, val int) error {


### PR DESCRIPTION
## Summary

`IndexedMapToComparable` keeps the reverse index map (`Value -> Set[Key]`) in sync with the forward map, but `Put` and `Delete` only remove the affected key from the old value's key set. When that set becomes empty, the empty-set entry stays in the reverse map forever.

### Impact
- **Memory leak**: one stale entry per reassignment/deletion, unbounded over the lifetime of a long-running controller. In the status controller this is `workStatusToObject` (`cache.ObjectName -> ObjectIdentifier`), whose values churn as WorkStatus objects are reassigned to workload objects.
- **Incorrect inverse iteration**: `ReadInverse().Iterate2` reports values that no longer have any keys in the forward map, which can mislead inverse-map consumers.

## Fix
After removing a key from the old value's key set in both `Put` and `Delete`, drop the reverse entry entirely if the set is now empty. The `val == oldVal` re-put path remains correct: deleting the emptied set triggers the `hadVal == false` branch, which recreates and re-inserts the set.

## Testing
- Added `TestIndexedMapToComparableNoStaleReverseEntries` with 4 subtests (delete, reassign, shared-value reassign, re-put same value). Verified it **fails on the old code** (stale empty sets reported) and passes with the fix.
- `go test ./pkg/abstract/...` and `go vet ./pkg/abstract/...` both clean.