### PR TITLE
🌱 chore: migrate deprecated workqueue to typed workqueue

### DIFF
--- a/pkg/binding/binding-controller.go
+++ b/pkg/binding/binding-controller.go
@@ -150,7 +150,7 @@ type Controller struct {
 	bindingPolicyResolver BindingPolicyResolver
 
 	// Contains bindingPolicyRef, bindingRef, util.ObjectIdentifier
-	workqueue        workqueue.RateLimitingInterface
+	workqueue        workqueue.TypedRateLimitingInterface[any]
 	initializedTs    time.Time
 	wdsName          string
 	allowedGroupsSet sets.Set[string]
@@ -292,9 +292,9 @@ func makeController(logger logr.Logger,
 	wdsName string, allowedGroupsSet sets.Set[string],
 	workloadObserver WorkloadEventHandler) (*Controller, error) {
 
-	ratelimiter := workqueue.NewMaxOfRateLimiter(
-		workqueue.NewItemExponentialFailureRateLimiter(5*time.Millisecond, 1000*time.Second),
-		&workqueue.BucketRateLimiter{Limiter: rate.NewLimiter(rate.Limit(50), 300)},
+	ratelimiter := workqueue.NewTypedMaxOfRateLimiter[any](
+		workqueue.NewTypedItemExponentialFailureRateLimiter[any](5*time.Millisecond, 1000*time.Second),
+		&workqueue.TypedBucketRateLimiter[any]{Limiter: rate.NewLimiter(rate.Limit(50), 300)},
 	)
 
 	clusterInformer := clusterPreInformer.Informer()
@@ -322,7 +322,7 @@ func makeController(logger logr.Logger,
 		informers:                   util.NewConcurrentMap[schema.GroupVersionResource, cache.SharedIndexInformer](),
 		stoppers:                    util.NewConcurrentMap[schema.GroupVersionResource, chan struct{}](),
 		bindingPolicyResolver:       NewBindingPolicyResolver(),
-		workqueue:                   workqueue.NewRateLimitingQueueWithConfig(ratelimiter, workqueue.RateLimitingQueueConfig{Name: ControllerName + "-" + wdsName}),
+		workqueue:                   workqueue.NewTypedRateLimitingQueueWithConfig(ratelimiter, workqueue.TypedRateLimitingQueueConfig[any]{Name: ControllerName + "-" + wdsName}),
 		allowedGroupsSet:            allowedGroupsSet,
 	}
 

--- a/pkg/status/status-controller.go
+++ b/pkg/status/status-controller.go
@@ -77,7 +77,7 @@ type Controller struct {
 	workStatusInformer      cache.SharedIndexInformer
 	workStatusLister        cache.GenericLister
 	workStatusIndexer       cache.Indexer
-	workqueue               workqueue.RateLimitingInterface
+	workqueue               workqueue.TypedRateLimitingInterface[any]
 	// all wds listers are used to retrieve objects and update status
 	// without having to re-create new caches for this controller
 	listers util.ConcurrentMap[schema.GroupVersionResource, cache.GenericLister]
@@ -127,9 +127,9 @@ func NewController(logger logr.Logger,
 	wdsRestConfig *rest.Config, itsRestConfig *rest.Config, wdsName string,
 	bindingPolicyResolver binding.BindingPolicyResolver) (*Controller, error) {
 	logger = logger.WithName(ControllerName)
-	ratelimiter := workqueue.NewMaxOfRateLimiter(
-		workqueue.NewItemExponentialFailureRateLimiter(5*time.Millisecond, 1000*time.Second),
-		&workqueue.BucketRateLimiter{Limiter: rate.NewLimiter(rate.Limit(50), 300)},
+	ratelimiter := workqueue.NewTypedMaxOfRateLimiter[any](
+		workqueue.NewTypedItemExponentialFailureRateLimiter[any](5*time.Millisecond, 1000*time.Second),
+		&workqueue.TypedBucketRateLimiter[any]{Limiter: rate.NewLimiter(rate.Limit(50), 300)},
 	)
 
 	wdsDynClientBase, err := dynamic.NewForConfig(wdsRestConfig)
@@ -160,7 +160,7 @@ func NewController(logger logr.Logger,
 		combinedStatusClient: ksmetrics.NewWrappedBasicNamespacedClient(wdsClientMetrics, v1alpha1.GroupVersion.WithResource("combinedstatuses"), func(ns string) ksmetrics.BasicClientModNamespace[*v1alpha1.CombinedStatus, *v1alpha1.CombinedStatusList] {
 			return wdsKsClient.ControlV1alpha1().CombinedStatuses(ns)
 		}),
-		workqueue:             workqueue.NewRateLimitingQueueWithConfig(ratelimiter, workqueue.RateLimitingQueueConfig{Name: ControllerName + "-" + wdsName}),
+		workqueue:             workqueue.NewTypedRateLimitingQueueWithConfig(ratelimiter, workqueue.TypedRateLimitingQueueConfig[any]{Name: ControllerName + "-" + wdsName}),
 		bindingPolicyResolver: bindingPolicyResolver,
 	}
 	controller.workStatusToObject = abstract.NewLockedMapToComparable(&controller.mutex,

--- a/pkg/transport/generic/generic_transport_controller.go
+++ b/pkg/transport/generic/generic_transport_controller.go
@@ -129,7 +129,7 @@ func NewTransportControllerForWrappedObjectGVR(ctx context.Context,
 	customTransformsClient := wdsClientset.ControlV1alpha1().CustomTransforms()
 	measuredCustomTransformClient := ksmetrics.NewWrappedClusterScopedClient[*v1alpha1.CustomTransform, *v1alpha1.CustomTransformList](wdsClientMetrics, v1alpha1.GroupVersion.WithResource("customtransforms"), customTransformsClient)
 	measuredITSNSClient := ksmetrics.NewWrappedClusterScopedClient[*corev1.Namespace, *corev1.NamespaceList](itsClientMetrics, corev1.SchemeGroupVersion.WithResource("namespaces"), itsNSClient)
-	workqueue := workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), ControllerName)
+	workqueue := workqueue.NewTypedRateLimitingQueueWithConfig(workqueue.DefaultTypedControllerRateLimiter[any](), workqueue.TypedRateLimitingQueueConfig[any]{Name: ControllerName})
 
 	transportController := &genericTransportController{
 		logger:                        klog.FromContext(ctx),
@@ -340,7 +340,7 @@ type genericTransportController struct {
 	// easy to ensure we are never processing the same item simultaneously in two different workers.
 	// An item can be either of two types: a string holding the name of a Binding, or a
 	// recollectProperties holding the name of a inventory object.
-	workqueue workqueue.RateLimitingInterface
+	workqueue workqueue.TypedRateLimitingInterface[any]
 
 	transport        transport.Transport //transport is a specific implementation for the transport interface.
 	transportClient  dynamic.Interface   // dynamic client to transport wrapped object. since object kind is unknown during complilation, we use dynamic


### PR DESCRIPTION
## Summary

This PR migrates several `RateLimitingInterface` instances across `pkg/binding`, `pkg/status`, and `pkg/transport` to the new `TypedRateLimitingInterface[any]` introduced in `k8s.io/client-go/util/workqueue` (Kubernetes 1.30). 

It resolves 14 staticcheck deprecation warnings (`SA1019`) related to the untyped rate limiter interfaces and functions, bringing the controller queues up to date with modern `client-go` recommendations without altering functional behavior.

## Related issue(s)

None

cc @MikeSpreitzer @waltforme please review!
