### PR TITLE
🐛 transport: strip binder-owned claimRef identity from PersistentVolumes before downsync

### DIFF
--- a/pkg/transport/generic/filtering/object_filtering_map.go
+++ b/pkg/transport/generic/filtering/object_filtering_map.go
@@ -31,8 +31,9 @@ type cleanObjectSpecificsFunction func(object *unstructured.Unstructured)
 
 func NewObjectFilteringMap() *ObjectFilteringMap {
 	filteringMap := map[schema.GroupVersionKind]cleanObjectSpecificsFunction{
-		corev1.SchemeGroupVersion.WithKind("Service"): cleanService,
-		batchv1.SchemeGroupVersion.WithKind("Job"):    cleanJob,
+		corev1.SchemeGroupVersion.WithKind("Service"):          cleanService,
+		corev1.SchemeGroupVersion.WithKind("PersistentVolume"): cleanPersistentVolume,
+		batchv1.SchemeGroupVersion.WithKind("Job"):             cleanJob,
 	}
 
 	return &ObjectFilteringMap{

--- a/pkg/transport/generic/filtering/persistentvolume.go
+++ b/pkg/transport/generic/filtering/persistentvolume.go
@@ -1,0 +1,53 @@
+/*
+Copyright 2026 The KubeStellar Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package filtering
+
+import (
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+// cleanPersistentVolume removes plane-local fields from a PersistentVolume
+// before it is wrapped into transport objects.
+//
+// A statically-bound PV carries a spec.claimRef with only name+namespace in
+// the seed YAML. The PV binder then stamps cluster-local identity
+// (uid, resourceVersion) onto claimRef. That identity must never propagate:
+// the edge binder attaches the *spoke* PVC uid itself, and enforcing hub-side
+// identity on the edge breaks static binding (PV stays Available, PVC goes
+// Lost; see kubestellar/kubestellar#3977). This matters in particular for
+// host-type WDS, where hub controllers may stamp the live WDS object.
+// Static binding intent (claimRef name/namespace, volumeName, storageClassName,
+// capacity, accessModes, persistentVolumeReclaimPolicy, nodeAffinity, …) is kept.
+func cleanPersistentVolume(object *unstructured.Unstructured) {
+	objectU := object.UnstructuredContent()
+	changed := false
+	if _, found, _ := unstructured.NestedFieldNoCopy(objectU, "spec", "claimRef", "uid"); found {
+		unstructured.RemoveNestedField(objectU, "spec", "claimRef", "uid")
+		changed = true
+	}
+	if _, found, _ := unstructured.NestedFieldNoCopy(objectU, "spec", "claimRef", "resourceVersion"); found {
+		unstructured.RemoveNestedField(objectU, "spec", "claimRef", "resourceVersion")
+		changed = true
+	}
+	if _, foundStatus, _ := unstructured.NestedFieldNoCopy(objectU, "status"); foundStatus {
+		unstructured.RemoveNestedField(objectU, "status")
+		changed = true
+	}
+	if changed {
+		object.SetUnstructuredContent(objectU)
+	}
+}

--- a/pkg/transport/generic/filtering/persistentvolume_test.go
+++ b/pkg/transport/generic/filtering/persistentvolume_test.go
@@ -1,0 +1,107 @@
+/*
+Copyright 2026 The KubeStellar Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package filtering
+
+import (
+	"reflect"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+func pvObject(t *testing.T, content map[string]any) *unstructured.Unstructured {
+	t.Helper()
+	obj := &unstructured.Unstructured{Object: content}
+	obj.SetGroupVersionKind(corev1.SchemeGroupVersion.WithKind("PersistentVolume"))
+	return obj
+}
+
+func TestCleanPersistentVolume(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    map[string]any
+		expected map[string]any
+	}{
+		{
+			name: "strips binder-owned claimRef identity and status, keeps static binding intent",
+			input: map[string]any{
+				"spec": map[string]any{
+					"capacity":                      map[string]any{"storage": "1Gi"},
+					"accessModes":                   []any{"ReadWriteOnce"},
+					"persistentVolumeReclaimPolicy": "Retain",
+					"storageClassName":              "manual",
+					"volumeName":                    "ursa-csipv-template",
+					"claimRef":                      map[string]any{"name": "ursa-claim", "namespace": "default", "uid": "hub-local-uid", "resourceVersion": "12345"},
+					"persistentVolumeSource":        map[string]any{"csi": map[string]any{"driver": "example.com/csi"}},
+				},
+				"status": map[string]any{"phase": "Available"},
+			},
+			expected: map[string]any{
+				"spec": map[string]any{
+					"capacity":                      map[string]any{"storage": "1Gi"},
+					"accessModes":                   []any{"ReadWriteOnce"},
+					"persistentVolumeReclaimPolicy": "Retain",
+					"storageClassName":              "manual",
+					"volumeName":                    "ursa-csipv-template",
+					"claimRef":                      map[string]any{"name": "ursa-claim", "namespace": "default"},
+					"persistentVolumeSource":        map[string]any{"csi": map[string]any{"driver": "example.com/csi"}},
+				},
+			},
+		},
+		{
+			name:     "no claimRef and no status is a no-op",
+			input:    map[string]any{"spec": map[string]any{"capacity": map[string]any{"storage": "1Gi"}}},
+			expected: map[string]any{"spec": map[string]any{"capacity": map[string]any{"storage": "1Gi"}}},
+		},
+		{
+			name:     "claimRef without binder fields is untouched",
+			input:    map[string]any{"spec": map[string]any{"claimRef": map[string]any{"name": "ursa-claim", "namespace": "default"}}},
+			expected: map[string]any{"spec": map[string]any{"claimRef": map[string]any{"name": "ursa-claim", "namespace": "default"}}},
+		},
+	}
+
+	filteringMap := NewObjectFilteringMap()
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			obj := pvObject(t, tt.input)
+			filteringMap.CleanObjectSpecifics(obj)
+			// SetGroupVersionKind injects apiVersion/kind into the live object;
+			// mirror them into the expectation before comparing.
+			want := map[string]any{
+				"apiVersion": "v1",
+				"kind":       "PersistentVolume",
+			}
+			for k, v := range tt.expected {
+				want[k] = v
+			}
+			if !reflect.DeepEqual(obj.Object, want) {
+				t.Errorf("mismatch:\n got: %#v\nwant: %#v", obj.Object, want)
+			}
+		})
+	}
+}
+
+func TestCleanObjectSpecificsUnknownGVKIsNoOp(t *testing.T) {
+	obj := &unstructured.Unstructured{Object: map[string]any{"spec": map[string]any{"foo": "bar"}}}
+	obj.SetGroupVersionKind(corev1.SchemeGroupVersion.WithKind("ConfigMap"))
+	before := obj.DeepCopy().Object
+	NewObjectFilteringMap().CleanObjectSpecifics(obj)
+	if !reflect.DeepEqual(obj.Object, before) {
+		t.Errorf("expected no change for unregistered GVK, got %#v", obj.Object)
+	}
+}


### PR DESCRIPTION
## Summary

Follows the existing transport filtering pattern (`pkg/transport/generic/filtering/`, same shape as #3979 for Service clusterIP): register a `PersistentVolume` cleaner that strips binder-owned identity (`spec.claimRef.uid`, `spec.claimRef.resourceVersion`) and edge-observed `status` from the wrapped object before it is propagated. Static binding intent (`claimRef` name/namespace, `volumeName`, `storageClassName`, capacity, accessModes, reclaim policy, nodeAffinity, …) is preserved untouched.

## Related issue(s)

Related to #3977 (PV stays `Available`, PVC goes `Lost` under static PV/PVC downsync).

## Problem

A statically-bound PV seed carries `spec.claimRef` with only name+namespace. The PV binder stamps cluster-local identity (`uid`, `resourceVersion`) onto it. If that hub-local identity is wrapped into the ManifestWork — notably with host-type WDS, where hub controllers stamp the live WDS object (cf. #3980) — the edge receives foreign identity and static binding can never complete.

## Solution

- New `cleanPersistentVolume` in `pkg/transport/generic/filtering/persistentvolume.go`, registered in `NewObjectFilteringMap` alongside Service/Job.
- New table-driven unit test `persistentvolume_test.go`: strips uid/resourceVersion + status while keeping all static fields; no-op when claimRef/status absent; unregistered GVKs untouched.

## How I tested and validated

- `gofmt -l` clean on the package.
- `go test ./pkg/transport/generic/filtering/ -v`: 5 passed (4 cleaner cases + 1 unknown-GVK no-op case).

## Honest scope note (please read before merging)

This hardens the **wrap side**. The issue also describes the work agent re-applying hub shape and pruning edge-binder fields on the spoke — if the agent uses full-object update semantics, that apply-side behavior needs separate handling plus an e2e run (`test/e2e/` with a static PV/PVC scenario) to prove the end-to-end bind completes. I deliberately used "Related to" (not "Fixes") so this does not auto-close #3977 until that e2e verification lands. Happy to follow up with the e2e scenario or an agent-side change if maintainers confirm the apply semantics.

## Updates to relevant documentation and examples

None required — no API or user-facing behavior change for correctly-formed seeds.