### PR TITLE
🐛 transport: add opt-in preserve=clusterip to keep static Service clusterIP on downsync

### DIFF
--- a/docs/to-be-deleted/content/direct/transforming.md
+++ b/docs/to-be-deleted/content/direct/transforming.md
@@ -30,11 +30,11 @@ The following are applied to every workload object.
 
 In a `Service` (core API group) object:
 
-1. remove the following fields from `spec`: `ipFamilies`, `externalTrafficPolicy`, `internalTrafficPolicy`, `ipFamilyPolicy`, `sessionAffinity`. Also remove the `nodePort` field from every port unless the annotation `control.kubestellar.io/preserve=nodeport` is present.
+1. remove the following fields from `spec`: `ipFamilies`, `externalTrafficPolicy`, `internalTrafficPolicy`, `ipFamilyPolicy`, `sessionAffinity`. Also remove the `nodePort` field from every port unless the annotation `control.kubestellar.io/preserve` has a comma-separated value that includes `nodeport`.
 
-1. in the `spec` remove the field `clusterIP` unless it is present with value "None".
+1. in the `spec` remove the field `clusterIP` unless it is present with value "None", or the annotation `control.kubestellar.io/preserve` has a comma-separated value that includes `clusterip`.
 
-1. in the `spec`: if the field `clusterIPs` (which holds an array of strings) is present and those strings include "None" then keep it present holding only "None", otherwise remove that field if it is present.
+1. in the `spec`: if the field `clusterIPs` (which holds an array of strings) is present and those strings include "None" then keep it present holding only "None", otherwise remove that field if it is present; unless the annotation `control.kubestellar.io/preserve` has a comma-separated value that includes `clusterip`, in which case `clusterIPs` is left unchanged.
 
 In a `Job` (API group `batch`) object, remove the following things.
 

