### PR TITLE
📖 docs: fix broken guide links in CONTRIBUTING after docs move

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,7 +17,7 @@ Please read the following guidelines if you're interested in contributing to Kub
 ### Contributing Code -- Prerequisites
 
 
-Please make sure that your environment has all the necessary versions as spelled out in the prerequisites section of our [user guide](docs/content/direct/pre-reqs.md)
+Please make sure that your environment has all the necessary versions as spelled out in the prerequisites section of our [user guide](https://github.com/kubestellar/docs/blob/main/docs/content/kubestellar/pre-reqs.md)
 
 ### Issues
 
@@ -72,7 +72,7 @@ A recommended format for final commit messages is as follows:
 In conformance with CNCF expectations, we will only merge commits that indicate your agreement with the [Developer Certificate of Origin](#certificate-of-origin). The CNCF defines how to do this, and there are two cases: one for developers working for an organization that is a CNCF member, and one for contributors acting as individuals. For the latter, assent is indicated by doing a Git "sign-off" on the commit. 
 
 
-See [Git Commit Signoff and Signing](docs/content/direct/pr-signoff.md) for more information on how to do that.
+See [Git Commit Signoff and Signing](https://github.com/kubestellar/docs/blob/main/docs/content/kubestellar/pr-signoff.md) for more information on how to do that.
 
 ### Pull Requests
 [View active Pull Requests on GitHub](https://github.com/kubestellar/kubestellar/pulls)
@@ -156,14 +156,14 @@ If you have any questions about contributing, don't hesitate to reach out to us 
 ## Testing Locally
 
 
-Our [Getting Started](docs/content/direct/get-started.md) guide shows a user how to install a simple "kick the tires" instance of KubeStellar using a helm chart and kind.
+Our [Getting Started](https://github.com/kubestellar/docs/blob/main/docs/content/kubestellar/get-started.md) guide shows a user how to install a simple "kick the tires" instance of KubeStellar using a helm chart and kind.
 
 To set up and test a development system, please refer to the _test/e2e/README.md_ file in the GitHub repository.
 After running any of those e2e (end to end) tests you will be left with a running system that can be exercised further.
 
 ### Testing changes to the helm chart
 
-If you are interested in modifying the Helm chart itself, look at the User Guide page on the [Core Helm chart](docs/content/direct/core-chart.md) for more information on its many options before you begin, notably on how to specify using a local version of the script.
+If you are interested in modifying the Helm chart itself, look at the User Guide page on the [Core Helm chart](https://github.com/kubestellar/docs/blob/main/docs/content/kubestellar/core-chart.md) for more information on its many options before you begin, notably on how to specify using a local version of the script.
 
 ### Testing the script against an upcoming release
 


### PR DESCRIPTION
## Summary

CONTRIBUTING.md links to four guides via relative paths under `docs/content/direct/` — that directory no longer exists in this repo (website docs moved to `kubestellar/docs`, per `docs/README.md`; this repo's `docs/content/` holds only `console/`). Every one of these links 404s on GitHub today. This PR repoints all four at their verified current locations.

## Related issue(s)

No linked issue — found while verifying contribution docs for new contributors.

## Problem

Broken links (all verified missing locally with `ls`, and the old paths 404 on github.com):

- `docs/content/direct/pre-reqs.md` (prerequisites section)
- `docs/content/direct/pr-signoff.md` (DCO sign-off how-to — the most-clicked link for first-time contributors)
- `docs/content/direct/get-started.md` (kick-the-tires guide)
- `docs/content/direct/core-chart.md` (Helm chart options)

## Solution

Repoint to absolute URLs in `kubestellar/docs` (each target verified to exist via the GitHub API before editing):

- …`/docs/content/kubestellar/pre-reqs.md`
- …`/docs/content/kubestellar/pr-signoff.md`
- …`/docs/content/kubestellar/get-started.md`
- …`/docs/content/kubestellar/core-chart.md`

Absolute URLs are used deliberately: relative links only work if the file lives in this repo, which these no longer do.

## How I tested and validated

- Confirmed each old path is absent from this checkout.
- Confirmed each new target exists in `kubestellar/docs@main` via `gh api repos/kubestellar/docs/contents/<path>` (all returned a blob SHA).
- Docs-only change: no build/test impact. I clicked-equivalent check is the API verification above.

## Follow-up note (not in scope)

`.github/pull_request_template.md` also references `docs/content/contribution-guidelines/operations/document-management.md`, which exists in neither repo (upstream has `docs/content/contributing/operations/` but no `document-management.md`). That one needs a maintainer decision (restore/rename vs. point at `testing-doc-prs.md`), so I left the template untouched — happy to do it as a follow-up once the target is decided.

## Updates to relevant documentation and examples

This PR *is* the documentation fix.