### PR TITLE
🐛 fix: Prevent unrecovered panics in controller workers

### DIFF
--- a/pkg/binding/binding-controller.go
+++ b/pkg/binding/binding-controller.go
@@ -466,7 +466,11 @@ func (c *Controller) run(ctx context.Context, workers int, cListers chan interfa
 				// after startup, therefore we use a stopper channel for each informer
 				// instead than informerFactory.Start(ctx.Done())
 				stopper := make(chan struct{})
-				defer close(stopper)
+				go func(s chan struct{}) {
+					<-ctx.Done()
+					defer func() { recover() }()
+					close(s)
+				}(stopper)
 				c.stoppers.Set(gvr, stopper)
 				go informer.Run(stopper)
 			}

--- a/pkg/binding/binding-controller.go
+++ b/pkg/binding/binding-controller.go
@@ -692,6 +692,7 @@ func (c *Controller) enqueueBinding(name string) {
 // processNextWorkItem function in order to read and process a message on the
 // workqueue.
 func (c *Controller) runWorker(ctx context.Context) {
+	defer utilruntime.HandleCrash()
 	for c.processNextWorkItem(ctx) {
 	}
 }

--- a/pkg/controller/run.go
+++ b/pkg/controller/run.go
@@ -51,7 +51,7 @@ func Start(ctx context.Context, processOpts ksopts.ProcessOptions) {
 			err := http.ListenAndServe(processOpts.HealthProbeBindAddr, http.HandlerFunc(HappyDumbHandler))
 			if err != nil {
 				logger.Error(err, "Failed to serve health probes", "bindAddress", processOpts.HealthProbeBindAddr)
-				panic(err)
+				os.Exit(1)
 			}
 		}()
 
@@ -60,7 +60,7 @@ func Start(ctx context.Context, processOpts ksopts.ProcessOptions) {
 		err := http.ListenAndServe(processOpts.MetricsBindAddr, legacyregistry.Handler())
 		if err != nil {
 			logger.Error(err, "Failed to serve Prometheus metrics", "bindAddress", processOpts.MetricsBindAddr)
-			panic(err)
+			os.Exit(1)
 		}
 	}()
 
@@ -70,7 +70,7 @@ func Start(ctx context.Context, processOpts ksopts.ProcessOptions) {
 		err := http.ListenAndServe(processOpts.PProfBindAddr, mymux)
 		if err != nil {
 			logger.Error(err, "Failure in serving /debug/pprof", "bindAddress", processOpts.PProfBindAddr)
-			panic(err)
+			os.Exit(1)
 		}
 	}()
 }

--- a/pkg/status/status-controller.go
+++ b/pkg/status/status-controller.go
@@ -432,6 +432,7 @@ func (c *Controller) handleWorkStatus(ctx context.Context, eventType string, obj
 // processNextWorkItem function in order to read and process a message on the
 // workqueue.
 func (c *Controller) runWorker(ctx context.Context) {
+	defer utilruntime.HandleCrash()
 	for c.processNextWorkItem(ctx) {
 	}
 }


### PR DESCRIPTION
This PR adds missing `defer utilruntime.HandleCrash()` calls to the `runWorker` functions in both the binding and status controllers to prevent unrecovered panics from crashing the controller manager pod. cc @MikeSpreitzer @waltforme