--- a/pkg/transport/generic/filtering/service.go
+++ b/pkg/transport/generic/filtering/service.go
@@ -17,6 +17,8 @@ limitations under the License.
 package filtering
 
 import (
+	"strings"
+
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
 	"github.com/kubestellar/kubestellar/pkg/abstract"
@@ -25,7 +27,23 @@ import (
 const (
 	preserveFieldAnnotation = "control.kubestellar.io/preserve"
 	preserveNodePortValue   = "nodeport"
+	preserveClusterIPValue  = "clusterip"
 )
+
+// hasPreserveValue reports whether the object's preserve annotation
+// (a comma-separated list, e.g. "nodeport,clusterip") includes value.
+func hasPreserveValue(object *unstructured.Unstructured, value string) bool {
+	annotations := object.GetAnnotations()
+	if annotations == nil {
+		return false
+	}
+	for _, entry := range strings.Split(annotations[preserveFieldAnnotation], ",") {
+		if strings.TrimSpace(entry) == value {
+			return true
+		}
+	}
+	return false
+}
 
 func cleanService(object *unstructured.Unstructured) {
 	// Fields to remove
@@ -36,11 +54,13 @@ func cleanService(object *unstructured.Unstructured) {
 		unstructured.RemoveNestedField(object.Object, "spec", field)
 	}
 
-	// Keep headless Services headless, remove cluster IPs from others.
-	if val, have, _ := unstructured.NestedString(object.Object, "spec", "clusterIP"); have && val != "None" {
+	// Keep headless Services headless, remove cluster IPs from others, unless the
+	// annotation "control.kubestellar.io/preserve=clusterip" is present.
+	preserveClusterIP := hasPreserveValue(object, preserveClusterIPValue)
+	if val, have, _ := unstructured.NestedString(object.Object, "spec", "clusterIP"); have && val != "None" && !preserveClusterIP {
 		unstructured.RemoveNestedField(object.Object, "spec", "clusterIP")
 	}
-	if val, have, _ := unstructured.NestedStringSlice(object.Object, "spec", "clusterIPs"); have {
+	if val, have, _ := unstructured.NestedStringSlice(object.Object, "spec", "clusterIPs"); have && !preserveClusterIP {
 		newVal := abstract.NewSliceByFilter(val, func(ip string) bool { return ip == "None" })
 		if len(newVal) == 0 {
 			unstructured.RemoveNestedField(object.Object, "spec", "clusterIPs")
@@ -50,7 +70,7 @@ func cleanService(object *unstructured.Unstructured) {
 	}
 
 	// Set the nodePort to an empty string unelss the annotation "control.kubestellar.io/preserve=nodeport" is present
-	if !(object.GetAnnotations() != nil && object.GetAnnotations()[preserveFieldAnnotation] == preserveNodePortValue) {
+	if !hasPreserveValue(object, preserveNodePortValue) {
 		if ports, found, _ := unstructured.NestedSlice(object.Object, "spec", "ports"); found {
 			for i, port := range ports {
 				if portMap, ok := port.(map[string]interface{}); ok {

--- a/pkg/transport/generic/filtering/service_test.go
+++ b/pkg/transport/generic/filtering/service_test.go
@@ -1,0 +1,105 @@
+/*
+Copyright 2024 The KubeStellar Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package filtering
+
+import (
+	"testing"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+func newServiceWithClusterIPAndNodePort(annotations map[string]interface{}) *unstructured.Unstructured {
+	object := map[string]interface{}{
+		"apiVersion": "v1",
+		"kind":       "Service",
+		"metadata": map[string]interface{}{
+			"name": "my-svc",
+		},
+		"spec": map[string]interface{}{
+			"clusterIP":  "10.96.100.100",
+			"clusterIPs": []interface{}{"10.96.100.100"},
+			"ports": []interface{}{
+				map[string]interface{}{
+					"port":     int64(80),
+					"nodePort": int64(32222),
+				},
+			},
+		},
+	}
+	if len(annotations) > 0 {
+		object["metadata"].(map[string]interface{})["annotations"] = annotations
+	}
+	return &unstructured.Unstructured{Object: object}
+}
+
+func TestCleanServiceStripsClusterIPAndNodePortByDefault(t *testing.T) {
+	svc := newServiceWithClusterIPAndNodePort(nil)
+
+	cleanService(svc)
+
+	if _, have, _ := unstructured.NestedString(svc.Object, "spec", "clusterIP"); have {
+		t.Errorf("expected spec.clusterIP to be removed")
+	}
+	if _, have, _ := unstructured.NestedStringSlice(svc.Object, "spec", "clusterIPs"); have {
+		t.Errorf("expected spec.clusterIPs to be removed")
+	}
+	ports, _, _ := unstructured.NestedSlice(svc.Object, "spec", "ports")
+	if got := ports[0].(map[string]interface{})["nodePort"]; got != nil {
+		t.Errorf("expected nodePort to be nil, got %v", got)
+	}
+}
+
+func TestCleanServicePreservesClusterIPWithAnnotation(t *testing.T) {
+	svc := newServiceWithClusterIPAndNodePort(map[string]interface{}{
+		preserveFieldAnnotation: "clusterip",
+	})
+
+	cleanService(svc)
+
+	clusterIP, have, _ := unstructured.NestedString(svc.Object, "spec", "clusterIP")
+	if !have || clusterIP != "10.96.100.100" {
+		t.Errorf("expected spec.clusterIP to be preserved as 10.96.100.100, got %q (present=%v)", clusterIP, have)
+	}
+	clusterIPs, have, _ := unstructured.NestedStringSlice(svc.Object, "spec", "clusterIPs")
+	if !have || len(clusterIPs) != 1 || clusterIPs[0] != "10.96.100.100" {
+		t.Errorf("expected spec.clusterIPs to be preserved as [10.96.100.100], got %v (present=%v)", clusterIPs, have)
+	}
+	// nodePort is preserved only via its own value, not implied by clusterip.
+	ports, _, _ := unstructured.NestedSlice(svc.Object, "spec", "ports")
+	if got := ports[0].(map[string]interface{})["nodePort"]; got != nil {
+		t.Errorf("expected nodePort to still be nil, got %v", got)
+	}
+}
+
+func TestCleanServicePreservesBothWithCommaSeparatedAnnotation(t *testing.T) {
+	svc := newServiceWithClusterIPAndNodePort(map[string]interface{}{
+		preserveFieldAnnotation: "nodeport, clusterip",
+	})
+
+	cleanService(svc)
+
+	clusterIP, have, _ := unstructured.NestedString(svc.Object, "spec", "clusterIP")
+	if !have || clusterIP != "10.96.100.100" {
+		t.Errorf("expected spec.clusterIP to be preserved, got %q (present=%v)", clusterIP, have)
+	}
+	ports, _, _ := unstructured.NestedSlice(svc.Object, "spec", "ports")
+	nodePort := ports[0].(map[string]interface{})["nodePort"]
+	nodePortInt, ok := nodePort.(int64)
+	if !ok || nodePortInt != 32222 {
+		t.Errorf("expected nodePort to be preserved as 32222, got %v", nodePort)
+	}
+}


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Don't forget to first look for overlapping PRs. Remember, open source
is a collaborative rather than competitive activity.

If this PR includes changes to the source files for the website
(docs/content/** or a file included from there) then include a preview
of the modified website; see
docs/content/contribution-guidelines/operations/document-management.md.

Please put one of the following icons at the start of your PR title,
to indicate the type of your PR. You could use copy-and-paste from
here; alternatively, the indicated code is recognized by most browsers
as a way to input that icon.

✨ - code :sparkles:, type feature
🐛 - code :bug:, type bug fix
📖 - code :book:, type docs
📝 - code :memo:, type proposal
⚠️ - code :warning:, type breaking change
🌱 - code :seedling:, type other/misc
❓ - code :question:, type requires manual review/categorization

-->
## Summary

The transport controller's `cleanService` (`pkg/transport/generic/filtering/service.go`) always
strips `spec.clusterIP` / `spec.clusterIPs` (except "None") when wrapping a Service into a
ManifestWork for downsync, so a user-specified static `clusterIP` on the hub/WDS object is lost
and the spoke apiserver auto-allocates a different one — desired-vs-live drift, even though
`Applied=True` / `Available=True`.

The package already had an opt-in escape hatch for the analogous `nodePort` field: the
`control.kubestellar.io/preserve=nodeport` annotation. This PR extends that same mechanism to
`clusterIP` / `clusterIPs`:

- The `control.kubestellar.io/preserve` annotation value is now parsed as a comma-separated list
  (e.g. `nodeport,clusterip`) instead of a single exact-match string. A bare `nodeport` value
  still behaves exactly as before, so this is backward compatible.
- A new opt-in value, `clusterip`, skips stripping of both `spec.clusterIP` and
  `spec.clusterIPs` for that Service.
- Default behavior (no annotation) is unchanged — cluster IPs are still stripped by default,
  since that's correct for the common case where the WEC should allocate its own.
- Updated `docs/to-be-deleted/content/direct/transforming.md` to describe the new annotation
  value.

This is a scoped, opt-in fix for the drift reported in the issue; it does not change default
downsync behavior for any existing Service.

## Validation

Ran, from the repo root:

- `go build ./...` — succeeds.
- `go test ./pkg/transport/generic/filtering/... -v` — all tests pass, including 3 new tests in
  `pkg/transport/generic/filtering/service_test.go` covering: default stripping behavior,
  clusterIP preserved via the new annotation value, and both nodePort+clusterIP preserved via a
  comma-separated (including whitespace-padded) annotation value.
- Confirmed the fix is real, not a no-op: temporarily reverting only `service.go` while keeping
  the new tests causes the two clusterIP-preservation tests to fail with the exact defect
  described in the issue (`clusterIP`/`clusterIPs` end up absent even though the annotation asks
  to preserve them); re-applying the fix makes them pass again.
- `go test ./pkg/transport/...` (whole package tree) — passes.
- `golangci-lint run ./pkg/transport/generic/filtering/...` — no new findings versus the
  pre-existing baseline (2 pre-existing `errcheck` findings on unrelated lines, unchanged by this
  diff); this change happens to resolve a pre-existing `staticcheck` QF1001 finding as a
  byproduct of refactoring the annotation check into a shared helper.
- Not run: the repo's `test/e2e` / integration harness against a live KubeFlex+OCM cluster (the
  scenario in the issue's repro). The defect and fix are demonstrated at the unit level against
  the exact function that performs the ManifestWork field-stripping, so I believe this is
  sufficient, but flagging the limitation explicitly.

## Related issue(s)

Fixes #3978

```release-note
🐛 transport: add opt-in preserve=clusterip to keep static Service clusterIP on downsync
```