### PR TITLE
📖 governance: add James Reilly and Doug Baggett to the Hive Maintainer Committee

### DIFF
--- a/GOVERNANCE-HIVE.md
+++ b/GOVERNANCE-HIVE.md
@@ -81,6 +81,8 @@ majority vote of the KubeStellar Steering Committee.
 | Name           | GitHub                                            | Role       |
 |----------------|---------------------------------------------------|------------|
 | Andy Anderson  | [@clubanderson](https://github.com/clubanderson)  | Maintainer |
+| James Reilly   | [@hanthor](https://github.com/hanthor)            | Maintainer |
+| Doug Baggett   | [@Danathar](https://github.com/Danathar)          | Maintainer |
 
 ## Contributor Ladder
 


### PR DESCRIPTION
Both accepted a maintainer invitation for the **Hive** subproject.

| Name | GitHub | Role |
|---|---|---|
| James Reilly | [@hanthor](https://github.com/hanthor) | Maintainer |
| Doug Baggett | [@Danathar](https://github.com/Danathar) | Maintainer |

## Paired with kubestellar/hive#4996

That PR updates hive's `OWNERS`, which is the machine-readable form of this table. **They must land together.** `OWNERS`' own header states a change to one without the other is governance drift, and CNCF maturity review checks that code ownership matches documented governance roles.

## Contribution basis

**Danathar** — ~180 commits to hive. Authored the fix for the fork `gate` bug that made *every* outside contributor PR structurally unmergeable, the restart-cost instrumentation, and a host-state command denylist that followed his own incident report.

**hanthor** — steady contribution across the relay and packaging surface.

## Why it matters for Incubation

Hive's Incubation application needs a **demonstrated** maintainer lifecycle — an actual add with outcomes, not a documented process with no exercise of it. This is that demonstration, and it closes the single-maintainer gap the security self-assessment identified as the project's largest institutional risk.